### PR TITLE
New Hellfire. Changes w/ Scale + Dmg

### DIFF
--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -15331,6 +15331,21 @@ public function corruptionScalingDA():Number {
     else corruptionScalingDA *= 3;
     return corruptionScalingDA;
 }
+/* Can provide a scaling or additive bonus to damage depending on usage. Uses player.cor in function to assign scaling.
+Uses Damage *= pcScalingBonusCorruption(player.cor); for scaling.
+ */
+public function pcScalingBonusCorruption(corStat:int):Number
+{
+    var scalingNum:Number;
+    if (corStat == 100) scalingNum = 1.5;
+    else if (corStat >= 85) scalingNum = 1.35;
+    else if (corStat >= 70) scalingNum = 1.2;
+    else if (corStat >= 55) scalingNum = 1;
+    else if (corStat >= 40) scalingNum = 0.75;
+    else if (corStat >= 25) scalingNum = 0.5;
+    else scalingNum = 0.1;
+    return scalingNum;
+}
 
 public function oniRampagePowerMulti():Number {
     var oniRampagePowerMulti:Number = 3;


### PR DESCRIPTION
Touched up hellfire Damage and Scaling to bring it better in line with other abilities. Now Scales off of Lib and Str. It splits the damage between fire and lust depending on monsters corruption. It also scales off of PC corruption.

New PC corruption scaling for those willing to use it in combat.as Currently it requires a minimum of 25 corruption to get any additive benefit and a corruption stat above 55 to break even or buff it if you multiply base X corrupt scaling.

If any issues are found please ping me. Should be gucci now. Does physical first but will still do lust damage for those corrupt baddies 👀 

I will be touching up the feral attack as currently, it does a mash of attacks. But for now here is the new Mspecial hellfire. 