### PR TITLE
Race fixes

### DIFF
--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -1017,9 +1017,12 @@ public class PlayerAppearance extends BaseContent {
 			outputText("[/font]");
 			if (rtier) {
 				if (rtier.hasBuffs()) {
-					outputText(" (");
-					outputText(rtier.describeBuffs(body));
-					outputText(")");
+					var s:String = rtier.describeBuffs(body);
+					if (s) {
+						outputText(" (");
+						outputText(s);
+						outputText(")");
+					}
 				}
 				outputText("[/font]");
 			}

--- a/classes/classes/Race.as
+++ b/classes/classes/Race.as
@@ -72,7 +72,6 @@ public class Race {
 			for each(var req:RacialRequirement in requirements) {
 				score += req.calcScore(body, score);
 			}
-			if (score < 0) score = 0;
 		} finally {
 			Utils.End("Race", "basicScore");
 		}
@@ -101,7 +100,7 @@ public class Race {
 		if (bloodlinePerks.length > 0) {
 			bonus = 0;
 			for each (var perk:PerkType in bloodlinePerks) {
-				if (score > mutationThreshold && body.player.hasPerk(perk)) {
+				if (/*score >= mutationThreshold && */body.player.hasPerk(perk)) {
 					bonus += body.player.increaseFromBloodlinePerks();
 					break;
 				}
@@ -117,7 +116,7 @@ public class Race {
 				var pt:PerkType = entry[0];
 				var pc:PerkClass = body.player.getPerk(pt);
 				var stage:Number = pc ? pc.value1 : 0;
-				bonus = score > mutationThreshold ? stage*entry[1] : 0;
+				bonus = score >= mutationThreshold ? stage*entry[1] : 0;
 				if (outputText != null) outputText("Mutation: "+pt.name(pc), bonus);
 				score += bonus;
 				maxStage = Math.max(maxStage, stage);
@@ -125,17 +124,17 @@ public class Race {
 			//if (outputText != null) outputText("Mutations", bonus);
 			//score += bonus;
 			if (body.player.hasPerk(PerkLib.ChimericalBodySemiImprovedStage)) {
-				bonus = score > mutationThreshold && maxStage >= 1 ? +1 : 0;
+				bonus = score >= mutationThreshold && maxStage >= 1 ? +1 : 0;
 				if (outputText != null) outputText("Chimerical Body: Semi-Improved Stage", bonus);
 				score += bonus;
 			}
 			if (body.player.hasPerk(PerkLib.ChimericalBodySemiSuperiorStage)) {
-				bonus = score > mutationThreshold && maxStage >= 2 ? +1 : 0;
+				bonus = score >= mutationThreshold && maxStage >= 2 ? +1 : 0;
 				if (outputText != null) outputText("Chimerical Body: Semi-Superior Stage", bonus);
 				score += bonus;
 			}
 			if (body.player.hasPerk(PerkLib.ChimericalBodySemiEpicStage)) {
-				bonus = score > mutationThreshold && maxStage >= 3 ? +1 : 0;
+				bonus = score >= mutationThreshold && maxStage >= 3 ? +1 : 0;
 				if (outputText != null) outputText("Chimerical Body: Semi-Epic Stage", bonus);
 				score += bonus;
 			}
@@ -167,6 +166,7 @@ public class Race {
 				score += 50;
 			}
 		}
+		if (score < 0) return 0;
 		return score;
 	}
 	


### PR DESCRIPTION
* Fixes mutationThreshold being 1 above declared value.
* Fixes score miscalculation that would allow to avoid absolute requirements.
* **Bloodline racial score bonus no longer has a threshold.** (if you need to get it back, uncomment at Race.as:103
* Fixes empty () for human score entry

There's an ongoing discussion what mutation score threshold should be. It is configured at Race.as:28, and could be tweaked for any race manually in the constructor. This PR doesn't change default 5, though it was reported as too high by chimera players.