### PR TITLE
Race bugfixes

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -1284,7 +1284,9 @@ public class Creature extends Utils
 				maxSfPerWisStat,
 				maxSfMultStat,
 				
-				spellpowerStat
+				spellpowerStat,
+				defStat,
+				mdefStat
 			]);
 
 			skin = new Skin(this);

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -863,34 +863,6 @@ use namespace CoC;
 				//if (wings.type == Wings.GARGOYLE_LIKE_LARGE) armorMDef += (30 * newGamePlusMod);
 				//if (faceType == Face.DEVIL_FANGS) armorMDef += (30 * newGamePlusMod);
 			//}
-			if (hasPerk(PerkLib.ElementalBody)) {
-				switch (ElementalRace.getElementAndTier(this)) {
-					case ElementalRace.GNOME_1:
-						armorMDef += (10 * newGamePlusMod);
-						break;
-					case ElementalRace.GNOME_2:
-						armorMDef += (20 * newGamePlusMod);
-						break;
-					case ElementalRace.GNOME_3:
-						armorMDef += (30 * newGamePlusMod);
-						break;
-					case ElementalRace.GNOME_4:
-						armorMDef += (40 * newGamePlusMod);
-						break;
-					case ElementalRace.UNDINE_1:
-						armorMDef += (5 * newGamePlusMod);
-						break;
-					case ElementalRace.UNDINE_2:
-						armorMDef += (10 * newGamePlusMod);
-						break;
-					case ElementalRace.UNDINE_3:
-						armorMDef += (15 * newGamePlusMod);
-						break;
-					case ElementalRace.UNDINE_4:
-						armorMDef += (20 * newGamePlusMod);
-						break;
-				}
-			}
 			//Soul Cultivators bonuses
 			if (hasPerk(PerkLib.FleshBodyApprenticeStage)) {
 				if (hasPerk(PerkLib.SoulApprentice)) armorMDef += 1 * newGamePlusMod;
@@ -3495,14 +3467,14 @@ use namespace CoC;
 		 * DOES NOT mean that this is player's top race!
 		 */
 		public function isAnyRace(...races:/*Race*/Array):Boolean {
-			if (races.length == 1 && races[0] is Array) return isAnyRace(races[0]);
+			if (races.length == 1 && races[0] is Array) races = flatten(races);
 			for each (var race:Race in races) {
 				if (isRace(race)) return true;
 			}
 			return false;
 		}
 		public function isAnyRaceCached(...races:/*Race*/Array):Boolean {
-			if (races.length == 1 && races[0] is Array) return isAnyRaceCached(races[0]);
+			if (races.length == 1 && races[0] is Array) races = flatten(races);
 			for each (var race:Race in races) {
 				if (isRaceCached(race)) return true;
 			}

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -1074,7 +1074,7 @@ public class PlayerAppearance extends BaseContent {
 		}
 		
 		// Other body part-related buffs that contribute to the "Racial" buff object in Player.calcRacialBuffs
-		outputText("\n[font-lblue]");
+		outputText("\n");
 		
 		var factor:Number = 0;
 		if (player.hasCoatOfType(Skin.CHITIN)) factor += 2;
@@ -1090,56 +1090,54 @@ public class PlayerAppearance extends BaseContent {
 			bonus += 5*factor;
 		}
 		if (bonus > 0) {
-			outputText("\nMantislike Agility: +"+bonus+"% Speed");
+			outputText("\n[font-lblue]Mantislike Agility[/font]: +"+bonus+"% Speed");
 		}
 		if (player.hasPerk(PerkLib.Flexibility) && player.isAnyRaceCached(Races.CatlikeRaces)) {
-			outputText("\nCat-like race + Flexibility: +10% Speed.");
+			outputText("\n[font-lblue]Cat-like race + Flexibility[/font]: +10% Speed.");
 		}
 		if (player.isNaga()) {
 			if (player.lowerBody == LowerBody.FROSTWYRM) {
-				outputText("\nFrost wyrm lower body: +20% Strength, +10% Toughness.");
+				outputText("\n[font-lblue]Frost wyrm lower body[/font]: +20% Strength, +10% Toughness.");
 			} else {
-				outputText("\nNaga lower body: +15% Strength, +15% Toughness.");
+				outputText("\n[font-lblue]Naga lower body[/font]: +15% Strength, +15% Toughness.");
 			}
 		}
 		
 		if (player.isTaur()) {
-			outputText("\nTaur lower body: +20% Speed.")
+			outputText("\n[font-lblue]Taur lower body[/font]: +20% Speed.")
 		}
 		
 		if (player.isDrider()) {
 			if (player.lowerBody == LowerBody.CANCER) {
-				outputText("\nCancer lower body: +15% Strength, +5% Speed, +10% Toughness.");
+				outputText("\n[font-lblue]Cancer lower body[/font]: +15% Strength, +5% Speed, +10% Toughness.");
 			} else {
-				outputText("\nDrider lower body: +15% Toughness, +15% Speed.");
+				outputText("\n[font-lblue]Drider lower body[/font]: +15% Toughness, +15% Speed.");
 			}
 		}
 		if (player.isScylla()) {
-			outputText("\nScylla lower body: +30% Strength.")
+			outputText("\n[font-lblue]Scylla lower body[/font]: +30% Strength.")
 		}
 		if (player.isKraken()) {
-			outputText("\nKraken lower body: +60% Strength, +15 Sensitivity");
+			outputText("\n[font-lblue]Kraken lower body[/font]: +60% Strength, +15 Sensitivity");
 		}
 		if (player.lowerBody == LowerBody.CENTIPEDE) {
-			outputText("\nCentipede lower body: +15% Strength, +5% Toughness, +10% Speed.")
+			outputText("\n[font-lblue]Centipede lower body[/font]: +15% Strength, +5% Toughness, +10% Speed.")
 		}
 		if (player.isAlraune()) {
-			outputText("\nAlraune lower body: +15% Toughness, +15% Libido.")
+			outputText("\n[font-lblue]Alraune lower body[/font]: +15% Toughness, +15% Libido.")
 		}
 		if (player.hasPerk(PerkLib.RacialParagon)) {
-			outputText("\nRacial Paragon: +"+player.level+"% to core stats.")
+			outputText("\n[font-lblue]Racial Paragon[/font]: +"+player.level+"% to core stats.")
 		}
 		if (player.hasPerk(PerkLib.Apex)) {
-			outputText("\nApex: +"+(2*player.level)+"% to core stats.")
+			outputText("\n[font-lblue]Apex[/font]: +"+(2*player.level)+"% to core stats.")
 		}
 		if (player.hasPerk(PerkLib.AlphaAndOmega)) {
-			outputText("\nAlpha And Omega: +"+(2*player.level)+"% to core stats.")
+			outputText("\n[font-lblue]Alpha And Omega[/font]: +"+(2*player.level)+"% to core stats.")
 		}
 		if (player.hasPerk(PerkLib.AscensionOneRaceToRuleThemAllX)) {
-			outputText("\nAscension: One Race To Rule Them All: +"+(2*player.perkv1(PerkLib.AscensionOneRaceToRuleThemAllX)*player.level)+"% to core stats.");
+			outputText("\n[font-lblue]Ascension: One Race To Rule Them All[/font]: +"+(2*player.perkv1(PerkLib.AscensionOneRaceToRuleThemAllX)*player.level)+"% to core stats.");
 		}
-		
-		outputText("[/font]");
 		
 		menu();
 		if (scrollPos) mainView.mainText.scrollV = scrollPos;

--- a/classes/classes/Race.as
+++ b/classes/classes/Race.as
@@ -350,6 +350,7 @@ public class Race {
 	/**
 	 * Key: debug form name
 	 * Value: a list of elements of type:
+	 * - function(player:Player):void
 	 * - Transformation
 	 * - StatusEffectType
 	 * - IMutationPerkType
@@ -364,6 +365,11 @@ public class Race {
 	}
 	public function takeForm(player:Player, tfName:String):void {
 		for each (var o:* in debugForms[tfName]) {
+			var f:Function = o as Function;
+			if (f) {
+				f(player);
+				continue;
+			}
 			var tf:Transformation = o as Transformation;
 			if (tf) {
 				if (tf.isPossible()) {

--- a/classes/classes/Race.as
+++ b/classes/classes/Race.as
@@ -22,6 +22,10 @@ public class Race {
 	 * Array of pairs: `[mutationPerk:IMutationPerkType, scorePerStage:int]`
 	 */
 	public var mutations:/*Array*/Array = [];
+	/**
+	 * Min score to get bonuses from mutation and bloodline
+	 */
+	public var mutationThreshold:int = 0
 	
 	/**
 	 * true - do not display the race in menus
@@ -97,7 +101,7 @@ public class Race {
 		if (bloodlinePerks.length > 0) {
 			bonus = 0;
 			for each (var perk:PerkType in bloodlinePerks) {
-				if (body.player.hasPerk(perk)) {
+				if (score > mutationThreshold && body.player.hasPerk(perk)) {
 					bonus += body.player.increaseFromBloodlinePerks();
 					break;
 				}
@@ -113,7 +117,7 @@ public class Race {
 				var pt:PerkType = entry[0];
 				var pc:PerkClass = body.player.getPerk(pt);
 				var stage:Number = pc ? pc.value1 : 0;
-				bonus = stage*entry[1];
+				bonus = score > mutationThreshold ? stage*entry[1] : 0;
 				if (outputText != null) outputText("Mutation: "+pt.name(pc), bonus);
 				score += bonus;
 				maxStage = Math.max(maxStage, stage);
@@ -121,17 +125,17 @@ public class Race {
 			//if (outputText != null) outputText("Mutations", bonus);
 			//score += bonus;
 			if (body.player.hasPerk(PerkLib.ChimericalBodySemiImprovedStage)) {
-				bonus = maxStage >= 1 ? +1 : 0;
+				bonus = score > mutationThreshold && maxStage >= 1 ? +1 : 0;
 				if (outputText != null) outputText("Chimerical Body: Semi-Improved Stage", bonus);
 				score += bonus;
 			}
 			if (body.player.hasPerk(PerkLib.ChimericalBodySemiSuperiorStage)) {
-				bonus = maxStage >= 2 ? +1 : 0;
+				bonus = score > mutationThreshold && maxStage >= 2 ? +1 : 0;
 				if (outputText != null) outputText("Chimerical Body: Semi-Superior Stage", bonus);
 				score += bonus;
 			}
 			if (body.player.hasPerk(PerkLib.ChimericalBodySemiEpicStage)) {
-				bonus = maxStage >= 3 ? +1 : 0;
+				bonus = score > mutationThreshold && maxStage >= 3 ? +1 : 0;
 				if (outputText != null) outputText("Chimerical Body: Semi-Epic Stage", bonus);
 				score += bonus;
 			}
@@ -265,7 +269,7 @@ public class Race {
 			s += reason+" ("+(change>0?"+"+change:change)+")";
 			s += "[/font]\n";
 		}
-		finalizeScore(body, score, finalizerOutput);
+		score = finalizeScore(body, score, finalizerOutput);
 		if (tiers.length>0) {
 			s += "\t<b>Tiers:</b>\n";
 		}

--- a/classes/classes/Races/AlicornRace.as
+++ b/classes/classes/Races/AlicornRace.as
@@ -26,6 +26,7 @@ public class AlicornRace extends Race {
 				.faceType(ANY(Face.HUMAN, Face.HORSE), +1, -1000)
 				.hornType(ANY(Horns.UNICORN, Horns.BICORN), 0, -1000)
 				.earType(Ears.HORSE, +1)
+				.tailType(Tail.HORSE, +1)
 				.legType(LowerBody.HOOFED, +2)
 				.eyeType(Eyes.HUMAN, +1)
 				.skinPlainOnly(+1)

--- a/classes/classes/Races/BeeRace.as
+++ b/classes/classes/Races/BeeRace.as
@@ -13,8 +13,7 @@ public class BeeRace extends Race {
 	
 	public override function setup():void {
 		addScores()
-				.hairType(Hair.GHOST, +1)
-				.skinCoatColorPair("yellow", "black", +1)
+				.skinCoatColorPair("yellow", ANY("black", "ebony"), +1)
 				.eyeType(Eyes.BLACK_EYES_SAND_TRAP, +2) //po dodaniu bee tongue wróci do +1
 				.antennaeType(Antennae.BEE, +1)
 				.faceType(Face.HUMAN, +1) //ptem zamienić na specificzną dla pszczół wariant twarzy

--- a/classes/classes/Races/DemonRace.as
+++ b/classes/classes/Races/DemonRace.as
@@ -12,6 +12,7 @@ public class DemonRace extends Race {
 	
 	public function DemonRace(id:int) {
 		super("Demon", id);
+		mutationThreshold = 5;
 	}
 	
 	public override function setup():void {

--- a/classes/classes/Races/DevilRace.as
+++ b/classes/classes/Races/DevilRace.as
@@ -10,6 +10,7 @@ import classes.VaginaClass;
 public class DevilRace extends Race {
 	public function DevilRace(id:int) {
 		super("Devil", id);
+		mutationThreshold = 5;
 	}
 	
 	public override function setup():void {

--- a/classes/classes/Races/DragonRace.as
+++ b/classes/classes/Races/DragonRace.as
@@ -15,6 +15,7 @@ import classes.lists.Gender;
 public class DragonRace extends Race {
 	public function DragonRace(id:int) {
 		super("Dragon", id);
+		mutationThreshold = 5;
 	}
 	
 	public override function setup():void {

--- a/classes/classes/Races/ElementalRace.as
+++ b/classes/classes/Races/ElementalRace.as
@@ -101,25 +101,29 @@ public class ElementalRace extends Race {
 			"tou.mult": +1.00,
 			"wis.mult": +0.75,
 			"str.mult": +0.50,
-			"def": +10
+			"def": +10,
+			"mdef": +10
 		},
 		22: { // GNOME_2
 			"tou.mult": +1.25,
 			"wis.mult": +1.00,
 			"str.mult": +0.75,
-			"def": +20
+			"def": +20,
+			"mdef": +20
 		},
 		23: { // GNOME_3
 			"tou.mult": +1.50,
 			"wis.mult": +1.25,
 			"str.mult": +1.00,
-			"def": +30
+			"def": +30,
+			"mdef": +30
 		},
 		24: { // GNOME_4
 			"tou.mult": +1.75,
 			"wis.mult": +1.50,
 			"str.mult": +1.25,
-			"def": +40
+			"def": +40,
+			"mdef": +40
 		},
 		31: { // IGNIS_1
 			"spe.mult": +1.00,
@@ -145,25 +149,29 @@ public class ElementalRace extends Race {
 			"wis.mult": +1.00,
 			"str.mult": +0.75,
 			"tou.mult": +0.50,
-			"def": +5
+			"def": +5,
+			"mdef": +5
 		},
 		42: { // UNDINE_2
 			"wis.mult": +1.25,
 			"str.mult": +1.00,
 			"tou.mult": +0.75,
-			"def": +10
+			"def": +10,
+			"mdef": +10
 		},
 		43: { // UNDINE_3
 			"wis.mult": +1.50,
 			"str.mult": +1.25,
 			"tou.mult": +1.00,
-			"def": +15
+			"def": +15,
+			"mdef": +15
 		},
 		44: { // UNDINE_4
 			"wis.mult": +1.75,
 			"str.mult": +1.50,
 			"tou.mult": +1.25,
-			"def": +20
+			"def": +20,
+			"mdef": +20
 		}
 	};
 	

--- a/classes/classes/Races/FrostWyrmRace.as
+++ b/classes/classes/Races/FrostWyrmRace.as
@@ -14,6 +14,7 @@ public class FrostWyrmRace extends Race {
 		super("Frost Wyrm", id);
 		chimeraTier = 0;
 		grandChimeraTier = 0;
+		mutationThreshold = 5;
 	}
 	
 	public override function setup():void {

--- a/classes/classes/Races/HarpyRace.as
+++ b/classes/classes/Races/HarpyRace.as
@@ -21,8 +21,6 @@ public class HarpyRace extends Race {
 				.wingType(Wings.FEATHERED_LARGE, +4)
 				.tailType(Tail.HARPY, +1)
 				.legType(LowerBody.HARPY, +1)
-				.hasVagina(+1)
-				.skinCoverage(Skin.COVERAGE_NONE, +1)
 				.hasPerk(PerkLib.HarpyWomb, +2)
 				.customRequirement("","not another harpy-like race",
 						function (body:BodyData):Boolean {
@@ -32,7 +30,9 @@ public class HarpyRace extends Race {
 									|| body.tailType == Tail.THUNDERBIRD
 							);
 						}, 0, -1000);
-		addScoresAfter(2)
+		addScoresAfter(3)
+				.hasVagina(+1)
+				.skinCoverage(Skin.COVERAGE_NONE, +1)
 				.faceType(ANY(Face.HUMAN, Face.ANIMAL_TOOTHS), +1)
 				.earType(ANY(Ears.HUMAN, Ears.ELFIN), +1);
 		

--- a/classes/classes/Races/HumanRace.as
+++ b/classes/classes/Races/HumanRace.as
@@ -9,6 +9,8 @@ import classes.VaginaClass;
 public class HumanRace extends Race {
 	public function HumanRace(id:int) {
 		super("Human", id);
+		chimeraTier = 0;
+		grandChimeraTier = 0;
 	}
 	
 	override public function setup():void {

--- a/classes/classes/Races/JabberwockyRace.as
+++ b/classes/classes/Races/JabberwockyRace.as
@@ -12,6 +12,7 @@ public class JabberwockyRace extends Race {
 	
 	public function JabberwockyRace(id:int) {
 		super("Jabberwocky", id);
+		mutationThreshold = 5;
 	}
 	
 	public override function setup():void {

--- a/classes/classes/Races/KitsuneRace.as
+++ b/classes/classes/Races/KitsuneRace.as
@@ -27,6 +27,7 @@ public class KitsuneRace extends Race {
 	
 	public function KitsuneRace(id:int) {
 		super("Kitsune", id);
+		mutationThreshold = 5;
 	}
 	
 	public override function setup():void {

--- a/classes/classes/Races/OniRace.as
+++ b/classes/classes/Races/OniRace.as
@@ -20,8 +20,6 @@ public class OniRace extends Race {
 				.legType(LowerBody.ONI, +1)
 				.eyeTypeAndColor(Eyes.ONI, ANY(OniEyeColors), +1)
 				.skinBasePattern(Skin.PATTERN_BATTLE_TATTOO, +1)
-				.noRearBody(+1)
-				.noTail(+1)
 				.tone(AT_LEAST(80),+1)
 				.customRequirement("",'vagina and H+ tits or 19\"+ long cock',
 						function (body:BodyData):Boolean {
@@ -29,6 +27,8 @@ public class OniRace extends Race {
 						}, +1)
 				.height(AT_LEAST(108), +1);
 		addScoresAfter(4)
+				.noRearBody(+1)
+				.noTail(+1)
 				.tone(AT_LEAST(120), +1);
 		addScoresAfter(8)
 				.tone(AT_LEAST(160), +1);

--- a/classes/classes/Races/README.md
+++ b/classes/classes/Races/README.md
@@ -104,6 +104,7 @@ Things you could add to the constructor:
 * `disabled = true`/`hidden=true` to make race disabled/hidden.
 * `chimeraTier = 0; grandChimeraTier = 0;` to disabled adding points to chimera/grand chimera.
 * `chimeraTier = <N>; grandChimeraTier = <N+1>;` to change default chimera/grand chimera min tiers from default 1 and 2.
+* `mutationThreshold = <N>;` By default always get bonuses from mutations and bloodlines. You can gate them behind certain score.
 
 ## Score calculation
 
@@ -201,6 +202,8 @@ addBloodline(PerkLib.KitsunesDescendant, PerkLib.BloodlineKitsune);
 addMutation(IMutationsLib.KitsuneThyroidGlandIM);
 addMutation(IMutationsLib.TwinHeartIM, +2);
 ```
+
+To gate mutation/bloodline bonuses behing certain score, set `mutatonThreshold` in the constructor. 
 
 ### finalizeScore
 

--- a/classes/classes/Races/README.md
+++ b/classes/classes/Races/README.md
@@ -302,6 +302,7 @@ To do that, overwrite a `debugForms` race with a map. Each element is a debug fo
 * StatusEffectType - added with zero values. To add a status effect with custom values, add a nested 5-element array `[effect type, value1, value2, value3, value4]`
 * IMutationPerkType - added with max stage. To add a different stage, add a nested 2-element array `[mutation type, stage]`
 * PerkType - added with zero values. To add a perk with custom values, add a nested 5-element array `[perk type, value1, value2, value3, value4]`.
+* functions with signature `function(player:Player):void`
 
 See Kitsune and Human races for example.
 

--- a/classes/classes/Races/SalamanderRace.as
+++ b/classes/classes/Races/SalamanderRace.as
@@ -20,16 +20,22 @@ public class SalamanderRace extends Race {
 	public override function setup():void {
 		addScores()
 				.skinCoatType(Skin.SCALES, +1)
-				.skinCoatTypeAndColor(Skin.SCALES, ANY(SalamanderScaleColors), +1)
-				.skinBaseColor(ANY(SalamanderSkinColors), +1)
 				.faceType(Face.SALAMANDER_FANGS, +1)
-				.earType(ANY(Ears.HUMAN, Ears.LIZARD), +1)
+				.customRequirement("","salamander fangs; human or lizard ears", function (body:BodyData): Boolean {
+					return body.faceType == Face.SALAMANDER_FANGS
+							&& (body.earType == Ears.HUMAN || body.earType == Ears.LIZARD);
+				}, +1)
 				.eyeType(Eyes.LIZARD, +1)
 				.armType(Arms.SALAMANDER, +1)
 				.tailType(Tail.SALAMANDER, +2)
-				.hasCockOfType(CockTypesEnum.LIZARD,1)
+				.hasCockOfType(CockTypesEnum.LIZARD,+1)
 				.hasPerk(PerkLib.Lustzerker, +1)
 				.wingType(NOT(Wings.FEATHERED_PHOENIX), 0, -1000);
+		addConditionedScores(function (body:BodyData):Boolean {
+			return body.skinCoatType == Skin.SCALES
+		},"scales;")
+				.skinCoatTypeAndColor(Skin.SCALES, ANY(SalamanderScaleColors), +1)
+				.skinBaseColor(ANY(SalamanderSkinColors), +1);
 		addConditionedScores(function (body:BodyData):Boolean {
 			return body.tailType == Tail.SALAMANDER
 		},"salamander tail;")

--- a/classes/classes/Races/SpiderRace.as
+++ b/classes/classes/Races/SpiderRace.as
@@ -10,6 +10,7 @@ public class SpiderRace extends Race {
 	
 	public function SpiderRace(id:int) {
 		super("Spider", id);
+		mutationThreshold = 4;
 	}
 	
 	public override function setup():void {

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -2513,9 +2513,12 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		for (i = 0; i < saveFile.data.statusAffects.length; i++)
 		{
 			if (saveFile.data.statusAffects[i].statusAffectName == "Lactation EnNumbere") continue; // ugh...
-			var stype:StatusEffectType = StatusEffectType.lookupStatusEffect(saveFile.data.statusAffects[i].statusAffectName);
+			var name:String = saveFile.data.statusAffects[i].statusAffectName;
+			var stype:StatusEffectType = StatusEffectType.lookupStatusEffect(name);
 			if (stype == null){
-				CoC_Settings.error("Cannot find status effect '"+saveFile.data.statusAffects[i].statusAffectName+"'");
+				if (StatusEffectType.RemovedIds.indexOf(name) < 0) {
+					CoC_Settings.error("Cannot find status effect '" + name + "'");
+				}
 				continue;
 			}
 			player.createStatusEffect(stype,

--- a/classes/classes/StatusEffectType.as
+++ b/classes/classes/StatusEffectType.as
@@ -7,6 +7,18 @@ import flash.utils.Dictionary;
 
 public class StatusEffectType
 {
+	/**
+	 * Do not report an error if one of these was found in save file
+	 */
+	public static const RemovedIds:/*String*/Array = [
+		"Str Tou Spe Counter 1",
+		"Str Tou Spe Counter 2",
+		"Int Wis Counter 1",
+		"Int Wis Counter 2",
+		"Lib Sens Counter 1",
+		"Lib Sens Counter 2",
+	];
+	
 	private static var STATUSAFFECT_LIBRARY:Dictionary = new Dictionary();
 	private var arity:int;
 	


### PR DESCRIPTION
Fixed endless recursion in `isAnyRace/isAnyRaceCached`.
Race.debugForms can take functions.
Elemental magical resistance bonus made into buff.
Added mutationThreshold property.
Adjusted certain racial scores.
Fixed defense/magic resistance stats.
Fixed human giving chimera score.
Removed error messages about known removed status effects.