### PR TITLE
"True" Mutations, Mutagen tweaks.

### DIFF
--- a/classes/classes/IMutationPerkType.as
+++ b/classes/classes/IMutationPerkType.as
@@ -105,7 +105,7 @@ public class IMutationPerkType extends PerkType
 		public function pReqs(pCheck:int = -1):void{
 		}
 
-		public function buffsForTier(pTier:int):Object {
+		public function buffsForTier(pTier:int, target:Creature):Object {
 			return _pBuffs;
 		}
 
@@ -114,7 +114,7 @@ public class IMutationPerkType extends PerkType
 		}
 
 		public function explainBuffs(pTier:int):String {
-			var tempObj:Object = buffsForTier(pTier);
+			var tempObj:Object = buffsForTier(pTier, player);
 			var res:String = "";
 			for (var key:String in tempObj)
 				res += StatUtils.explainBuff(key, tempObj[key]);
@@ -122,7 +122,8 @@ public class IMutationPerkType extends PerkType
 		}
 
 		public function pBuffs(target:Creature = null):Object{
-			return buffsForTier(currentTier(this, (target == null) ? player : target));
+			var target2:Creature =(target == null) ? player : target;
+			return buffsForTier(currentTier(this, target2), target2);
 		}
 
 		public function trueMutationBuffs(statStr:String, pTier:int, racePoint:int):Object{ //Probably wanna pass "xxx.bonus"

--- a/classes/classes/IMutationPerkType.as
+++ b/classes/classes/IMutationPerkType.as
@@ -84,11 +84,13 @@ public class IMutationPerkType extends PerkType
 		private var _maxLvl:int;
 		private var _slot:String;
 		private var _pBuffs:Object;
+		private var _trueVariant:Boolean;
 
-		public function IMutationPerkType(id:String, name:String, slot:String, maxLvl:int) {
+		public function IMutationPerkType(id:String, name:String, slot:String, maxLvl:int, trueVariant:Boolean = false) {
 			super(id, name, name, name, false);
 			this._maxLvl = maxLvl;
 			this._slot = slot;
+			this._trueVariant = trueVariant;
 			(MutationsBySlot[slot] ||= []).push(this);
 		}
 
@@ -100,11 +102,15 @@ public class IMutationPerkType extends PerkType
 			return _slot;
 		}
 
-		public function pReqs():void{
+		public function pReqs(pCheck:int = -1):void{
 		}
 
 		public function buffsForTier(pTier:int):Object {
 			return _pBuffs;
+		}
+
+		public function get trueMutation():Boolean{
+			return _trueVariant;
 		}
 
 		public function explainBuffs(pTier:int):String {
@@ -117,6 +123,12 @@ public class IMutationPerkType extends PerkType
 
 		public function pBuffs(target:Creature = null):Object{
 			return buffsForTier(currentTier(this, (target == null) ? player : target));
+		}
+
+		public function trueMutationBuffs(statStr:String, pTier:int, racePoint:int):Object{ //Probably wanna pass "xxx.bonus"
+			var pBuffs:Object = {};
+			pBuffs[statStr] = ((30 + pTier*15)*racePoint)
+			return pBuffs
 		}
 
 		/**
@@ -143,6 +155,7 @@ public class IMutationPerkType extends PerkType
 		 * @param target	Type: Creature. 					Takes Player/enemy class as arg. Indicates if the mutation goes to Player or to an NPC.
 		 * @param nextFunc	Type: *(String/function). 			Takes "none"/ function as arg. If NPC, put "none", else put in next function it should go to.
 		 * @param pTier		Type:Int. Takes perkTier as arg. 	If target is NPC, you can also directly assign a tier to them, to skip having to add the perk in x times.
+		 * Note: V1 is used to track Mutation Level, V2 has been taken for mutation self-evolution tracking, V3 is used for verifying if player has the true variant of the Mutation.
 		 */
 		public function acquireMutation(target:Creature, nextFunc:*, pTier:int = 1):void{
 			var mutations:IMutationPerkType = this;

--- a/classes/classes/IMutations/AlphaHowlMutation.as
+++ b/classes/classes/IMutations/AlphaHowlMutation.as
@@ -55,9 +55,9 @@ public class AlphaHowlMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){
@@ -94,8 +94,7 @@ public class AlphaHowlMutation extends IMutationPerkType
         }
 
         public function AlphaHowlMutation() {
-            super(mName + " IM", mName, SLOT_LUNGS, 4);
+            super(mName + " IM", mName, SLOT_LUNGS, 4, true);
         }
-        
     }
 }

--- a/classes/classes/IMutations/AlphaHowlMutation.as
+++ b/classes/classes/IMutations/AlphaHowlMutation.as
@@ -76,7 +76,7 @@ public class AlphaHowlMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['str.mult'] = 0.05;
             else if (pTier == 2) pBuffs['str.mult'] = 0.15;

--- a/classes/classes/IMutations/ArachnidBookLungMutation.as
+++ b/classes/classes/IMutations/ArachnidBookLungMutation.as
@@ -47,9 +47,9 @@ import classes.Races;
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){
@@ -77,7 +77,7 @@ import classes.Races;
         }
 
         public function ArachnidBookLungMutation() {
-            super(mName + " IM", mName, SLOT_ADAPTATIONS, 3);
+            super(mName + " IM", mName, SLOT_ADAPTATIONS, 3, true);
         }
         
     }

--- a/classes/classes/IMutations/ArachnidBookLungMutation.as
+++ b/classes/classes/IMutations/ArachnidBookLungMutation.as
@@ -68,7 +68,7 @@ import classes.Races;
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['int.mult'] = 0.05;
             else if (pTier == 2) pBuffs['int.mult'] = 0.15;

--- a/classes/classes/IMutations/BlackHeartMutation.as
+++ b/classes/classes/IMutations/BlackHeartMutation.as
@@ -47,9 +47,9 @@ public class BlackHeartMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/BlackHeartMutation.as
+++ b/classes/classes/IMutations/BlackHeartMutation.as
@@ -67,7 +67,7 @@ public class BlackHeartMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['lib.mult'] = 0.05;
             else if (pTier == 2) pBuffs['lib.mult'] = 0.15;

--- a/classes/classes/IMutations/CatLikeNimblenessMutation.as
+++ b/classes/classes/IMutations/CatLikeNimblenessMutation.as
@@ -53,9 +53,9 @@ public class CatLikeNimblenessMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/CatLikeNimblenessMutation.as
+++ b/classes/classes/IMutations/CatLikeNimblenessMutation.as
@@ -73,7 +73,7 @@ public class CatLikeNimblenessMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 2) pBuffs['spe.mult'] = 0.1;
             if (pTier == 3) pBuffs['spe.mult'] = 0.3;

--- a/classes/classes/IMutations/CaveWyrmLungsMutation.as
+++ b/classes/classes/IMutations/CaveWyrmLungsMutation.as
@@ -45,9 +45,9 @@ import classes.Creature;
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/CaveWyrmLungsMutation.as
+++ b/classes/classes/IMutations/CaveWyrmLungsMutation.as
@@ -63,7 +63,7 @@ import classes.Creature;
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/DiamondHeartMutation.as
+++ b/classes/classes/IMutations/DiamondHeartMutation.as
@@ -46,9 +46,9 @@ public class DiamondHeartMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/DiamondHeartMutation.as
+++ b/classes/classes/IMutations/DiamondHeartMutation.as
@@ -65,7 +65,7 @@ public class DiamondHeartMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 3) {
                 pBuffs['str.mult'] = 0.05;

--- a/classes/classes/IMutations/DisplacerMetabolismMutation.as
+++ b/classes/classes/IMutations/DisplacerMetabolismMutation.as
@@ -48,9 +48,9 @@ public class DisplacerMetabolismMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/DisplacerMetabolismMutation.as
+++ b/classes/classes/IMutations/DisplacerMetabolismMutation.as
@@ -67,7 +67,7 @@ public class DisplacerMetabolismMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/DraconicBonesMutation.as
+++ b/classes/classes/IMutations/DraconicBonesMutation.as
@@ -78,7 +78,7 @@ public class DraconicBonesMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['tou.mult'] = 0.05;
             if (pTier == 2) pBuffs['tou.mult'] = 0.15;

--- a/classes/classes/IMutations/DraconicBonesMutation.as
+++ b/classes/classes/IMutations/DraconicBonesMutation.as
@@ -50,9 +50,9 @@ public class DraconicBonesMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/DraconicHeartMutation.as
+++ b/classes/classes/IMutations/DraconicHeartMutation.as
@@ -46,9 +46,9 @@ public class DraconicHeartMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/DraconicHeartMutation.as
+++ b/classes/classes/IMutations/DraconicHeartMutation.as
@@ -66,7 +66,7 @@ public class DraconicHeartMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['str.mult'] = 0.05;
             if (pTier == 2) pBuffs['str.mult'] = 0.15;

--- a/classes/classes/IMutations/DraconicLungMutation.as
+++ b/classes/classes/IMutations/DraconicLungMutation.as
@@ -67,7 +67,7 @@ public class DraconicLungMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['spe.mult'] = 0.05;
             if (pTier == 2) pBuffs['spe.mult'] = 0.15;

--- a/classes/classes/IMutations/DraconicLungMutation.as
+++ b/classes/classes/IMutations/DraconicLungMutation.as
@@ -47,9 +47,9 @@ public class DraconicLungMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/DrakeLungMutation.as
+++ b/classes/classes/IMutations/DrakeLungMutation.as
@@ -47,9 +47,9 @@ public class DrakeLungMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/DrakeLungMutation.as
+++ b/classes/classes/IMutations/DrakeLungMutation.as
@@ -67,7 +67,7 @@ public class DrakeLungMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['spe.mult'] = 0.05;
             if (pTier == 2) pBuffs['spe.mult'] = 0.15;

--- a/classes/classes/IMutations/EasterBunnyEggBagMutation.as
+++ b/classes/classes/IMutations/EasterBunnyEggBagMutation.as
@@ -71,7 +71,7 @@ public class EasterBunnyEggBagMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/EasterBunnyEggBagMutation.as
+++ b/classes/classes/IMutations/EasterBunnyEggBagMutation.as
@@ -51,9 +51,9 @@ public class EasterBunnyEggBagMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/EclipticMindMutation.as
+++ b/classes/classes/IMutations/EclipticMindMutation.as
@@ -48,9 +48,9 @@ public class EclipticMindMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/EclipticMindMutation.as
+++ b/classes/classes/IMutations/EclipticMindMutation.as
@@ -69,7 +69,7 @@ public class EclipticMindMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/ElvishPeripheralNervSysMutation.as
+++ b/classes/classes/IMutations/ElvishPeripheralNervSysMutation.as
@@ -67,7 +67,7 @@ public class ElvishPeripheralNervSysMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 2) pBuffs['spe.mult'] = 0.05;
             if (pTier == 3) pBuffs['spe.mult'] = 0.1;

--- a/classes/classes/IMutations/ElvishPeripheralNervSysMutation.as
+++ b/classes/classes/IMutations/ElvishPeripheralNervSysMutation.as
@@ -47,9 +47,9 @@ public class ElvishPeripheralNervSysMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/EyeOfTheTigerMutation.as
+++ b/classes/classes/IMutations/EyeOfTheTigerMutation.as
@@ -70,7 +70,7 @@ public class EyeOfTheTigerMutation extends IMutationPerkType
         }
         
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1){
                 pBuffs['int.mult'] = 0.05;

--- a/classes/classes/IMutations/EyeOfTheTigerMutation.as
+++ b/classes/classes/IMutations/EyeOfTheTigerMutation.as
@@ -51,9 +51,9 @@ public class EyeOfTheTigerMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/FeyArcaneBloodstreamMutation.as
+++ b/classes/classes/IMutations/FeyArcaneBloodstreamMutation.as
@@ -46,9 +46,9 @@ public class FeyArcaneBloodstreamMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/FeyArcaneBloodstreamMutation.as
+++ b/classes/classes/IMutations/FeyArcaneBloodstreamMutation.as
@@ -65,7 +65,7 @@ public class FeyArcaneBloodstreamMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['int.mult'] = 0.05;
             if (pTier == 2) pBuffs['int.mult'] = 0.15;

--- a/classes/classes/IMutations/FloralOvariesMutation.as
+++ b/classes/classes/IMutations/FloralOvariesMutation.as
@@ -46,9 +46,9 @@ public class FloralOvariesMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/FloralOvariesMutation.as
+++ b/classes/classes/IMutations/FloralOvariesMutation.as
@@ -65,7 +65,7 @@ public class FloralOvariesMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['lib.mult'] = 0.05;
             if (pTier == 2) pBuffs['lib.mult'] = 0.15;

--- a/classes/classes/IMutations/FrozenHeartMutation.as
+++ b/classes/classes/IMutations/FrozenHeartMutation.as
@@ -47,9 +47,9 @@ public class FrozenHeartMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/FrozenHeartMutation.as
+++ b/classes/classes/IMutations/FrozenHeartMutation.as
@@ -66,7 +66,7 @@ public class FrozenHeartMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/GazerEyesMutation.as
+++ b/classes/classes/IMutations/GazerEyesMutation.as
@@ -65,7 +65,7 @@ public class GazerEyesMutation extends IMutationPerkType
         }
         
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1){
                 pBuffs['int.mult'] = 0.05;

--- a/classes/classes/IMutations/GazerEyesMutation.as
+++ b/classes/classes/IMutations/GazerEyesMutation.as
@@ -46,9 +46,9 @@ public class GazerEyesMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/GorgonEyesMutation.as
+++ b/classes/classes/IMutations/GorgonEyesMutation.as
@@ -47,9 +47,9 @@ public class GorgonEyesMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/GorgonEyesMutation.as
+++ b/classes/classes/IMutations/GorgonEyesMutation.as
@@ -69,7 +69,7 @@ public class GorgonEyesMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) {
                 pBuffs['spe.mult'] = 0.05;

--- a/classes/classes/IMutations/HarpyHollowBonesMutation.as
+++ b/classes/classes/IMutations/HarpyHollowBonesMutation.as
@@ -46,9 +46,9 @@ public class HarpyHollowBonesMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/HarpyHollowBonesMutation.as
+++ b/classes/classes/IMutations/HarpyHollowBonesMutation.as
@@ -65,7 +65,7 @@ public class HarpyHollowBonesMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) {
                 pBuffs['spe.mult'] = 0.2;

--- a/classes/classes/IMutations/HeartOfTheStormMutation.as
+++ b/classes/classes/IMutations/HeartOfTheStormMutation.as
@@ -48,9 +48,9 @@ public class HeartOfTheStormMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/HeartOfTheStormMutation.as
+++ b/classes/classes/IMutations/HeartOfTheStormMutation.as
@@ -67,7 +67,7 @@ public class HeartOfTheStormMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['spe.mult'] = 0.05;
             if (pTier == 2) pBuffs['spe.mult'] = 0.15;

--- a/classes/classes/IMutations/HellHoundFireBallsMutation.as
+++ b/classes/classes/IMutations/HellHoundFireBallsMutation.as
@@ -81,7 +81,7 @@ public class HellHoundFireBallsMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             pBuffs['lib.mult'] = 0.05 * currentTier(this, player);
             return pBuffs;

--- a/classes/classes/IMutations/HellHoundFireBallsMutation.as
+++ b/classes/classes/IMutations/HellHoundFireBallsMutation.as
@@ -58,9 +58,9 @@ public class HellHoundFireBallsMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){
@@ -88,7 +88,7 @@ public class HellHoundFireBallsMutation extends IMutationPerkType
         }
 
         public function HellHoundFireBallsMutation() {
-            super(mName + " IM", mName, SLOT_TESTICLES, 4);
+            super(mName + " IM", mName, SLOT_TESTICLES, 4, true);
         }
 
     }

--- a/classes/classes/IMutations/HellcatParathyroidGlandMutation.as
+++ b/classes/classes/IMutations/HellcatParathyroidGlandMutation.as
@@ -45,9 +45,9 @@ import classes.Creature;
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/HellcatParathyroidGlandMutation.as
+++ b/classes/classes/IMutations/HellcatParathyroidGlandMutation.as
@@ -64,7 +64,7 @@ import classes.Creature;
 
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/HinezumiBurningBloodMutation.as
+++ b/classes/classes/IMutations/HinezumiBurningBloodMutation.as
@@ -53,9 +53,9 @@ public class HinezumiBurningBloodMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/HinezumiBurningBloodMutation.as
+++ b/classes/classes/IMutations/HinezumiBurningBloodMutation.as
@@ -75,7 +75,7 @@ public class HinezumiBurningBloodMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['tou.mult'] = 0.05;
             if (pTier == 2) pBuffs['tou.mult'] = 0.15;

--- a/classes/classes/IMutations/HollowFangsMutation.as
+++ b/classes/classes/IMutations/HollowFangsMutation.as
@@ -56,9 +56,9 @@ public class HollowFangsMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/HollowFangsMutation.as
+++ b/classes/classes/IMutations/HollowFangsMutation.as
@@ -79,7 +79,7 @@ public class HollowFangsMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['tou.mult'] = 0.05;
             if (pTier == 2) pBuffs['tou.mult'] = 0.15;

--- a/classes/classes/IMutations/IMutationsLib.as
+++ b/classes/classes/IMutations/IMutationsLib.as
@@ -13,7 +13,8 @@ import classes.IMutationPerkType;
  * The goal of Mutations 3.0 is to allow for everything related to the mutation itself to be hosted within its own file, and to reduce the number of perks being created for the player.
  *
  * Addendum: The fundamental reason for Mutations3.0 is to clearly define the "perks" that are limited by the organ slots, as well as being obtained by Evangeline only.
- * This is why Mindbreaker, as well as HellhoundFireBalls, despite acting in a similar fashion, do not qualify for this list.
+ * PermTF, or PermTF Adjacent races, with mutations such as Mindbreaker/HellhoundFireBalls/FeyArcaneBloodstream, have a "True" Variant, in which their buffs are significantly stronger,
+ * to offset the penalty of not being able to obtain other mutations form other races.
  *
  * Mutations 3.0 Handles perk creation slightly differently in a few ways.
  *
@@ -23,6 +24,8 @@ import classes.IMutationPerkType;
  * These can be checked seperately, or when sent to createDynamicPerks, will handle it as well.
  *
  * Mutations are themselves handling their iterations via v1 checks.
+ * V2 is used for the Mutations to track any special conditions for upgrading, as in cases such as HellHoundFireBalls.
+ * V3 is used to track if the user has the regular (0) or the True (1) variant of the Mutation.
  *
  * Refer to Basecontent's createDynamicPerk function to see how they are used.
  *

--- a/classes/classes/IMutations/KitsuneParathyroidGlandMutation.as
+++ b/classes/classes/IMutations/KitsuneParathyroidGlandMutation.as
@@ -48,9 +48,9 @@ public class KitsuneParathyroidGlandMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/KitsuneParathyroidGlandMutation.as
+++ b/classes/classes/IMutations/KitsuneParathyroidGlandMutation.as
@@ -68,7 +68,7 @@ public class KitsuneParathyroidGlandMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) {
                 pBuffs['spe.mult'] = 0.05;

--- a/classes/classes/IMutations/KitsuneThyroidGlandMutation.as
+++ b/classes/classes/IMutations/KitsuneThyroidGlandMutation.as
@@ -48,9 +48,9 @@ import classes.BodyParts.Tail;
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/KitsuneThyroidGlandMutation.as
+++ b/classes/classes/IMutations/KitsuneThyroidGlandMutation.as
@@ -69,7 +69,7 @@ import classes.BodyParts.Tail;
             }
         }
 
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) {
                 pBuffs['spe.mult'] = 0.05;

--- a/classes/classes/IMutations/LactaBovinaOvariesMutation.as
+++ b/classes/classes/IMutations/LactaBovinaOvariesMutation.as
@@ -72,7 +72,7 @@ public class LactaBovinaOvariesMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 2) pBuffs['lib.mult'] = 0.1;
             if (pTier == 3){

--- a/classes/classes/IMutations/LactaBovinaOvariesMutation.as
+++ b/classes/classes/IMutations/LactaBovinaOvariesMutation.as
@@ -47,9 +47,9 @@ public class LactaBovinaOvariesMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/LizanMarrowMutation.as
+++ b/classes/classes/IMutations/LizanMarrowMutation.as
@@ -47,9 +47,9 @@ public class LizanMarrowMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/LizanMarrowMutation.as
+++ b/classes/classes/IMutations/LizanMarrowMutation.as
@@ -66,7 +66,7 @@ public class LizanMarrowMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/ManticoreMetabolismMutation.as
+++ b/classes/classes/IMutations/ManticoreMetabolismMutation.as
@@ -46,9 +46,9 @@ public class ManticoreMetabolismMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/ManticoreMetabolismMutation.as
+++ b/classes/classes/IMutations/ManticoreMetabolismMutation.as
@@ -65,7 +65,7 @@ public class ManticoreMetabolismMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/MantislikeAgilityMutation.as
+++ b/classes/classes/IMutations/MantislikeAgilityMutation.as
@@ -63,7 +63,7 @@ public class MantislikeAgilityMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/MantislikeAgilityMutation.as
+++ b/classes/classes/IMutations/MantislikeAgilityMutation.as
@@ -43,9 +43,9 @@ public class MantislikeAgilityMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/MelkieLungMutation.as
+++ b/classes/classes/IMutations/MelkieLungMutation.as
@@ -46,9 +46,9 @@ public class MelkieLungMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/MelkieLungMutation.as
+++ b/classes/classes/IMutations/MelkieLungMutation.as
@@ -65,7 +65,7 @@ public class MelkieLungMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/MinotaurTesticlesMutation.as
+++ b/classes/classes/IMutations/MinotaurTesticlesMutation.as
@@ -72,7 +72,7 @@ public class MinotaurTesticlesMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 2) pBuffs['lib.mult'] = 0.1;
             if (pTier == 3){

--- a/classes/classes/IMutations/MinotaurTesticlesMutation.as
+++ b/classes/classes/IMutations/MinotaurTesticlesMutation.as
@@ -47,9 +47,9 @@ public class MinotaurTesticlesMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/MutationTemplate.as
+++ b/classes/classes/IMutations/MutationTemplate.as
@@ -45,9 +45,9 @@ import classes.PerkClass;
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){
@@ -66,6 +66,7 @@ import classes.PerkClass;
         //Mutations Buffs
         override public function buffsForTier(pTier:int):Object {
             var pBuffs:Object = {};
+            //if (player.perkv3(this) == 1){} //This checks in player has the "true" mutation.
             /*
             if (pTier == 1) {
                 pBuffs['spe.mult'] = 0;
@@ -81,7 +82,7 @@ import classes.PerkClass;
 
         public function MutationTemplate() {
             // replace SLOT_NONE with other SLOT_XXXX constant
-            super(mName + " IM", mName, SLOT_NONE, 3);
+            super(mName + " IM", mName, SLOT_NONE, 3, true);
         }
 
     }

--- a/classes/classes/IMutations/MutationTemplate.as
+++ b/classes/classes/IMutations/MutationTemplate.as
@@ -64,7 +64,7 @@ import classes.PerkClass;
 
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             //if (player.perkv3(this) == 1){} //This checks in player has the "true" mutation.
             /*

--- a/classes/classes/IMutations/NaturalPunchingBagMutation.as
+++ b/classes/classes/IMutations/NaturalPunchingBagMutation.as
@@ -69,7 +69,7 @@ public class NaturalPunchingBagMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             var buffVal:Number = 0;
             if (pTier == 1) buffVal = 0.05;

--- a/classes/classes/IMutations/NaturalPunchingBagMutation.as
+++ b/classes/classes/IMutations/NaturalPunchingBagMutation.as
@@ -47,9 +47,9 @@ public class NaturalPunchingBagMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/NekomataThyroidGlandMutation.as
+++ b/classes/classes/IMutations/NekomataThyroidGlandMutation.as
@@ -45,9 +45,9 @@ import classes.Creature;
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/NekomataThyroidGlandMutation.as
+++ b/classes/classes/IMutations/NekomataThyroidGlandMutation.as
@@ -63,7 +63,7 @@ import classes.Creature;
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/NukiNutsMutation.as
+++ b/classes/classes/IMutations/NukiNutsMutation.as
@@ -67,7 +67,7 @@ public class NukiNutsMutation extends IMutationPerkType
             }
         }
 
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['lib.mult'] = 0.05;
             if (pTier == 2) pBuffs['lib.mult'] = 0.15;

--- a/classes/classes/IMutations/NukiNutsMutation.as
+++ b/classes/classes/IMutations/NukiNutsMutation.as
@@ -47,9 +47,9 @@ public class NukiNutsMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/ObsidianHeartMutation.as
+++ b/classes/classes/IMutations/ObsidianHeartMutation.as
@@ -46,9 +46,9 @@ public class ObsidianHeartMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/ObsidianHeartMutation.as
+++ b/classes/classes/IMutations/ObsidianHeartMutation.as
@@ -65,7 +65,7 @@ public class ObsidianHeartMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 3) {
                 pBuffs['str.mult'] = 0.05;

--- a/classes/classes/IMutations/OniMusculatureMutation.as
+++ b/classes/classes/IMutations/OniMusculatureMutation.as
@@ -47,9 +47,9 @@ public class OniMusculatureMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/OniMusculatureMutation.as
+++ b/classes/classes/IMutations/OniMusculatureMutation.as
@@ -69,7 +69,7 @@ public class OniMusculatureMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['str.mult'] = 0.05;
             if (pTier == 2) pBuffs['str.mult'] = 0.15;

--- a/classes/classes/IMutations/OrcAdrenalGlandsMutation.as
+++ b/classes/classes/IMutations/OrcAdrenalGlandsMutation.as
@@ -66,7 +66,7 @@ public class OrcAdrenalGlandsMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 2) pBuffs['str.mult'] = 0.5;
             else if (pTier == 3) pBuffs['str.mult'] = 1;

--- a/classes/classes/IMutations/OrcAdrenalGlandsMutation.as
+++ b/classes/classes/IMutations/OrcAdrenalGlandsMutation.as
@@ -47,9 +47,9 @@ public class OrcAdrenalGlandsMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/PigBoarFatMutation.as
+++ b/classes/classes/IMutations/PigBoarFatMutation.as
@@ -70,7 +70,7 @@ public class PigBoarFatMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['tou.mult'] = 0.05;
             if (pTier == 2) pBuffs['tou.mult'] = 0.15;

--- a/classes/classes/IMutations/PigBoarFatMutation.as
+++ b/classes/classes/IMutations/PigBoarFatMutation.as
@@ -48,9 +48,9 @@ public class PigBoarFatMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/RaijuCathodeMutation.as
+++ b/classes/classes/IMutations/RaijuCathodeMutation.as
@@ -65,7 +65,7 @@ public class RaijuCathodeMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['spe.mult'] = 0.1;
             else if (pTier == 2) pBuffs['spe.mult'] = 0.25;

--- a/classes/classes/IMutations/RaijuCathodeMutation.as
+++ b/classes/classes/IMutations/RaijuCathodeMutation.as
@@ -46,9 +46,9 @@ public class RaijuCathodeMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/RatatoskrSmartsMutation.as
+++ b/classes/classes/IMutations/RatatoskrSmartsMutation.as
@@ -46,9 +46,9 @@ public class RatatoskrSmartsMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/RatatoskrSmartsMutation.as
+++ b/classes/classes/IMutations/RatatoskrSmartsMutation.as
@@ -65,7 +65,7 @@ public class RatatoskrSmartsMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['int.mult'] = 0.05;
             if (pTier == 2) pBuffs['int.mult'] = 0.15;

--- a/classes/classes/IMutations/SalamanderAdrenalGlandsMutation.as
+++ b/classes/classes/IMutations/SalamanderAdrenalGlandsMutation.as
@@ -67,7 +67,7 @@ public class SalamanderAdrenalGlandsMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) {
                 pBuffs['tou.mult'] = 0.05;

--- a/classes/classes/IMutations/SalamanderAdrenalGlandsMutation.as
+++ b/classes/classes/IMutations/SalamanderAdrenalGlandsMutation.as
@@ -48,9 +48,9 @@ public class SalamanderAdrenalGlandsMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/ScyllaInkGlandsMutation.as
+++ b/classes/classes/IMutations/ScyllaInkGlandsMutation.as
@@ -47,9 +47,9 @@ public class ScyllaInkGlandsMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/ScyllaInkGlandsMutation.as
+++ b/classes/classes/IMutations/ScyllaInkGlandsMutation.as
@@ -67,7 +67,7 @@ public class ScyllaInkGlandsMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['str.mult'] = 0.1;
             //else if (pTier == 2) pBuffs['int.mult'] = 0;

--- a/classes/classes/IMutations/SharkOlfactorySystemMutation.as
+++ b/classes/classes/IMutations/SharkOlfactorySystemMutation.as
@@ -80,7 +80,7 @@ public class SharkOlfactorySystemMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) {
                 pBuffs['spe.mult'] = 0.05;

--- a/classes/classes/IMutations/SharkOlfactorySystemMutation.as
+++ b/classes/classes/IMutations/SharkOlfactorySystemMutation.as
@@ -51,7 +51,7 @@ public class SharkOlfactorySystemMutation extends IMutationPerkType
                 case 3:
                     sufval = "(Evolved)";
                     break;
-                case 3:
+                case 4:
                     sufval = "(Final Form)";
                     break;
                 default:
@@ -61,9 +61,9 @@ public class SharkOlfactorySystemMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/SlimeMetabolismMutation.as
+++ b/classes/classes/IMutations/SlimeMetabolismMutation.as
@@ -45,9 +45,9 @@ import classes.Creature;
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/SlimeMetabolismMutation.as
+++ b/classes/classes/IMutations/SlimeMetabolismMutation.as
@@ -63,7 +63,7 @@ import classes.Creature;
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/TrachealSystemMutation.as
+++ b/classes/classes/IMutations/TrachealSystemMutation.as
@@ -53,9 +53,9 @@ public class TrachealSystemMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/TrachealSystemMutation.as
+++ b/classes/classes/IMutations/TrachealSystemMutation.as
@@ -72,7 +72,7 @@ public class TrachealSystemMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1){
                 pBuffs['str.mult'] = 0.01;

--- a/classes/classes/IMutations/TwinHeartMutation.as
+++ b/classes/classes/IMutations/TwinHeartMutation.as
@@ -73,7 +73,7 @@ public class TwinHeartMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) {
                 pBuffs['tou.mult'] = 0.05;

--- a/classes/classes/IMutations/TwinHeartMutation.as
+++ b/classes/classes/IMutations/TwinHeartMutation.as
@@ -52,9 +52,9 @@ public class TwinHeartMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/VampiricBloodstreamMutation.as
+++ b/classes/classes/IMutations/VampiricBloodstreamMutation.as
@@ -60,7 +60,7 @@ public class VampiricBloodstreamMutation extends IMutationPerkType
                 case 3:
                     sufval = "(Evolved)";
                     break;
-                case 3:
+                case 4:
                     sufval = "(Final Form)";
                     break;
                 default:
@@ -70,9 +70,9 @@ public class VampiricBloodstreamMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/VampiricBloodstreamMutation.as
+++ b/classes/classes/IMutations/VampiricBloodstreamMutation.as
@@ -92,7 +92,7 @@ public class VampiricBloodstreamMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['lib.mult'] = 0.05;
             if (pTier == 2) pBuffs['lib.mult'] = 0.15;

--- a/classes/classes/IMutations/VenomGlandsMutation.as
+++ b/classes/classes/IMutations/VenomGlandsMutation.as
@@ -76,7 +76,7 @@ public class VenomGlandsMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['tou.mult'] = 0.05;
             else if (pTier == 2) pBuffs['tou.mult'] = 0.15;

--- a/classes/classes/IMutations/VenomGlandsMutation.as
+++ b/classes/classes/IMutations/VenomGlandsMutation.as
@@ -54,9 +54,9 @@ public class VenomGlandsMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/WhaleFatMutation.as
+++ b/classes/classes/IMutations/WhaleFatMutation.as
@@ -50,9 +50,9 @@ public class WhaleFatMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/IMutations/WhaleFatMutation.as
+++ b/classes/classes/IMutations/WhaleFatMutation.as
@@ -69,7 +69,7 @@ public class WhaleFatMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             if (pTier == 1) pBuffs['tou.mult'] = 0.05;
             else if (pTier == 2) pBuffs['tou.mult'] = 0.15;

--- a/classes/classes/IMutations/YetiFatMutation.as
+++ b/classes/classes/IMutations/YetiFatMutation.as
@@ -65,7 +65,7 @@ public class YetiFatMutation extends IMutationPerkType
         }
 
         //Mutations Buffs
-        override public function buffsForTier(pTier:int):Object {
+        override public function buffsForTier(pTier:int, target:Creature):Object {
             var pBuffs:Object = {};
             return pBuffs;
         }

--- a/classes/classes/IMutations/YetiFatMutation.as
+++ b/classes/classes/IMutations/YetiFatMutation.as
@@ -46,9 +46,9 @@ public class YetiFatMutation extends IMutationPerkType
         }
 
         //Mutation Requirements
-        override public function pReqs():void{
+        override public function pReqs(pCheck:int = -1):void{
             try{
-                var pTier:int = currentTier(this, player);
+                var pTier:int = (pCheck != -1 ? pCheck : currentTier(this, player));
                 //This helps keep the requirements output clean.
                 this.requirements = [];
                 if (pTier == 0){

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -5056,6 +5056,20 @@ use namespace CoC;
 				removePerk(PerkLib.ChimericalBodySemiEpicStage);
 				perkPoints += 1;
 			}
+			//PermTFTrueMutations();	//Uncomment to unleash armageddon..... or when ready to roll out "true" mutations.
+
+		}
+
+		public function PermTFTrueMutations():void{
+			for each (var pPerks:IMutationPerkType in IMutationsLib.mutationsArray("")){
+				if (pPerks.trueMutation){
+					pPerks.pReqs(0);
+					if (pPerks.available(this)){
+						curry(pPerks.acquireMutation, this, "none", Math.min(this.level%30 + 1), pPerks.maxLvl);
+						this.setPerkValue(pPerks, 3, 1);
+					}
+				}
+			}
 		}
 
 		public function requiredXP():int {

--- a/classes/classes/Scenes/NPCs/EvangelineFollower.as
+++ b/classes/classes/Scenes/NPCs/EvangelineFollower.as
@@ -1100,21 +1100,27 @@ private function InternalMutations():void {
 		addButton(3, "Yes", IMutationsYN);
 	}
 	else if (EvangelinePeepTalkOnInternalMutations == 2) {
-		outputText("\"<i>Did you bring gems or find a vial of the mutagen?</i>\" she asks.\n\n");
-		outputText("Her eyes briefly graze your form, \"<i>It looks like the only that way we can do anything about that 'unhealthy drive' of yours is with a little mutation.</i>\" She snickers softly as she waits for your response.");
-		menu();
-		addButton(1, "Gems", IMutationsGemsOrMutagen, 1).disableIf(player.gems < 500, "Gotta get that 500 gems first.");
-		addButton(3, "Mutagen", IMutationsGemsOrMutagen, 2).disableIf(!player.hasItem(useables.E_ICHOR, 1), "Gotta get that vial of mutagen first.");
-		addButton(14, "Back", meetEvangeline);
+		if (player.blockingBodyTransformations()){
+			outputText("Evangeline examines you for a moment, before stating \"Uh, hey [name], your body is kind of tightly hard-wired up together, I don't think any Mutagens are going to be able to help you now. \"\n");
+			outputText("It seems, because you're now transformatively immune, she won't be able to help you with your mutations.");
+			doNext(meetEvangeline);
+		}
+		else{
+			outputText("\"<i>Did you bring gems or find a vial of the mutagen?</i>\" she asks.\n\n");
+			outputText("Her eyes briefly graze your form, \"<i>It looks like the only that way we can do anything about that 'unhealthy drive' of yours is with a little mutation.</i>\" She snickers softly as she waits for your response.");
+			menu();
+			addButton(1, "Gems", IMutationsGemsOrMutagen, 1).disableIf(player.gems < 500, "Gotta get that 500 gems first.");
+			addButton(3, "Mutagen", IMutationsGemsOrMutagen, 2).disableIf(!player.hasItem(useables.E_ICHOR, 1), "Gotta get that vial of mutagen first.");
+			addButton(14, "Back", meetEvangeline);
+		}
 	}
 
-	function IMutationsYN(yn:Boolean = true):void{
-		if (yn){
+	function IMutationsYN(yn:Boolean = true):void {
+		if (yn) {
 			outputText("\n\nEvangeline sighs in relief.");
 			outputText("\n\n\"<i>Glad to hear you at least are smarter than a minotaur. Anyways, there are means to reduce the stress on your body from internal mutations. With proper training you can develop the Chimera Corpus Exocell, or in common terms, the chimera body adaptation. This will allow your body to adapt to stress and slowly negate the drawbacks. Of course the lazy route would be to acquire regeneration from a species' inner mutation and thus negate the need to train entirely.</i>\"");
 			EvangelinePeepTalkOnInternalMutations = 2;
-		}
-		else{
+		} else {
 			outputText("\n\nYour confused look annoys Evangeline to no end.");
 			outputText("\n\n\"<i>That's fine, but trust me, you really will want my help on this, eventually.</i>\"");
 			EvangelinePeepTalkOnInternalMutations = 1;
@@ -1161,7 +1167,7 @@ private function IMutationsSelector(page:int = 0):void {
 			bdFunc = null;
 			mutations.pReqs();
 			//trace("" + mutations.name() + ": Checking requirements. v");
-			if (flags[kFLAGS.EVA_MUTATIONS_BYPASS] || (mutations.available(target) && mutations.maxLvl > target.perkv1(mutations))) {
+			if (flags[kFLAGS.EVA_MUTATIONS_BYPASS] || ((mutations.available(target) || GoM == 2 && target.hasMutation(mutations)) && mutations.maxLvl > target.perkv1(mutations))) {
 				//trace("Requirements met, adding in.");
 				bdFunc = curry(mutations.acquireMutation, player, costTaker)
 				bdDesc = mutations.desc();

--- a/classes/classes/display/PerkMenu.as
+++ b/classes/classes/display/PerkMenu.as
@@ -860,6 +860,8 @@ public class PerkMenu extends BaseContent {
 				}
 				outputText("\nRequirements for next tier: " + reqs.join(", "));
 
+				if (player.perkv3(mutation) == 1) outputText(" Your Mutation is empowered, and provides you with a much greater buff!\n");
+
 				if (pMutateLvl > 0) {
 					outputText("\nCurrent Tier Description: ");
 					if(mutation.mDesc(player.getPerk(mutation), pMutateLvl).length <= 1) {	//Some desc. contains only "."


### PR DESCRIPTION
Mutations now have a "true" variant, of which usually only PermTF mutations can access.

True mutations must be tagged as such under their Supers. True Mutations can be checked with their v3 values, which will be set automatically, when a PermTF event triggers, and wipes all existing Mutations. True Mutations can use the above value to call trueMutationBuffs under IMutationPerkType to build the buffs in a standard way. True Mutations will also be indicated when you open the Database. Note: This function is currently incomplete. It is missing which stats they will buff, as well as which Mutations qualify for taking in "True" variants.

True Mutations were designed due to the way some Mutations were instead planned to be acquirable naturally, so, that idea was buffed, and placed behind this moniker, to prevent Evangeline from effectively being entirely useless in Mutations functions.

-----
Mutations are now able to bypass Level requirements if given Mutagen instead of Gems for the tf cost.

This was due to players indicating the costs of gems vs the RNG and acquisition of the Mutagen to be unbalanced. This will likely be further modified, to further incentivize getting Mutagens.