### PR TITLE
Perk distance

### DIFF
--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -121,7 +121,7 @@ public class CoC extends MovieClip
     public var compiler:StoryCompiler = new StoryCompiler("content/").attach(rootStory);
     public var context:StoryContext;
 
-    public var perkTree:PerkTree = new PerkTree();
+    public var perkTree:PerkTree;
 
     /****
      This is used purely for bodges while we get things cleaned up.

--- a/classes/classes/PerkTree.as
+++ b/classes/classes/PerkTree.as
@@ -14,33 +14,131 @@ public class PerkTree extends BaseContent {
 	public function PerkTree() {
 		var library:Dictionary = PerkType.getPerkLibrary();
 		var perk:PerkType;
+		var entry:PerkTreeEntry;
+		var req:Object;
 		// 0. Initialize PerkTreeEntries
 		for each(perk in library) {
 			//var perk:PerkType = library[k];
-			pdata[perk.id] = new PerkTreeEntry(perk);
+			entry = new PerkTreeEntry(perk);
+			pdata[perk.id] = entry;
+			if (perk.requirements.length > 0) perk.distance = PerkType.DISTANCE_STARTING;
+			for each (req in perk.requirements) {
+				// Starting perk distance
+				if (req.distance is Number && !isNaN(req.distance)) perk.distance += req.distance;
+			}
 		}
 		// 1. Build PerkTreeEntry.unlocks array - for every perk i, for every requirement j, add i to j.unlocks
+		var processedIds:Object = {}; // processed perk ids
+		var queue:/*PerkType*/Array = [];
 		for each(perk in library) {
-			var entry:PerkTreeEntry = pdata[perk.id];
-			for each (var c:Object in perk.requirements) {
+			entry = pdata[perk.id];
+			var done:Boolean = true;
+			for each (req in perk.requirements) {
 				var p2:PerkType;
-				switch (c.type) {
+				switch (req.type) {
 					case "perk":
-						p2 = c.perk;
+						done = false;
+						p2 = req.perk;
 						(pdata[p2.id] as PerkTreeEntry).unlocks.push(entry);
 						break;
 					case "anyperk":
-						var ps:Array = c.perks;
+						done = false;
+						var ps:Array = req.perks;
 						for each(p2 in ps) (pdata[p2.id] as PerkTreeEntry).unlocks.push(entry);
 						break;
 					case "allperks":
-						var aps:Array = c.perks;
+						done = false;
+						var aps:Array = req.allperks;
 						for each(p2 in aps) (pdata[p2.id] as PerkTreeEntry).unlocks.push(entry);
 						break;
 				}
 			}
+			if (done) {
+				processedIds[perk.id] = true;
+				if (perk.requirements.length > 0) {
+					perksByDistance.push(perk);
+				}
+			} else {
+				queue.push(perk);
+			}
+		}
+		// 2. Compute perk distance for perk/anyperk/allperks requirements
+		while(queue.length > 0) {
+			var oldSz:int = queue.length;
+			for (var i:int = queue.length-1; i >= 0; i--) {
+				perk = queue[i];
+				entry = pdata[perk.id];
+				done = true;
+				for each (req in perk.requirements) {
+					switch (req.type) {
+						case "perk":
+							p2 = req.perk;
+							if (processedIds[p2.id]) {
+								perk.distance = Math.max(perk.distance, p2.distance) + PerkType.DISTANCE_PER_PERK;
+							} else {
+								done = false;
+							}
+							break;
+						case "anyperk":
+							var mindist:Number = Infinity;
+							for each(p2 in req.perks) {
+								if (processedIds[p2.id]) {
+									mindist = Math.min(mindist, p2.distance);
+								} else {
+									done = false;
+									break;
+								}
+							}
+							if (done && isFinite(mindist)) {
+								perk.distance = Math.max(perk.distance, mindist) + PerkType.DISTANCE_PER_PERK;
+							}
+							break;
+						case "allperks":
+							var maxdist:Number = -Infinity;
+							for each(p2 in req.allperks) {
+								if (processedIds[p2.id]) {
+									maxdist = Math.max(maxdist, p2.distance);
+								} else {
+									done = false;
+									break;
+								}
+							}
+							if (done && isFinite(maxdist)) {
+								perk.distance = Math.max(perk.distance, maxdist) + PerkType.DISTANCE_PER_PERK * req.allperks.length;
+							}
+							break;
+					}
+				}
+				if (done) {
+					processedIds[perk.id] = true;
+					perksByDistance.push(perk);
+					// Remove i-th element: move last to i-th place and remove last
+					queue[i] = queue[queue.length - 1];
+					queue.pop();
+				}
+			}
+			if (queue.length >= oldSz) {
+				// Halt if queue was not changed
+				trace("[ERROR] PerkTree distance calculation stuck in a loop: queue.length = "+queue.length);
+				break;
+			}
+		}
+		if (queue.length > 0) {
+			trace("[ERROR] Failed to compute distance of perks:")
+			for each (perk in queue) {
+				trace("[ERROR]     "+perk.id);
+			}
+			trace("[ERROR]   (total "+queue.length+")");
+		}
+		perksByDistance.sortOn(["distance","id"], Array.NUMERIC);
+		if (CoC_Settings.debugBuild) {
+			for each (perk in perksByDistance) {
+				trace("" + perk.distance + " " + perk.id);
+			}
 		}
 	}
+	
+	public var perksByDistance:/*PerkType*/Array = [];
 	
 	/**
 	 * Returns Array of PerkType
@@ -51,17 +149,20 @@ public class PerkTree extends BaseContent {
 			return entry.perk;
 		});
 	}
+	public static var obtanablePerksCached:/*PerkType*/Array = null;
 	/**
 	 * Returns Array of PerkType
 	 */
 	public static function obtainablePerks():Array {
+		if (obtanablePerksCached) return obtanablePerksCached;
 		var rslt:Array=[];
 		for each(var perk:PerkType in PerkType.getPerkLibrary()) {
 			if (perk.requirements.length > 0) {
 				rslt.push(perk);
 			}
 		}
-		return rslt.sortOn("name");
+		obtanablePerksCached = rslt.sortOn("name");
+		return obtanablePerksCached;
 	}
 	/**
 	 * Returns Array of PerkType

--- a/classes/classes/display/PerkMenu.as
+++ b/classes/classes/display/PerkMenu.as
@@ -6,6 +6,7 @@ import classes.BaseContent;
 import classes.BodyParts.Face;
 import classes.BodyParts.Tail;
 import classes.CoC;
+import classes.CoC_Settings;
 import classes.GlobalFlags.kFLAGS;
 import classes.IMutationPerkType;
 import classes.IMutations.*;
@@ -14,7 +15,6 @@ import classes.PerkLib;
 import classes.PerkTree;
 import classes.PerkType;
 import classes.Races;
-import classes.Scenes.Dungeons.BeeHive.CorruptBeeQueen;
 import classes.Scenes.NPCs.EvangelineFollower;
 import classes.Scenes.NPCs.TyrantiaFollower;
 import classes.Scenes.SceneLib;
@@ -72,6 +72,7 @@ public class PerkMenu extends BaseContent {
 		}
 		addButton(2, "SuperPerk Up", CoC.instance.playerInfo.superPerkBuyMenu);
 		addButton(3, "Mutations DB", mutationsDatabase, 0, true);
+		if (sorter === sorterRelativeDistance) sortedPerks = null; // clear cache, relative distance could've been changed
 		addButton(4, "Perks Database", perkDatabase);
 		if ((player.calculateMultiAttacks() > 1) || combat.canSpearDance() ||player.hasPerk(PerkLib.Poisoning) || player.hasPerk(PerkLib.SwiftCasting) ||
 			((player.hasPerk(PerkLib.JobBeastWarrior) || player.hasPerk(PerkLib.HistoryFeral) || player.hasPerk(PerkLib.PastLifeFeral)) && (player.haveNaturalClaws() || player.haveNaturalClawsTypeWeapon())) || player.hasPerk(PerkLib.NaturalInstincts) || player.hasPerk(PerkLib.WayOfTheWarrior) || player.hasPerk(PerkLib.Berzerker) ||
@@ -918,8 +919,40 @@ public class PerkMenu extends BaseContent {
 		outputText("\n");
 	}
 
+	// Sort by perk name
+	private function sorterName(e:PerkType):* {
+		return e.name(null).toUpperCase();
+	}
+	// Sort by absolute distance (from zero)
+	private function sorterDistance(e:PerkType):* {
+		return e.distance
+	}
+	// Sort by relative distance (from player)
+	private function sorterRelativeDistance(e:PerkType):* {
+		return e.distanceFor(player);
+	}
+	private var sorter:Function = sorterRelativeDistance;
+	private var sortedPerks:/*PerkType*/Array;
+	
+	public function formatPerkRequirements(ptype:PerkType):String {
+		var reqs:Array = [];
+		var color:String;
+		for each (var cond:Object in ptype.requirements) {
+			if (cond.fn(player)) color=(darkTheme()?'#ffffff':'#000000');
+			else color=darkTheme()?'#ff4444':'#aa2222';
+			if (cond.text is String){
+				reqs.push("<font color='"+color+"'>"+cond.text+"</font>");
+			}
+			else {
+				reqs.push("<font color='"+color+"'>"+cond.text(player)+"</font>");
+			}
+		}
+		return ("<b>Requires:</b> " + reqs.join(", ")+". " +
+				(CoC_Settings.debugBuild ? "<i>Distance: "+ptype.distanceFor(player)+"/"+ptype.distance+"</i>" : ""));
+	}
+	
 	public function perkDatabase(page:int=0, count:int=50):void {
-		var allPerks:Array = PerkTree.obtainablePerks().sort();
+		var allPerks:/*PerkType*/Array = sortedPerks ? sortedPerks : (sortedPerks = sortedBy(PerkTree.obtainablePerks(),sorter));
 		var mutationList2:Array = IMutationsLib.mutationsArray("All");
 
 		var temp:Array = [];
@@ -945,18 +978,7 @@ public class PerkMenu extends BaseContent {
 			outputText("<font color='" +color +"'><b>"+ptype.name()+"</b></font>: ");
 			outputText(pclass?ptype.desc(pclass):ptype.longDesc);
 			if (!pclass && ptype.requirements.length>0) {
-				var reqs:Array = [];
-				for each (var cond:Object in ptype.requirements) {
-					if (cond.fn(player)) color=(darkTheme()?'#ffffff':'#000000');
-					else color=darkTheme()?'#ff4444':'#aa2222';
-					if (cond.text is String){
-						reqs.push("<font color='"+color+"'>"+cond.text+"</font>");
-					}
-					else {
-						reqs.push("<font color='"+color+"'>"+cond.text(player)+"</font>");
-					}
-				}
-				outputText("<ul><li><b>Requires:</b> " + reqs.join(", ")+".</li></ul>");
+				outputText("<ul><li>"+formatPerkRequirements(ptype)+"</li></ul>");
 			} else {
 				outputText("\n");
 			}
@@ -965,7 +987,26 @@ public class PerkMenu extends BaseContent {
 		else addButtonDisabled(0,"Prev");
 		if (page*count<allPerks.length) addButton(1,"Next",perkDatabase,page+1);
 		else addButtonDisabled(1,"Next");
+		addButton(5,
+				sorter === sorterName ? "Sort: Name"
+						: sorter === sorterDistance ? "Sort: Dist."
+						: "Sort: RelDist",
+				perkDbToggleSort, page)
+				.hint("Sort by Name - self-explanatory\n" +
+						"Sort by Distance - perks with fewer/easier total requirements first\n" +
+						"Sort by Relative Distance - perks with fewer/easier unfulfilled requirements first");
 		addButton(9, "Back", displayPerks);
+	}
+	private function perkDbToggleSort(page:int):void {
+		if (sorter === sorterName) {
+			sorter = sorterDistance;
+		} else if (sorter === sorterDistance) {
+			sorter = sorterRelativeDistance;
+		} else {
+			sorter = sorterName;
+		}
+		sortedPerks = null;
+		perkDatabase(page);
 	}
 
 	public function perkDatabase2():void { //Messy code... Again, probably optimizable by someone else with more experience.


### PR DESCRIPTION
Adds "perk distance" - a score indicating how difficult perk requirements are.
Adds different sorting modes to PerkDatabase - by name, distance, relative distance.
By default, perks in database are sorted by relative distance, so perks that are easier for player character to obtain will go first.

Distance calculation constants are in the beginning of PerkType.as