### PR TITLE
Creature of night sleep fix

### DIFF
--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -3654,10 +3654,18 @@ public class Camp extends NPCAwareContent{
 		if (CoC.instance.timeQ == 0) {
 			CanDream = true;
 			model.time.minutes = 0;
-			if (model.time.hours >= 21)
-				CoC.instance.timeQ += 24-model.time.hours +6;
-			if (model.time.hours < 6)
-				CoC.instance.timeQ += 6-model.time.hours;
+			if (player.isNightCreature() == true)
+			{
+				if (model.time.hours >= 6 && model.time.hours <=21)
+						CoC.instance.timeQ += 15 - model.time.hours + 7;
+			}
+			else
+			{
+				if (model.time.hours >= 21)
+					CoC.instance.timeQ += 24-model.time.hours +6;
+				if (model.time.hours < 6)
+					CoC.instance.timeQ += 6-model.time.hours;
+			}
 			if (flags[kFLAGS.BENOIT_CLOCK_ALARM] > 0) {
 				CoC.instance.timeQ += (flags[kFLAGS.BENOIT_CLOCK_ALARM] - 6);
 			}


### PR DESCRIPTION
Fixed the issue of creatures of night being unable to sleep during the day. 0600 - 2100. Will break nighttime followers as you wake up once the game removes the button. Will fix in following patch. 