### PR TITLE
encounter table tweaks

### DIFF
--- a/classes/classes/Scenes/Areas/Desert.as
+++ b/classes/classes/Scenes/Areas/Desert.as
@@ -171,6 +171,7 @@ use namespace CoC;
 						when  : SceneLib.helScene.helSexualAmbushCondition
 					}, {
 						name: "mimic",
+						chance: 0.25,
 						when: fn.ifLevelMin(3),
 						call: curry(SceneLib.mimicScene.mimicTentacleStart, 1)
 					}, {

--- a/classes/classes/Scenes/Areas/Forest.as
+++ b/classes/classes/Scenes/Areas/Forest.as
@@ -92,6 +92,7 @@ use namespace CoC;
 			_forestOutskirtsEncounter = Encounters.group("outskirtsforest", {
 						//General Golems, Goblin and Imp Encounters
 						name: "common",
+						chance: 0.4,
 						call: function ():void {
 							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 							SceneLib.exploration.genericGolGobImpEncounters();
@@ -99,6 +100,7 @@ use namespace CoC;
 					}, {
 						//General Angels Encounters
 						name: "common",
+						chance: 0.4,
 						call: function ():void {
 							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 							SceneLib.exploration.genericAngelsEncounters();
@@ -235,6 +237,7 @@ use namespace CoC;
 			_forestEncounter = Encounters.group("forest", {
 						//General Golems, Goblin and Imp Encounters
 						name: "common",
+						chance: 0.4,
 						call: function ():void {
 							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 							SceneLib.exploration.genericGolGobImpEncounters();
@@ -445,14 +448,14 @@ use namespace CoC;
 						when: fn.ifLevelMin(3),
 						call: function ():void {
 							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							curry(SceneLib.mimicScene.mimicTentacleStart, 1);
+							curry(SceneLib.mimicScene.mimicTentacleStart, 3);
 						},
-						chance: 0.50
+						chance: 0.25
 					}, {
 						name  : "succubus",
 						call  : SceneLib.ivorySuccubusScene.encounterSuccubus,
 						when  : fn.ifLevelMin(3),
-						chance: 0.50
+						chance: 0.25
 					}, {
 						name  : "werewolfFemale",
 						day : false,

--- a/classes/classes/Scenes/Areas/Mountain.as
+++ b/classes/classes/Scenes/Areas/Mountain.as
@@ -42,10 +42,12 @@ public class Mountain extends BaseContent
 					Encounters.group(/*game.commonEncounters.withImpGob,*/{
 						//General Golems, Goblin and Imp Encounters
 						name: "common",
+						chance: 0.4,
 						call: SceneLib.exploration.genericGolGobImpEncounters
 					}, {
 						//General Angels Encounters
 						name: "common",
+						chance: 0.4,
 						call: SceneLib.exploration.genericAngelsEncounters
 					}, {
 						//Helia monogamy fucks
@@ -88,12 +90,6 @@ public class Mountain extends BaseContent
 						when: fn.not(salon.isDiscovered),
 						call: salon.hairDresser
 					},{
-						/* [INTERMOD: Revamp]
-						name: "mimic",
-						when: fn.ifLevelMin(3),
-						call: curry(game.mimicScene.mimicTentacleStart,2)
-					},{
-						*/
 						name: "highmountains",
 						when: function ():Boolean {
 							return !SceneLib.highMountains.isDiscovered()
@@ -272,6 +268,7 @@ public class Mountain extends BaseContent
 						call:hike
 					}, {
 						name: "mimic",
+						chance:0.25,
 						when: fn.ifLevelMin(3),
 						call: curry(SceneLib.mimicScene.mimicTentacleStart,2)
 					})

--- a/classes/classes/Scenes/Areas/Plains.as
+++ b/classes/classes/Scenes/Areas/Plains.as
@@ -39,6 +39,7 @@ use namespace CoC;
 			explorationEncounter = Encounters.group(/*SceneLib.commonEncounters,*/ {
 				//General Golems, Goblin and Imp Encounters
 				name: "common",
+				chance: 0.4,
 				call: function ():void {
 					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 					SceneLib.exploration.genericGolGobImpEncounters();


### PR DESCRIPTION
* Lowered mimics chances to 0.25 everywhere. Fixed one wrongly displayed encounter
* Lowered "common" encounter groups in Forest and Mountains - goblins/imps and angels - to 0.4