### PR TITLE
Split trainable part from primary stat core

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -139,12 +139,12 @@ import coc.view.MainView;
             }
 
 			model.player = player;
-			player.strStat.core.value = 15;
-			player.touStat.core.value = 15;
-			player.speStat.core.value = 15;
-			player.intStat.core.value = 15;
-			player.wisStat.core.value = 15;
-			player.libStat.core.value = 15;
+			player.strStat.train.value = 15;
+			player.touStat.train.value = 15;
+			player.speStat.train.value = 15;
+			player.intStat.train.value = 15;
+			player.wisStat.train.value = 15;
+			player.libStat.train.value = 15;
 			player.sensStat.redefine({base:15});
 			player.cor = 15;
 			player.soulforce = 50;
@@ -545,8 +545,8 @@ import coc.view.MainView;
 		private function isAMan():void {
 			//Attributes
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] == 0) {
-				player.strStat.core.value += 3;
-				player.touStat.core.value += 2;
+				player.strStat.train.value += 3;
+				player.touStat.train.value += 2;
 			}
 			//Body attributes
 			player.fertility = 5;
@@ -572,8 +572,8 @@ import coc.view.MainView;
 		private function isAWoman():void {
 			//Attributes
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] == 0) {
-				player.speStat.core.value += 3;
-				player.intStat.core.value += 2;
+				player.speStat.train.value += 3;
+				player.intStat.train.value += 2;
 			}
 			//Body attributes
 			player.fertility = 10;
@@ -599,10 +599,10 @@ import coc.view.MainView;
 		private function isAHerm():void {
 			//Attributes
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] == 0) {
-				player.strStat.core.value += 1;
-				player.touStat.core.value += 1;
-				player.speStat.core.value +=1;
-				player.intStat.core.value += 1;
+				player.strStat.train.value += 1;
+				player.touStat.train.value += 1;
+				player.speStat.train.value +=1;
+				player.intStat.train.value += 1;
 			}
 			//Body attributes
 			player.fertility = 10;
@@ -634,8 +634,8 @@ import coc.view.MainView;
 
 
 		private function buildLeanMale():void {
-			player.strStat.core.value -= 1;
-			player.speStat.core.value += 1;
+			player.strStat.train.value -= 1;
+			player.speStat.train.value += 1;
 
 			player.femininity = 34;
 			player.thickness = 30;
@@ -648,8 +648,8 @@ import coc.view.MainView;
 		}
 
 		private function buildSlenderFemale():void {
-			player.strStat.core.value -= 1;
-			player.speStat.core.value += 1;
+			player.strStat.train.value -= 1;
+			player.speStat.train.value += 1;
 
 			player.femininity = 66;
 			player.thickness = 30;
@@ -682,9 +682,9 @@ import coc.view.MainView;
 		}
 
 		private function buildThickMale():void {
-			player.speStat.core.value -= 4;
-			player.strStat.core.value += 2;
-			player.touStat.core.value += 2;
+			player.speStat.train.value -= 4;
+			player.strStat.train.value += 2;
+			player.touStat.train.value += 2;
 
 			player.femininity = 29;
 			player.thickness = 70;
@@ -697,9 +697,9 @@ import coc.view.MainView;
 		}
 
 		private function buildCurvyFemale():void {
-			player.speStat.core.value -= 2;
-			player.strStat.core.value += 1;
-			player.touStat.core.value += 1;
+			player.speStat.train.value -= 2;
+			player.strStat.train.value += 1;
+			player.touStat.train.value += 1;
 
 			player.femininity = 71;
 			player.thickness = 70;
@@ -711,8 +711,8 @@ import coc.view.MainView;
 		}
 
 		private function buildGirlyMale():void {
-			player.strStat.core.value -= 2;
-			player.speStat.core.value += 2;
+			player.strStat.train.value -= 2;
+			player.speStat.train.value += 2;
 
 			player.femininity = 50;
 			player.thickness = 50;
@@ -725,8 +725,8 @@ import coc.view.MainView;
 		}
 
 		private function buildTomboyishFemale():void {
-			player.strStat.core.value += 1;
-			player.speStat.core.value -= 1;
+			player.strStat.train.value += 1;
+			player.speStat.train.value -= 1;
 
 			player.femininity = 56;
 			player.thickness = 50;

--- a/classes/classes/CharSpecial.as
+++ b/classes/classes/CharSpecial.as
@@ -243,10 +243,10 @@ import classes.Items.*;
 			player.createStatusEffect(StatusEffects.KnowsBlind,0,0,0,0);
 			player.createStatusEffect(StatusEffects.KnowsWhitefire,0,0,0,0);
 			//magic, 50 Int, 50 tough, Speed 15, Str 10, 30 corruption, 30 libido, 10 sensitivity.
-			player.intStat.core.value = 50;
-			player.touStat.core.value = 50;
-			player.strStat.core.value = 10;
-			player.libStat.core.value = 30;
+			player.intStat.train.value = 50;
+			player.touStat.train.value = 50;
+			player.strStat.train.value = 10;
+			player.libStat.train.value = 30;
 			player.cor = 30;
 			outputText("As a wandering mage you, had found your way into no small amount of trouble in the search for knowledge.  A strange tome here, a ritual there, most people found your pale form unsettling. They would be further troubled if they could see your feet!  Lets not even begin on the blood magic.  Yes, your interest in examining every aspect of magic has run you down a strange path, so when you wandered into Ingnam and began to hear of the exile of the Champion, and the superstitions that surrounded it you were intrigued, as every little rumor and ritual often had a grain of truth.  You snuck into the cave prior to the ritual, where the old man supposedly led every Champion, and there you found a strange portal that emanated a certain degree of spacial transparency -  more than the portal's own.  Within it must have been a whole new world!  Throwing caution to the wind, your curiosities engulfing you, you dove in with nary a thought for the consequences.");
 		}
@@ -301,7 +301,7 @@ import classes.Items.*;
 
 		private function customCharlie():void {
 			outputText("You're strong, smart, fast, and tough.  It also helps that you've got four dongs, well beyond what others have lurking in their trousers.  With your wings, bow, weapon, and tough armor, you're a natural for protecting the town.");
-			player.touStat.core.value += 2;
+			player.touStat.train.value += 2;
 			player.fertility = 5;
 			player.hairLength= 26;
 			player.hairColor    = "blond";
@@ -336,11 +336,11 @@ import classes.Items.*;
 			//Tone 90
 			player.tone = 90;
 			//Int 50 (if possible)
-			player.intStat.core.value = 50;
+			player.intStat.train.value = 50;
 			//Str/Tou/Spd 25 (if possible)
-			player.strStat.core.value = 25;
-			player.touStat.core.value = 25;
-			player.speStat.core.value = 25;
+			player.strStat.train.value = 25;
+			player.touStat.train.value = 25;
+			player.speStat.train.value = 25;
 			//Bow
 			//player.createKeyItem("Bow",0,0,0,0);
 			player.setWeaponRange(weaponsrange.BOWOLD_);
@@ -386,7 +386,7 @@ import classes.Items.*;
 			//-Chainmail armor
 			player.setArmor(armors.FULLCHN);
 			//-Large Claymore (i understand 40 Strength is need so if he could start with that would be great if not hit the gyms)"
-			player.strStat.core.value = 40;
+			player.strStat.train.value = 40;
 			player.setWeapon(weapons.CLAYMOR);
 		}
 
@@ -423,7 +423,7 @@ import classes.Items.*;
 
 			//Stats: (if possible)
 			//Strength: 90
-			player.strStat.core.value = 90;
+			player.strStat.train.value = 90;
 			//Fertility: 100
 			player.fertility = 100;
 			player.cor = 25;
@@ -460,7 +460,7 @@ import classes.Items.*;
 		private function customIsaac():void {
 			outputText("Born of a disgraced priestess, Isaac was raised alone until she was taken by illness.  He worked a number of odd jobs until he was eventually chosen as champion.");
 			//- gift: fast
-			player.speStat.core.value += 5;
+			player.speStat.train.value += 5;
 			player.tone += 10;
 			player.createPerk(PerkLib.Fast, 1, 0, 0, 0);
 			//- history: religion
@@ -557,9 +557,9 @@ import classes.Items.*;
 			player.fertility = 10;
 			player.hips.type = 8;
 			player.butt.type = 8;
-			player.speStat.core.value = 18;
-			player.intStat.core.value = 17;
-			player.wisStat.core.value = 17;
+			player.speStat.train.value = 18;
+			player.intStat.train.value = 17;
+			player.wisStat.train.value = 17;
 			player.cor = 0;
 			player.HP = EngineCore.maxHP();
 			player.hairLength=13;
@@ -633,8 +633,8 @@ import classes.Items.*;
 			player.balls = 4;
 			player.cumMultiplier = 8;
 			player.ballSize = 2;
-			player.strStat.core.value = 18;
-			player.touStat.core.value = 17;
+			player.strStat.train.value = 18;
+			player.touStat.train.value = 17;
 			player.cor = 0;
 			player.HP = EngineCore.maxHP();
 			player.hairLength = 1;
@@ -675,8 +675,8 @@ import classes.Items.*;
 			//#226096893686530
 			//For the custom PC Profile can you make a Bimbo Bunny girl (no bunny feet) (named Mara) dont really care about clothes i can get what i want pretty quickly and I change from time to time.
 			outputText("You're a bunny-girl with bimbo-tier curves, jiggly and soft. A curvy, wet girl with a bit of a flirty past.");
-			player.speStat.core.value += 3;
-			player.intStat.core.value += 2;
+			player.speStat.train.value += 3;
+			player.intStat.train.value += 2;
 			player.clitLength = .5;
 			player.tone = 30;
 			player.fertility = 10;
@@ -708,11 +708,11 @@ import classes.Items.*;
 			//I'm kinda going under the assumption you are letting us go hog wild if not, take what's allowed and do what you wish out of what's below
 			outputText("The portal is not something you fear, not with your imposing armor and inscribed spellblade.  You're much faster and stronger than every champion that came before you, but will it be enough?");
 			//Core Stats:
-			player.strStat.core.value = 40;
-			player.touStat.core.value = 20;
-			player.speStat.core.value = 100;
-			player.intStat.core.value = 80;
-			player.libStat.core.value = 25;
+			player.strStat.train.value = 40;
+			player.touStat.train.value = 20;
+			player.speStat.train.value = 100;
+			player.intStat.train.value = 80;
+			player.libStat.train.value = 25;
 
 			//Body Values:
 			//breastRows
@@ -762,9 +762,9 @@ import classes.Items.*;
 		private function customMirvanna():void {
 			//Any equine or dragonny attributes accompanying it a big plus! As I'm a dragon-unicorn furry (Qilin~). Bonus points if you add a horns type for unicorn horns.
 			outputText("You're an equine dragon-herm with a rather well-proportioned body.  Ingnam is certainly going to miss having you whoring yourself out around town.  You don't think they'll miss cleaning up after all the messy sex, though.");
-			player.speStat.core.value += 3;
-			player.intStat.core.value += 2;
-			player.strStat.core.value += 3;
+			player.speStat.train.value += 3;
+			player.intStat.train.value += 2;
+			player.strStat.train.value += 3;
 			player.clitLength = .5;
 			player.fertility = 20;
 			player.hairLength= 15;
@@ -869,9 +869,9 @@ import classes.Items.*;
 			player.femininity = 75;
 			player.butt.type = 7;
 			player.hips.type = 7;
-			player.intStat.core.value = 40;
-			player.strStat.core.value = 20;
-			player.speStat.core.value = 25;
+			player.intStat.train.value = 40;
+			player.strStat.train.value = 20;
+			player.speStat.train.value = 25;
 
 			clearOutput();
 			outputText("Your exotic appearance caused you some trouble growing up, but you buried your nose in books until it came time to go through the portal.");
@@ -888,7 +888,7 @@ import classes.Items.*;
 			player.setArmor(armors.FULLPLT);
 			//-Large Claymore (i understand 40 Strength is need so if he could start with that would be great if not hit the gyms)"
 			player.setWeapon(weapons.CLAYMOR);
-			player.strStat.core.value = 40;
+			player.strStat.train.value = 40;
 			//femininity: 95
 			player.femininity = 95;
 			//(0 lust cum production: 10000)
@@ -1007,8 +1007,8 @@ import classes.Items.*;
 			player.fertility = 45;
 			player.hips.type = 6;
 			player.butt.type = 6;
-			player.speStat.core.value = 18;
-			player.intStat.core.value += 2;
+			player.speStat.train.value = 18;
+			player.intStat.train.value += 2;
 			player.cor = 0;
 			player.HP = EngineCore.maxHP();
 			player.skin.restore();
@@ -1051,7 +1051,7 @@ import classes.Items.*;
 			////"	"I'm picturing a tall, feminine German-Shepherd morph, solid white and gorgeous. She has both sets of genitals, with no balls, and a large set of breasts. She wields a large claymore and is dressed in a full chain vest and pants.
 			//large claymore (and the strength to use it)
 			player.setWeapon(weapons.CLAYMOR);
-			player.strStat.core.value = 40;
+			player.strStat.train.value = 40;
 			//full chain
 			player.setArmor(armors.FULLCHN);
 			outputText("As a German-Shepherd morph, the rest of the village never really knew what to do with you... until they sent you through the portal to face whatever's on the other side...");
@@ -1062,7 +1062,7 @@ import classes.Items.*;
 			player.createVagina();
 			player.clitLength = 0.25;
 			player.fertility = 4;
-			player.speStat.core.value += 20;
+			player.speStat.train.value += 20;
 			outputText("You're more of a scout than a fighter, but you still feel confident you can handle your responsibilities as champion.  After all, what's to worry about when you can outrun everything you encounter?  You have olive skin, deep red hair, and a demonic tail and wings to blend in with the locals.");
 			//Perk is speed, she was a scout, and it'd be neat (if possible) to give her something akin to the Runner perk. She might not start out very strong or tough, but at least she's fast.
 			player.createPerk(PerkLib.Fast, 1, 0, 0, 0);
@@ -1115,8 +1115,8 @@ import classes.Items.*;
 
 		private function customSera():void {
 			outputText("You're something of a shemale - three rows of C-cup breasts matched with three, plump, juicy cocks.  Some decent sized balls, bat wings, and cat-like ears round out the package.");
-			player.touStat.core.value += 2;
-			player.strStat.core.value += 3;
+			player.touStat.train.value += 2;
+			player.strStat.train.value += 3;
 			player.fertility = 5;
 			player.hairLength= 26;
 			player.hairColor    = "white";
@@ -1201,11 +1201,11 @@ import classes.Items.*;
 			//human face
 			//no tail, fur, or scales"
 			flags[kFLAGS.HISTORY_PERK_SELECTED] = 0;
-			player.strStat.core.value = 25;
-			player.touStat.core.value = 25;
-			player.speStat.core.value = 25;
-			player.intStat.core.value = 25;
-			player.wisStat.core.value = 25;
+			player.strStat.train.value = 25;
+			player.touStat.train.value = 25;
+			player.speStat.train.value = 25;
+			player.intStat.train.value = 25;
+			player.wisStat.train.value = 25;
 			outputText("You are a literal angel from beyond, and you take the place of a village's champion in the name of celestial intervention.");
 		}
 
@@ -1216,7 +1216,7 @@ import classes.Items.*;
 			player.ears.type = Ears.FOX;
 			player.tailType = Tail.FOX;
 			player.tailCount = 2;
-			player.intStat.core.value = 30;
+			player.intStat.train.value = 30;
 			if(!player.hasStatusEffect(StatusEffects.BonusVCapacity)) player.createStatusEffect(StatusEffects.BonusVCapacity,0,0,0,0);
 			else player.addStatusValue(StatusEffects.BonusVCapacity,1, 5 + rand(10));
 			outputText("As a Kitsune, you always got weird looks, but none could doubt your affinity for magic...");
@@ -1235,9 +1235,9 @@ import classes.Items.*;
 			player.cocks[0].cockType = CockTypesEnum.DRAGON;
 			player.cocks[0].knotMultiplier = 1.3;
 			player.createBreastRow();
-			player.strStat.core.value = 20;
-			player.touStat.core.value = 30;
-			player.speStat.core.value = 40;
+			player.strStat.train.value = 20;
+			player.touStat.train.value = 30;
+			player.speStat.train.value = 40;
 			player.gems += 300;
 			player.tone = 60;
 			player.femininity = 30;
@@ -1252,7 +1252,7 @@ import classes.Items.*;
 			player.createPerk(PerkLib.BloodlineKitsune,0,0,0,0);
 			if (player.hasVagina()) player.vaginas[0].virgin = true;
 			if (!player.hasPerk(PerkLib.PastLifeAlchemist)) player.createPerk(PerkLib.HistoryAlchemist,0,0,0,0);
-			player.intStat.core.value = 30;
+			player.intStat.train.value = 30;
 			outputText("As a Kitsune, you always got weird looks, but none could doubt your affinity for magic...");
 		}
 
@@ -1261,7 +1261,7 @@ import classes.Items.*;
 			player.createPerk(PerkLib.BloodlineMinotaur,0,0,0,0);
 			if (player.hasVagina()) player.vaginas[0].virgin = true;
 			if (!player.hasPerk(PerkLib.PastLifeAlchemist)) player.createPerk(PerkLib.HistoryAlchemist,0,0,0,0);
-			player.intStat.core.value = 30;
+			player.intStat.train.value = 30;
 			outputText("As a Kitsune, you always got weird looks, but none could doubt your affinity for magic...");
 		}
 
@@ -1297,8 +1297,8 @@ import classes.Items.*;
 			player.hips.type = 6;
 			player.createVagina();
 			player.vaginas[0].virgin = true;
-			player.intStat.core.value = 40;
-			player.wisStat.core.value = 40;
+			player.intStat.train.value = 40;
+			player.wisStat.train.value = 40;
 			player.gems += 250;
 			player.tallness = 45;
 			player.tone = 30;
@@ -1322,7 +1322,7 @@ import classes.Items.*;
 			//Character Creation	Female,virgin	A human with raiju bloodline	Sora
 			player.createPerk(PerkLib.BloodlineRaiju,0,0,0,0);
 			if(player.hasVagina()) player.vaginas[0].virgin = true;
-			player.intStat.core.value = 30;
+			player.intStat.train.value = 30;
 			outputText("As a Kitsune, you always got weird looks, but none could doubt your affinity for magic...");
 		}
 
@@ -1330,7 +1330,7 @@ import classes.Items.*;
 			//Character Creation	Female,virgin	A human with oni bloodline	Sora(tone at 100, fighter past story + second for fight too? oni beard necklace?)keeping titanic strength perk at any race score? start with this event perk?
 			player.createPerk(PerkLib.BloodlineOni,0,0,0,0);
 			if(player.hasVagina()) player.vaginas[0].virgin = true;
-			player.intStat.core.value = 30;
+			player.intStat.train.value = 30;
 			outputText("As a Kitsune, you always got weird looks, but none could doubt your affinity for magic...");
 		}
 
@@ -1345,12 +1345,12 @@ import classes.Items.*;
 			player.fertility = 50;
 			player.hips.type = 6;
 			player.butt.type = 6;
-			player.strStat.core.value = 100;
-			player.touStat.core.value = 100;
-			player.speStat.core.value = 100;
-			player.intStat.core.value = 100;
-			player.wisStat.core.value = 100;
-			player.libStat.core.value = 30;
+			player.strStat.train.value = 100;
+			player.touStat.train.value = 100;
+			player.speStat.train.value = 100;
+			player.intStat.train.value = 100;
+			player.wisStat.train.value = 100;
+			player.libStat.train.value = 30;
 			player.cor = 71;
 			player.HP = EngineCore.maxHP();
 			player.hairLength = 10;
@@ -1524,8 +1524,8 @@ import classes.Items.*;
 			player.nippleLength = 3.5;
 			//Perks: Slut and Fertile"
 
-			player.speStat.core.value += 3;
-			player.intStat.core.value += 2;
+			player.speStat.train.value += 3;
+			player.intStat.train.value += 2;
 
 			if (!player.hasPerk(PerkLib.PastLifeSlut)) player.createPerk(PerkLib.HistorySlut, 0, 0, 0, 0);
 			player.createPerk(PerkLib.Fertile, 1.5, 0, 0, 0);
@@ -1540,8 +1540,8 @@ import classes.Items.*;
 			player.fertility = 25;
 			player.hips.type = 6;
 			player.butt.type = 6;
-			player.speStat.core.value = 18;
-			player.intStat.core.value = 17;
+			player.speStat.train.value = 18;
+			player.intStat.train.value = 17;
 			player.cor = 0;
 			player.HP = EngineCore.maxHP();
 			player.hairLength = 10;
@@ -1630,10 +1630,10 @@ import classes.Items.*;
 			player.itemSlot7.unlocked = true;
 			player.itemSlot8.unlocked = true;
 			if (!player.hasPerk(PerkLib.PastLifeSlacker)) player.createPerk(PerkLib.HistorySlacker,0,0,0,0);
-			player.strStat.core.value += 4;
-			player.touStat.core.value += 4;
-			player.intStat.core.value += 2;
-			player.speStat.core.value += 2;
+			player.strStat.train.value += 4;
+			player.touStat.train.value += 4;
+			player.intStat.train.value += 2;
+			player.speStat.train.value += 2;
 			player.gems += 300;
 			outputText("You're something of a powerhouse, and you wager that between your odd mutations, power strong enough to threaten the village order, and talents, you're the natural choice to send through the portal.");
 		}
@@ -1675,10 +1675,10 @@ import classes.Items.*;
 			player.createStatusEffect(StatusEffects.KnowsManyBirds,0,0,0,0);
 			player.createStatusEffect(StatusEffects.KnowsBlind,0,0,0,0);
 			player.createStatusEffect(StatusEffects.KnowsWhitefire,0,0,0,0);
-			player.intStat.core.value = 40;
-			player.touStat.core.value = 25;
-			player.speStat.core.value = 20;
-			player.libStat.core.value = 30;
+			player.intStat.train.value = 40;
+			player.touStat.train.value = 25;
+			player.speStat.train.value = 20;
+			player.libStat.train.value = 30;
 			player.cor = 30;
 			outputText("You have been fascinated with magic as long as you can remember.  The villagers humored this at first, regaling you with stories about mages of old and providing â€œspellbooksâ€� that were more superstition than fact.  When you learned to cast whitefire without any instruction, the villagers got worried. Your salvation came in the form of a traveling mage, a hero himself in his youth. He provided the apprenticeship you craved and focused your eccentricities into mastering the art of magical healing.  While you had earned yourself a respectable livelihood well before your coming of age, your fascination with the unnatural has always unnerved your friends and neighbors.  One year, an unknown disease passed through the town.  You saw this peculiar sickness as a challenge, and devised a spell to neutralize it.  ");
 			outputText("While you saved several lives, a handful of villagers died before you bested the plague. Rumors spread that you used their deaths to fuel unnatural rituals, bringing all the fear and suspicion focused on you over the years to a crux.  Your trial was swift, but you accepted the outcome without a second thought.  Whatever lay beyond that portal, you knew it would fall to your powers.");
@@ -1742,11 +1742,11 @@ import classes.Items.*;
 			player.horns.type = Horns.DRACONIC_X2; // draconic horns adds to your exotic look, counts towards dragon score and keeps your tentacle hair out of your face! and your partners can use them as handles on occasions, letting your delicate ears uncrumpled!
 			player.horns.count = 12;
 			player.wings.type = Wings.DRACONIC_LARGE; // wings! to fly!
-			player.strStat.core.value = 5; // strength? not a kitsune way, besides, you are small and really neglected physical training
-			player.speStat.core.value += 5; // can take some advantage from small frame
-			player.intStat.core.value = 55; // your mind is your power!
-			player.wisStat.core.value = 55; // your mind is your power!
-			player.libStat.core.value = 85; // yes, you have problems
+			player.strStat.train.value = 5; // strength? not a kitsune way, besides, you are small and really neglected physical training
+			player.speStat.train.value += 5; // can take some advantage from small frame
+			player.intStat.train.value = 55; // your mind is your power!
+			player.wisStat.train.value = 55; // your mind is your power!
+			player.libStat.train.value = 85; // yes, you have problems
 			player.cor += 31; // have high initial corruption, but also have religious history to meditate
 			// bow and concealing leather armor with robes, also can handle rapier well, but doesn't have one
 			if (player.armor.isNothing || player.armor == armors.C_CLOTH) player.setArmor(armors.LTHRROB); // you like concealing clothes, your body is your masterpiece, but your extra benefits are more fun when not expected... ok, you are a bit shy of your tentacles
@@ -1935,7 +1935,7 @@ import classes.Items.*;
 			player.beardStyle = 0;
 
 			// wrecked body and obsessed mind...
-			player.intStat.core.value = 60;
+			player.intStat.train.value = 60;
 			//player.sens = 15;
 			//player.lib = 15;
 			player.cor += 2;

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -69,7 +69,7 @@ public class CoC extends MovieClip
     public var date:Date = new Date();
 
     //Mod save version.
-    public var modSaveVersion:Number = 36.024;
+    public var modSaveVersion:Number = 36.025;
     public var levelCap:Number = 185;
 
     //Lock cheats menus from public builds.

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -423,16 +423,27 @@ public class Creature extends Utils
 		public function get wis():Number { return Math.round(wisStat.value); }
 		public function get lib():Number { return Math.round(libStat.value); }
 
-		public function trainStat(statName: String, amount: Number, limit: Number):void {
+		public function canTrain(statName: String, limit:Number):Boolean {
 			var stat:PrimaryStat = statStore.findStat(statName) as PrimaryStat;
-			if (stat.core.value < limit){
-				stat.core.value += amount;
-				if (stat.core.value > limit){
-					stat.core.value = limit;
+			return stat.train.value < limit;
+		}
+		
+		/**
+		 * Increase stat `statName`'s train component by `amount`, up to `limit`.
+		 * @return true if stat was changed
+		 */
+		public function trainStat(statName: String, amount: Number, limit: Number):Boolean {
+			var stat:PrimaryStat = statStore.findStat(statName) as PrimaryStat;
+			if (stat.train.value < limit){
+				stat.train.value += amount;
+				if (stat.train.value > limit){
+					stat.train.value = limit;
 				}
 				CoC.instance.mainView.statsView.refreshStats(CoC.instance);
 				CoC.instance.mainView.statsView.showStatUp(statName);
+				return true;
 			}
+			return false;
 		}
 
 		/**
@@ -1526,12 +1537,12 @@ public class Creature extends Utils
 			breastRows    = [];
 			_perks        = new PerkManager(this);
 			_statusEffects = new StatusEffectManager(this);
-			this.strStat.core.value = 15;
-			this.touStat.core.value = 15;
-			this.speStat.core.value = 15;
-			this.intStat.core.value = 15;
-			this.wisStat.core.value = 15;
-			this.libStat.core.value = 15;
+			this.strStat.train.value = 15;
+			this.touStat.train.value = 15;
+			this.speStat.train.value = 15;
+			this.intStat.train.value = 15;
+			this.wisStat.train.value = 15;
+			this.libStat.train.value = 15;
 			//keyItems = new Array();
 		}
 

--- a/classes/classes/Items/Armor.as
+++ b/classes/classes/Items/Armor.as
@@ -47,6 +47,7 @@ public class Armor extends Equipable
 			var list:Array = super.effectDescriptionParts();
 			// Type
 			var type:String;
+			var name:String = this.name.toLowerCase();
 			if (name.indexOf("armor") >= 0 || name.indexOf("armour") >= 0 || name.indexOf("chain") >= 0 || name.indexOf("mail") >= 0 || name.indexOf("plates") >= 0) {
 				type = "Armor ";
 				if (perk == "Light" || perk == "Medium") {

--- a/classes/classes/Items/Consumables/HoneydewCake.as
+++ b/classes/classes/Items/Consumables/HoneydewCake.as
@@ -26,15 +26,15 @@ public class HoneydewCake extends Consumable {
 		clearOutput();
 		outputText("You scarf down the sweet cake, feeling a bit of a sugar high.");
 		//Strength up to 125
-		if ((player.str < player.strStat.max && player.str < 125)&& (changes < changeLimit && rand(3) == 0)) {
+		if (player.canTrain('str',100)&& (changes < changeLimit && rand(3) == 0)) {
 			changes++;
-            player.trainStat("str", +1, 125);
+            player.trainStat("str", +1, 100);
 			outputText("\n\nAfter eating the cake, your muscles suddenly feel sore, as though you just lifted heavy weights. You're probably stronger.");
 		}
 		//Toughness up to 125
-		if ((player.tou < player.touStat.max && player.tou < 125) && (changes < changeLimit && rand(3) == 0)) {
+		if (player.canTrain('tou', 100) && (changes < changeLimit && rand(3) == 0)) {
 			outputText("\n\nAfter eating the cake, a soreness starts building up in your arms, as though you just blocked a boxer's punches. As it goes away, you feel like you've gotten tougher.");
-            player.trainStat("tou", +1, 200);
+            player.trainStat("tou", +1, 100);
 			changes++;
 		}
         if (player.inte > 50 && changes < changeLimit && rand(3) == 0) {
@@ -70,7 +70,7 @@ public class HoneydewCake extends Consumable {
 			player.MutagenBonus("spe", 3);
 			changes++;
 		}
-        //oviposition 
+        //oviposition
         if (changes < changeLimit && player.hasCoatOfType(Skin.CHITIN) && !player.hasPerk(PerkLib.AntOvipositor) && player.tailType == Tail.ANT_ABDOMEN && rand(2) == 0) {
             CoC.instance.transformations.OvipositorAnt.applyEffect();
             changes++;

--- a/classes/classes/Items/WeaponLib.as
+++ b/classes/classes/Items/WeaponLib.as
@@ -184,7 +184,7 @@ public final class WeaponLib extends ItemConstants
 		public const WDSTAFF:Weapon = new Weapon("WDStaff", "WardensStaff", "Warden’s staff", "a Warden’s staff", "smack", 10, 1600, "This staff looks ordinary up until the crystal at its tip, which is attached by tendrils grown from the staff’s body. The sacred wood faintly seethes with arcane power, and the light within the crystal pulses to the tempo of Yggdrasil's song.", "Staff", WT_STAFF)
 				.withBuffs({
 					'spellpower': +0.6,
-					'soulskillpower': +0.4
+					'msoulskillpower': +0.4
 				})
 				.withPerk(PerkLib.MageWarden) as Weapon;
 		public const WGSWORD:Wardensgreatsword = new Wardensgreatsword();

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -85,12 +85,12 @@ public class PlayerEvents extends BaseContent implements TimeAwareInterface {
 			}
 			//Normal
 			if (!player.hasPerk(PerkLib.WellAdjusted)) {
-				dynStats("lus", player.libStat.core.value * 0.04, "scale", false); //Raise lust
-				if (player.hasPerk(PerkLib.Lusty)) dynStats("lus", player.libStat.core.value * 0.01, "scale", false); //Double lust rise if lusty.
+				dynStats("lus", player.libStat.totalCore * 0.04, "scale", false); //Raise lust
+				if (player.hasPerk(PerkLib.Lusty)) dynStats("lus", player.libStat.totalCore * 0.01, "scale", false); //Double lust rise if lusty.
 			}
 			else { //Well adjusted perk
-				dynStats("lus", player.libStat.core.value * 0.02, "scale", false); //Raise lust
-				if (player.hasPerk(PerkLib.Lusty)) dynStats("lus", player.libStat.core.value * 0.005, "scale", false); //Double lust rise if lusty.
+				dynStats("lus", player.libStat.totalCore * 0.02, "scale", false); //Raise lust
+				if (player.hasPerk(PerkLib.Lusty)) dynStats("lus", player.libStat.totalCore * 0.005, "scale", false); //Double lust rise if lusty.
 			}
 			//Jewelry effect
 			if (player.jewelryEffectId == JewelryLib.CORRUPTION)

--- a/classes/classes/PlayerInfo.as
+++ b/classes/classes/PlayerInfo.as
@@ -14,6 +14,8 @@ import classes.Scenes.NPCs.ZenjiScenes;
 import classes.Scenes.Places.HeXinDao.JourneyToTheEast;
 import classes.Scenes.Places.Mindbreaker;
 import classes.Scenes.SceneLib;
+import classes.Stats.PrimaryStat;
+import classes.Stats.StatUtils;
 import classes.StatusEffects.VampireThirstEffect;
 
 import coc.view.MainView;
@@ -1442,29 +1444,27 @@ public class PlayerInfo extends BaseContent {
 		clearOutput();
 		outputText("You have <b>" + (player.statPoints) + "</b> left to spend.\n\n");
 
-		outputText("Strength: ");
-		if (player.strStat.core.value < player.strStat.core.max) outputText("" + Math.floor(player.strStat.core.value) + " + <b>" + player.tempStr + "</b> → " + Math.floor(player.strStat.core.value + player.tempStr) + " Total "+Math.floor((player.strStat.core.value + player.tempStr + player.strStat.bonus.value) * player.strStat.mult.value)+"\n");
-		else outputText("" + Math.floor(player.strStat.core.value) + " (Maximum)\n");
-
-		outputText("Toughness: ");
-		if (player.touStat.core.value < player.touStat.core.max) outputText("" + Math.floor(player.touStat.core.value) + " + <b>" + player.tempTou + "</b> → " + Math.floor(player.touStat.core.value + player.tempTou) + " Total "+Math.floor((player.touStat.core.value + player.tempTou + player.touStat.bonus.value) * player.touStat.mult.value)+"\n");
-		else outputText("" + Math.floor(player.touStat.core.value) + " (Maximum)\n");
-
-		outputText("Speed: ");
-		if (player.speStat.core.value < player.speStat.core.max) outputText("" + Math.floor(player.speStat.core.value) + " + <b>" + player.tempSpe + "</b> → " + Math.floor(player.speStat.core.value + player.tempSpe) + " Total "+Math.floor((player.speStat.core.value + player.tempSpe + player.speStat.bonus.value) * player.speStat.mult.value)+"\n");
-		else outputText("" + Math.floor(player.speStat.core.value) + " (Maximum)\n");
-
-		outputText("Intelligence: ");
-		if (player.intStat.core.value < player.intStat.core.max) outputText("" + Math.floor(player.intStat.core.value) + " + <b>" + player.tempInt + "</b> → " + Math.floor(player.intStat.core.value + player.tempInt) + " Total "+Math.floor((player.intStat.core.value + player.tempInt + player.intStat.bonus.value) * player.intStat.mult.value)+"\n");
-		else outputText("" + Math.floor(player.intStat.core.value) + " (Maximum)\n");
-
-		outputText("Wisdom: ");
-		if (player.wisStat.core.value < player.wisStat.core.max) outputText("" + Math.floor(player.wisStat.core.value) + " + <b>" + player.tempWis + "</b> → " + Math.floor(player.wisStat.core.value + player.tempWis) + " Total "+Math.floor((player.wisStat.core.value + player.tempWis + player.wisStat.bonus.value) * player.wisStat.mult.value)+"\n");
-		else outputText("" + Math.floor(player.wisStat.core.value) + " (Maximum)\n");
-
-		outputText("Libido: ");
-		if (player.libStat.core.value < player.libStat.core.max) outputText("" + Math.floor(player.libStat.core.value) + " + <b>" + player.tempLib + "</b> → " + Math.floor(player.libStat.core.value + player.tempLib) + " Total "+Math.floor((player.libStat.core.value + player.tempLib + player.libStat.bonus.value) * player.libStat.mult.value)+"\n");
-		else outputText("" + Math.floor(player.libStat.core.value) + " (Maximum)\n");
+		var primaryStats:Array = [player.strStat,player.touStat,player.speStat,player.intStat,player.wisStat,player.libStat];
+		var tempStats:Array = [player.tempStr,player.tempTou,player.tempSpe,player.tempInt,player.tempWis,player.tempLib];
+		for (var i:int = 0; i < primaryStats.length; i++) {
+			var stat:PrimaryStat = primaryStats[i];
+			outputText(StatUtils.nameOfStat(stat.statName)+": ");
+			// print either
+			// ( core + points -> newCore) x multiplier% + training&bonus = Total
+			// core x multiplie%r + training&bonus = Total (Maximum)
+			if (stat.core.value < stat.core.max) {
+				outputText("(" + stat.core.value +" + <b>"+tempStats[i]+"</b> → "+(stat.core.value+tempStats[i])+")")
+			} else {
+				outputText(""+stat.core.value);
+			}
+			outputText(" × "+floor(stat.mult.value*100)+"%");
+			outputText(" + " + floor(stat.train.value + stat.bonus.value));
+			outputText(" = " + floor(
+					(stat.core.value + tempStats[i]) * stat.mult.value + stat.train.value + stat.bonus.value
+			));
+			if (stat.core.value >= stat.core.max) outputText(" (Maximum)");
+			outputText("\n");
+		}
 
 		menu();
 		//Add

--- a/classes/classes/SaveUpdater.as
+++ b/classes/classes/SaveUpdater.as
@@ -14,7 +14,9 @@ import classes.Items.*;
 import classes.Scenes.*;
 import classes.Scenes.NPCs.*;
 import classes.Scenes.Places.HeXinDao.AdventurerGuild;
+import classes.Scenes.Places.HeXinDao.JourneyToTheEast;
 import classes.Stats.Buff;
+import classes.Stats.PrimaryStat;
 
 use namespace CoC;
 
@@ -461,13 +463,8 @@ public class SaveUpdater extends NPCAwareContent {
 	private var initialVersion:Number;
 	public function promptSaveUpdate():void {
 		clearOutput();
+		doNext(camp.doCamp); //safeguard
 		initialVersion = flags[kFLAGS.MOD_SAVE_VERSION];
-		saveUpdatePre35();
-		saveUpdate35();
-		saveUpdate36();
-		camp.doCamp();
-	}
-	private function saveUpdatePre35():void {
 		if (flags[kFLAGS.MOD_SAVE_VERSION] < 2) {
 			flags[kFLAGS.MOD_SAVE_VERSION] = 2;
 			outputText("<b><u>CAUTION</u></b>\n");
@@ -1370,8 +1367,6 @@ public class SaveUpdater extends NPCAwareContent {
 			doNext(camp.doCamp);
 			return;
 		}
-	}
-	private function saveUpdate35():void {
 		if (int(flags[kFLAGS.MOD_SAVE_VERSION]) == 35) { //now using float to store versions!
 			clearOutput();
 			if (flags[kFLAGS.MOD_SAVE_VERSION] < 35.001) {
@@ -1533,8 +1528,6 @@ public class SaveUpdater extends NPCAwareContent {
 			doNext(camp.doCamp);
 			return;
 		}
-	}
-	private function saveUpdate36():void {
 		if (int(flags[kFLAGS.MOD_SAVE_VERSION]) == 36) {
 			clearOutput();
 			if (flags[kFLAGS.MOD_SAVE_VERSION] < 36.001) {
@@ -1847,6 +1840,76 @@ public class SaveUpdater extends NPCAwareContent {
 					player.perkPoints += 1;
 				}
 				flags[kFLAGS.MOD_SAVE_VERSION] = 36.024;
+			}
+			if (flags[kFLAGS.MOD_SAVE_VERSION] < 36.025) {
+				// Split existing core stats into core + train
+				// - Refund core points
+				// - Compute how much total training pc did
+				// - Try to re-allocate training, maintain the ratio between stats
+				var primaryStats:/*PrimaryStat*/Array = [player.strStat,player.touStat,player.speStat,player.intStat,player.wisStat,player.libStat];
+				
+				var oldCoreTotal:int = 0;
+				var oldCoreStats:/*int*/Array = [0,0,0,0,0,0];
+				outputText("\n\nStat rework! Training is separated from level-up, <b>but no longer benefits from multipliers</b>.\nOld core stat values:")
+				for (i = 0; i < primaryStats.length; i++) {
+					var stat:PrimaryStat = primaryStats[i];
+					oldCoreTotal += stat.core.value;
+					oldCoreStats[i] = stat.core.value;
+					outputText(" "+stat.core.value);
+					stat.core.value = 0;
+				}
+				outputText(" = total "+oldCoreTotal+".");
+				
+				// Compute total stat points spent
+				var statPoints:int = player.level*5;
+				if (player.level <= 6) statPoints += player.level*5; else statPoints += 6*5;
+				statPoints -= player.statPoints;
+				statPoints -= JourneyToTheEast.AhriStatsToPerksConvertCounter*5;
+				statPoints += JourneyToTheEast.EvelynnPerksToStatsConvertCounter*5;
+				
+				var totalTrainPoints:int = oldCoreTotal - statPoints;
+				var remainingTrainPoints:int = totalTrainPoints;
+				// Re-allocate training stats, maintaining ratio
+				for (i = 0; i < primaryStats.length; i++) {
+					stat = primaryStats[i];
+					// ratio
+					var x:Number = (oldCoreStats[i] - 15) / (oldCoreTotal - 6 * 15);
+					// don't train over max or old value
+					x = Math.min(stat.train.max, 15 + int(x*(totalTrainPoints-6*15)), oldCoreStats[i]);
+					remainingTrainPoints -= x;
+					stat.train.value = x;
+				}
+				// Leftover points
+				while (remainingTrainPoints > 0) {
+					// Count trainable stats (not maxed, below old value) and split reamining points evenly
+					n = 0;
+					for (i = 0; i < primaryStats.length; i++) {
+						stat = primaryStats[i];
+						if (stat.train.value < stat.train.max && stat.train.value < oldCoreStats[i]) n++;
+					}
+					if (n == 0) break;
+					for (i = 0; i < primaryStats.length; i++) {
+						stat = primaryStats[i];
+						if (stat.train.value < stat.train.max && stat.train.value < oldCoreStats[i]) {
+							x = int(remainingTrainPoints/n+0.999); // round up
+							// don't train over max or old value
+							x = Math.min(x, stat.train.max - stat.train.value, oldCoreStats[i] - stat.train.value);
+							if (x > 0) {
+								stat.train.value += x;
+								remainingTrainPoints -= x;
+								n--;
+							}
+						}
+					}
+				}
+				outputText("\nRe-allocated " + (totalTrainPoints - remainingTrainPoints) + " training points:");
+				for (i = 0; i < primaryStats.length; i++) {
+					outputText(" "+primaryStats[i].train.value);
+				}
+				
+				player.statPoints += statPoints;
+				outputText("\n\n<b>Your have " + statPoints + " stat points refunded. Don't forget to allocate them</b>.")
+				flags[kFLAGS.MOD_SAVE_VERSION] = 36.025;
 			}
 			outputText("\n\n<i>Save</i> version updated to " + flags[kFLAGS.MOD_SAVE_VERSION] + "\n");
 			doNext(camp.doCamp);

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -2494,7 +2494,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		//Set soulforce
 		if (saveFile.data.soulforce == undefined) player.soulforce = 25;
 		//Set wisdom
-		if (saveFile.data.wis == undefined) player.wisStat.core.value = 15;
+		if (saveFile.data.wis == undefined) player.wisStat.train.value = 15;
 		//Set wrath
 		if (saveFile.data.wrath == undefined) player.wrath = 0;
 		//Set mana

--- a/classes/classes/Scenes/Areas/Ashlands.as
+++ b/classes/classes/Scenes/Areas/Ashlands.as
@@ -102,9 +102,8 @@ use namespace CoC;
 				default:
 					clearOutput();
 					outputText("You spend one hour exploring ashlands but you don't manage to find anything interesting.");
-					if (player.tou < 50){
+					if (player.trainStat("tou", +1, 50)){
 						outputText("But on your way back you feel you're a little more used to traveling through this harsh area.");
-						player.trainStat("tou", +1, 50);
 					}
 					dynStats("tou", .5);
 					doNext(camp.returnToCampUseOneHour);

--- a/classes/classes/Scenes/Areas/Desert.as
+++ b/classes/classes/Scenes/Areas/Desert.as
@@ -266,13 +266,13 @@ use namespace CoC;
 			//Chance of boost == 50%
 			if (rand(2) == 0) {
 				//50/50 strength/toughness
-				if (rand(2) == 0 && player.str < 50) {
+				if (rand(2) == 0 && player.canTrain('str', 50)) {
 					outputText("The effort of struggling with the uncertain footing has made you stronger.");
 					player.trainStat("str", 1, 50);
 					dynStats("str", .5);
 				}
 				//Toughness
-				else if (player.tou < 50) {
+				else if (player.canTrain('tou', 50)) {
 					outputText("The effort of struggling with the uncertain footing has made you tougher.");
 					player.trainStat("tou", 1, 50);
 					dynStats("tou", .5);

--- a/classes/classes/Scenes/Areas/GlacialRift.as
+++ b/classes/classes/Scenes/Areas/GlacialRift.as
@@ -226,7 +226,7 @@ use namespace CoC;
 				default:
 					clearOutput();
 					outputText("You spend an hour trudging through the bleak and bitingly cold glaciers but you don’t find anything interesting. ");
-					if (player.tou < 50){
+					if (player.canTrain('tou', 50)){
 						outputText("But on your way back you feel you're a little more used to traveling through this harsh area.");
 						player.trainStat("tou", +1, 50);
 					}

--- a/classes/classes/Scenes/Areas/Lake.as
+++ b/classes/classes/Scenes/Areas/Lake.as
@@ -114,7 +114,7 @@ use namespace CoC;
 			//Build choice list.
 			//==================================================
 			//COMMON EVENTS
-			if (player.level < 3 || player.speStat.core.value < 50) choice[choice.length] = 0;
+			if (player.level < 3 || player.canTrain('spe',50)) choice[choice.length] = 0;
 			choice[choice.length] = 1;
 			choice[choice.length] = 2;
 			//Fetish cultist not encountered till level 3
@@ -236,7 +236,7 @@ use namespace CoC;
 			else if (select == 0) {
 				clearOutput();
 				outputText("Your quick walk along the lakeshore feels good.");
-				if (player.speStat.core.value < 50) {
+				if (player.canTrain('spe', 50)) {
 					outputText("  You bet you could cover the same distance even faster next time.\n");
 					player.trainStat("spe",+1,50);
 				}

--- a/classes/classes/Scenes/Areas/Tundra.as
+++ b/classes/classes/Scenes/Areas/Tundra.as
@@ -3,7 +3,7 @@
  * Area with lvl 40-55 enemies.
  * Currently a Work in Progress
  */
-package classes.Scenes.Areas 
+package classes.Scenes.Areas
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
@@ -19,7 +19,7 @@ use namespace CoC;
 		public var valkyrieScene:ValkyrieScene = new ValkyrieScene();
 		public var alrauneScene:AlrauneScene = new AlrauneScene();
 		
-		public function Tundra() 
+		public function Tundra()
 		{
 		}
 		
@@ -95,7 +95,7 @@ use namespace CoC;
 				default:
 					clearOutput();
 					outputText("You spend one hour exploring tundra but you don't manage to find anything interesting.");
-					if (player.tou < 50){
+					if (player.canTrain('tou', 50)){
 						outputText("But on your way back you feel you're a little more used to traveling through this harsh area.");
 						player.trainStat("tou", +1, 50);
 					}

--- a/classes/classes/Scenes/Areas/VolcanicCrag.as
+++ b/classes/classes/Scenes/Areas/VolcanicCrag.as
@@ -4,7 +4,7 @@
  * This zone was mentioned in Glacial Rift doc.
  */
 
-package classes.Scenes.Areas 
+package classes.Scenes.Areas
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
@@ -18,7 +18,7 @@ public class VolcanicCrag extends BaseContent
 		public var behemothScene:BehemothScene = new BehemothScene();
 		public var phoenixScene:PhoenixScene = new PhoenixScene();
 		
-		public function VolcanicCrag() 
+		public function VolcanicCrag()
 		{
 		}
 		
@@ -104,7 +104,7 @@ public class VolcanicCrag extends BaseContent
 				default:
 					clearOutput();
 					outputText("You spend one hour exploring the infernal landscape but you don't manage to find anything interesting.");
-					if (player.spe < 50){
+					if (player.canTrain('spe', 50)){
 						outputText(" Despite this you this time you managed walk a little further inside this place than the last time.");
 						player.trainStat("spe", +1, 50);
 					}

--- a/classes/classes/Scenes/NPCs/AlvinaFollower.as
+++ b/classes/classes/Scenes/NPCs/AlvinaFollower.as
@@ -764,7 +764,7 @@ public function alvinaCampStudy():void
 		outputText("\"<i>Still daydreaming in the middle of my lectures [name]?</i>\"\n\n");
 		outputText("You quickly jerk back into action to show you're listening. Alvina resumes explaining the universal principle of how to channel desire into power. You learn a lot, but the way she flaunts her body, and the many innuendos she punctuates the lesson with, make you flush red in arousal.  During the entire lesson, your teacher is teasing you, ");
 		outputText("and there's nothing you can do about it but wait patiently for the end of the lecture. By the time you get to doing something practical, you are so aroused you feel your lust rise uncontrollably just from casting those spells as wild fantasies assault your mind.\n\n");
-		if (player.intStat.core.value > 80 && player.libStat.core.value > 80 && flags[kFLAGS.ALVINA_FOLLOWER] == 15) {
+		if (player.intStat.train.value > 80 && player.libStat.train.value > 80 && flags[kFLAGS.ALVINA_FOLLOWER] == 15) {
 			outputText("You finally achieved complete mastery over your lust, conquering your arousal and turning it into a weapon to use against your foe as you unleash a massive blast of black magic on the target dummy.\n\n");
 			outputText("\"<i>Very good [name], you finally achieved mastery of the theory. Tomorrow we will discuss more advanced principles.</i>\" She dismisses you with these congratulations as you head back to camp feeling both sexy and powerful.\n\n");
 			player.createStatusEffect(StatusEffects.AlvinaTraining, 0, 0, 0, 0);
@@ -772,7 +772,7 @@ public function alvinaCampStudy():void
 			player.trainStat("int",4,100)
 			player.trainStat("lib",4,100)
 			flags[kFLAGS.ALVINA_FOLLOWER] = 16;
-		} else if (player.intStat.core.value > 50 && player.libStat.core.value > 50 && flags[kFLAGS.ALVINA_FOLLOWER] == 14) {
+		} else if (player.intStat.train.value > 50 && player.libStat.train.value > 50 && flags[kFLAGS.ALVINA_FOLLOWER] == 14) {
 			outputText("Against all odds, you manage to hold your lust in check and cast the spells properly.\n\n");
 			outputText("\"<i>That will be all for today [name], we will continue tomorrow.</i>\" You head back to camp feeling extremely pent-up, but also smarter.\n\n");
 			dynStats("inte", 7, "lib", 7, "cor", 2);

--- a/classes/classes/Scenes/NPCs/JojoScene.as
+++ b/classes/classes/Scenes/NPCs/JojoScene.as
@@ -2678,29 +2678,29 @@ public function apparantlyJojoDOESlift():void
 		outputText(enlightenedBlurbs[rand(enlightenedBlurbs.length)] + "\n\n");
 	}
 	//Boost attributes!
-	if (player.strStat.core.value < 50) {
+	if (player.canTrain('str', 50)) {
 		dynStats("str", 1); //Str boost to 45
-		player.strStat.core.value += .5;
+		player.trainStat('str', .5, 50);
 	}
-	if (player.strStat.core.value < 80) {
+	if (player.canTrain('str', 80)) {
 		dynStats("str", 1); //Str boost to 45
-		player.strStat.core.value += .5;
+		player.trainStat('str', .5, 80);
 	}
-	if (player.intStat.core.value < 50){
+	if (player.canTrain('int', 50)){
 		dynStats("int", 1); //Int boost to 80
-		player.intStat.core.value += .5;
+		player.trainStat('int', .5, 80);
 	}
-	if (player.intStat.core.value < 80){
+	if (player.canTrain('int', 80)){
 		dynStats("int", 1); //Int boost to 80
-		player.intStat.core.value += .5;
+		player.trainStat('int', .5, 80);
 	}
-	if (player.wisStat.core.value < 50){
+	if (player.canTrain('wis', 50)){
 		dynStats("wis", 1); //Wisdom boost to 100
-		player.wisStat.core.value += .5;
+		player.trainStat('wis', .5, 50);
 	}
-	if (player.wisStat.core.value < 100){
+	if (player.canTrain('wis', 100)){
 		dynStats("wis", 1); //Wisdom boost to 100
-		player.wisStat.core.value += .5;
+		player.trainStat('wis', .5, 100);
 	}
 	doNext(camp.returnToCampUseOneHour);
 }

--- a/classes/classes/Scenes/NPCs/JoyScene.as
+++ b/classes/classes/Scenes/NPCs/JoyScene.as
@@ -939,9 +939,7 @@ import classes.lists.Gender;
 				dynStats("lus", 20);
 			}
 			//Increase strength
-			if (player.strStat.core.value < 50){
-				player.strStat.core.value += 1;
-			}
+			player.trainStat('str', 1, 50);
 			dynStats("str", 0.5);
 			fatigue(40);
 			doNext(camp.returnToCampUseOneHour);

--- a/classes/classes/Scenes/NPCs/LunaFollower.as
+++ b/classes/classes/Scenes/NPCs/LunaFollower.as
@@ -336,10 +336,10 @@ public class LunaFollower extends NPCAwareContent implements SaveableState
 			if (flags[kFLAGS.LUNA_MOON_CYCLE] == 8) bonusStats += 40;
 			if (!player.hasPerk(PerkLib.Lycanthropy)) player.createPerk(PerkLib.Lycanthropy,bonusStats,0,0,0);
 			player.statStore.replaceBuffObject({ 'str': bonusStats,'tou': bonusStats,'spe': bonusStats}, 'Lycanthropy', { text: 'Lycanthropy'});
-			player.strStat.core.value += 5;
-			player.touStat.core.value += 5;
-			player.speStat.core.value += 5;
-			player.libStat.core.value += 5;
+			player.trainStat('str', +5, 100);
+			player.trainStat('tou', +5, 100);
+			player.trainStat('spe', +5, 100);
+			player.trainStat('lib', +5, 100);
 			player.dynStats("cor", 20);
 			statScreenRefresh();
 			outputText("The process complete, you begin seething with newfound strength, of body and of lust. You push out of Luna's embrace, reeling backward, but quickly lunge at her again. She emits a half-frightened, half-aroused yip as you bowl her over, with you on top. Your pack-mate, your bitch... you must take her, make her yours... NOW!\n\n");

--- a/classes/classes/Scenes/Places/Farm.as
+++ b/classes/classes/Scenes/Places/Farm.as
@@ -571,27 +571,24 @@ public function exploreFarm():void {
 		//Less than 30 speed (+2 speed)
 		if(player.spe100 < 30) {
 			dynStats("spe", 2);
-			player.trainStat("spe", 1, 50);
 			outputText("Whitney easily outpaces you, leaving you so far behind that she laps around the farm twice for each pass you make.");
 		}
 		//Less than 50 speed (+1 speed)
 		else if(player.spe100 < 50) {
 			dynStats("spe", 1);
-			player.trainStat("spe", 1, 50);
 			outputText("Whitney is still faster than you, and manages to get far enough ahead of you to disappear from time to time.");
 		}
 		//Less than 70 speed (+.75 speed)
 		else if(player.spe100 < 70) {
 			dynStats("spe", .75);
-			player.trainStat("spe", 1, 50);
 			outputText("Whitney and you are evenly matched, and the two of you run together for a while, each pushing yourself harder in an effort to best the other.");
 		}
 		//Else (+.5 speed)
 		else {
 			dynStats("spe", .5);
-			player.trainStat("spe", 1, 50);
 			outputText("Whitney falls behind, unable to cope with your speed as you tear around the farm.");
 		}
+		player.trainStat("spe", 1, 50);
 		outputText("\n\nAfterwards, both of you lie back against a tree, panting heavily and exchanging pleasantries.  Once you've both had a chance to rest, she bids you farewell and returns to her labors, leaving you to journey home to camp.");
 		doNext(camp.returnToCampUseOneHour);
 		return;

--- a/classes/classes/Stats/CoreStat.as
+++ b/classes/classes/Stats/CoreStat.as
@@ -5,7 +5,7 @@ import classes.Monster;
 
 public class CoreStat extends RawStat{
 	public function CoreStat(host:Creature, name:String) {
-		super(host, name, {min:1, value:1, max: 100});
+		super(host, name, {min:0, value:0, max: 100});
 	}
 	
 	override public function get max():Number {

--- a/classes/classes/Stats/PrimaryStat.as
+++ b/classes/classes/Stats/PrimaryStat.as
@@ -8,6 +8,7 @@ import classes.internals.Utils;
 
 public class PrimaryStat implements IStat,IStatHolder,Jsonable {
 	private var _core:RawStat;
+	private var _train:RawStat;
 	private var _mult:BuffableStat;
 	private var _bonus:BuffableStat;
 	private var _name:String;
@@ -16,6 +17,7 @@ public class PrimaryStat implements IStat,IStatHolder,Jsonable {
 	
 	public function reset(core:Number):void {
 		_core.value = core;
+		_train.value = 0;
 		_mult.removeAllBuffs();
 		_bonus.removeAllBuffs();
 	}
@@ -31,6 +33,9 @@ public class PrimaryStat implements IStat,IStatHolder,Jsonable {
 	public function get core():RawStat {
 		return _core;
 	}
+	public function get train():RawStat {
+		return _train;
+	}
 	public function get mult():BuffableStat {
 		return _mult;
 	}
@@ -44,10 +49,12 @@ public class PrimaryStat implements IStat,IStatHolder,Jsonable {
 		_name = name;
 		_host = host;
 		_core = new CoreStat(host,name+'.core');
+		_train = new TrainingStat(host, name+'.train');
 		_mult = new BuffableStat(host,name+'.mult', {base:1.0,min:0});
 		_bonus = new BuffableStat(host,name+'.bonus', {});
 		_substats = {
 			"core": _core,
+			"train": _train,
 			"mult": _mult,
 			"bonus": _bonus
 		};
@@ -72,18 +79,22 @@ public class PrimaryStat implements IStat,IStatHolder,Jsonable {
 		return Utils.keys(_substats);
 	}
 	public function get value():Number {
-		return Math.max(min, core.value * mult.value + bonus.value);
+		return Math.max(min, core.value * mult.value + train.value + bonus.value);
+	}
+	public function get totalCore():Number {
+		return Math.max(min, core.value + train.value);
 	}
 	public function get min():Number {
 		return 1;
 	}
 	public function get max():Number {
-		return core.max * mult.value + Math.max(0, bonus.value);
+		return core.max * mult.value + train.max + Math.max(0, bonus.value);
 	}
 	
 	public function saveToObject():Object {
 		return {
 			core:core.saveToObject(),
+			train:train.saveToObject(),
 			mult:mult.saveToObject(),
 			bonus:bonus.saveToObject()
 		};
@@ -93,6 +104,9 @@ public class PrimaryStat implements IStat,IStatHolder,Jsonable {
 			core.value = o.core;
 		} else {
 			core.loadFromObject(o.core, ignoreErrors)
+		}
+		if (o.train) {
+			train.loadFromObject(o.train, ignoreErrors);
 		}
 		mult.loadFromObject(o.mult,ignoreErrors);
 		bonus.loadFromObject(o.bonus,ignoreErrors);

--- a/classes/classes/Stats/TrainingStat.as
+++ b/classes/classes/Stats/TrainingStat.as
@@ -1,0 +1,9 @@
+package classes.Stats {
+import classes.Creature;
+
+public class TrainingStat extends RawStat {
+	public function TrainingStat(host:Creature, name:String) {
+		super(host, name, {min:1, value: 0, max: 100});
+	}
+}
+}

--- a/classes/coc/view/StatsView.as
+++ b/classes/coc/view/StatsView.as
@@ -453,15 +453,16 @@ public class StatsView extends Block {
 					if (!primStat) return;
 					CoC.instance.mainView.toolTipView.header = bar.statName;
 					if (statname == "sens" || statname == "cor") isPositiveStat = false;
+					var s:String = "Core: "+primStat.core.value+"/"+primStat.core.max+". ";
+					s += "Training: "+primStat.train.value+"/"+primStat.train.max+". ";
 					if (statname == "tou" && (player.hasPerk(PerkLib.IcyFlesh) || player.hasPerk(PerkLib.HaltedVitals))) {
-						CoC.instance.mainView.toolTipView.text = "Base: "+primStat.core.value+"\n" +
-								"You are currently in a state of undeath and cannot benefit from bonus to toughness.";
+						s += "\nYou are currently in a state of undeath and cannot benefit from bonus to toughness.";
+					} else {
+						s += "\n" +
+								"" + StatUtils.describeBuffs(primStat.bonus, false, isPositiveStat) + "" +
+								"" + StatUtils.describeBuffs(primStat.mult, true, isPositiveStat) + "";
 					}
-					else{
-						CoC.instance.mainView.toolTipView.text = "Base: "+primStat.core.value+"\n" +
-								""+StatUtils.describeBuffs(primStat.bonus, false, isPositiveStat)+"" +
-								""+StatUtils.describeBuffs(primStat.mult, true, isPositiveStat)+"";
-					}
+					CoC.instance.mainView.toolTipView.text = s;
 					CoC.instance.mainView.toolTipView.showForElement(bar);
 					break;
 				}


### PR DESCRIPTION
* **Reworked primary stat structure - new formula is `total = (core*mult) + training + bonus`** 
* Old saves get their stat points refunded and training re-applied to have the same stat ratios and total points (spent+unspent) 
* New `player.canTrain(stat, limit)` function. Replaced checks for core with it. 
* `player.trainStat` returns true if stat was changed - can be used `if (player.trainStat(...)) outputText("you git gud")`
* Fixed some training events checking total instead of core/train 
* Fixed armor type detection 
* Fixed Warden's Staff buff