### PR TITLE
Enchanted item system

### DIFF
--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -235,7 +235,10 @@ import coc.xxc.StoryContext;
 		}
 
 		protected static function printLink(linkText:String, eventArgument:String):void {
-			outputText('<u><a href="event:'+Eval.escapeString(eventArgument)+'">'+linkText+"</a></u>");
+			outputText(mkLink(linkText, eventArgument));
+		}
+		protected static function mkLink(linkText:String, eventArgument:String):String {
+			return '<u><a href="event:'+encodeURI(eventArgument)+'">'+linkText+"</a></u>";
 		}
 		
 		protected static function outputText(output:String):void

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -391,6 +391,7 @@ public class CoC extends MovieClip
         trace("Initializing perks");
         PerkLib.initDependencies();
 		perkTree = new PerkTree();
+        EnchantmentLib.instance;
         mainMenu.mainMenu();
         this.stop();
 

--- a/classes/classes/ItemType.as
+++ b/classes/classes/ItemType.as
@@ -109,6 +109,10 @@ import flash.utils.Dictionary;
 		protected var _description:String;
 		protected var _value:Number;
 		protected var _tags:Object;
+		/**
+		 * Max stack size for items of that type
+		 */
+		public var stackSize:int = 5;
 
 		public function get tagForBuffs():String {
 			return "item_"+_id;
@@ -118,6 +122,9 @@ import flash.utils.Dictionary;
 		}
 		public function get cursed():Boolean {
 			return false;
+		}
+		public function get buttonColor():String {
+			return "#000000";
 		}
 		public function templateId():String {
 			var i:int = _id.indexOf(';');

--- a/classes/classes/ItemType.as
+++ b/classes/classes/ItemType.as
@@ -3,12 +3,29 @@
  */
 package classes
 {
+import classes.Items.Enchantment;
+import classes.Items.EnchantmentType;
 import classes.internals.Utils;
 
 import flash.utils.Dictionary;
 
 	public class ItemType extends Utils
 	{
+		public static const CATEGORY_WEAPON_MELEE:String = "weapon";
+		public static const CATEGORY_WEAPON_RANGED:String = "weaponranged";
+		public static const CATEGORY_SHIELD:String = "shield";
+		public static const CATEGORY_ARMOR:String = "armor";
+		public static const CATEGORY_UNDERGARMENT:String = "undergarment";
+		public static const CATEGORY_NECKLACE:String = "necklace";
+		public static const CATEGORY_JEWELRY_HEAD:String = "headjewelry";
+		public static const CATEGORY_JEWELRY_RING:String = "jewelry";
+		public static const CATEGORY_JEWELRY_MISC:String = "miscjewelry";
+		public static const CATEGORY_VEHICLE:String = "vehicle";
+		public static const CATEGORY_FLYING_SWORD:String = "flyingsword";
+		public static const CATEGORY_CONSUMABLE:String = "consumable";
+		public static const CATEGORY_USABLE:String = "useable";
+		public static const CATEGORY_OTHER:String = "other";
+		
 		/**
 		 * Unique item DB
 		 */
@@ -17,6 +34,7 @@ import flash.utils.Dictionary;
 		 * Dynamic item cache
 		 */
 		private static var DYNAMIC_ITEM_LIBRARY:Dictionary = new Dictionary();
+		private static var dynamicItemCounter:int = 0;
 		/**
 		 * Short name -> Item mapping. Used for button labeling.
 		 */
@@ -63,6 +81,13 @@ import flash.utils.Dictionary;
 			}
 			return ITEM_LIBRARY[id];
 		}
+		
+		public static function lookupCachedItem(id:String):ItemType {
+			if (id in LEGACY_REMAP) id = LEGACY_REMAP[id];
+			var i:int = id.indexOf(";");
+			if (i >= 0) return DYNAMIC_ITEM_LIBRARY[id];
+			return ITEM_LIBRARY[id];
+		}
 
 		/**
 		 * Looks up item by <b>shortName</b>.
@@ -85,6 +110,50 @@ import flash.utils.Dictionary;
 		protected var _value:Number;
 		protected var _tags:Object;
 
+		public function get tagForBuffs():String {
+			return "item_"+_id;
+		}
+		public function get isDynamicItem():Boolean {
+			return _id.indexOf(';') >= 0;
+		}
+		public function get cursed():Boolean {
+			return false;
+		}
+		public function templateId():String {
+			var i:int = _id.indexOf(';');
+			if (i < 0) throw new Error(longName+" is not a dynamic item!");
+			return _id.substr(0, i);
+		}
+		public function templateParams():Object {
+			var i:int = _id.indexOf(';');
+			if (i < 0) throw new Error(longName+" is not a dynamic item!");
+			return JSON.parse(_id.substr(i+1));
+		}
+		
+		public function getEnchantments():/*Enchantment*/Array {
+			return [];
+		}
+		
+		/**
+		 * @return true if enchantment of that type is present on an item
+		 */
+		public function hasEnchantment(type:EnchantmentType):Boolean {
+			return false;
+		}
+		/**
+		 * @return power of enchantment of that type, or 0 if there's no such enchantment
+		 */
+		public function enchantmentPower(type:EnchantmentType):Number {
+			return 0;
+		}
+		
+		/**
+		 * @return enchantment of specified type, or null if there's no such enchantment
+		 */
+		public function enchantmentOfType(type:EnchantmentType):Enchantment{
+			return null;
+		}
+		
 		/**
 		 * Short name to be displayed on buttons
 		 */
@@ -140,7 +209,12 @@ import flash.utils.Dictionary;
 			this._value = _value;
 			this._tags = {};
 			if (_id.indexOf(";") > 0) {
+				if (_id in DYNAMIC_ITEM_LIBRARY) {
+					trace("[WARNING] Duplicate dynamic item "+_id);
+				}
 				DYNAMIC_ITEM_LIBRARY[_id] = this;
+				dynamicItemCounter++;
+				trace("new "+_id+" / "+dynamicItemCounter);
 			} else {
 				if (ITEM_LIBRARY[_id] != null) {
 					CoC_Settings.error("Duplicate itemid " + _id + ", old item is " + (ITEM_LIBRARY[_id] as ItemType).longName);

--- a/classes/classes/Items/Dynamic/DynamicWeapon.as
+++ b/classes/classes/Items/Dynamic/DynamicWeapon.as
@@ -3,35 +3,65 @@ import classes.EngineCore;
 import classes.Items.DynamicItems;
 import classes.Items.Enchantment;
 import classes.Items.EnchantmentType;
-import classes.Items.ItemTemplateLib;
+import classes.Items.IDynamicItem;
 import classes.Items.Weapon;
 
-public class DynamicWeapon extends Weapon {
-	public var subtypeId:String;
-	public var subtype:Object;
-	public var quality:int;
-	public var rarity:int;
-	public var curseStatus:int;
+public class DynamicWeapon extends Weapon implements IDynamicItem {
+	public var _subtypeId:String;
+	public var _subtype:Object;
+	public var _quality:int;
+	public var _rarity:int;
+	public var _curseStatus:int;
 	public var _cursed:Boolean;
-	public var curseKnown:Boolean;
-	public var identified:Boolean;
-	public var effects:/*Enchantment*/Array;
+	public var _identified:Boolean;
+	public var _effects:/*Enchantment*/Array;
 	
 	public override function get cursed():Boolean {
 		return _cursed;
 	}
 	
+	public function get subtypeId():String {
+		return _subtypeId;
+	}
+	
+	public function get subtype():Object {
+		return _subtype;
+	}
+	
+	public function get quality():int {
+		return _quality;
+	}
+	
+	public function get rarity():int {
+		return _rarity;
+	}
+	
+	public function get curseStatus():int {
+		return _curseStatus;
+	}
+	
+	public function get identified():Boolean {
+		return _identified;
+	}
+	
+	public function get effects():/*Enchantment*/Array {
+		return _effects;
+	}
+	
+	override public function get buttonColor():String {
+		return DynamicItems.itemButtonColor(this);
+	}
+	
 	public function DynamicWeapon(id:String, params:Object) {
 		var parsedParams:Object = DynamicItems.loadCommonDynamicItemParams(params, Subtypes);
-		subtypeId               = parsedParams.subtypeId;
-		subtype                 = parsedParams.subtype || {};
-		quality                 = parsedParams.quality;
-		rarity                  = parsedParams.rarity;
-		curseStatus             = parsedParams.curseStatus;
+		_subtypeId              = parsedParams.subtypeId;
+		_subtype                = parsedParams.subtype || {};
+		_quality                = parsedParams.quality;
+		_rarity                 = parsedParams.rarity;
+		_curseStatus            = parsedParams.curseStatus;
 		_cursed                 = parsedParams.cursed;
-		curseKnown              = parsedParams.curseKnown;
-		identified              = parsedParams.identified;
-		effects                 = parsedParams.effects;
+		_identified             = parsedParams.identified;
+		_effects                = parsedParams.effects;
 		var shortName:String    = parsedParams.shortName;
 		var name:String         = parsedParams.name;
 		var longName:String     = parsedParams.longName;
@@ -62,7 +92,9 @@ public class DynamicWeapon extends Weapon {
 				desc,
 				perks.join(", "),
 				type
-		)
+		);
+		
+		stackSize = 1;
 	}
 	
 	
@@ -109,7 +141,7 @@ public class DynamicWeapon extends Weapon {
 	override public function useText():void {
 		outputText("You equip " + longName + ".  ");
 		if (cursed) {
-			if (!curseKnown) {
+			if (curseStatus == DynamicItems.HIDDEN_CURSED) {
 				if (EngineCore.silly()) {
 					outputText("A horrible chill runs down your spine - <b>this weapon is cursed!</b> ")
 				} else {

--- a/classes/classes/Items/Dynamic/DynamicWeapon.as
+++ b/classes/classes/Items/Dynamic/DynamicWeapon.as
@@ -1,0 +1,187 @@
+package classes.Items.Dynamic {
+import classes.EngineCore;
+import classes.Items.DynamicItems;
+import classes.Items.Enchantment;
+import classes.Items.EnchantmentType;
+import classes.Items.ItemTemplateLib;
+import classes.Items.Weapon;
+
+public class DynamicWeapon extends Weapon {
+	public var subtypeId:String;
+	public var subtype:Object;
+	public var quality:int;
+	public var rarity:int;
+	public var curseStatus:int;
+	public var _cursed:Boolean;
+	public var curseKnown:Boolean;
+	public var identified:Boolean;
+	public var effects:/*Enchantment*/Array;
+	
+	public override function get cursed():Boolean {
+		return _cursed;
+	}
+	
+	public function DynamicWeapon(id:String, params:Object) {
+		var parsedParams:Object = DynamicItems.loadCommonDynamicItemParams(params, Subtypes);
+		subtypeId               = parsedParams.subtypeId;
+		subtype                 = parsedParams.subtype || {};
+		quality                 = parsedParams.quality;
+		rarity                  = parsedParams.rarity;
+		curseStatus             = parsedParams.curseStatus;
+		_cursed                 = parsedParams.cursed;
+		curseKnown              = parsedParams.curseKnown;
+		identified              = parsedParams.identified;
+		effects                 = parsedParams.effects;
+		var shortName:String    = parsedParams.shortName;
+		var name:String         = parsedParams.name;
+		var longName:String     = parsedParams.longName;
+		var desc:String         = parsedParams.desc;
+		var value:Number        = parsedParams.value;
+		var verb:String         = subtype.verb;
+		var type:String         = subtype.type;
+		var perks:Array         = (subtype.perks || []).slice();
+		var attack:Number       = subtype.attack;
+		if (parsedParams.error) {
+			trace("[ERROR] Failed to parse "+id+" with error "+parsedParams.error);
+			name      = "ERROR " + name;
+			shortName = "ERROR " + shortName;
+			longName  = "ERROR " + longName;
+			desc      = "INVALID ITEM:\n" + parsedParams.error + "\n" + desc;
+		}
+		
+		attack += quality;
+		
+		super(
+				id,
+				shortName,
+				name,
+				longName,
+				verb,
+				Math.max(1, attack),
+				Math.max(1, value),
+				desc,
+				perks.join(", "),
+				type
+		)
+	}
+	
+	
+	override public function getEnchantments():Array {
+		return effects;
+	}
+	
+	override public function hasEnchantment(type:EnchantmentType):Boolean {
+		return DynamicItems.itemHasEnchantment(this, type);
+	}
+	
+	override public function enchantmentPower(type:EnchantmentType):Number {
+		return DynamicItems.itemEnchantmentPower(this, type);
+	}
+	
+	override public function enchantmentOfType(type:EnchantmentType):Enchantment {
+		return DynamicItems.itemEnchantmentOfType(this, type);
+	}
+	
+	private var _identifiedCopy:DynamicWeapon;
+	/**
+	 * Returns fully identified copy of this weapon (this if it is already identified)
+	 */
+	public function identifiedCopy():DynamicWeapon {
+		if (identified) return this;
+		if (!_identifiedCopy) {
+			var params:Object = templateParams();
+			params.c |= DynamicItems.CS_KNOWN_MASK; // set known flag
+			for each (var effect:Array in params.e) {
+				effect[0] = 1; // set identified flag
+			}
+			var id:String = dynamicItemId(templateId(),params);
+			_identifiedCopy = lookupItem(id) as DynamicWeapon;
+		}
+		return _identifiedCopy;
+	}
+	public function uncursedCopy():DynamicWeapon {
+		if (!cursed) return this;
+		var params:Object = templateParams();
+		params.c = DynamicItems.KNOWN_UNCURSED;
+		var id:String = dynamicItemId(templateId(),params);
+		return lookupItem(id) as DynamicWeapon;
+	}
+	override public function useText():void {
+		outputText("You equip " + longName + ".  ");
+		if (cursed) {
+			if (!curseKnown) {
+				if (EngineCore.silly()) {
+					outputText("A horrible chill runs down your spine - <b>this weapon is cursed!</b> ")
+				} else {
+					outputText("You feel a nasty zap in your hand and realize you cannot let go of the weapon - <b>it is cursed!</b> ")
+				}
+			} else {
+				outputText("<b>You cannot unequip it</b>. ")
+			}
+		}
+		if (!identified) {
+			if (effects.length > 0) {
+				// This should be in sync with playerEquip
+				outputText("You discover it to be " + identifiedCopy().longName + ". ");
+			} else {
+				outputText("It is not cursed. ");
+			}
+		}
+	}
+	
+	override public function playerEquip():Weapon {
+		if (!identified) {
+			return identifiedCopy().playerEquip();
+		}
+		for each (var e:Enchantment in effects) {
+			e.onEquip(game.player, this);
+		}
+		return super.playerEquip();
+	}
+	
+	
+	override public function playerRemove():Weapon {
+		for each (var e:Enchantment in effects) {
+			e.onUnequip(game.player, this);
+		}
+		return super.playerRemove();
+	}
+	
+	/**
+	 * Key: subtype id
+	 * Values:
+	 * - name: displayed name
+	 * - weight: chance to generate item of this category, default 1
+	 * - shortName: for buttons. keep it VERY short
+	 * - verb: used in attack texts, ex. "slash"
+	 * - desc: description, can contain templates
+	 * - type: Weapon class
+	 * - (optional) perks: Weapon perks
+	 * - attack: Base attack power
+	 * - value: Base cost in gems
+	 */
+	public static const Subtypes:Object = {
+		"sword": {
+			name: "sword",
+			weight: 1,
+			shortName: "swd",
+			verb: "slash",
+			desc: "A long sword made of the finest steel.",
+			type: "Sword",
+			attack: 10,
+			value: 200
+		},
+		"dagger": {
+			name: "dagger",
+			weight: 1,
+			shortName: "dgr",
+			verb: "stab",
+			desc: "A small blade. Preferred weapon for the rogues.",
+			perks: ["Small"],
+			type: "Dagger",
+			attack: 3,
+			value: 120
+		}
+	}
+}
+}

--- a/classes/classes/Items/Dynamic/Effects/SimpleEnchtantmentType.as
+++ b/classes/classes/Items/Dynamic/Effects/SimpleEnchtantmentType.as
@@ -1,4 +1,4 @@
-package classes.Items.Effects {
+package classes.Items.Dynamic.Effects {
 import classes.Items.Enchantment;
 import classes.Items.EnchantmentType;
 
@@ -10,7 +10,7 @@ public class SimpleEnchtantmentType extends EnchantmentType {
 	public var valueMulBase:Number;
 	public var valueMulPerPower:Number;
 	
-	protected override function doSpawn(identified:Boolean, params:Array):Enchantment {
+	protected override function doDecode(identified:Boolean, params:Array):Enchantment {
 		var power:Number = params[0];
 		
 		return new Enchantment(
@@ -26,9 +26,13 @@ public class SimpleEnchtantmentType extends EnchantmentType {
 		)
 	}
 	
+	public function spawn(identified:Boolean, power:int):Enchantment {
+		return doDecode(identified, [power]);
+	}
+	
 	public override function generateRandom(options:Object = null):Enchantment {
 		var power:int = (maxPower <= minPower) ? minPower : (rand(maxPower + 1 - minPower) + minPower);
-		return doSpawn(valueOr(options.identified, false), [power]);
+		return doDecode(valueOr(options.identified, false), [power]);
 	}
 	
 	public function SimpleEnchtantmentType(id:int,

--- a/classes/classes/Items/Dynamic/Effects/StatEnchantmentType.as
+++ b/classes/classes/Items/Dynamic/Effects/StatEnchantmentType.as
@@ -1,4 +1,4 @@
-package classes.Items.Effects {
+package classes.Items.Dynamic.Effects {
 import classes.ItemType;
 import classes.Items.DynamicItems;
 import classes.Items.Enchantment;

--- a/classes/classes/Items/Dynamic/README.md
+++ b/classes/classes/Items/Dynamic/README.md
@@ -1,0 +1,191 @@
+# Enchanted items
+
+## Adding new enchantment type
+
+Three ways:
+1. `SimpleEnchantmentType`. A standard enchantment template. Has a random generator and power-dependent value calculator. A good option if enchantment has single "power" parameter (or no parameters at all) and its logic is implemented somewhere else.
+2. Subclass `SimpleEnchantmentType`. If you want to perform an action (for example, add buff) when item with such enchantment is equipped/unequipped. See `StatEnchantmentType` for example.
+3. Subclass `EnchantmentType`. When you need to tweak random generation, loading, or have more parameters than enchantment power.
+
+### Adding SimpleEnchantmentType
+
+Use the template in `EnchantmentLib`.
+
+For example:
+
+```as
+ public static const FireDamage:EnchantmentType = mk(14, "Fire Damage", {
+      prefix: "Fiery ",
+      suffix: " of Fire",
+      shortSuffix: "FD",
+      description: "+{power}..{power*2} fire damage",
+      rarity: RARITY_MAGICAL,
+      categories: [ItemType.CATEGORY_WEAPON_MELEE, ItemType.CATEGORY_WEAPON_RANGED],
+      minPower: 1,
+      maxPower: 10,
+      valuePerPower: 100, // +100 gems per power
+      valueX: 1.5, // +50% item value
+ }); 
+```
+(More parameters documented in `EnchantmentLib`).
+
+### Subclassing SimpleEnchantmentType
+
+See `StatEnchantmentType` as an example.
+
+Subclass `SimpleEnchantmentType`. 
+* Provide needed superclass arguments. 
+* Override `onEquip`, `onUnequip` if needed.
+
+Add a `public static const` member of that class in `EnchantmentLib`.
+
+### Subclassing EnchantmentType
+
+First, design enchantment parameters. Enchantment is encoded as `[identified:0|1, id:int, ...params]`.
+
+Subclass `Enchantment`. 
+* Add enchantment parameters in constructor and as fields.
+* Override `encode()`.
+
+Subclass `EnchantmentType`. 
+* Provide superclass arguments.
+* Implement `doDecode`.
+* Implement `generateRandom`. Generate params and call `doDecode` or instantiate enchantment directly.
+* Override `onEquip`, `onEquip` if needed.
+* Write a `spawn()` item to create enchantment with params.
+
+Add a `public static const` member of that class in `EnchantmentLib`.
+
+## Using enchantments
+
+Checking specific item:
+```as
+// Returns array enchantments 
+item.getEnchantments()
+
+// Returns true if has enchantment of that type
+item.hasEnchantment(EnchantmentLib.Xxxx)
+
+// Power of specific enchantment, or 0
+item.enchantmentPower(EnchantmentLib.Xxxx)
+
+// Enchantment object of specified type, or null
+item.enchantmentOfType(EnchantmentLib.Xxxx)
+```
+
+Checking any item on player:
+```as
+// True if any equipped item has specific enchantment
+player.hasEnchantment(EnchantmentLib.Xxxx)
+
+// Power of specific enchantment, 0 if none
+// 2nd param="sum"|"max"|"min" - if multiple same-type enchantments
+player.enchantmentPower(EnchantmentLib.Xxxx, "sum")
+
+// Enchantment object of specified type, or null
+// If multiple items has it, return first
+player.findEnchantment(EnchantmentLib.Xxxx)
+
+// All enchantments of specific type
+player.allEnchantments(EnchantmentLib.Xxxx)
+```
+
+Example:
+```as
+var fd:Number = player.weapon.enchantmentPower(EnchantmentLib.FireDamage);
+if (fd > 0) {
+    doFireDamage(fd.power + rand(fd.power));
+}
+```
+
+## Generating random item
+
+`DynamicItems.randomItem(options)`.
+
+Many its properties can accept either fixed value, or weighted table. A weighted table is a list of `[weight, value]` pairs used to generate random value.
+
+For example, `{ subtype: "sword" }` would generate sword and `{ subtype: [[1, "sword"], [3, "dagger"]] }` would generate sword with 25% chance and dagger with 75%.
+
+Options:
+* `rarity`: value or table of `DynamicItems.RARITY_COMMON/MAGICAL/RARE/LEGENDARY/DIVINE`
+* `quality`: value or table
+* `category`: value or table of `ItemType.CATEGORY_XXX`
+* `subtype`: (only if `category` is constant) value or table of item subtype. Refer to dynamic item docs on available subtypes.
+* `cursed`: value or table of`DynamicItems.HIDDEN/KNOWN_CURSED/UNCURSED`. By default, depends on generated effects.
+* `identified`: generate an identified or unidentified item. Default false.
+
+Examples:
+
+```as
+// Generate random unidentified cursed sword
+var item:ItemType = DynamicItems.randomItem({
+    category: ItemType.CATEGORY_WEAPON_MELEE,
+    subtype: "sword",
+    cursed: DynamicItems.HIDDEN_CURSED
+});
+
+// Generate magical (80%) or rare (20%) item
+var item:ItemType = DynamicItems.randomItem({
+    rarity: [
+        [8, DynamicItems.RARITY_MAGICAL],
+        [2, DynamicItems.RARITY_RARE]
+    ]
+});
+```
+
+To add random drop to a monster, just generate an item type and add it the usual way:
+
+```as
+this.drop = new WeightedDrop()
+    .add(consumables.GOB_ALE,5)
+    .add(consumables.PONAILS,2)
+    .add(DynamicItems.randomItem())
+```
+
+## Creating specific item
+
+Use `itemTemplates.createWeapon()` with `EnchantmentLib.Xxxx.doSpawn`
+
+```as
+var item:ItemType = itemTemplates.createWeapon(
+    "rapier",
+    DynamicItems.RARITY_RARE,
+    +1,
+    DynamicItems.UNKNOWN_CURSED,
+    [
+        EnchantmentLib.Speed.spawn(false, 5),
+        EnchantmentLib.Toughness.spawn(false, 5)
+    ]
+);
+// (?) rare rapier +1
+// cursed Fast rapier of Toughness +1
+```
+
+## Modifying item
+
+An `ItemType` is immutable. You need to re-create it and replace the original.
+
+Dynamic items provide helper methods to spawn a partially modified copy:
+
+```as
+// Identify item
+player.itemSlots[0] = (player.itemSlots[0] as IDynamicItem).identifiedCopy();
+
+// Remove curse 
+player.itemSlots[0] = (player.itemSlots[0] as IDynamicItem).uncursedCopy();
+
+// Increase quality by 2 and remove enchantments
+var weapon:DynamicWeapon = player.weapon as DynamicWeapon;
+player.weapon = weapon.copy({
+    q: weapon.quality+1,
+    e: []
+}) as DynamicWeapon;
+
+// Add Strength enchantment
+var weapon:DynamicWeapon = player.weapon as DynamicWeapon;
+var effects = weapon.effects.slice(); // copy
+effects.push(EnchantmentLib.Strength.spawn(true, 4)); 
+player.weapon = weapon.copy({
+    e: effects
+}) as DynamicWeapon; 
+```

--- a/classes/classes/Items/DynamicItems.as
+++ b/classes/classes/Items/DynamicItems.as
@@ -127,11 +127,11 @@ public class DynamicItems extends Utils {
 	];
 	
 	/**
-	 * @param options.rarity Rarity, const or weighted random spec
-	 * @param options.quality Quality, const or weighted random spec
-	 * @param options.category Item category (see ItemType.CATEGORY_XXXX) or weighted random spec
-	 * @param options.subtype Subtype within the category, or weighted random spec
-	 * @param options.cursed Curse status or weighted random spec
+	 * @param options.rarity Rarity, const or weighted random table
+	 * @param options.quality Quality, const or weighted random table
+	 * @param options.category Item category (see ItemType.CATEGORY_XXXX) or weighted random table
+	 * @param options.subtype Subtype within the category, or weighted random spetable
+	 * @param options.cursed Curse status or weighted random table
 	 * @param options.identified Effects are identified (defualt false)
 	 * @return
 	 */
@@ -143,9 +143,10 @@ public class DynamicItems extends Utils {
 			identified: false
 		}, options);
 		
-		var rarity:int      = weightedRandom(options.rarity);
-		var quality:int     = weightedRandom(options.quality);
-		var category:String = weightedRandom(options.category);
+		var rarity:int         = weightedRandom(options.rarity);
+		var quality:int        = weightedRandom(options.quality);
+		var category:String    = weightedRandom(options.category);
+		var identified:Boolean = weightedRandom(options.identified);
 		trace("Generating random " + Rarities[rarity].name + " q=" + quality + " " + category + "...");
 		var subtype:String;
 		
@@ -178,7 +179,7 @@ public class DynamicItems extends Utils {
 		var hasCursed:Boolean   = false;
 		
 		function addEnchantment(rarity:int, tries:int = 5):void {
-			var e:Enchantment = EnchantmentLib.instance.randomEnchantment(category, rarity, {identified: options.identified});
+			var e:Enchantment = EnchantmentLib.instance.randomEnchantment(category, rarity, {identified: identified});
 			if (e) {
 				// Reroll max 5 times if found a duplicate
 				for each (var e2:Array in enchantments) {
@@ -210,7 +211,7 @@ public class DynamicItems extends Utils {
 		} else {
 			cursed = weightedRandom(CURSE_CHANCES_DEFAULT);
 		}
-		if (options.identified) cursed |= CS_KNOWN_MASK; // set known flag
+		if (identified) cursed |= CS_KNOWN_MASK; // set known flag
 		trace("  cursed=" + cursed);
 		
 		switch (rarity) {
@@ -446,6 +447,31 @@ public class DynamicItems extends Utils {
 	public static function itemButtonColor(item:IDynamicItem):String {
 		if (item.curseStatus == KNOWN_CURSED) return BTNCOLOR_CURSED;
 		return Rarities[item.rarity].buttonColor;
+	}
+	
+	public static function encodeEnchantments(effects:/*Enchantment*/Array):Array {
+		var e:Array = [];
+		for each (var eff:Enchantment in effects) {
+			e.push(eff.encode());
+		}
+		return e;
+	}
+	
+	public static function createItem(
+			template: ItemTemplate,
+			subtype: String,
+			rarity: int,
+			quality: int,
+			curseStatus: int,
+			effects: /*Enchantment*/Array
+	):ItemType {
+		return template.createItem({
+			t: subtype,
+			r: rarity,
+			q: quality,
+			c: curseStatus,
+			e: DynamicItems.encodeEnchantments(effects)
+		});
 	}
 	
 	public function DynamicItems() {

--- a/classes/classes/Items/DynamicItems.as
+++ b/classes/classes/Items/DynamicItems.as
@@ -1,0 +1,451 @@
+package classes.Items {
+import classes.ItemTemplate;
+import classes.ItemType;
+import classes.Items.Dynamic.DynamicWeapon;
+import classes.internals.EnumValue;
+import classes.internals.Utils;
+
+/**
+ * Dynamic Item Utilities
+ */
+public class DynamicItems extends Utils {
+	
+	/**
+	 * EnumValue properties:
+	 * - value: code (1)
+	 * - id: var name ("MAGICAL")
+	 *
+	 * - name: display name ("magical")
+	 * - shortName: button label part for unidentified item
+	 */
+	public static const Rarities:/*EnumValue*/Array = [];
+	
+	public static const RARITY_COMMON:int    = 0;
+	public static const RARITY_MAGICAL:int   = 1;
+	public static const RARITY_RARE:int      = 2;
+	public static const RARITY_LEGENDARY:int = 3;
+	public static const RARITY_DIVINE:int    = 4;
+	
+	EnumValue.add(Rarities, RARITY_COMMON, "COMMON", {
+		name: "common",
+		shortName: "Cm ",
+		erarities: []
+	});
+	EnumValue.add(Rarities, RARITY_MAGICAL, "MAGICAL", {
+		name: "magical",
+		shortName: "Mg "
+	});
+	EnumValue.add(Rarities, RARITY_RARE, "RARE", {
+		name: "rare",
+		shortName: "Rr "
+	});
+	
+	EnumValue.add(Rarities, RARITY_LEGENDARY, "LEGENDARY", {
+		name: "legendary",
+		shortName: "Lg "
+	});
+	
+	EnumValue.add(Rarities, RARITY_DIVINE, "DIVINE", {
+		name: "divine",
+		shortName: "Dv "
+	});
+	
+	public static const HIDDEN_UNCURSED:int = 0;
+	public static const KNOWN_UNCURSED:int  = 1;
+	public static const HIDDEN_CURSED:int   = 2;
+	public static const KNOWN_CURSED:int    = 3;
+	
+	public static const CS_CURSED_MASK:int = 2; // 0b10
+	public static const CS_KNOWN_MASK:int  = 1; // 0b01
+	
+	//////////////////////
+	// Random generation Tables
+	// (weights do not have to sum to 100)
+	/////////////////////
+	
+	public static const RARITY_CHANCES_DEFAULT:Array = [
+		// weights sum to 100 so chances are in %
+		[30, RARITY_COMMON],
+		[40, RARITY_MAGICAL],
+		[20, RARITY_RARE],
+		[8, RARITY_LEGENDARY],
+		[2, RARITY_DIVINE]
+	];
+	
+	public static const QUALITY_CHANCES_DEFAULT:Array = [
+		[1 / 20, -10],
+		[1 / 18, -9],
+		[1 / 16, -8],
+		[1 / 14, -7],
+		[1 / 12, -6],
+		[1 / 10, -5],
+		[1 / 8, -4],
+		[1 / 6, -3],
+		[1 / 4, -2],
+		[1 / 2, -1],
+		[1, 0],
+		[1, +1],
+		[1 / 2, +2],
+		[1 / 3, +3],
+		[1 / 4, +4],
+		[1 / 5, +5],
+		[1 / 6, +6],
+		[1 / 7, +7],
+		[1 / 8, +8],
+		[1 / 9, +9],
+		[1 / 10, +10],
+		[1 / 11, +11],
+		[1 / 12, +12],
+		[1 / 13, +13],
+		[1 / 14, +14],
+		[1 / 15, +15],
+	];
+	
+	public static const CURSE_CHANCES_FOR_NEGATIVE:Array = [
+		[30, HIDDEN_CURSED],
+		[70, HIDDEN_UNCURSED],
+	];
+	public static const CURSE_CHANCES_DEFAULT:Array      = [
+		[10, HIDDEN_CURSED],
+		[90, HIDDEN_UNCURSED],
+	];
+	
+	public static const ITEM_CATEGORY_CHANCES_DEFAULT:Array = [
+		[5, ItemType.CATEGORY_WEAPON_MELEE],
+		//		[1, ItemType.CATEGORY_WEAPON_RANGED],
+		//		[1, ItemType.CATEGORY_SHIELD],
+		//		[5, ItemType.CATEGORY_ARMOR],
+		//		[1, ItemType.CATEGORY_UNDERGARMENT],
+		//		[1, ItemType.CATEGORY_NECKLACE],
+		//		[1, ItemType.CATEGORY_JEWELRY_HEAD],
+		//		[1, ItemType.CATEGORY_JEWELRY_RING],
+		//		[1, ItemType.CATEGORY_JEWELRY_MISC],
+		//		[0.1, ItemType.CATEGORY_VEHICLE],
+		//		[0.1, ItemType.CATEGORY_FLYING_SWORD],
+	];
+	
+	/**
+	 * @param options.rarity Rarity, const or weighted random spec
+	 * @param options.quality Quality, const or weighted random spec
+	 * @param options.category Item category (see ItemType.CATEGORY_XXXX) or weighted random spec
+	 * @param options.subtype Subtype within the category, or weighted random spec
+	 * @param options.cursed Curse status or weighted random spec
+	 * @param options.identified Effects are identified (defualt false)
+	 * @return
+	 */
+	public static function randomItem(options:Object = null):ItemType {
+		options = extend({
+			rarity: RARITY_CHANCES_DEFAULT,
+			quality: QUALITY_CHANCES_DEFAULT,
+			category: ITEM_CATEGORY_CHANCES_DEFAULT,
+			identified: false
+		}, options);
+		
+		var rarity:int      = weightedRandom(options.rarity);
+		var quality:int     = weightedRandom(options.quality);
+		var category:String = weightedRandom(options.category);
+		trace("Generating random " + Rarities[rarity].name + " q=" + quality + " " + category + "...");
+		var subtype:String;
+		
+		function randomSubtype(subtypes:Object):String {
+			var items:Array = [];
+			for (var subtype:String in subtypes) {
+				items.push([numberOr(subtypes[subtype].weight, 1), subtype]);
+			}
+			return weightedRandom(items);
+		}
+		
+		var template:ItemTemplate;
+		switch (category) {
+			case ItemType.CATEGORY_WEAPON_MELEE:
+				template = ItemTemplateLib.instance.TDynamicWeapon;
+				if (options.subtype) {
+					subtype = weightedRandom(options.subtype);
+				} else {
+					subtype = randomSubtype(DynamicWeapon.Subtypes);
+				}
+				break;
+			default:
+				throw new Error("Unsupported item category " + category);
+		}
+		trace("  subtype=" + subtype);
+		
+		// encoded enchantments [identified, type, ...]
+		var enchantments:Array  = [];
+		var hasNegative:Boolean = false;
+		var hasCursed:Boolean   = false;
+		
+		function addEnchantment(rarity:int, tries:int = 5):void {
+			var e:Enchantment = EnchantmentLib.instance.randomEnchantment(category, rarity, {identified: options.identified});
+			if (e) {
+				// Reroll max 5 times if found a duplicate
+				for each (var e2:Array in enchantments) {
+					if (e2[1] === e.type.id) {
+						if (tries > 0) {
+							trace("  " + e.description + " (rerolling)");
+							addEnchantment(rarity, tries - 1);
+						} else {
+							trace("  " + e.description + " (reroll limit reached)");
+						}
+						return;
+					}
+				}
+				trace("  " + e.description);
+				enchantments.push(e.encode());
+				if (e.curse) hasCursed = true;
+			} else {
+				trace("  (failed to generate magical effect)")
+			}
+		}
+		
+		var cursed:int;
+		if (hasCursed) {
+			cursed = HIDDEN_CURSED;
+		} else if ('cursed' in options) {
+			cursed = weightedRandom(options.cursed);
+		} else if (hasNegative) {
+			cursed = weightedRandom(CURSE_CHANCES_FOR_NEGATIVE);
+		} else {
+			cursed = weightedRandom(CURSE_CHANCES_DEFAULT);
+		}
+		if (options.identified) cursed |= CS_KNOWN_MASK; // set known flag
+		trace("  cursed=" + cursed);
+		
+		switch (rarity) {
+			case RARITY_DIVINE:
+				addEnchantment(RARITY_MAGICAL);
+				addEnchantment(RARITY_MAGICAL);
+				addEnchantment(RARITY_LEGENDARY);
+				addEnchantment(RARITY_DIVINE);
+				break;
+			case RARITY_LEGENDARY:
+				addEnchantment(RARITY_MAGICAL);
+				addEnchantment(RARITY_MAGICAL);
+				addEnchantment(RARITY_LEGENDARY);
+				break;
+			case RARITY_RARE:
+				addEnchantment(RARITY_MAGICAL);
+				addEnchantment(RARITY_MAGICAL);
+				break;
+			case RARITY_MAGICAL:
+				addEnchantment(RARITY_MAGICAL);
+				break;
+			case RARITY_COMMON:
+			default:
+				break;
+		}
+		
+		var itemType:ItemType = template.createItem({
+			t: subtype,
+			c: cursed,
+			q: quality,
+			r: rarity,
+			e: enchantments
+		});
+		trace("Generated '" + itemType.longName + "' " + itemType.id);
+		return itemType;
+	}
+	
+	/////////////////////
+	// Utilities
+	/////////////////////
+	
+	/**
+	 * Load and process dynamic item params, generate name and desciption.
+	 * @param params Encoded dynamic item params
+	 * @param subtypes A subtype dictionary
+	 * @return {{
+	 *     subtypeId: String,
+	 *     subtype: Object,
+	 *     quality: int,
+	 *     rarity: int,
+	 *     curseStatus: int,
+	 *     cursed: Boolean,
+	 *     curseKnown: Boolean,
+	 *     identified: Boolean,
+	 *     effects: Enchantment[],
+	 *     shortName: String,
+	 *     name: String,
+	 *     longName: String,
+	 *     desc: String,
+	 *     error: String
+	 * }}
+	 */
+	public static function loadCommonDynamicItemParams(params:Object, subtypes:Object):Object {
+		var o:Array;
+		var e:Enchantment;
+		
+		if (!("t" in params && "q" in params && "r" in params && "c" in params && "e" in params)) {
+			return {error: "Missing param key"};
+		}
+		// Pull out params
+		var subtypeId:String = params["t"];
+		var quality:int      = params["q"];
+		var rarity:int       = params["r"];
+		var curseStatus:int  = params["c"];
+		var enchData:Array   = params["e"];
+		if (rarity < RARITY_COMMON || rarity > RARITY_DIVINE
+				|| curseStatus < 0 || curseStatus > 3
+				|| !enchData
+				|| !subtypeId
+		) {
+			return {error: "Invalid params"}
+		}
+		
+		// Compute props
+		var cursed:Boolean     = !!(curseStatus & CS_CURSED_MASK);
+		var curseKnown:Boolean = !!(curseStatus & CS_KNOWN_MASK);
+		var identified:Boolean = curseKnown;
+		for each (o in enchData) {
+			if (!o || o.length<2) return {error: "Invalid enchantment"}
+			if (!o[1]) continue;
+			if (!o[0]) {
+				identified = false;
+				break;
+			}
+		}
+		var effects:/*Enchantment*/Array = [];
+		for each (o in enchData) {
+			if (!o[1]) continue;
+			e = EnchantmentLib.decode(o);
+			if (!e) return {error: "Invalid enchantment type "+o[1]};
+			effects.push(e);
+		}
+		
+		// Pull stuff from the subtype and generate name and description
+		var subtype:Object   = subtypes[subtypeId];
+		var shortName:String = subtype.shortName;
+		var name:String      = subtype.name;
+		var desc:String      = subtype.desc;
+		var value:Number     = subtype.value;
+		var rname:String     = Rarities[rarity].name;
+		var qname:String     = (quality < 0) ? "" + quality : "+" + quality;
+		var longName:String;
+		if (!subtype) return {error:"Invalid subtype"};
+		
+		// value = (base_value * rarity + sum of effects' add_value)
+		//         * product of effects' mul_value
+		// If quality > 0, add 20%*quality
+		// If quality < 0, subtract 10%*quality but no less than 50%
+		var valueMul:Number = 1.0;
+		value *= rarity;
+		if (quality > 0) valueMul *= quality * 0.2;
+		if (quality < 0) valueMul *= Math.max(0.5, quality * 0.1);
+		
+		// Description:
+		// 		Rarity: Divine
+		// 		Quality: +15
+		// 		This item is cursed!
+		// 		+30% Int
+		// 		(Unknown effet)
+		// 		+10% EXP gain
+		// 		(Unknown effect)
+		// Names:
+		// 		cursed Taoth's Vulpine sword of kitsune legacy +15
+		// 		(?) legendary sword -5
+		// Button names:
+		// 		!sword Tao Vlp oKL +15
+		// 		?Cmn sword ??? -5
+		desc += "\n";
+		if (!curseKnown) desc += "\nCurse: Unknown.";
+		else if (cursed) desc += "\n<b>Cursed!</b>";
+		desc += "\nRarity: " + capitalizeFirstLetter(rname);
+		desc += "\nQuality: " + qname;
+		var hasUnknownEffects:Boolean = false;
+		for each (e in effects) {
+			if (e.identified) {
+				desc += "\n" + e.description;
+				value += e.valueAdd;
+				valueMul *= e.valueMul;
+			} else {
+				hasUnknownEffects = true;
+				desc += "\n(Unknown effect)";
+			}
+		}
+		if (identified) {
+			var prefix:String       = "";
+			var suffix:String       = "";
+			var divinePrefix:String = "";
+			for each (e in effects) {
+				switch (e.rarity) {
+					case DynamicItems.RARITY_DIVINE:
+						divinePrefix += e.prefix;
+						break;
+					case DynamicItems.RARITY_LEGENDARY:
+						break;
+					case DynamicItems.RARITY_MAGICAL:
+						if (!prefix) {
+							prefix = e.prefix;
+						} else if (!suffix) {
+							suffix = e.suffix;
+						}
+						break;
+				}
+			}
+			name = divinePrefix + prefix + name + suffix;
+		} else {
+			if (hasUnknownEffects) {
+				if (rarity != DynamicItems.RARITY_COMMON) name = rname + " " + name;
+				name = "unidentified " + name;
+			}
+			shortName = Rarities[rarity].shortName + shortName;
+		}
+		if (effects.length > 0) shortName += " ";
+		for each (e in effects) {
+			if (e.identified) shortName += e.shortSuffix;
+			else shortName += "?";
+		}
+		// common name parts
+		longName = name; // name - long name without (?) or +X
+		if (quality != 0) {
+			longName  = longName + " " + qname;
+			shortName = shortName + " " + qname;
+		}
+		if (!curseKnown) {
+			longName  = "(?) " + longName;
+			shortName = "?" + shortName;
+		} else if (cursed) {
+			longName  = "cursed " + longName;
+			name      = "cursed " + name;
+			shortName = "!" + shortName;
+		}
+		
+		return {
+			subtypeId: subtypeId,
+			subtype: subtype,
+			quality: quality,
+			rarity: rarity,
+			curseStatus: curseStatus,
+			cursed: cursed,
+			curseKnown: curseKnown,
+			identified: identified,
+			effects: effects,
+			shortName: shortName,
+			name: name,
+			longName: longName,
+			desc: desc,
+			value: Math.round(value * valueMul),
+			error: ""
+		};
+	}
+	
+	public static function itemHasEnchantment(item:ItemType, type:EnchantmentType):Boolean {
+		return itemEnchantmentOfType(item, type) != null;
+	}
+	
+	public static function itemEnchantmentPower(item:ItemType, type:EnchantmentType):Number {
+		var e:Enchantment = itemEnchantmentOfType(item, type);
+		return e ? e.power : 0;
+	}
+	
+	public static function itemEnchantmentOfType(item:ItemType, type:EnchantmentType):Enchantment {
+		for each (var e:Enchantment in item.getEnchantments()) {
+			if (e.type == type) return e;
+		}
+		return null;
+	}
+	
+	public function DynamicItems() {
+	}
+}
+}

--- a/classes/classes/Items/DynamicItems.as
+++ b/classes/classes/Items/DynamicItems.as
@@ -5,6 +5,8 @@ import classes.Items.Dynamic.DynamicWeapon;
 import classes.internals.EnumValue;
 import classes.internals.Utils;
 
+import coc.view.CoCButton;
+
 /**
  * Dynamic Item Utilities
  */
@@ -16,7 +18,7 @@ public class DynamicItems extends Utils {
 	 * - id: var name ("MAGICAL")
 	 *
 	 * - name: display name ("magical")
-	 * - shortName: button label part for unidentified item
+	 * - buttonColor: button label color
 	 */
 	public static const Rarities:/*EnumValue*/Array = [];
 	
@@ -28,27 +30,27 @@ public class DynamicItems extends Utils {
 	
 	EnumValue.add(Rarities, RARITY_COMMON, "COMMON", {
 		name: "common",
-		shortName: "Cm ",
-		erarities: []
+		buttonColor: CoCButton.DEFAULT_COLOR
 	});
 	EnumValue.add(Rarities, RARITY_MAGICAL, "MAGICAL", {
 		name: "magical",
-		shortName: "Mg "
+		buttonColor: "#0000C0"
 	});
 	EnumValue.add(Rarities, RARITY_RARE, "RARE", {
 		name: "rare",
-		shortName: "Rr "
+		buttonColor: "#006000"
 	});
-	
 	EnumValue.add(Rarities, RARITY_LEGENDARY, "LEGENDARY", {
 		name: "legendary",
-		shortName: "Lg "
+		buttonColor: "#FFFF40"
 	});
 	
 	EnumValue.add(Rarities, RARITY_DIVINE, "DIVINE", {
 		name: "divine",
-		shortName: "Dv "
+		buttonColor: "#80EEEE"
 	});
+	
+	public static const BTNCOLOR_CURSED:String = "#800000";
 	
 	public static const HIDDEN_UNCURSED:int = 0;
 	public static const KNOWN_UNCURSED:int  = 1;
@@ -297,7 +299,7 @@ public class DynamicItems extends Utils {
 		var curseKnown:Boolean = !!(curseStatus & CS_KNOWN_MASK);
 		var identified:Boolean = curseKnown;
 		for each (o in enchData) {
-			if (!o || o.length<2) return {error: "Invalid enchantment"}
+			if (!o || o.length < 2) return {error: "Invalid enchantment"}
 			if (!o[1]) continue;
 			if (!o[0]) {
 				identified = false;
@@ -308,7 +310,7 @@ public class DynamicItems extends Utils {
 		for each (o in enchData) {
 			if (!o[1]) continue;
 			e = EnchantmentLib.decode(o);
-			if (!e) return {error: "Invalid enchantment type "+o[1]};
+			if (!e) return {error: "Invalid enchantment type " + o[1]};
 			effects.push(e);
 		}
 		
@@ -321,7 +323,7 @@ public class DynamicItems extends Utils {
 		var rname:String     = Rarities[rarity].name;
 		var qname:String     = (quality < 0) ? "" + quality : "+" + quality;
 		var longName:String;
-		if (!subtype) return {error:"Invalid subtype"};
+		if (!subtype) return {error: "Invalid subtype"};
 		
 		// value = (base_value * rarity + sum of effects' add_value)
 		//         * product of effects' mul_value
@@ -344,8 +346,8 @@ public class DynamicItems extends Utils {
 		// 		cursed Taoth's Vulpine sword of kitsune legacy +15
 		// 		(?) legendary sword -5
 		// Button names:
-		// 		!sword Tao Vlp oKL +15
-		// 		?Cmn sword ??? -5
+		// 		!swd TaoVlKL
+		// 		?swd ??
 		desc += "\n";
 		if (!curseKnown) desc += "\nCurse: Unknown.";
 		else if (cursed) desc += "\n<b>Cursed!</b>";
@@ -366,7 +368,9 @@ public class DynamicItems extends Utils {
 			var prefix:String       = "";
 			var suffix:String       = "";
 			var divinePrefix:String = "";
+			if (effects.length > 0) shortName += " ";
 			for each (e in effects) {
+				shortName += e.shortSuffix;
 				switch (e.rarity) {
 					case DynamicItems.RARITY_DIVINE:
 						divinePrefix += e.prefix;
@@ -387,19 +391,13 @@ public class DynamicItems extends Utils {
 			if (hasUnknownEffects) {
 				if (rarity != DynamicItems.RARITY_COMMON) name = rname + " " + name;
 				name = "unidentified " + name;
+				shortName += " ??";
 			}
-			shortName = Rarities[rarity].shortName + shortName;
-		}
-		if (effects.length > 0) shortName += " ";
-		for each (e in effects) {
-			if (e.identified) shortName += e.shortSuffix;
-			else shortName += "?";
 		}
 		// common name parts
 		longName = name; // name - long name without (?) or +X
 		if (quality != 0) {
-			longName  = longName + " " + qname;
-			shortName = shortName + " " + qname;
+			longName = longName + " " + qname;
 		}
 		if (!curseKnown) {
 			longName  = "(?) " + longName;
@@ -443,6 +441,11 @@ public class DynamicItems extends Utils {
 			if (e.type == type) return e;
 		}
 		return null;
+	}
+	
+	public static function itemButtonColor(item:IDynamicItem):String {
+		if (item.curseStatus == KNOWN_CURSED) return BTNCOLOR_CURSED;
+		return Rarities[item.rarity].buttonColor;
 	}
 	
 	public function DynamicItems() {

--- a/classes/classes/Items/Effects/SimpleEnchtantmentType.as
+++ b/classes/classes/Items/Effects/SimpleEnchtantmentType.as
@@ -1,0 +1,57 @@
+package classes.Items.Effects {
+import classes.Items.Enchantment;
+import classes.Items.EnchantmentType;
+
+public class SimpleEnchtantmentType extends EnchantmentType {
+	public var minPower:int;
+	public var maxPower:int;
+	public var valueAddBase:int;
+	public var valueAddPerPower:int;
+	public var valueMulBase:Number;
+	public var valueMulPerPower:Number;
+	
+	protected override function doSpawn(identified:Boolean, params:Array):Enchantment {
+		var power:Number = params[0];
+		
+		return new Enchantment(
+				identified,
+				this,
+				prefix,
+				suffix,
+				shortSuffix,
+				power,
+				params,
+				valueAddBase + valueAddPerPower * power,
+				valueMulBase + valueMulPerPower * power
+		)
+	}
+	
+	public override function generateRandom(options:Object = null):Enchantment {
+		var power:int = (maxPower <= minPower) ? minPower : (rand(maxPower + 1 - minPower) + minPower);
+		return doSpawn(valueOr(options.identified, false), [power]);
+	}
+	
+	public function SimpleEnchtantmentType(id:int,
+										   name:String,
+										   curse:Boolean,
+										   prefix:String,
+										   suffix:String,
+										   shortSuffix:String,
+										   description:String,
+										   rarity:int,
+										   minPower:int,
+										   maxPower:int,
+										   valueAddBase:int,
+										   valueAddPerPower:int,
+										   valueMulBase:Number,
+										   valueMulPerPower:Number) {
+		super(id, name, curse, prefix, suffix, shortSuffix, description, rarity);
+		this.minPower         = minPower;
+		this.maxPower         = maxPower;
+		this.valueAddBase     = valueAddBase;
+		this.valueAddPerPower = valueAddPerPower;
+		this.valueMulBase     = valueMulBase;
+		this.valueMulPerPower = valueMulPerPower;
+	}
+}
+}

--- a/classes/classes/Items/Effects/StatEnchantmentType.as
+++ b/classes/classes/Items/Effects/StatEnchantmentType.as
@@ -1,0 +1,46 @@
+package classes.Items.Effects {
+import classes.ItemType;
+import classes.Items.DynamicItems;
+import classes.Items.Enchantment;
+import classes.Player;
+import classes.Stats.StatUtils;
+
+/**
+ * Buff stat by (power x 0.5%)
+ */
+public class StatEnchantmentType extends SimpleEnchtantmentType {
+	public var statName:String;
+	
+	public function StatEnchantmentType(
+			id:int,
+			name:String,
+			statName:String,
+			prefix:String,
+			suffix:String,
+			shortSuffix:String,
+			minPower:int,
+			maxPower:int,
+			valueAddBase:int,
+			valueAddPerPower:int,
+			valueMulBase:Number,
+			valueMulPerPower:Number
+	) {
+		this.statName          = statName;
+		var displayName:String = StatUtils.nameOfStat(statName);
+		super(id, name, false, prefix, suffix, shortSuffix, displayName + " {power*0.5;+1f}%", DynamicItems.RARITY_MAGICAL, minPower, maxPower, valueAddBase, valueAddPerPower, valueMulBase, valueMulPerPower);
+	}
+	
+	override public function onEquip(player:Player, enchantment:Enchantment, item:ItemType):void {
+		player.buff(item.tagForBuffs)
+				.addStat(statName, enchantment.power * 0.005)
+				.withText("Equipment")
+				.withOptions({save: false})
+				.permanent();
+	}
+	
+	override public function onUnequip(player:Player, enchantment:Enchantment, item:ItemType):void {
+		player.buff(item.tagForBuffs)
+				.removeFromStat(statName);
+	}
+}
+}

--- a/classes/classes/Items/Enchantment.as
+++ b/classes/classes/Items/Enchantment.as
@@ -13,18 +13,21 @@ public class Enchantment {
 	public var valueAdd:Number;
 	public var valueMul:Number;
 	public var description:String;
+	
 	public function get id():int {
 		return type.id;
 	}
+	
 	public function get rarity():int {
 		return type.rarity;
 	}
+	
 	public function get curse():Boolean {
 		return type.curse;
 	}
 	
 	public function encode():Array {
-		return [identified?1:0,type.id].concat(params);
+		return [identified ? 1 : 0, type.id].concat(params);
 	}
 	
 	public function Enchantment(
@@ -38,28 +41,29 @@ public class Enchantment {
 			valueAdd:Number,
 			valueMul:Number
 	) {
-		this.identified = identified;
-		this.type = type;
-		this.prefix = prefix;
-		this.suffix = suffix;
+		this.identified  = identified;
+		this.type        = type;
+		this.prefix      = prefix;
+		this.suffix      = suffix;
 		this.shortSuffix = shortSuffix;
-		this.power = power;
-		this.params = params;
-		this.valueAdd = valueAdd;
-		this.valueMul = valueMul;
+		this.power       = power;
+		this.params      = params;
+		this.valueAdd    = valueAdd;
+		this.valueMul    = valueMul;
 		this.description = type.genDescription(this);
 	}
 	
 	/**
 	 * Apply effects when enchanted item is equipped
 	 */
-	public function onEquip(player:Player, item:ItemType):void{
+	public function onEquip(player:Player, item:ItemType):void {
 		type.onEquip(player, this, item);
 	}
+	
 	/**
 	 * Remove effects when enchanted item is unequipped
 	 */
-	public function onUnequip(player:Player, item:ItemType):void{
+	public function onUnequip(player:Player, item:ItemType):void {
 		type.onUnequip(player, this, item);
 	}
 }

--- a/classes/classes/Items/Enchantment.as
+++ b/classes/classes/Items/Enchantment.as
@@ -1,0 +1,66 @@
+package classes.Items {
+import classes.ItemType;
+import classes.Player;
+
+public class Enchantment {
+	public var identified:Boolean;
+	public var type:EnchantmentType;
+	public var prefix:String;
+	public var suffix:String;
+	public var shortSuffix:String;
+	public var power:Number;
+	public var params:Array;
+	public var valueAdd:Number;
+	public var valueMul:Number;
+	public var description:String;
+	public function get id():int {
+		return type.id;
+	}
+	public function get rarity():int {
+		return type.rarity;
+	}
+	public function get curse():Boolean {
+		return type.curse;
+	}
+	
+	public function encode():Array {
+		return [identified?1:0,type.id].concat(params);
+	}
+	
+	public function Enchantment(
+			identified:Boolean,
+			type:EnchantmentType,
+			prefix:String,
+			suffix:String,
+			shortSuffix:String,
+			power:Number,
+			params:Array,
+			valueAdd:Number,
+			valueMul:Number
+	) {
+		this.identified = identified;
+		this.type = type;
+		this.prefix = prefix;
+		this.suffix = suffix;
+		this.shortSuffix = shortSuffix;
+		this.power = power;
+		this.params = params;
+		this.valueAdd = valueAdd;
+		this.valueMul = valueMul;
+		this.description = type.genDescription(this);
+	}
+	
+	/**
+	 * Apply effects when enchanted item is equipped
+	 */
+	public function onEquip(player:Player, item:ItemType):void{
+		type.onEquip(player, this, item);
+	}
+	/**
+	 * Remove effects when enchanted item is unequipped
+	 */
+	public function onUnequip(player:Player, item:ItemType):void{
+		type.onUnequip(player, this, item);
+	}
+}
+}

--- a/classes/classes/Items/EnchantmentLib.as
+++ b/classes/classes/Items/EnchantmentLib.as
@@ -1,0 +1,141 @@
+package classes.Items {
+import classes.Items.Effects.SimpleEnchtantmentType;
+import classes.Items.Effects.StatEnchantmentType;
+
+public class EnchantmentLib extends DynamicItems {
+	// See EnchatmentType.genDescription for description expression syntax
+	
+	/*
+	 * template
+	 *
+	 * public static const Xxxx:EnchantmentType = mk(UNIQUE_ID, "Name", {
+	 * 	curse: true, // optional, default false. Guarantees cursed item
+	 * 	negative: true, // optional, default false. Bigger chance for cursed item
+	 * 	prefix: "Xxxx ", // optional, default empty
+	 * 	suffix: " of Xxxx", // optional, default empty
+	 * 	shortSuffix: "Xx", // optional, default empty. Button label. 2-3 chars!
+	 * 	description: "+{X} to Xxxx", // required
+	 * 	rarity: RARITY_LEGENDARY, // optional, default = RARITY_MAGICAL. don't use RARITY_RARE or RARITY_COMMON.
+	 * 	categoies: [ItemType.CATEGORY_WEAPON], // optional, default = all categories
+	 * 	weight: 2.0, // optional, relative spawn chance, default 1
+	 * 	minPower: 0, // optional, default 1
+	 * 	maxPower: 10, // optional, default 1
+	 * 	value: 100, // optional, default 0
+	 * 	valuePerPower: 100, // optional, default 0
+	 * 	valueX: 1.2, // optional, default 1
+	 * 	valueXPerPower: 0.1, // optional, default 0
+	 * });
+	 */
+	
+	// Number IDs are written in saved and should never change across versions!
+	// Everything else - can.
+	
+	public static const Strength:EnchantmentType     = new StatEnchantmentType(1, "Strength",
+			"str.mult",
+			"Strong ", " of Strength", "St",
+			// minPower, maxPower, value, valuePerPower, valueX, valueXPerPower
+			2, 5, 0, 300, 1, 0)
+			.setSpawnChance(1);
+	public static const Toughness:EnchantmentType    = new StatEnchantmentType(2, "Toughness",
+			"tou.mult",
+			"Tough ", " of Toughness", "To",
+			2, 5, 0, 300, 1, 0)
+			.setSpawnChance(1);
+	public static const Speed:EnchantmentType        = new StatEnchantmentType(3, "Speed",
+			"spe.mult",
+			"Fast ", " of Speed", "Sp",
+			2, 5, 0, 300, 1, 0)
+			.setSpawnChance(1);
+	public static const Intelligence:EnchantmentType = new StatEnchantmentType(4, "Intelligence",
+			"int.mult",
+			"Smart ", " of Intellect", "In",
+			2, 5, 0, 300, 1, 0)
+			.setSpawnChance(1);
+	public static const Wisdom:EnchantmentType       = new StatEnchantmentType(5, "Wisdom",
+			"wis.mult",
+			"Wise ", " of Wisdom", "Ws",
+			2, 5, 0, 300, 1, 0)
+			.setSpawnChance(1);
+	public static const Libido:EnchantmentType       = new StatEnchantmentType(6, "Libido",
+			"lib.mult", "Libidinous ", " of Libido", "Lb",
+			2, 5, 0, 300, 1, 0)
+			.setSpawnChance(1);
+	
+	public static function decode(o:Array):Enchantment {
+		var id:int               = o[1];
+		var type:EnchantmentType = EnchantmentType.ENCHANTMENT_TYPES[id];
+		if (!type) return null;
+		return type.spawn(o);
+	}
+	
+	/**
+	 * (itemCategory+"/"+rarity) -> weighted table of enchantment types
+	 */
+	private var categoryTables:Object = {};
+	
+	public function getWeightedTable(itemCategory:String, rarity:int):Array {
+		var key:String = itemCategory + "/" + rarity;
+		if (!(key in categoryTables)) {
+			var table:Array = [];
+			var etype:EnchantmentType;
+			for each (etype in values(EnchantmentType.ENCHANTMENT_TYPES)) {
+				if (etype.rarity === rarity && etype.itemCategories.indexOf(itemCategory) >= 0) {
+					table.push([etype.weight, etype]);
+				}
+			}
+			categoryTables[key] = table;
+		}
+		return categoryTables[key];
+	}
+	
+	/**
+	 * Might return null if no suitable enchantment types
+	 */
+	public function randomEnchantmentType(itemCategory:String, rarity:int):EnchantmentType {
+		return weightedRandom(getWeightedTable(itemCategory, rarity));
+	}
+	
+	/**
+	 * Might return null if no suitable enchantment types
+	 * @param options passed to EnchantmentType to fine-tune the roll
+	 */
+	public function randomEnchantment(itemCategory:String, rarity:int, options:Object = null):Enchantment {
+		var etype:EnchantmentType = randomEnchantmentType(itemCategory, rarity);
+		if (!etype) return null;
+		return etype.generateRandom(options);
+	}
+	
+	private static var _instance:EnchantmentLib;
+	public static function get instance():EnchantmentLib {
+		if (!_instance) new EnchantmentLib();
+		return _instance;
+	}
+	
+	public function EnchantmentLib() {
+		_instance = this;
+	}
+	
+	public static function mk(id:int, name:String, params:Object):EnchantmentType {
+		var enchantmentType:EnchantmentType = new SimpleEnchtantmentType(
+				id,
+				name,
+				valueOr(params.curse, false),
+				valueOr(params.prefix, ""),
+				valueOr(params.suffix, ""),
+				valueOr(params.shortSuffix, ""),
+				valueOrThrow(params.description, "Missing description"),
+				valueOr(params.rarity, DynamicItems.RARITY_MAGICAL),
+				valueOr(params.minPower, 1),
+				valueOr(params.maxPower, 1),
+				valueOr(params.value, 0),
+				valueOr(params.valuePerPower, 0),
+				valueOr(params.valueX, 1),
+				valueOr(params.valueXPerPower, 0)
+		);
+		if ('weight' in params) enchantmentType.setSpawnChance(params.weight);
+		if ('categories' in params) enchantmentType.setItemCategories(params.categories.slice());
+		if (params['negative']) enchantmentType.setNegative();
+		return enchantmentType;
+	}
+}
+}

--- a/classes/classes/Items/EnchantmentLib.as
+++ b/classes/classes/Items/EnchantmentLib.as
@@ -1,6 +1,6 @@
 package classes.Items {
-import classes.Items.Effects.SimpleEnchtantmentType;
-import classes.Items.Effects.StatEnchantmentType;
+import classes.Items.Dynamic.Effects.SimpleEnchtantmentType;
+import classes.Items.Dynamic.Effects.StatEnchantmentType;
 
 public class EnchantmentLib extends DynamicItems {
 	// See EnchatmentType.genDescription for description expression syntax
@@ -14,7 +14,7 @@ public class EnchantmentLib extends DynamicItems {
 	 * 	prefix: "Xxxx ", // optional, default empty
 	 * 	suffix: " of Xxxx", // optional, default empty
 	 * 	shortSuffix: "Xx", // optional, default empty. Button label. 2-3 chars!
-	 * 	description: "+{X} to Xxxx", // required
+	 * 	description: "+{X} to Xxxx", // required. See EnchantmentType.genDescription for formatter description
 	 * 	rarity: RARITY_LEGENDARY, // optional, default = RARITY_MAGICAL. don't use RARITY_RARE or RARITY_COMMON.
 	 * 	categories: [ItemType.CATEGORY_WEAPON_MELEE], // optional, default = all categories
 	 * 	weight: 2.0, // optional, relative spawn chance, default 1
@@ -65,7 +65,7 @@ public class EnchantmentLib extends DynamicItems {
 		var id:int               = o[1];
 		var type:EnchantmentType = EnchantmentType.ENCHANTMENT_TYPES[id];
 		if (!type) return null;
-		return type.spawn(o);
+		return type.decode(o);
 	}
 	
 	/**

--- a/classes/classes/Items/EnchantmentLib.as
+++ b/classes/classes/Items/EnchantmentLib.as
@@ -16,7 +16,7 @@ public class EnchantmentLib extends DynamicItems {
 	 * 	shortSuffix: "Xx", // optional, default empty. Button label. 2-3 chars!
 	 * 	description: "+{X} to Xxxx", // required
 	 * 	rarity: RARITY_LEGENDARY, // optional, default = RARITY_MAGICAL. don't use RARITY_RARE or RARITY_COMMON.
-	 * 	categoies: [ItemType.CATEGORY_WEAPON], // optional, default = all categories
+	 * 	categories: [ItemType.CATEGORY_WEAPON_MELEE], // optional, default = all categories
 	 * 	weight: 2.0, // optional, relative spawn chance, default 1
 	 * 	minPower: 0, // optional, default 1
 	 * 	maxPower: 10, // optional, default 1

--- a/classes/classes/Items/EnchantmentType.as
+++ b/classes/classes/Items/EnchantmentType.as
@@ -1,0 +1,164 @@
+package classes.Items {
+import classes.CoC;
+import classes.CoC_Settings;
+import classes.ItemType;
+import classes.Player;
+import classes.internals.Utils;
+
+import coc.script.Eval;
+
+import flash.utils.Dictionary;
+
+public class EnchantmentType extends Utils {
+	public static const ENCHANTMENT_TYPES:Dictionary = new Dictionary();
+	
+	public var id:int;
+	public var name:String;
+	/** Always makes a cursed item */
+	public var curse:Boolean;
+	/** Negative effect, greater cursed item chance */
+	public var negative:Boolean = false;
+	public var prefix:String;
+	public var suffix:String;
+	public var shortSuffix:String;
+	public var descPattern:String;
+	public var rarity:int;
+	public var itemCategories:Array = [
+		ItemType.CATEGORY_WEAPON_MELEE,
+		ItemType.CATEGORY_WEAPON_RANGED,
+		ItemType.CATEGORY_SHIELD,
+		ItemType.CATEGORY_ARMOR,
+		ItemType.CATEGORY_UNDERGARMENT,
+		ItemType.CATEGORY_NECKLACE,
+		ItemType.CATEGORY_JEWELRY_HEAD,
+		ItemType.CATEGORY_JEWELRY_RING,
+		ItemType.CATEGORY_JEWELRY_MISC,
+		ItemType.CATEGORY_VEHICLE,
+		ItemType.CATEGORY_FLYING_SWORD
+	];
+	public var weight:Number        = 1;
+	
+	public function spawn(o:Array):Enchantment {
+		var identified:Boolean = o[0];
+		return doSpawn(identified, o.slice(2));
+	}
+	
+	public function generateRandom(options:Object = null):Enchantment {
+		// Implement in subclass
+		CoC_Settings.errorAMC("EnchantmentType","generateRandom");
+		return null;
+	}
+	
+	/**
+	 * Description patterns:
+	 * <pre>
+	 * {expression} - evaluated with Enchantment as context
+	 * {expression;format} - also apply number formatting:
+	 *   d - integer
+	 *  +d - signed integer
+	 *  2f - float 2 decimals (or any other number)
+	 * +2f - signed float 2 decimals
+	 *
+	 * Examples for enchantment of power=5:
+	 * "{power} fire damage" -> "5 fire damage"
+	 * "{power*5;+d}% strength" -> "+50% strength"
+	 * "{power*0.5;+1f}% fire resistance" -> "+2.5% fire resistance"
+	 * </pre>
+	 */
+	public function genDescription(enchantment:Enchantment):String {
+		const substitute:RegExp = /\{[^}]+}/g;
+		const fmtPattern:RegExp  = /^\{(.*);(\+?)(\d*)([fd])}$/;
+		return descPattern.replace(substitute, function ($0:String, ...rest):String {
+			var fmt:Array = $0.match(fmtPattern);
+			if (fmt) {
+				// fmt = [match, expr, sign, decimals, type]
+				var expr:*         = fmt[1];
+				var signed:Boolean = fmt[2] === "+";
+				var decimals:int   = fmt[3] ? parseInt(fmt[3]) : -1;
+				var type:String    = fmt[4];
+				var value:Number   = Eval.compile(expr).call(enchantment, {
+					player: CoC.instance.player,
+					game: CoC.instance
+				});
+				var sign:String    = (signed && value >= 0) ? "+" : "";
+				if (type === "d") {
+					return sign + value.toFixed(0);
+				} else if (type === "f") {
+					if (decimals >= 0) {
+						return sign + value.toFixed(decimals);
+					} else {
+						return sign + value.toString();
+					}
+				} else {
+					trace("[ERROR] Bad description substitution " + fmt);
+					return "(Unknown formatter " + type + ")" + value;
+				}
+			} else {
+				return Eval.compile($0).call(enchantment);
+			}
+		})
+	}
+	
+	/**
+	 * Create an item, according to parameters.
+	 * @param identified return identified enchantment
+	 * @param params raw enchantment params (minus identified flag and id)
+	 */
+	protected function doSpawn(identified:Boolean, params:Array):Enchantment {
+		// implement in subclasses
+		CoC_Settings.errorAMC("EnchantmentType", "doSpawn");
+		return null;
+	}
+	
+	/**
+	 * Apply effects when enchanted item is equipped
+	 */
+	public function onEquip(player:Player, enchantment:Enchantment, item:ItemType):void {
+		// override in subclasses
+	}
+	
+	/**
+	 * Remove effects when enchanted item is unequipped
+	 */
+	public function onUnequip(player:Player, enchantment:Enchantment, item:ItemType):void {
+		// override in subclasses
+	}
+	
+	public function setSpawnChance(weight:Number):EnchantmentType {
+		this.weight = weight;
+		return this;
+	}
+	public function setNegative():EnchantmentType {
+		this.negative = true;
+		return this;
+	}
+	public function setItemCategories(categories:Array):EnchantmentType {
+		this.itemCategories = categories.slice();
+		return this;
+	}
+	
+	public function EnchantmentType(
+			id:int,
+			name:String,
+			curse:Boolean,
+			prefix:String,
+			suffix:String,
+			shortSuffix:String,
+			description:String,
+			rarity:int
+	) {
+		if (id in ENCHANTMENT_TYPES) {
+			throw new Error("Duplicate enchantment ID " + id);
+		}
+		ENCHANTMENT_TYPES[id] = this;
+		this.id               = id;
+		this.name             = name;
+		this.curse            = curse;
+		this.prefix           = prefix;
+		this.suffix           = suffix;
+		this.shortSuffix      = shortSuffix;
+		this.descPattern      = description;
+		this.rarity           = rarity;
+	}
+}
+}

--- a/classes/classes/Items/EnchantmentType.as
+++ b/classes/classes/Items/EnchantmentType.as
@@ -38,11 +38,15 @@ public class EnchantmentType extends Utils {
 	];
 	public var weight:Number        = 1;
 	
-	public function spawn(o:Array):Enchantment {
+	public function decode(o:Array):Enchantment {
 		var identified:Boolean = o[0];
-		return doSpawn(identified, o.slice(2));
+		return doDecode(identified, o.slice(2));
 	}
 	
+	/**
+	 * Generate random enchantment of this type
+	 * @param options.identified Should be identified
+	 */
 	public function generateRandom(options:Object = null):Enchantment {
 		// Implement in subclass
 		CoC_Settings.errorAMC("EnchantmentType","generateRandom");
@@ -100,13 +104,13 @@ public class EnchantmentType extends Utils {
 	}
 	
 	/**
-	 * Create an item, according to parameters.
+	 * Decode enchantment.
 	 * @param identified return identified enchantment
 	 * @param params raw enchantment params (minus identified flag and id)
 	 */
-	protected function doSpawn(identified:Boolean, params:Array):Enchantment {
+	protected function doDecode(identified:Boolean, params:Array):Enchantment {
 		// implement in subclasses
-		CoC_Settings.errorAMC("EnchantmentType", "doSpawn");
+		CoC_Settings.errorAMC("EnchantmentType", "doDecode");
 		return null;
 	}
 	

--- a/classes/classes/Items/IDynamicItem.as
+++ b/classes/classes/Items/IDynamicItem.as
@@ -1,4 +1,6 @@
 package classes.Items {
+import classes.ItemType;
+
 public interface IDynamicItem {
 	function get subtypeId():String;
 	function get subtype():Object;
@@ -7,5 +9,25 @@ public interface IDynamicItem {
 	function get curseStatus():int;
 	function get identified():Boolean;
 	function get effects():/*Enchantment*/Array;
+	/**
+	 * Returns fully identified copy of this item (this if it is already identified)
+	 */
+	function identifiedCopy():ItemType;
+	
+	/**
+	 * Returns copy of this item with curse flag removed
+	 */
+	function uncursedCopy():ItemType;
+	
+	/**
+	 * Returns a copy of this item, modified with options
+	 * @param options
+	 * @param options.t (optional) New subtype
+	 * @param options.c (optional) New curse status
+	 * @param options.q (optional) New quality
+	 * @param options.r (optional) New rarity
+	 * @param options.e (optional) New Enchantment[] array
+	 */
+	function moddedCopy(options:Object):ItemType;
 }
 }

--- a/classes/classes/Items/IDynamicItem.as
+++ b/classes/classes/Items/IDynamicItem.as
@@ -1,0 +1,11 @@
+package classes.Items {
+public interface IDynamicItem {
+	function get subtypeId():String;
+	function get subtype():Object;
+	function get quality():int;
+	function get rarity():int;
+	function get curseStatus():int;
+	function get identified():Boolean;
+	function get effects():/*Enchantment*/Array;
+}
+}

--- a/classes/classes/Items/ItemTemplateLib.as
+++ b/classes/classes/Items/ItemTemplateLib.as
@@ -1,6 +1,7 @@
 package classes.Items {
 import classes.ItemTemplate;
 import classes.Items.Consumables.HairDye;
+import classes.Items.Dynamic.DynamicWeapon;
 
 public class ItemTemplateLib {
 	public static var instance:ItemTemplateLib;
@@ -18,8 +19,22 @@ public class ItemTemplateLib {
 		return THairDye.createItem({color: color, rarity: rarity}) as HairDye;
 	}
 	
+	// Generic dynamic items
+	
+	public const TDynamicWeapon:ItemTemplate = mk("DynamicWeapon", "Enchanted Weapon", DynamicWeapon, {
+		category: "weapon",
+		params: [
+			{name: "t", label:"Subtpye", type:"text", value:"sword"},
+			{name: "r", label:"Rarity", type:"number", value:0, min:0, max: 4},
+			{name: "q", label:"Quality", type:"number", value:0, min:-15, max:15},
+			{name: "c", label:"Curse", type:"number", value:0, min:0, max:3},
+			{name: "e", label:"Effects", type:"enchantments", value:[]}
+		]
+	})
+	
 	/**
 	 * @param itemClass constructor should be (id:String, params:Object)
+	 * @param metadata template metadata. Used for debugging and in save editor
 	 */
 	private function mk(templateId:String, name:String, itemClass:Class, metadata:Object):SimpleItemTemplate {
 		return new SimpleItemTemplate(templateId, name, itemClass, metadata);

--- a/classes/classes/Items/ItemTemplateLib.as
+++ b/classes/classes/Items/ItemTemplateLib.as
@@ -30,7 +30,11 @@ public class ItemTemplateLib {
 			{name: "c", label:"Curse", type:"number", value:0, min:0, max:3},
 			{name: "e", label:"Effects", type:"enchantments", value:[]}
 		]
-	})
+	});
+	
+	public function createWeapon(subtype:String, rarity:int, quality:int, curseStatus:int, effects:/*Enchantment*/Array):DynamicWeapon {
+		return DynamicItems.createItem(TDynamicWeapon, subtype, rarity, quality, curseStatus, effects) as DynamicWeapon;
+	}
 	
 	/**
 	 * @param itemClass constructor should be (id:String, params:Object)

--- a/classes/classes/Items/SimpleItemTemplate.as
+++ b/classes/classes/Items/SimpleItemTemplate.as
@@ -15,6 +15,8 @@ public class SimpleItemTemplate extends ItemTemplate {
 	
 	override public function createItem(parameters:Object):ItemType {
 		var itemId:String = ItemType.dynamicItemId(templateId, parameters);
+		var item:ItemType = ItemType.lookupCachedItem(itemId);
+		if (item) return item;
 		return new itemClass(itemId, parameters) as ItemType;
 	}
 }

--- a/classes/classes/Items/Weapon.as
+++ b/classes/classes/Items/Weapon.as
@@ -94,6 +94,10 @@ public class Weapon extends Useable //Equipable
 		}
 		
 		override public function canUse():Boolean {
+			if (game.player.weapon.cursed) {
+				outputText("You cannot replace "+game.player.weapon.name+"!");
+				return false;
+			}
 			if ((perk == "Large" && game.player.shield != ShieldLib.NOTHING && !game.player.hasPerk(PerkLib.GigantGrip)) || (perk == "Massive" && game.player.shield != ShieldLib.NOTHING)) {
 				outputText("Because this weapon requires the use of two hands, you have unequipped your shield. ");
 				SceneLib.inventory.unequipShield();

--- a/classes/classes/PerkTree.as
+++ b/classes/classes/PerkTree.as
@@ -46,6 +46,7 @@ public class PerkTree extends BaseContent {
 	 * Returns Array of PerkType
 	 */
 	public function listUnlocks(p:PerkType):Array {
+		if (!pdata[p.id]) return [];
 		return pdata[p.id].unlocks.map(function(entry:PerkTreeEntry,idx:int,array:/*PerkTreeEntry*/Array):PerkType {
 			return entry.perk;
 		});

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1260,10 +1260,20 @@ use namespace CoC;
 			return false;
 		}
 		
-		public function enchantmentPower(type:EnchantmentType):Number {
+		/**
+		 * @param aggregate "sum"|"max"|"min".
+		 */
+		public function enchantmentPower(type:EnchantmentType, aggregate:String="sum"):Number {
 			var power:Number = 0;
 			for each (var itype:ItemType in allEquipment()) {
-				power = Math.max(power, itype.enchantmentPower(type));
+				var ipower:Number = itype.enchantmentPower(type);
+				if (aggregate === "sum") {
+					power += ipower
+				} else if (aggregate === "max") {
+					power = Math.max(power, ipower);
+				} else if (aggregate === "min") {
+					power = Math.min(power, ipower);
+				}
 			}
 			return power;
 		}

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -5144,7 +5144,7 @@ use namespace CoC;
 		// 0..5 or -1 if no
 		public function roomInExistingStack(itype:ItemType):Number {
 			for (var i:int = 0; i<itemSlots.length; i++){
-				if(itemSlot(i).itype == itype && itemSlot(i).quantity != 0 && itemSlot(i).quantity < 5)
+				if(itemSlot(i).itype == itype && itemSlot(i).quantity != 0 && itemSlot(i).quantity < itype.stackSize)
 					return i;
 			}
 			return -1;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -16,6 +16,8 @@ import classes.GlobalFlags.kFLAGS;
 import classes.IMutations.IMutationsLib;
 import classes.Items.Armor;
 import classes.Items.ArmorLib;
+import classes.Items.Enchantment;
+import classes.Items.EnchantmentType;
 import classes.Items.FlyingSwords;
 import classes.Items.FlyingSwordsLib;
 import classes.Items.HeadJewelry;
@@ -31,11 +33,13 @@ import classes.Items.Shield;
 import classes.Items.ShieldLib;
 import classes.Items.Undergarment;
 import classes.Items.UndergarmentLib;
+import classes.Items.UndergarmentLib;
 import classes.Items.Vehicles;
 import classes.Items.VehiclesLib;
 import classes.Items.Weapon;
 import classes.Items.WeaponLib;
 import classes.Items.WeaponRange;
+import classes.Items.WeaponRangeLib;
 import classes.Items.WeaponRangeLib;
 import classes.Races.HumanRace;
 import classes.Scenes.Combat.CombatAbilities;
@@ -213,7 +217,7 @@ use namespace CoC;
 		public var itemSlot18:ItemSlotClass;
 		public var itemSlot19:ItemSlotClass;
 		public var itemSlot20:ItemSlotClass;
-		public var itemSlots:Array;
+		public var itemSlots:/*ItemSlotClass*/Array;
 
 		public var prisonItemSlots:Array = [];
 		public var previouslyWornClothes:Array = []; //For tracking achievement.
@@ -1227,6 +1231,60 @@ use namespace CoC;
 		{
 			return arms.type == Arms.DISPLACER;
 		}
+		
+		public function allEquipment():/*ItemType*/Array {
+			var result:Array = [];
+			if (weapon !== WeaponLib.FISTS) result.push(weapon);
+			if (weaponRange !== WeaponRangeLib.NOTHING) result.push(weapon);
+			if (shield !== ShieldLib.NOTHING) result.push(weapon);
+			if (armor !== ArmorLib.NOTHING) result.push(weapon);
+			if (upperGarment !== UndergarmentLib.NOTHING) result.push(weapon);
+			if (lowerGarment !== UndergarmentLib.NOTHING) result.push(weapon);
+			if (headJewelry !== HeadJewelryLib.NOTHING) result.push(weapon);
+			if (necklace !== NecklaceLib.NOTHING) result.push(weapon);
+			if (jewelry !== JewelryLib.NOTHING) result.push(weapon);
+			if (jewelry2 !== JewelryLib.NOTHING) result.push(weapon);
+			if (jewelry3 !== JewelryLib.NOTHING) result.push(weapon);
+			if (jewelry4 !== JewelryLib.NOTHING) result.push(weapon);
+			if (miscJewelry !== MiscJewelryLib.NOTHING) result.push(weapon);
+			if (miscJewelry2 !== MiscJewelryLib.NOTHING) result.push(weapon);
+			if (weaponFlyingSwords !== FlyingSwordsLib.NOTHING) result.push(weapon);
+			if (vehicles !== VehiclesLib.NOTHING) result.push(weapon);
+			return result;
+		}
+		
+		public function hasEnchantment(type:EnchantmentType):Boolean {
+			for each (var itype:ItemType in allEquipment()) {
+				if (itype.hasEnchantment(type)) return true;
+			}
+			return false;
+		}
+		
+		public function enchantmentPower(type:EnchantmentType):Number {
+			var power:Number = 0;
+			for each (var itype:ItemType in allEquipment()) {
+				power = Math.max(power, itype.enchantmentPower(type));
+			}
+			return power;
+		}
+		
+		public function findEnchantment(type:EnchantmentType):Enchantment {
+			for each (var itype:ItemType in allEquipment()) {
+				var e:Enchantment = itype.enchantmentOfType(type);
+				if (e) return e;
+			}
+			return null;
+		}
+		
+		public function allEnchantments(type:EnchantmentType):/*Enchantment*/Array {
+			var result:/*Enchantment*/Array = [];
+			for each (var itype:ItemType in allEquipment()) {
+				var e:Enchantment = itype.enchantmentOfType(type);
+				if (e) result.push(e);
+			}
+			return result;
+		}
+		
 		//override public function get weapons
 		override public function get weaponName():String {
 			return _weapon.name;

--- a/classes/classes/Scenes/DebugMenu.as
+++ b/classes/classes/Scenes/DebugMenu.as
@@ -19,8 +19,14 @@ import classes.BodyParts.Tail;
 import classes.BodyParts.Tongue;
 import classes.BodyParts.Wings;
 import classes.GlobalFlags.kFLAGS;
+import classes.ItemSlotClass;
 import classes.Items.Consumable;
 import classes.Items.ConsumableLib;
+import classes.Items.Dynamic.DynamicWeapon;
+import classes.Items.DynamicItems;
+import classes.Items.EnchantmentLib;
+import classes.Items.EnchantmentType;
+import classes.Items.ItemTemplateLib;
 import classes.Parser.Parser;
 import classes.Scenes.NPCs.JojoScene;
 import classes.Transformations.PossibleEffect;
@@ -212,11 +218,12 @@ public class DebugMenu extends BaseContent
 			addButton(8, "Undergarments", displayItemPage, undergarmentArray, 1);
 			addButton(9, "Accessories", displayItemPage, accessoryArray, 1);
 			addButton(10,"ConsumableLib",displayItemPage,testArray,1);
-			addButton(12, "Templated", templatedItemMenu);
+			addButton(12, "Dynamic", dynamicItemMenu);
+			addButton(13, "Enchanted", enchantedItemMenu);
 			addButton(14, "Back", accessDebugMenu);
 		}
 		
-		private function templatedItemMenu():void {
+		private function dynamicItemMenu():void {
 			hideItemParams();
 			clearOutput();
 			menu();
@@ -243,7 +250,7 @@ public class DebugMenu extends BaseContent
 				layoutConfig: {
 					type: "flow",
 					direction: "column",
-					gap: 1
+					gap: 2
 				},
 				x: mainView.mainText.x,
 				y: mainView.mainText.y + 24,
@@ -261,23 +268,14 @@ public class DebugMenu extends BaseContent
 					case "text":
 						element = (function(def:Object):DisplayObject{
 							return row.addTextInput({
-								text: def.value,
-								onchange: function(event:Event):void {
-									parameters[def.name] = (this as TextInput).text;
-								}
+								bindText: [parameters, def.name]
 							})
 						})(def);
 						break;
 					case "number":
 						element = (function(def:Object):DisplayObject{
 							return row.addTextInput({
-								text: ""+def.value,
-								onchange: function(event:Event):void {
-									var x:Number = parseFloat((this as TextInput).text);
-									if (!isNaN(x)) {
-										parameters[def.name] = x;
-									}
-								}
+								bindNumber: [parameters, def.name]
 							})
 						})(def);
 						break;
@@ -294,13 +292,162 @@ public class DebugMenu extends BaseContent
 			}
 			
 			menu();
-			addButton(0, "Create", createTemplatedItem, template, parameters);
-			addButton(14, "Back", templatedItemMenu);
+			addButton(0, "Create", createDynamicItem, template, parameters);
+			addButton(14, "Back", dynamicItemMenu);
 		}
-		private function createTemplatedItem(template:ItemTemplate, parameters:Object):void {
+		private function createDynamicItem(template:ItemTemplate, parameters:Object):void {
 			clearOutput();
 			hideItemParams();
-			inventory.takeItem(template.createItem(parameters), templatedItemMenu);
+			inventory.takeItem(template.createItem(parameters), dynamicItemMenu);
+		}
+
+		private function enchantedItemMenu():void {
+			clearOutput();
+			outputText("Create an enchanted item");
+			flushOutputTextToGUI();
+			
+			var params:Object = {
+				typeSubtype: "weapon/sword",
+				rarity: DynamicItems.RARITY_COMMON,
+				curse: DynamicItems.HIDDEN_UNCURSED,
+				quality: +0,
+				effects: [
+					{identified: true, type: 0, params: "0"},
+					{identified: true, type: 0, params: "0"},
+					{identified: true, type: 0, params: "0"},
+					{identified: true, type: 0, params: "0"}
+				]
+			};
+			
+			hideItemParams();
+			itemParamsBlock = new Block({
+				layoutConfig: {
+					type: "flow",
+					direction: "column",
+					gap: 2,
+					stretch: true
+				},
+				x: mainView.mainText.x,
+				y: mainView.mainText.y + 24,
+				width: mainView.mainText.width,
+				height: mainView.mainText.height - 24
+			});
+			
+			var paramGrid:Block = new Block({
+				layoutConfig: {
+					type: "grid",
+					columns: [1/3, 2/3],
+					gap: 2,
+					setWidth: true
+				}
+			});
+			
+			paramGrid.addTextField("Type/Subtype");
+			paramGrid.addComboBox({
+				bindValue: [params, "typeSubtype"],
+				items: [
+					"weapon/sword",
+					"weapon/dagger",
+				]
+			});
+			paramGrid.addTextField("Rarity");
+			paramGrid.addComboBox({
+				bindValue: [params, "rarity"],
+				items: DynamicItems.Rarities,
+				labelKey: "name",
+				valueKey: "value"
+			});
+			paramGrid.addTextField("Curse status");
+			paramGrid.addComboBox({
+				bindValue: [params, "curse"],
+				items: [
+					{label:"Unknown uncursed", data:DynamicItems.HIDDEN_UNCURSED},
+					{label:"Known uncursed", data:DynamicItems.KNOWN_UNCURSED},
+					{label:"Unknown cursed", data:DynamicItems.HIDDEN_CURSED},
+					{label:"Known cursed", data:DynamicItems.KNOWN_CURSED}
+				]
+			});
+			paramGrid.addTextField("Quality");
+			paramGrid.addTextInput({
+				bindNumber: [params, "quality"]
+			});
+			itemParamsBlock.addElement(paramGrid);
+			
+			var effectGrid:Block = new Block({
+				layoutConfig: {
+					type: "grid",
+					columns: [1/3, 1/3, 1/3],
+					gap: 2,
+					setWidth: true
+				}
+			});
+			effectGrid.addTextField("Identified");
+			effectGrid.addTextField("Enchantment type");
+			effectGrid.addTextField("Enchantment power/params");
+			for (var i:int = 0; i < params.effects.length; i++) {
+				effectGrid.addComboBox({
+					bindValue: [params.effects[i], "identified"],
+					items:[
+						{label:"identified", data:true},
+						{label:"unidentified", data:false}
+					]
+				}, {setWidth:false});
+				effectGrid.addComboBox({
+					items: [{name:"(none)", id:0}].concat(values(EnchantmentType.ENCHANTMENT_TYPES)),
+					labelKey: "name",
+					valueKey: "id",
+					bindValue: [params.effects[i], "type"]
+				});
+				effectGrid.addTextInput({
+					bindText: [params.effects[i], "params"]
+				});
+			}
+			itemParamsBlock.addElement(effectGrid);
+			
+			mainView.hotkeysDisabled = true;
+			mainView.addElement(itemParamsBlock);
+			
+			menu();
+			addButton(0, "Spawn", function():void {
+				hideItemParams();
+				clearOutput();
+				rawOutputText(JSON.stringify(params));
+				outputText("\n\n");
+				var effs:Array = [];
+				for each (var e:Object in params.effects) {
+					if (e.type) {
+						effs.push(
+								[
+									e.identified ? 1 : 0,
+									e.type
+								].concat(JSON.parse("[" + e.params + "]"))
+						);
+					}
+				}
+				var p:Object = {
+					t: params.typeSubtype.split("/")[1],
+					r: params.rarity,
+					q: params.quality,
+					c: params.curse,
+					e: effs
+				}
+				rawOutputText(JSON.stringify(p));
+				outputText("\n\n");
+				var item:ItemType = itemTemplates.TDynamicWeapon.createItem(p);
+				outputText(item.shortName+"\n"+item.longName+"\n"+item.description);
+				
+				doNext(curry(inventory.takeItem, item, itemSpawnMenu));
+			});
+			addButton(5, "Random", function():void {
+				hideItemParams();
+				clearOutput();
+				var item:ItemType = DynamicItems.randomItem({identified:true});
+				inventory.takeItem(item, enchantedItemMenu);
+			});
+			addButton(14, "Back", function():void {
+				hideItemParams();
+				itemSpawnMenu();
+			})
 		}
 
 		private function displayItemPage(array:Array, page:int):void {

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -87,9 +87,15 @@ use namespace CoC;
 			hideMenus();
 			hideUpDown();
 			clearOutput();
+			mainView.linkHandler = function(itemid:String):void {
+				var item:ItemType = ItemType.lookupItem(itemid);
+				mainView.toolTipView.header = item.longName;
+				mainView.toolTipView.text = item.description;
+				mainView.toolTipView.show(mainView.mouseX, mainView.mouseY, 0, 0);
+			}
 			EngineCore.displayHeader("Inventory");
 			outputText("<b><u>Equipment:</u></b>\n");
-			outputText("<b>Weapon (Melee):</b> " + player.weapon.name + " (Attack: " + player.weaponAttack + ")");
+			outputText("<b>Weapon (Melee):</b> "+mkLink(player.weapon.name, player.weapon.id)+" (Attack: " + player.weaponAttack + ")");
 			if (player.isGauntletWeapon()) outputText(" (Gauntlet-type weapon)");
 			if (player.isSwordTypeWeapon()) outputText(" (Sword-type weapon)");
 			if (player.isAxeTypeWeapon()) outputText(" (Axe-type weapon)");
@@ -101,32 +107,32 @@ use namespace CoC;
 			if (player.isRibbonTypeWeapon()) outputText(" (Ribbon-type weapon)");
 			if (player.isExoticTypeWeapon()) outputText(" (Exotic-type weapon)");
 			outputText("\n");
-			outputText("<b>Weapon (Range):</b> " + player.weaponRange.name + " (Attack: " + player.weaponRangeAttack + ")");
+			outputText("<b>Weapon (Range):</b> " + mkLink(player.weaponRange.name, player.weaponRange.id) + " (Attack: " + player.weaponRangeAttack + ")");
 			if (player.weaponRangePerk == "Bow" || player.weaponRangePerk == "Crossbow") outputText(" (Bow/Crosbow-type weapon)");
 			if (player.weaponRangePerk == "Throwing") outputText(" (Throwing weapon-type weapon)");
 			if (player.weaponRangePerk == "Pistol" || player.weaponRangePerk == "Rifle" || player.weaponRangePerk == "2H Firearm" || player.weaponRangePerk == "Dual Firearms" || player.weaponRangePerk == "Quad Firearms") outputText(" (Firearms-type weapon)");
 			outputText("\n");
-			outputText("<b>Shield:</b> " + player.shield.name + " (Block Rating: " + player.shieldBlock + ")");
+			outputText("<b>Shield:</b> " + mkLink(player.shield.name, player.shield.id) + " (Block Rating: " + player.shieldBlock + ")");
 			if (player.shieldPerk == "Large") outputText(" (Large)");
 			if (player.shieldPerk == "Massive") outputText(" (Massive)");
 			outputText("\n");
-			outputText("<b>Armour:</b> " + player.armor.name + " (Physical / Magical Defense: " + player.armorDef + " / " + player.armorMDef + ")\n");
-			outputText("<b>Upper underwear:</b> " + player.upperGarment.name + "\n");
-			outputText("<b>Lower underwear:</b> " + player.lowerGarment.name + "\n");
-			outputText("<b>Head Accessory/Helm:</b> " + player.headjewelryName + "\n");
-			outputText("<b>Necklace:</b> " + player.necklaceName + "\n");
-			outputText("<b>Ring (1st):</b> " + player.jewelry.name + "\n");
-			if (player.hasPerk(PerkLib.SecondRing)) outputText("<b>Ring (2nd):</b> " + player.jewelry2.name + "\n");
+			outputText("<b>Armour:</b> " + mkLink(player.armor.name, player.armor.id) + " (Physical / Magical Defense: " + player.armorDef + " / " + player.armorMDef + ")\n");
+			outputText("<b>Upper underwear:</b> " + mkLink(player.upperGarment.name, player.upperGarment.id) + "\n");
+			outputText("<b>Lower underwear:</b> " + mkLink(player.lowerGarment.name, player.lowerGarment.id) + "\n");
+			outputText("<b>Head Accessory/Helm:</b> " + mkLink(player.headJewelry.name, player.headJewelry.id) + "\n");
+			outputText("<b>Necklace:</b> " + mkLink(player.necklace.name, player.necklace.id) + "\n");
+			outputText("<b>Ring (1st):</b> " + mkLink(player.jewelry.name, player.jewelry.id) + "\n");
+			if (player.hasPerk(PerkLib.SecondRing)) outputText("<b>Ring (2nd):</b> " + mkLink(player.jewelry2.name, player.jewelry2.id) + "\n");
 			else outputText("<b>Ring (2nd):</b> <i>LOCKED</i> (req. Second Ring perk)\n");
-			if (player.hasPerk(PerkLib.ThirdRing)) outputText("<b>Ring (3rd):</b> " + player.jewelry3.name + "\n");
+			if (player.hasPerk(PerkLib.ThirdRing)) outputText("<b>Ring (3rd):</b> " + mkLink(player.jewelry3.name, player.jewelry3.id) + "\n");
 			else outputText("<b>Ring (3rd):</b> <i>LOCKED</i> (req. Third Ring perk)\n");
-			if (player.hasPerk(PerkLib.FourthRing)) outputText("<b>Ring (4th):</b> " + player.jewelry4.name + "\n");
+			if (player.hasPerk(PerkLib.FourthRing)) outputText("<b>Ring (4th):</b> " + mkLink(player.jewelry4.name, player.jewelry4.id) + "\n");
 			else outputText("<b>Ring (4th):</b> <i>LOCKED</i> (req. Fourth Ring perk)\n");
-			outputText("<b>Accessory (1st):</b> " + player.miscjewelryName + "\n");
-			outputText("<b>Accessory (2nd):</b> " + player.miscjewelryName2 + "\n");
-			if (player.hasPerk(PerkLib.FlyingSwordPath)) outputText("<b>Flying Sword:</b> " + player.weaponFlyingSwordsName + "\n");
+			outputText("<b>Accessory (1st):</b> " + mkLink(player.miscJewelry.name, player.miscJewelry.id) + "\n");
+			outputText("<b>Accessory (2nd):</b> " + mkLink(player.miscJewelry2.name, player.miscJewelry2.id) + "\n");
+			if (player.hasPerk(PerkLib.FlyingSwordPath)) outputText("<b>Flying Sword:</b> " + mkLink(player.weaponFlyingSwords.name, player.weaponFlyingSwords.id) + "\n");
 			else outputText("<b>Flying Sword:</b> <i>LOCKED</i> (req. Flying Swords Control perk)\n");
-			outputText("<b>Vehicle:</b> " + player.vehiclesName + "\n");
+			outputText("<b>Vehicle:</b> " + mkLink(player.vehicles.name, player.vehicles.id) + "\n");
 			if (player.hasKeyItem("Bag of Cosmos") >= 0 || player.hasKeyItem("Sky Poison Pearl") >= 0) {
 				outputText("\n");
 				if (player.hasKeyItem("Bag of Cosmos") >= 0) outputText("<i>At your belt hangs bag of cosmos.</i>\n");
@@ -1012,6 +1018,7 @@ use namespace CoC;
 //				if (!item.hasSubMenu()) itemGoNext(); //Don't call itemGoNext if there's a sub menu, otherwise it would never be displayed
 			}
 			CoC.instance.mainViewManager.updateCharviewIfNeeded();
+			statScreenRefresh();
 		}
 
 		private function takeItemFull(itype:ItemType, showUseNow:Boolean, source:ItemSlotClass, page:int = 1):void {
@@ -1198,7 +1205,10 @@ use namespace CoC;
 			menu();
 			if (page == 1) {
 				if (player.weapon != WeaponLib.FISTS && !player.hasPerk(PerkLib.Rigidity)) {
-					addButton(0, "Weapon (M)", unequipWeapon).hint(player.weapon.description, capitalizeFirstLetter(player.weapon.name));
+					addButton(0, "Weapon (M)", unequipWeapon)
+							.hint(player.weapon.description, capitalizeFirstLetter(player.weapon.name))
+							.disableIf(player.weapon.cursed, "You cannot unequip a cursed item!")
+					;
 				}
 				else addButtonDisabled(0, "Weapon (M)", "You not have melee weapon equipped.");
 				if (player.weaponRange != WeaponRangeLib.NOTHING && !player.hasPerk(PerkLib.Rigidity)) {
@@ -1299,12 +1309,13 @@ use namespace CoC;
 		}
 		//Unequip!
 		public function unequipWeapon():void {
+			player.weapon.removeText();
 			if (player.weaponName == "Aether (Dex)") {
-				player.weapon.removeText();
 				player.setWeapon(WeaponLib.FISTS);
 				manageEquipment(1);
 			}
 			else takeItem(player.setWeapon(WeaponLib.FISTS), inventoryMenu);
+			statScreenRefresh();
 			CoC.instance.mainViewManager.updateCharviewIfNeeded();
 		}
 		public function unequipWeaponRange():void {

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -150,7 +150,7 @@ use namespace CoC;
 			if (page == 1) {
 				for (x = 0; x < 10; x++) {
 					if (player.itemSlots[x].unlocked && player.itemSlots[x].quantity > 0) {
-						addButton(x, (player.itemSlots[x].itype.shortName + " x" + player.itemSlots[x].quantity), doWhatWithItem, x);
+						button(x).showForItemSlot(player.itemSlots[x], curry(doWhatWithItem, x));
 						//foundItem = true;
 					}
 				}
@@ -159,7 +159,7 @@ use namespace CoC;
 			if (page == 2) {
 				for (x = 10; x < 20; x++) {
 					if (player.itemSlots[x].unlocked && player.itemSlots[x].quantity > 0) {
-						addButton(x-10, (player.itemSlots[x].itype.shortName + " x" + player.itemSlots[x].quantity), doWhatWithItem, x);
+						button(x-10).showForItemSlot(player.itemSlots[x], curry(doWhatWithItem, x));
 						//foundItem = true;
 					}
 				}
@@ -1037,14 +1037,14 @@ use namespace CoC;
 			if (page == 1) {
 				for (x = 0; x < 10; x++) {
 					if (player.itemSlots[x].unlocked)
-						addButton(x, (player.itemSlots[x].itype.shortName + " x" + player.itemSlots[x].quantity), createCallBackFunction2(replaceItem, itype, x));
+							button(x).showForItemSlot(player.itemSlots[x], curry(replaceItem, itype, x));
 				}
 				if (getMaxSlots() > 10) addButton(13, "Next", curry(takeItemFull, itype, showUseNow, source, page + 1));
 			}
 			if (page == 2) {
 				for (x = 10; x < 20; x++) {
 					if (player.itemSlots[x].unlocked)
-						addButton(x-10, (player.itemSlots[x].itype.shortName + " x" + player.itemSlots[x].quantity), createCallBackFunction2(replaceItem, itype, x));
+						button(x-10).showForItemSlot(player.itemSlots[x], curry(replaceItem, itype, x));
 				}
 				addButton(13, "Prev", curry(takeItemFull, itype, showUseNow, source, page - 1));
 			}
@@ -1498,10 +1498,11 @@ use namespace CoC;
 				return;
 			}
 			outputText("What " + text + " slot do you wish to take an item from?");
-			var button:int = 0;
+			var btnidx:int = 0;
 			menu();
-			for (var x:int = startSlot; x < endSlot; x++, button++) {
-				if (storage[x].quantity > 0) addButton(button, (storage[x].itype.shortName + " x" + storage[x].quantity), createCallBackFunction2(pickFrom, storage, x));
+			for (var x:int = startSlot; x < endSlot; x++, btnidx++) {
+				if (storage[x].quantity > 0)
+						button(btnidx).showForItemSlot(storage[x], curry(pickFrom, storage, x));
 			}
 			addButton(14, "Back", stash);
 		}
@@ -1514,10 +1515,11 @@ use namespace CoC;
 				return;
 			}
 			outputText("What " + text + " slot do you wish to take an item from?");
-			var button:int = 0;
+			var btnidx:int = 0;
 			menu();
-			for (var x:int = startSlot; x < endSlot; x++, button++) {
-				if (storage[x].quantity > 0) addButton(button, (storage[x].itype.shortName + " x" + storage[x].quantity), createCallBackFunction2(pickFrom, storage, x));
+			for (var x:int = startSlot; x < endSlot; x++, btnidx++) {
+				if (storage[x].quantity > 0)
+						button(btnidx).showForItemSlot(storage[x], curry(pickFrom, storage, x));
 			}
 			addButton(14, "Back", inventoryMenu);
 		}
@@ -1530,10 +1532,11 @@ use namespace CoC;
 				return;
 			}
 			outputText("What " + text + " slot do you wish to take an item from?");
-			var button:int = 0;
+			var btnid:int = 0;
 			menu();
-			for (var x:int = startSlot; x < endSlot; x++, button++) {
-				if (storage[x].quantity > 0) addButton(button, (storage[x].itype.shortName + " x" + storage[x].quantity), createCallBackFunction2(pickFrom, storage, x));
+			for (var x:int = startSlot; x < endSlot; x++, btnid++) {
+				if (storage[x].quantity > 0)
+					button(btnid).showForItemSlot(storage[x], curry(pickFrom, storage, x));
 			}
 			addButton(14, "Back", warehouse);
 		}
@@ -1612,7 +1615,7 @@ use namespace CoC;
 			if (page == 1) {
 				for (x = 0; x < 10; x++) {
 					if (player.itemSlots[x].unlocked && player.itemSlots[x].quantity > 0 && typeAcceptableFunction(player.itemSlots[x].itype)) {
-						addButton(x, (player.itemSlots[x].itype.shortName + " x" + player.itemSlots[x].quantity), placeInStorageFunction, x);
+						button(x).showForItemSlot(player.itemSlots[x], curry(placeInStorageFunction, x));
 						foundItem = true;
 					}
 				}
@@ -1621,7 +1624,7 @@ use namespace CoC;
 			if (page == 2) {
 				for (x = 10; x < 20; x++) {
 					if (player.itemSlots[x].unlocked && player.itemSlots[x].quantity > 0 && typeAcceptableFunction(player.itemSlots[x].itype)) {
-						addButton(x-10, (player.itemSlots[x].itype.shortName + " x" + player.itemSlots[x].quantity), placeInStorageFunction, x);
+						button(x-10).showForItemSlot(player.itemSlots[x], curry(placeInStorageFunction, x));
 						foundItem = true;
 					}
 				}
@@ -1644,7 +1647,7 @@ use namespace CoC;
 			if (page == 1) {
 				for (x = 0; x < 10; x++) {
 					if (player.itemSlots[x].unlocked && player.itemSlots[x].quantity > 0 && typeAcceptableFunction(player.itemSlots[x].itype)) {
-						addButton(x, (player.itemSlots[x].itype.shortName + " x" + player.itemSlots[x].quantity), placeInStorageFunction, x);
+						button(x).showForItemSlot(player.itemSlots[x], curry(placeInStorageFunction, x));
 						foundItem = true;
 					}
 				}
@@ -1653,7 +1656,7 @@ use namespace CoC;
 			if (page == 2) {
 				for (x = 10; x < 20; x++) {
 					if (player.itemSlots[x].unlocked && player.itemSlots[x].quantity > 0 && typeAcceptableFunction(player.itemSlots[x].itype)) {
-						addButton(x-10, (player.itemSlots[x].itype.shortName + " x" + player.itemSlots[x].quantity), placeInStorageFunction, x);
+						button(x-10).showForItemSlot(player.itemSlots[x], curry(placeInStorageFunction, x));
 						foundItem = true;
 					}
 				}
@@ -1676,7 +1679,7 @@ use namespace CoC;
 			if (page == 1) {
 				for (x = 0; x < 10; x++) {
 					if (player.itemSlots[x].unlocked && player.itemSlots[x].quantity > 0 && typeAcceptableFunction(player.itemSlots[x].itype)) {
-						addButton(x, (player.itemSlots[x].itype.shortName + " x" + player.itemSlots[x].quantity), placeInStorageFunction, x);
+						button(x).showForItemSlot(player.itemSlots[x], curry(placeInStorageFunction, x));
 						foundItem = true;
 					}
 				}
@@ -1685,7 +1688,7 @@ use namespace CoC;
 			if (page == 2) {
 				for (x = 10; x < 20; x++) {
 					if (player.itemSlots[x].unlocked && player.itemSlots[x].quantity > 0 && typeAcceptableFunction(player.itemSlots[x].itype)) {
-						addButton(x-10, (player.itemSlots[x].itype.shortName + " x" + player.itemSlots[x].quantity), placeInStorageFunction, x);
+						button(x-10).showForItemSlot(player.itemSlots[x], curry(placeInStorageFunction, x));
 						foundItem = true;
 					}
 				}

--- a/classes/classes/Scenes/TestMenu.as
+++ b/classes/classes/Scenes/TestMenu.as
@@ -9,6 +9,7 @@ import classes.BodyParts.*;
 import classes.GeneticMemories.*;
 import classes.GlobalFlags.kFLAGS;
 import classes.Items.*;
+import classes.Items.Dynamic.DynamicWeapon;
 import classes.Scenes.Areas.DeepSea.Kraken;
 import classes.Scenes.Dungeons.D3.Lethice;
 import classes.Scenes.Dungeons.D3.SuccubusGardener;
@@ -129,9 +130,52 @@ public class TestMenu extends BaseContent
 		menuItems.push("NY(S/NS)MA-D", anTrigger, "Now you see or not see me.\n\n<i><b>(Anty-Dexterity)</b></i>");
 		menuItems.push("EvaMutateReq", mutateReqNope, "Turns on/off mutation requirements");
 		//menuItems.push("WeaponsXPtest", SceneLib.dilapidatedShrine.weaponsXPtrader, "");
+		menuItems.push("IdentifyAll", identifyAll, "Identify all items");
+		menuItems.push("UncurseAll", uncurseAll, "Uncurse all items");
 		menuGen(menuItems, page, playerMenu);
 	}
 	
+		private function identifyAll():void {
+			clearOutput();
+			if (player.weapon is DynamicWeapon && !(player.weapon as DynamicWeapon).identified) {
+				player.setWeapon((player.weapon as DynamicWeapon).identifiedCopy());
+				outputText("\nIdentified "+player.weapon.longName);
+			}
+			for (var i:int = 0; i < player.itemSlots.length; i++) {
+				var item:ItemSlotClass = player.itemSlots[i];
+				if (item.unlocked && item.quantity > 0) {
+					if (item.itype is DynamicWeapon && !(item.itype as DynamicWeapon).identified) {
+						player.itemSlots[i].setItemAndQty(
+								(item.itype as DynamicWeapon).identifiedCopy(),
+								item.quantity
+						);
+						outputText("\nIdentified "+item.itype.longName);
+					}
+				}
+			}
+			doNext(curry(SoulforceCheats1, 3));
+		}
+		private function uncurseAll():void {
+			clearOutput();
+			if (player.weapon.cursed && player.weapon is DynamicWeapon) {
+				player.setWeapon((player.weapon as DynamicWeapon).uncursedCopy());
+				outputText("\nUncursed "+player.weapon.longName);
+			}
+			for (var i:int = 0; i < player.itemSlots.length; i++) {
+				var item:ItemSlotClass = player.itemSlots[i];
+				if (item.unlocked && item.quantity > 0 && item.itype.cursed) {
+					if (item.itype is DynamicWeapon) {
+						player.itemSlots[i].setItemAndQty(
+								(item.itype as DynamicWeapon).uncursedCopy(),
+								item.quantity
+						);
+						outputText("\nUncursed "+item.itype.longName);
+					}
+				}
+			}
+			doNext(curry(SoulforceCheats1, 3));
+		}
+		
 	private function anTrigger():void {
 		clearOutput();
 		if (player.hasPerk(PerkLib.AntyDexterity)) {

--- a/classes/classes/Scenes/TestMenu.as
+++ b/classes/classes/Scenes/TestMenu.as
@@ -138,7 +138,7 @@ public class TestMenu extends BaseContent
 		private function identifyAll():void {
 			clearOutput();
 			if (player.weapon is DynamicWeapon && !(player.weapon as DynamicWeapon).identified) {
-				player.setWeapon((player.weapon as DynamicWeapon).identifiedCopy());
+				player.setWeapon((player.weapon as DynamicWeapon).identifiedCopy() as DynamicWeapon);
 				outputText("\nIdentified "+player.weapon.longName);
 			}
 			for (var i:int = 0; i < player.itemSlots.length; i++) {
@@ -158,7 +158,7 @@ public class TestMenu extends BaseContent
 		private function uncurseAll():void {
 			clearOutput();
 			if (player.weapon.cursed && player.weapon is DynamicWeapon) {
-				player.setWeapon((player.weapon as DynamicWeapon).uncursedCopy());
+				player.setWeapon((player.weapon as DynamicWeapon).uncursedCopy() as DynamicWeapon);
 				outputText("\nUncursed "+player.weapon.longName);
 			}
 			for (var i:int = 0; i < player.itemSlots.length; i++) {

--- a/classes/classes/display/BindDisplay.as
+++ b/classes/classes/display/BindDisplay.as
@@ -1,4 +1,4 @@
-package classes.display 
+package classes.display
 {
 import coc.view.BitmapDataSprite;
 import coc.view.Block;
@@ -15,7 +15,7 @@ import flash.display.MovieClip;
 	
 
 	/**
-	 * Defines a composite display object of all the seperate components required to display a 
+	 * Defines a composite display object of all the seperate components required to display a
 	 * single BoundControlMethod, its associated primary and secondary bindings with the buttons
 	 * used to bind methods to new keys.
 	 * @author Gedan
@@ -30,10 +30,10 @@ import flash.display.MovieClip;
 		/**
 		 * Create a new composite object, initilizing the label to be used for display, as well as the two
 		 * buttons used for user interface.
-		 * 
+		 *
 		 * @param	maxWidth	Defines the maximum available width that the control can consume for positining math
 		 */
-		public function BindDisplay(maxWidth:int) 
+		public function BindDisplay(maxWidth:int)
 		{
 			layoutConfig = {
 				type: Block.LAYOUT_GRID,
@@ -47,8 +47,8 @@ import flash.display.MovieClip;
 					font: 'Times New Roman',
 					size: 20,
 					align: 'right'
-		}
-				});
+				}
+			});
 			addElement(_button1 = new CoCButton({
 				labelText: 'Unbound',
 				bitmapClass: MainView.ButtonBackground0

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -78,6 +78,10 @@ public class Utils extends Object
 		public static function objectOr(input:*,def:Object=null):Object {
 			return (input is Object && input !== null) ? input : def;
 		}
+		public static function valueOrThrow(input:*, errorMsg:String="Missing value"):* {
+			if (input === null || input === undefined) throw new Error(errorMsg);
+			return input;
+		}
 		public static function ipow(base:Number,exp:int):Number {
 			// See wiki/Exponentiation_by_squaring
 			if (exp < 0) {
@@ -253,6 +257,7 @@ public class Utils extends Object
 		public static function extend(dest:Object, src:Object, ...srcRest:Array):Object {
 			srcRest.unshift(src);
 			for each(src in srcRest) {
+				if (!src) continue;
 				for (var k:String in src) {
 					if (src.hasOwnProperty(k)) dest[k] = src[k];
 				}
@@ -413,6 +418,21 @@ public class Utils extends Object
 			return returnArray;
 		}
 
+		public static function escapeXml(s:String):String {
+			return s.replace(/[\n\r'"<>&]/g,function ($0:String,...rest):String {
+				switch($0){
+					case '\r': return '&#13;';
+					case '\n': return '&#10;';
+					case "'": return '&apos;';
+					case '"': return '&quot;';
+					case '<': return '&lt;';
+					case '>': return '&gt;';
+					case '&': return '&amp;';
+					default: return $0;
+				}
+			});
+		}
+		
 		public static function num2Text(number:int):String {
 			if (number >= 0 && number <= 10) return NUMBER_WORDS_NORMAL[number];
 			return number.toString();
@@ -537,6 +557,7 @@ public class Utils extends Object
 				return null;
 			}
 			if (pairs.length == 1) {
+				if (!(pairs[0] is Array)) return pairs[0];
 				// imitate spread
 				// 1st argument could be the list of pairs
 				if (pairs[0].length != 2) return weightedRandom.apply(null, pairs[0]);
@@ -816,7 +837,7 @@ public class Utils extends Object
 			PF_TIME[methodName] = (PF_TIME[methodName]|0)+dt;
 			var pfcount:int   = PF_COUNT[methodName];
 			var pfintct:int   = PF_INTCOUNT[PF_DEPTH];
-			PF_INTERNALS[methodName] += pfintct;
+			PF_INTERNALS[methodName] = (PF_INTERNALS[methodName]|0) + pfintct;
 			var args:Array = PF_ARGS[PF_DEPTH];
 			if (shouldReportProfiling(classname,origMethodName,dt, pfcount)) {
 				var s:String = "[PROFILE] ";

--- a/classes/coc/view/Block.as
+++ b/classes/coc/view/Block.as
@@ -4,16 +4,25 @@
 package coc.view {
 import classes.internals.Utils;
 
+import fl.controls.Button;
+
+import fl.controls.ComboBox;
+import fl.controls.LabelButton;
+
 import fl.controls.TextInput;
+import fl.data.DataProvider;
 
 import flash.display.DisplayObject;
 import flash.display.Sprite;
 import flash.events.Event;
+import flash.events.MouseEvent;
 import flash.text.AntiAliasType;
 import flash.text.TextField;
 import flash.text.TextFieldAutoSize;
 import flash.utils.Dictionary;
 import flash.utils.setTimeout;
+
+import mx.controls.CheckBox;
 
 public class Block extends Sprite {
 	public static const ON_LAYOUT:String                       = 'coc$layout';
@@ -31,8 +40,11 @@ public class Block extends Sprite {
 	/**
 	 * Grid layout. Aligns elements in a grid of fixed cell size, fixed cell count
 	 * Config:
-	 * * `rows`, `cols` - number or rows and columns. Default 1
+	 * * `rows` - number of rows. Default 0 (indefinite number, keep adding more rows)
+	 * * `cols` - number of columns. Default 1 (or `columns` size)
+	 * * `columns` - column widths. -1: autosize, 0..1: fraction, >1: pixels. Defaults to 1.0 / rows
 	 * * `setWidth`, `setHeight - should set width/height of elements. Default false
+	 * * `gap` - gap between cells
 	 * Hints:
 	 * * `row`, `col` - 2D position in grid. Defaults to "next cell"
 	 * * `setWidth`, `setHeight - should set width/height of this element. Default to layout config
@@ -41,36 +53,92 @@ public class Block extends Sprite {
 	private function applyGridLayout():void {
 		var config:Object        = _layoutConfig;
 		var ignoreHidden:Boolean = 'ignoreHidden' in config ? config['ignoreHidden'] : false;
-		var rows:Number          = config["rows"] || 1;
-		var cols:Number          = config["cols"] || 1;
+		var rows:Number          = Utils.intOr(config["rows"], 0);
+		var cols:Number          = Utils.intOr(config["cols"], 1);
+		var gap:Number           = Utils.numberOr(config["gap"], 0);
 		var innerw:Number        = innerWidth;
-		var innerh:Number        = innerHeight;
-		var cellw:Number         = innerw / cols;
-		var cellh:Number         = innerh / rows;
+		var columns:Array        = config['columns'];
 		var setcw:Boolean        = config['setWidth'];
 		var setch:Boolean        = config['setHeight'];
-
+		var debug:Boolean        = config['debug'];
+		
+		if (!('cols' in config) && columns) cols = columns.length;
+		innerw -= gap*(cols-1);
+		if (!columns || columns.length != cols) {
+			columns = [];
+			for (var i:int = 0; i < cols; i++) {
+				columns[i] = -1; // 1fr
+			}
+		} else {
+			columns = columns.slice();
+		}
+		// calculate column size
+		var autocols:int = 0;
+		var freespace:Number = innerw;
+		// count autocols and convert fraction widths to pixels
+		for (i = 0; i < cols; i++) {
+			if (columns[i] < 0) {
+				autocols++;
+				continue;
+			} else if (columns[i] <= 1) {
+				// fraction
+				columns[i] *= innerw;
+			} // else size in pixels
+			freespace -= columns[i];
+		}
+		// calculate autocol sizes
+		if (autocols > 0) {
+			for (i = 0; i < cols; i++) {
+				if (columns[i] < 0) columns[i] = freespace/autocols;
+			}
+		}
+		
 		var row:int = 0;
 		var col:int = 0;
+		var grid:Array = [];
+		var innerh:Number = innerHeight - (rows > 1 ? gap*(rows-1) : 0);
+		var cellh:Number  = rows > 0 ? innerh / rows : 0;
 		for (var ci:int = 0, cn:int = _container.numChildren; ci < cn; ci++) {
 			var child:DisplayObject = _container.getChildAt(ci);
 			var hint:Object         = _layoutHints[child] || {};
 			if (hint['ignore'] || !child.visible && ignoreHidden) continue;
-			var setw:Boolean = 'setWidth' in hint ? hint['setWidth'] : setcw;
-			var seth:Boolean = 'setHeight' in hint ? hint['setHeight'] : setch;
 			if ('row' in hint && 'col' in hint) {
 				row = hint['row'];
 				col = hint['col'];
 			}
-			child.x = col * cellw + paddingLeft;
-			child.y = row * cellh + paddingTop;
-			if (setw) child.width = cellw;
-			if (seth) child.height = cellh;
-			col = col + 1;
+			if (!grid[row]) grid[row] = [];
+			grid[row][col] = child;
+			col++;
 			if (col >= cols) {
 				col = 0;
 				row++;
 			}
+		}
+		var y:Number = paddingTop+gap/2;
+		for (row = 0; row < grid.length; row++) {
+			if (!grid[row]) continue;
+			var h:Number = 0;
+			var x:Number = paddingLeft;
+			for (col = 0; col < columns.length; col++) {
+				child = grid[row][col];
+				if (child) {
+					if (debug) trace("[" + row + "][" + col + "] x="+(x|0)+" y="+(y|0)+" w="+(columns[col]|0)+" h="+(cellh|0)+" "+child);
+					var setw:Boolean = 'setWidth' in hint ? hint['setWidth'] : setcw;
+					var seth:Boolean = 'setHeight' in hint ? hint['setHeight'] : setch;
+					child.x          = x + gap / 2;
+					child.y          = y;
+					if (setw) {
+						child.width = columns[col];
+					}
+					if (seth) {
+						child.height = cellh;
+					}
+					if (debug) trace(""+child.x+" "+child.y+" "+child.width+" "+child.height);
+					h = Math.max(h, child.height);
+				}
+				x += columns[col]+gap;
+			}
+			y += h+gap;
 		}
 	}
 	/**
@@ -79,6 +147,7 @@ public class Block extends Sprite {
 	 * `direction` - 'row'|'column'. Defaults to 'row'
 	 * `gap` - Gap between neighbouring elements. Defaults to 2.
 	 * `ignoreHidden` defaults to true
+	 * `stretch` - Stretch children horizontally (column mode) or vertically (row mode). Default false
 	 * Hints:
 	 * `before`, `after` - Additional gap before/after that element. May be negative
 	 */
@@ -87,23 +156,30 @@ public class Block extends Sprite {
 		var config:Object        = _layoutConfig;
 		var ignoreHidden:Boolean = 'ignoreHidden' in config ? config['ignoreHidden'] : true;
 		var dir:String           = config['direction'] || 'row';
+		var stretch:Boolean      = config['stretch'];
 		var gap:Number           = 'gap' in config ? config['gap'] : 2;
 		var x:Number             = paddingLeft;
 		var y:Number             = paddingTop;
+		var column:Boolean       = dir === 'column';
 		for (var ci:int = 0, cn:int = _container.numChildren; ci < cn; ci++) {
 			var child:DisplayObject = _container.getChildAt(ci);
 			var hint:Object         = _layoutHints[child] || {};
 			if (hint['ignore'] || !child.visible && ignoreHidden) continue;
+			var stretchChild:Boolean = Utils.valueOr(hint["stretch"], stretch);
 			var before:Number = 'before' in hint ? hint['before'] : 0;
-			if (dir == 'column') {
+			if (column) {
 				y += before;
 			} else {
 				x += before;
 			}
 			child.x          = x;
 			child.y          = y;
+			if (stretchChild) {
+				if (column) child.width = innerWidth;
+				else child.height = innerHeight;
+			}
 			var after:Number = 'after' in hint ? hint['after'] : 0;
-			if (dir == 'column') {
+			if (column) {
 				y += child.height + after + gap;
 			} else {
 				x += child.width + after + gap;
@@ -167,6 +243,7 @@ public class Block extends Sprite {
 		}
 	}
 	private function resize():void {
+		invalidateLayout();
 		if (width > 0 || height > 0) {
 			graphics.clear();
 			graphics.beginFill(0, 0);
@@ -301,6 +378,7 @@ public class Block extends Sprite {
 		return e;
 	}
 	public function addTextField(options:Object, hint:Object = null):TextField {
+		if (options is String) return addTextField({text:options});
 		var e:TextField = new TextField();
 		e.antiAliasType = AntiAliasType.ADVANCED;
 		if ('defaultTextFormat' in options) {
@@ -317,9 +395,82 @@ public class Block extends Sprite {
 		addElement(e, hint);
 		return e;
 	}
+	
+	/**
+	 * Create text input
+	 * @param options TextInput properties
+	 * @param options.bindText [object, keyName]. On change set object[keyName]=value
+	 * @param options.bindNumber [object, keyName]. On change set object[keyName]=parseFloat(value) if not NaN
+	 * @param hint Layout hint
+	 */
 	public function addTextInput(options:Object, hint:Object = null):TextInput {
 		var e:TextInput = new TextInput();
 		UIUtils.setProperties(e, options);
+		if ('bindText' in options) {
+			var obj:Object = options.bindText[0];
+			var key:String = options.bindText[1];
+			e.text = obj[key];
+			e.addEventListener(Event.CHANGE, function(event:Event):void {
+				obj[key] = e.text;
+			});
+		} else if ('bindNumber' in options) {
+			obj = options.bindNumber[0];
+			key = options.bindNumber[1];
+			e.text = obj[key];
+			e.addEventListener(Event.CHANGE, function(event:Event):void {
+				var value:Number = parseFloat(e.text);
+				if (!isNaN(value)) obj[key] = value;
+			});
+		}
+		addElement(e, hint);
+		return e;
+	}
+	
+	/**
+	 * Create dropdown list
+	 * @param options ComboBox properties
+	 * @param options.items Array of objects or primitives to select from
+	 * @param options.labelKey Item property name to use as label, default "label"
+	 * @param options.valueKey Item property name to use as value, default "data"
+	 * @param options.bindValue [object, propname]. On change set object[propname] to selected item
+	 * @param hint Layout hint
+	 */
+	public function addComboBox(options:Object, hint:Object = null):ComboBox {
+		var e:ComboBox = new ComboBox();
+		UIUtils.setProperties(e, options, {value:null});
+		var labelKey:String = Utils.valueOr(options["labelKey"], "label");
+		var valueKey:String = Utils.valueOr(options["valueKey"], "data");
+		var selectedIndex:int = 0;
+		var selectedValue:*;
+		var bindObject:Object;
+		var bindProp:String;
+		if ('bindValue' in options) {
+			bindObject = options.bindValue[0];
+			bindProp = options.bindValue[1];
+			selectedValue = bindObject[bindProp];
+		} else if ('value' in options) {
+			selectedValue = options.value;
+		}
+		var i:int=0;
+		var items:Array = [];
+		for each (var item:* in options.items) {
+			var entry:Object;
+			if (item is Object && !(item is String) && item != null) {
+				entry = {label:item[labelKey], data:item[valueKey]}
+			} else {
+				entry = {label:""+item, data:item}
+			}
+			if (entry.data == selectedValue) selectedIndex = i;
+			items.push(entry);
+			i++;
+		}
+		e.dataProvider = new DataProvider(items);
+		if (bindObject) {
+			e.addEventListener(Event.CHANGE, function(event:Event):void {
+				event.preventDefault();
+				bindObject[bindProp] = e.selectedItem.data;
+			})
+		}
 		addElement(e, hint);
 		return e;
 	}

--- a/classes/coc/view/ButtonData.as
+++ b/classes/coc/view/ButtonData.as
@@ -3,6 +3,8 @@
  */
 package coc.view {
 import classes.CoC;
+import classes.ItemSlotClass;
+import classes.ItemType;
 import classes.PerkLib;
 import classes.StatusEffects;
 
@@ -13,6 +15,7 @@ public class ButtonData {
 	public var visible:Boolean = true;
 	public var toolTipHeader:String = "";
 	public var toolTipText:String = "";
+	public var labelColor:String = CoCButton.DEFAULT_COLOR;
 	public function ButtonData(text:String, callback:Function =null, toolTipText:String ="", toolTipHeader:String ="") {
 		this.text = text;
 		this.callback = callback;
@@ -43,6 +46,21 @@ public class ButtonData {
 		if (this.enabled && condition) {
 			disable(toolTipText,toolTipHeader, text);
 		}
+		return this;
+	}
+	public function color(color:String):ButtonData {
+		labelColor = color;
+		return this;
+	}
+	public function forItem(item:ItemType):ButtonData {
+		text = item.shortName;
+		hint(item.longName, item.description);
+		labelColor = item.buttonColor;
+		return this;
+	}
+	public function forItemSlot(slot:ItemSlotClass):ButtonData {
+		forItem(slot.itype);
+		if (slot.itype.stackSize > 1 || slot.quantity > 1) text += " x"+slot.quantity;
 		return this;
 	}
 	public function applyTo(btn:CoCButton):void {

--- a/classes/coc/view/CoCButton.as
+++ b/classes/coc/view/CoCButton.as
@@ -11,6 +11,8 @@ package coc.view {
  keyboard events.
  ****/
 
+import classes.ItemSlotClass;
+import classes.ItemType;
 import classes.internals.Utils;
 import flash.text.Font;
 import flash.text.TextField;
@@ -31,6 +33,7 @@ public class CoCButton extends Block {
 	 * function(error:Error, button:CoCButton):void
 	 */
 	public static var clickErrorHandler:Function;
+	public static const DEFAULT_COLOR:String = "#000000";
 
 	private var _labelField:TextField,
 				_backgroundGraphic:BitmapDataSprite,
@@ -149,6 +152,7 @@ public class CoCButton extends Block {
 	 * @return this
 	 */
 	public function show(text:String,callback:Function,toolTipText:String="",toolTipHeader:String=""):CoCButton {
+		this.reset();
 		this.labelText     = text;
 		this.callback      = callback;
 		this.toolTipText = toolTipText;
@@ -161,7 +165,37 @@ public class CoCButton extends Block {
             this.toolTipHeader = Parser.recursiveParser(this.toolTipHeader);
 		this.visible       = true;
 		this.enabled       = (this.callback != null);
-		this.alpha         = 1;
+		return this;
+	}
+	
+	public function color(rgb:String):CoCButton {
+		this._labelField.textColor = Color.convertColor(rgb);
+		return this;
+	}
+	/**
+	 * Set color, text, and hint from the item
+	 */
+	public function itemTexts(item:ItemType):CoCButton {
+		text(item.shortName, item.description, item.longName);
+		color(item.buttonColor);
+		return this;
+	}
+	/**
+	 * Set color, text, and hint from the item slot
+	 */
+	public function itemSlotTexts(slot:ItemSlotClass):CoCButton {
+		itemTexts(slot.itype);
+		if (slot.quantity > 1 || slot.itype.stackSize > 1) labelText += " x"+slot.quantity;
+		return this;
+	}
+	public function showForItem(item:ItemType, callback:Function):CoCButton {
+		show(item.shortName, callback);
+		itemTexts(item);
+		return this;
+	}
+	public function showForItemSlot(slot:ItemSlotClass, callback:Function):CoCButton {
+		show(slot.itype.shortName, callback);
+		itemSlotTexts(slot);
 		return this;
 	}
 	/**
@@ -226,6 +260,18 @@ public class CoCButton extends Block {
 	 */
 	public function call(fn:Function,...args:Array):CoCButton {
 		this.callback = Utils.curry.apply(null,[fn].concat(args));
+		return this;
+	}
+	
+	public function reset():CoCButton {
+		color(DEFAULT_COLOR);
+		visible       = false;
+		labelText     = "";
+		toolTipHeader = "";
+		toolTipText   = "";
+		alpha         = 1;
+		enabled       = false;
+		callback      = null;
 		return this;
 	}
 	/**

--- a/classes/coc/view/MainView.as
+++ b/classes/coc/view/MainView.as
@@ -377,7 +377,7 @@ public class MainView extends Block {
 			}
 		});
 		mainText.addEventListener(TextEvent.LINK, function(e:TextEvent):void {
-			if (linkHandler != null) linkHandler(e.text);
+			if (linkHandler != null) linkHandler(decodeURI(e.text));
 		});
 		scrollBar = new UIScrollBar();
 		UIUtils.setProperties(scrollBar,{

--- a/classes/coc/view/MainView.as
+++ b/classes/coc/view/MainView.as
@@ -577,7 +577,7 @@ public class MainView extends Block {
 		var button:CoCButton = this.bottomButtons[index] as CoCButton;
 		// Should error.
 		if (!button) return null;
-		return button.hide();
+		return button.reset();
 	}
 
 	public function hideCurrentBottomButtons():void {

--- a/classes/coc/view/ToolTipView.as
+++ b/classes/coc/view/ToolTipView.as
@@ -31,23 +31,24 @@ import flash.text.TextFieldAutoSize;
 				stretch: true,
 				bitmapClass: tooltipBg
 			});
-			this.ln = addBitmapDataSprite({
-				x:15,y:40,
-				width: WIDTH-30,
-				height:1,
-				fillColor:'#000000'
-			});
 			this.hd = addTextField({
 				x:15,y:15,
 				width: WIDTH-34,
-				height: 25.35,
+				//height: 25.35,
 				multiline:true,
-				wordWrap:false,
+				autosize: TextFieldAutoSize.LEFT,
+				wordWrap:true,
 				embedFonts:true,
 				defaultTextFormat:{
 					size: 18,
 					font: CoCButton.ButtonLabelFontName
 				}
+			});
+			this.ln = addBitmapDataSprite({
+				x:15,y:40,
+				width: WIDTH-30,
+				height:1,
+				fillColor:'#000000'
 			});
 			this.tf = addTextField({
 				x:15,y:40,
@@ -70,7 +71,7 @@ import flash.text.TextFieldAutoSize;
 			} else if (this.x + this.width > mainView.width) {
 				this.x = mainView.width - this.width; // right border
 			}
-			bg.height = Math.max(tf.height + 63, MIN_HEIGHT);
+			resize();
 			if (by+bh < mainView.height/2) {
 				// put to the bottom
 				this.y = by + bh;
@@ -91,6 +92,7 @@ import flash.text.TextFieldAutoSize;
 
 		public function set header(newText:String):void {
 			this.hd.htmlText = newText || '';
+			resize();
 		}
 
 		public function get header():String {
@@ -99,10 +101,17 @@ import flash.text.TextFieldAutoSize;
 		
 		public function set text(newText:String):void {
 			this.tf.htmlText = newText || '';
+			resize();
 		}
 
 		public function get text():String {
 			return this.tf.htmlText;
+		}
+		
+		private function resize():void {
+			this.ln.y = Math.max(40, this.hd.x + this.hd.textHeight);
+			this.tf.y = this.ln.y;
+			bg.height = Math.max(tf.textHeight + tf.y + 23, MIN_HEIGHT);
 		}
 	}
 }

--- a/classes/coc/view/UIUtils.as
+++ b/classes/coc/view/UIUtils.as
@@ -33,9 +33,11 @@ public class UIUtils {
 			if (key.indexOf('on') == 0) {
 				e.addEventListener(key.substr(2), Utils.bindThis(options[key] as Function, e));
 			} else if (options.hasOwnProperty(key) && key in e) {
-				var spc:Function = special ? special[key] as Function : null;
-				var value:*     = options[key];
-				e[key] = spc != null ? spc(value) : value;
+				var spcobj:* = special ? special[key] : undefined;
+				if (spcobj === null) continue;
+				var spc:Function = spcobj as Function;
+				var value:*      = options[key];
+				e[key]           = spc != null ? spc(value) : value;
 			}
 		}
 		return e;

--- a/devTools/saveEditor/CoCXSaveEditor.html
+++ b/devTools/saveEditor/CoCXSaveEditor.html
@@ -1974,7 +1974,7 @@
 				this.perks = Object.values(perkmap);
 				this.perkmap = perkmap;
 				for (let entry of Object.values(perkmap)) {
-					let unlocks = Gamedata.perks[entry.id].unlocks;
+					let unlocks = Gamedata.perks[entry.id]?.unlocks;
 					if (unlocks && unlocks.length>0) {
 						entry.children = unlocks.map(id=>perkmap[id]).sortBy("name");
 					}


### PR DESCRIPTION
Enchanted item system.
New content is hidden in debug menu, but there's lot of internal changes to bugtest.

Noticeable changes:
* Tooltip header can be multiline. Tooltip stretches vertically if text is long.
* Equipment in inventory is clickable, displays tooltips
* Debug menu > Spawn Item > Enchanted to create enchanted item
* Cheat menu has "Identify all" & "Uncurse all"

For coders:
* Buttons can be colored
* Added button methods showForItem/showForItemStack. They apply item label, color, and hint. **Use them whenever you display an item-related button!**
* Added ItemType.stackSize (default 5)
* Added universal "cursed" flag for any item. Cursed weapons cannot be unequipped.
* Added Player.allEquipment - array of all equipped items
* Added Utils.valueOrThrow
* Added mkLink to return `<a>` with param (like printLink but returns instead of printing).