### PR TITLE
Notifications

### DIFF
--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -20,6 +20,7 @@ import coc.view.ButtonData;
 import coc.view.ButtonDataList;
 import coc.view.CoCButton;
 import coc.view.MainView;
+import coc.view.NotificationView;
 import coc.view.charview.DragButton;
 import coc.xxc.StoryContext;
 
@@ -718,6 +719,10 @@ import coc.xxc.StoryContext;
 		protected function get mainViewManager():MainViewManager
 		{
 			return CoC.instance.mainViewManager;
+		}
+		
+		protected static function get notificationView():NotificationView {
+			return CoC.instance.mainView.notificationView;
 		}
 
 		protected static function get model():GameModel

--- a/classes/classes/EngineCore.as
+++ b/classes/classes/EngineCore.as
@@ -667,6 +667,7 @@ public class EngineCore {
         if (!CoC.instance.mainViewManager.buttonsTweened) CoC.instance.mainView.statsView.hide();
         CoC.instance.mainViewManager.tweenOutStats();
         CoC.instance.mainView.monsterStatsView.hide();
+        CoC.instance.mainView.notificationView.clearNotifications();
     }
 
     /**

--- a/classes/classes/MainViewManager.as
+++ b/classes/classes/MainViewManager.as
@@ -1,9 +1,7 @@
 //The code that is responsible for managing MainView.
 package classes {
 import classes.GlobalFlags.kFLAGS;
-import classes.CoC;
 
-import coc.view.BitmapDataSprite;
 import coc.view.BoundClip;
 import coc.view.MainView;
 import coc.view.StatsView;
@@ -17,7 +15,6 @@ import flash.events.TimerEvent;
 import flash.ui.Keyboard;
 import flash.utils.Timer;
 import flash.utils.getQualifiedClassName;
-
 
 public class MainViewManager extends BaseContent {
 	//Interface flags
@@ -92,7 +89,7 @@ public class MainViewManager extends BaseContent {
 		} else {
 			// display in the corner
 			mainView.placeCharviewAtRight();
-			mainView.addElement(mainView.charView);
+			mainView.addElementBelow(mainView.charView, mainView.notificationView);
 		}
 	}
 	public function hidePlayerDoll():void {

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -5924,14 +5924,16 @@ use namespace CoC;
 		}
 
 		public function gainCombatXP(index:int, exp:Number):void{
-			var level:Number = combatMastery[index].level;
-			var levelUp:Boolean = false;
-			var experience:Number = combatMastery[index].experience;
-			var melee:Boolean = combatMastery[index].melee;
-			var desc:String = combatMastery[index].desc;
+			var masteryObj:Object = combatMastery[index];
+			var level:Number = masteryObj.level;
+			var levelUp:Boolean        = false;
+			var experience:Number      = masteryObj.experience;
+			var melee:Boolean          = masteryObj.melee;
+			var desc:String            = masteryObj.desc;
 
 			var xpToLevel:Number = CombatExpToLevelUp(level, melee);
 			var xpLoop:Number = exp;
+			var oldProgress:Number = experience/xpToLevel;
 			// for tracking bonus attack masteries
 			var grantsBonusAttacks:Boolean = Combat.bonusAttackMasteries.indexOf(index) != -1;
 			var maxAttacksOld:int = SceneLib.combat.maxCurrentAttacks();
@@ -5944,6 +5946,9 @@ use namespace CoC;
 				if (level < maxCombatLevel(melee) && experience >= xpToLevel) {
 					levelUp = true;
 					outputText("\n<b>" + desc + " leveled up to " + (++level) + "!</b>\n");
+					game.mainView.notificationView.popupIconText(
+							"CombatMastery"+masteryObj.combat,
+							desc+" leveled up to "+level+"!");
 					// Any Leftover EXP?
 					xpLoop = experience - xpToLevel;
 					experience = 0;
@@ -5951,8 +5956,18 @@ use namespace CoC;
 					xpToLevel = CombatExpToLevelUp(level, melee);
 				}
 			}
-            combatMastery[index].level = level;
-            combatMastery[index].experience = experience;
+            masteryObj.level = level;
+            masteryObj.experience = experience;
+			var newProgress:Number = experience/xpToLevel;
+			if (!levelUp && level < maxCombatLevel(melee)) {
+				game.mainView.notificationView.popupProgressBar2(
+						"CombatMastery"+masteryObj.combat,
+						"CombatMastery"+masteryObj.combat,
+						trimSides(desc).replace(/<\/b>/g,""),
+						oldProgress,
+						newProgress
+				)
+			}
 			// Can we get any new attacks?
 			if (grantsBonusAttacks && levelUp) {// if it grants bonus attacks
 				var maxAttacksNew:int = SceneLib.combat.maxCurrentAttacks();
@@ -6235,6 +6250,7 @@ use namespace CoC;
 
 		public function SexXP(XP:Number = 0):void {
 			if (XP <= 0) return;
+			var oldProgress:Number = teaseXP/teaseExpToLevelUp();
 			teaseXP += XP;
 			//Level dat shit up!
 			if (teaseLevel < maxTeaseLevel()) {
@@ -6244,8 +6260,9 @@ use namespace CoC;
 					teaseXP = 0;
 					game.mainView.notificationView.popupIconText("TeaseXP","Tease skill level up!");
 				} else {
-					game.mainView.notificationView.popupProgressBar(
+					game.mainView.notificationView.popupProgressBar2(
 							"teaseXP","TeaseXP","Tease XP",
+							oldProgress,
 							teaseXP/teaseExpToLevelUp(),
 							"#ff00ff");
 				}

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -6234,20 +6234,20 @@ use namespace CoC;
 		}
 
 		public function SexXP(XP:Number = 0):void {
-			while (XP > 0) {
-				if (XP == 1) {
-					teaseXP++;
-					XP--;
-				}
-				else {
-					teaseXP += XP;
-					XP -= XP;
-				}
-				//Level dat shit up!
-				if (teaseLevel < maxTeaseLevel() && teaseXP >= teaseExpToLevelUp()) {
+			if (XP <= 0) return;
+			teaseXP += XP;
+			//Level dat shit up!
+			if (teaseLevel < maxTeaseLevel()) {
+				if (teaseXP >= teaseExpToLevelUp()) {
 					outputText("\n<b>Tease skill leveled up to " + (teaseLevel + 1) + "!</b>");
 					teaseLevel++;
 					teaseXP = 0;
+					game.mainView.notificationView.popupIconText("TeaseXP","Tease skill level up!");
+				} else {
+					game.mainView.notificationView.popupProgressBar(
+							"teaseXP","TeaseXP","Tease XP",
+							teaseXP/teaseExpToLevelUp(),
+							"#ff00ff");
 				}
 			}
 		}

--- a/classes/coc/view/Block.as
+++ b/classes/coc/view/Block.as
@@ -317,7 +317,9 @@ public class Block extends Sprite {
 	}
 
 	public function removeElement(e:DisplayObject):void {
-		_container.removeChild(e);
+		try {
+			_container.removeChild(e);
+		} catch (error:ArgumentError) {}
 		delete _layoutHints[e];
 		invalidateLayout();
 	}

--- a/classes/coc/view/Block.as
+++ b/classes/coc/view/Block.as
@@ -4,18 +4,13 @@
 package coc.view {
 import classes.internals.Utils;
 
-import fl.controls.Button;
-
 import fl.controls.ComboBox;
-import fl.controls.LabelButton;
-
 import fl.controls.TextInput;
 import fl.data.DataProvider;
 
 import flash.display.DisplayObject;
 import flash.display.Sprite;
 import flash.events.Event;
-import flash.events.MouseEvent;
 import flash.text.AntiAliasType;
 import flash.text.TextField;
 import flash.text.TextFieldAutoSize;
@@ -191,6 +186,7 @@ public class Block extends Sprite {
 	private var _layoutConfig:Object;
 	private var explicitWidth:Number    = 0;
 	private var explicitHeight:Number   = 0;
+	public var dataset:Object = {};
 
 	public function Block(options:Object = null) {
 		super();
@@ -275,10 +271,24 @@ public class Block extends Sprite {
 		layElement(e, hint);
 		return e;
 	}
+	
+	public function hasElement(e:DisplayObject):Boolean {
+		return getElementIndex(e) >= 0;
+	}
 
 	public function addElementAt(e:DisplayObject, index:int, hint:Object = null):DisplayObject {
 		_container.addChildAt(e, index);
 		layElement(e, hint);
+		return e;
+	}
+	public function addElementAbove(e:DisplayObject, reference:DisplayObject, hint:Object = null):DisplayObject {
+		var i:int = getElementIndex(reference) + 1;
+		addElementAt(e, i, hint);
+		return e;
+	}
+	public function addElementBelow(e:DisplayObject, reference:DisplayObject, hint:Object = null):DisplayObject {
+		var i:int = getElementIndex(reference);
+		addElementAt(e, i, hint);
 		return e;
 	}
 
@@ -287,9 +297,13 @@ public class Block extends Sprite {
 		invalidateLayout();
 		return this;
 	}
-
+	
 	public function getElementIndex(e:DisplayObject):int {
-		return _container.getChildIndex(e);
+		var i:int = -1;
+		try {
+			i = _container.getChildIndex(e);
+		} catch (e:ArgumentError) {}
+		return i;
 	}
 
 	public function getElementByName(name:String):DisplayObject {
@@ -305,6 +319,11 @@ public class Block extends Sprite {
 	public function removeElement(e:DisplayObject):void {
 		_container.removeChild(e);
 		delete _layoutHints[e];
+		invalidateLayout();
+	}
+	public function removeAllElements():void {
+		_container.removeChildren();
+		_layoutHints = new Dictionary();
 		invalidateLayout();
 	}
 
@@ -385,12 +404,16 @@ public class Block extends Sprite {
 		}
 		UIUtils.setProperties(e, options, {
 			defaultTextFormat: UIUtils.convertTextFormat,
-			background: UIUtils.convertColor
+			background: UIUtils.convertColor,
+			text: null, // set later
+			htmlText: null
 		});
 		if (!('mouseEnabled' in options) && options['type'] != 'input') e.mouseEnabled = false;
 		if (!('width' in options || 'height' in options || 'autoSize' in options)) {
 			e.autoSize = TextFieldAutoSize.LEFT;
 		}
+		if ('htmlText' in options) e.htmlText = options.htmlText;
+		else if ('text' in options) e.text = options.text;
 		addElement(e, hint);
 		return e;
 	}

--- a/classes/coc/view/Color.as
+++ b/classes/coc/view/Color.as
@@ -42,6 +42,15 @@ public class Color {
 	public static function fromRgb(r:uint, g:uint, b:uint):uint {
 		return ((r & 0xff) << 16) | ((g & 0xff) << 8) | (b & 0xff);
 	}
+	/** @return {{a:Number, r:Number, g:Number, b:Number}} object */
+	public static function getFloatComponents(argb:uint):Object {
+		return {
+			a: ((argb >> 24) & 0xff) / 255,
+			r: ((argb >> 16) & 0xff) / 255,
+			g: ((argb >> 8) & 0xff) / 255,
+			b: (argb & 0xff) / 255
+		}
+	}
 	public static function fromArgbFloat(a:Number,r:Number, g:Number, b:Number):uint {
 		return fromArgb(a*255,r*255,g*255,b*255);
 	}

--- a/classes/coc/view/IconLib.as
+++ b/classes/coc/view/IconLib.as
@@ -61,7 +61,8 @@ public class IconLib {
 	 * @return null if no icon with such id
 	 */
 	public function getBitmap(id:String):Bitmap {
-		while (id in aliases && id != aliases[id]) id = aliases[id];
+		var i:int = 100; // circular dependency protection
+		while (i-->0 && id in aliases && id != aliases[id]) id = aliases[id];
 		return icons[id] || null;
 	}
 	public static function getBitmap(id:String):Bitmap {

--- a/classes/coc/view/MainView.as
+++ b/classes/coc/view/MainView.as
@@ -216,6 +216,7 @@ public class MainView extends Block {
 	internal static const CHARVIEW_X:Number      = 0;
 	internal static const CHARVIEW_H:Number      = 202*2;
 	internal static const CHARVIEW_BOTTOM:Number = SCREEN_H;
+	internal static const CHARVIEW_Y:Number      = CHARVIEW_BOTTOM - CHARVIEW_H;
 	// Text zone
 	internal static const TEXTZONE_X:Number      = STATBAR_RIGHT;
 	internal static const TEXTZONE_Y:Number      = TOPROW_BOTTOM + GAP;
@@ -262,6 +263,7 @@ public class MainView extends Block {
 	public var toolTipView:ToolTipView;
 	public var cornerStatsView:CornerStatsView;
 	public var statsView:StatsView;
+	public var notificationView:NotificationView;
 	public var monsterStatsView:MonsterStatsView;
 	public var sideBarDecoration:Sprite;
 
@@ -428,7 +430,13 @@ public class MainView extends Block {
 		this.statsView = new StatsView(this, this.cornerStatsView);
 		this.statsView.hide();
 		this.addElement(this.statsView);
-
+		this.notificationView = new NotificationView({
+			x: CHARVIEW_X,
+			y: CHARVIEW_Y,
+			width: COLUMN_1_W
+		});
+		this.addElement(this.notificationView);
+		
 		this.monsterStatsView = new MonsterStatsView(this);
 		this.monsterStatsView.hide();
 		this.addElement(this.monsterStatsView);

--- a/classes/coc/view/NotificationView.as
+++ b/classes/coc/view/NotificationView.as
@@ -1,0 +1,152 @@
+package coc.view {
+import classes.internals.Utils;
+
+import flash.display.Bitmap;
+import flash.display.DisplayObject;
+import flash.display.Sprite;
+import flash.text.TextField;
+import flash.text.TextFieldAutoSize;
+import flash.utils.setTimeout;
+
+public class NotificationView extends Block {
+	public static const FADEIN_TIME:int  = 250;
+	/** Default notification time, ms */
+	public static const DEFAULT_TTL:int  = 5000;
+	public static const FADEOUT_TIME:int = 1000;
+	public static const DEFAULT_TEXT_FORMAT:Object = {
+		font: "Arial",
+		size: 16,
+		bold: true
+	};
+	public static const DEFAULT_BAR_COLOR:String = "#eeee00";
+	public static const ICON_SIZE:int = 32;
+	public static const BAR_BG:String = "#222222";
+	public static const BAR_BORDER:String = "#222222";
+	public static const BAR_WIDTH:int = 64;
+	public static const BAR_HEIGHT:int = 8;
+	public static const BAR_Y:int = (ICON_SIZE-BAR_HEIGHT)/2;
+	public static const BAR_BORDER_WIDTH:int = 2;
+	
+	public function NotificationView(options:Object = null) {
+		super(options);
+		this.layoutConfig = {
+			type        : 'flow',
+			direction   : 'column',
+			ignoreHidden: true,
+			gap         : 1
+		};
+	}
+	
+	private function animateNotification(notification:DisplayObject, ttl:int = DEFAULT_TTL):void {
+		var alpha:Number   = notification.alpha;
+		notification.alpha = 0.0;
+		// Fade-in animation
+		new SimpleTween(notification, "alpha", alpha, FADEIN_TIME)
+				.then(function ():void {
+					if (!hasElement(notification)) return;
+					setTimeout(function ():void {
+						if (!hasElement(notification)) return;
+						new SimpleTween(notification, "alpha", 0.0, FADEOUT_TIME)
+								.then(function():void {
+									removeElement(notification);
+								})
+					}, ttl);
+				})
+	}
+	
+	public function popupDisplayObject(sprite:DisplayObject, ttl:int = DEFAULT_TTL):void {
+		addElement(sprite);
+		animateNotification(sprite, ttl);
+	}
+	public function popupText(htmlText:String, textFormat:Object = null, ttl:int = DEFAULT_TTL):void {
+		textFormat = Utils.extend({}, DEFAULT_TEXT_FORMAT, textFormat)
+		var tf:TextField = addTextField({
+			defaultTextFormat:textFormat,
+			wordWrap:true,
+			autoSize: TextFieldAutoSize.LEFT,
+			width: width,
+			height: ICON_SIZE,
+			htmlText: htmlText
+		});
+		animateNotification(tf, ttl);
+	}
+	public function popupIconText(iconId:String, htmlText:String, textFormat:Object = null, ttl:int = DEFAULT_TTL):void {
+		var bitmap:Bitmap = IconLib.getBitmap(iconId);
+		if (!bitmap) {
+			popupText(htmlText, textFormat, ttl);
+			return;
+		}
+		
+		var block:Block = new Block({
+			layoutConfig: {
+				type: "grid",
+				columns: [ICON_SIZE,-1],
+				gap: 2
+			},
+			width: width
+		});
+		block.addBitmapDataSprite({bitmap:bitmap});
+		block.addTextField({
+			defaultTextFormat: Utils.extend({}, DEFAULT_TEXT_FORMAT, textFormat),
+			autoSize: TextFieldAutoSize.LEFT,
+			wordWrap: true,
+			width: width - ICON_SIZE - 2,
+			htmlText: htmlText
+		});
+		
+		popupDisplayObject(block, ttl);
+	}
+	public function popupProgressBar(id:String, iconId:String, label:String, progress:Number, barColor:String=DEFAULT_BAR_COLOR, ttl:int = DEFAULT_TTL):void {
+		
+		var bitmap:Bitmap = IconLib.getBitmap(iconId);
+		var block:Block = new Block({
+			layoutConfig: {
+				type: "grid",
+				columns: bitmap ? [ICON_SIZE, BAR_WIDTH, -1] : [-1,BAR_WIDTH, -1],
+				gap: 2
+			},
+			width: width
+		});
+		if (bitmap) block.addBitmapDataSprite({bitmap:bitmap});
+		var progressBar:Sprite = new Sprite();
+		progressBar.addChild(new BitmapDataSprite({
+			// Border + Background
+			y: BAR_Y,
+			width: BAR_WIDTH,
+			height: BAR_HEIGHT,
+			fillColor: BAR_BG
+		}));
+		progressBar.addChild(new BitmapDataSprite({
+			// Fill
+			x: BAR_BORDER_WIDTH,
+			y: BAR_Y + BAR_BORDER_WIDTH,
+			height: BAR_HEIGHT - 2*BAR_BORDER_WIDTH,
+			width: BAR_WIDTH*progress,
+			fillColor: barColor
+		}))
+		block.addElement(progressBar);
+		block.addTextField({
+			defaultTextFormat: DEFAULT_TEXT_FORMAT,
+			autoSize: TextFieldAutoSize.LEFT,
+			wordWrap: true,
+			width: width - ICON_SIZE - 2,
+			text: label
+		});
+		
+		// Mark the block and remove existing with similar ID
+		block.dataset.progress = id;
+		for (var i:int = 0; i < numElements; i++) {
+			var ib:Block = getElementAt(i) as Block;
+			if (ib && ib.dataset.progress == id) {
+				removeElement(ib);
+				break;
+			}
+		}
+		popupDisplayObject(block, ttl);
+	}
+	
+	public function clearNotifications():void {
+		removeAllElements();
+	}
+}
+}

--- a/classes/coc/view/SimpleTween.as
+++ b/classes/coc/view/SimpleTween.as
@@ -1,0 +1,77 @@
+package coc.view {
+import classes.internals.Utils;
+
+import flash.display.DisplayObject;
+
+import mx.effects.Tween;
+import mx.effects.easing.Exponential;
+
+public class SimpleTween {
+    /**
+     * Animate a property `prop` of sprite `spr` from its current value to `endVal`.
+     * @param spr
+     * @param prop
+     * @param endVal
+     * @param ms Animation duration in milliseconds
+     * @param {Object} [options] Extra options
+     * @param {int} [options.ms] Animation time, milliseconds (default 300)
+     * @param {Function} [options.onEnd] Function to call on animation end
+     * @param {Function} [options.easing] Easing function, default mx.effects.easing.Expontential.easeInOut
+     */
+    public function SimpleTween(spr:DisplayObject, prop:String, endVal:*, ms:int=300, options:Object = null) {
+        this._spr  = spr;
+        this._prop = prop;
+        options = Utils.extend({
+            onEnd: null,
+            easing: Exponential.easeInOut
+        }, options);
+        this._onEnd  = options.onEnd;
+        _active    = true;
+        _tween = new Tween(this, _spr[_prop], endVal, ms);
+        _tween.easingFunction = options.easing;
+    }
+    
+    private var _spr:DisplayObject;
+    private var _prop:String;
+    private var _onEnd:Function;
+    private var _tween:Tween;
+    private var _active:Boolean;
+    
+    // This function is called by the tween every tick
+    public function onTweenUpdate(val:*):void {
+        this._spr[_prop] = val;
+    }
+    
+    // This function is called by the tween after it ends
+    public function onTweenEnd(val:*):void {
+        onTweenUpdate(val);
+        _active    = false;
+        this._prop = null;
+        
+        if (_onEnd != null) {
+            _onEnd();
+        }
+    }
+    
+    public function then(callback:Function):void {
+        if (!_active) return;
+        if (_onEnd != null) {
+            var oldOnEnd:Function = _onEnd;
+            _onEnd = function():void {
+                oldOnEnd();
+                callback();
+            }
+        } else {
+            _onEnd = callback;
+        }
+    }
+    
+    public function dispose():void {
+        if (_active && _tween) {
+            _tween.stop();
+        }
+        _tween = null;
+    }
+}
+
+}

--- a/classes/coc/view/charview/DragButton.as
+++ b/classes/coc/view/charview/DragButton.as
@@ -1,9 +1,10 @@
 package coc.view.charview {
 
-import coc.view.*;
-
+import classes.EngineCore;
 import classes.ItemSlotClass;
 import classes.ItemType;
+
+import coc.view.*;
 
 import flash.display.DisplayObjectContainer;
 import flash.display.Stage;
@@ -11,6 +12,8 @@ import flash.events.MouseEvent;
 import flash.geom.Point;
 import flash.geom.Rectangle;
 import flash.utils.Timer;
+
+import mx.effects.easing.Elastic;
 
 //Port from /hgg/ by Oxdeception
 public class DragButton {
@@ -52,8 +55,8 @@ public class DragButton {
     private var _selected:Boolean = false;
     private var _dragging:Boolean = false;
     private var _tweening:Boolean = false;
-    private var _xTween:TweenListener;
-    private var _yTween:TweenListener;
+    private var _xTween:SimpleTween;
+    private var _yTween:SimpleTween;
 
     private var _itemSlot:ItemSlotClass;
     private var _acceptable:Function;
@@ -202,8 +205,20 @@ public class DragButton {
         if (swap()) {
             resetPosition();
         } else {
-            _xTween = new TweenListener(_button, "x", _origin.x, resetPosition);
-            _yTween = new TweenListener(_button, 'y', _origin.y);
+            var ms:int = 300;
+            var easing:Function = Elastic.easeOut;
+            if (EngineCore.silly()) {
+                ms = 750;
+                easing = Elastic.easeOut;
+            }
+            _xTween = new SimpleTween(_button, "x", _origin.x, ms,{
+                easing: easing,
+                fun: resetPosition
+            });
+            _yTween = new SimpleTween(_button, 'y', _origin.y, ms,{
+                ms    : ms,
+                easing: easing
+            });
         }
         _container.addChild(_toolTip); // reset tool tip to top of display stack
 
@@ -220,60 +235,3 @@ public class DragButton {
 }
 }
 
-import classes.EngineCore;
-
-import flash.display.Sprite;
-
-import mx.effects.Tween;
-import mx.effects.easing.Elastic;
-
-import mx.effects.easing.Exponential;
-
-class TweenListener {
-    public function TweenListener(spr:Sprite, prop:String, endVal:*, fun:Function = null) {
-        this._spr  = spr;
-        this._prop = prop;
-        this._fun  = fun;
-        _active    = true;
-
-        var ms:int      = 300;
-        var fn:Function = Exponential.easeOut;
-
-        if (EngineCore.silly()) {
-            ms = 750;
-            fn = Elastic.easeOut;
-        }
-
-        _tween = new Tween(this, _spr[_prop], endVal, ms);
-        _tween.easingFunction = fn;
-    }
-
-    private var _spr:Sprite;
-    private var _prop:String;
-    private var _fun:Function;
-    private var _tween:Tween;
-    private var _active:Boolean;
-
-    // This function is called by the tween every tick
-    public function onTweenUpdate(val:*):void {
-        this._spr[_prop] = val;
-    }
-
-    // This function is called by the tween after it ends
-    public function onTweenEnd(val:*):void {
-        onTweenUpdate(val);
-        _active    = false;
-        this._prop = null;
-
-        if (_fun != null) {
-            _fun();
-        }
-    }
-
-    public function dispose():void {
-        if (_active && _tween) {
-            _tween.stop();
-        }
-        _tween = null;
-    }
-}

--- a/res/icons.xml
+++ b/res/icons.xml
@@ -312,8 +312,8 @@
     <!-- Aliases - images sharing IDs -->
     <aliases>
         <!--
-            Example: existing icon "I_IncubiD" is also available under id "I_HairDye"
-            <alias icon="I_IncubiD" alias="I_HairDye"/>
+            Example: icon "I_HairDye" uses icon of "I_IncubiD"
+            <alias alias="I_HairDye" icon="I_IncubiD"/>
         -->
 
         <!--===========
@@ -374,19 +374,46 @@
         = MELEE WEAPONS =
         ==============-->
         <alias alias="I_GenericItem_weapon" icon="I_Sword_Unknown"/>
-        <!-- Swords -->
+        <!--
+        missing icons
+        <alias alias="I_GenericWeapon_Axe" icon=""/>
+        <alias alias="I_GenericWeapon_Dagger" icon=""/>
+        <alias alias="I_GenericWeapon_Dueling" icon=""/>
+        <alias alias="I_GenericWeapon_Exotic" icon=""/>
+        <alias alias="I_GenericWeapon_Gauntlet" icon=""/>
+        <alias alias="I_GenericWeapon_Mace/Hammer" icon=""/>
+        <alias alias="I_GenericWeapon_Polearm" icon=""/>
+        <alias alias="I_GenericWeapon_Ribbon" icon=""/>
+        <alias alias="I_GenericWeapon_Scythe" icon=""/>
+        <alias alias="I_GenericWeapon_Spear" icon=""/>
+        <alias alias="I_GenericWeapon_Staff" icon=""/>
+        <alias alias="I_GenericWeapon_Throwing" icon=""/>
+        <alias alias="I_GenericWeapon_Whip" icon=""/>
+        <alias alias="I_GenericWeapon_Wand" icon=""/>
+        -->
+        <alias alias="I_GenericWeapon_Tome" icon="I_Book_Red"/>
 
+        <!--==============
+        = RANGED WEAPONS =
+        ===============-->
+
+        <alias alias="I_GenericItem_weaponranged" icon="I_GenericWeapon_Bow"/>
+        <!--
+        missing icons
+        <alias alias="I_GenericWeapon_Crossbow" icon=""/>
+        <alias alias="I_GenericWeapon_Dual Firearms" icon=""/>
+        <alias alias="I_GenericWeapon_Pistol" icon=""/>
+        <alias alias="I_GenericWeapon_Rifle" icon=""/>
+        <alias alias="I_GenericWeapon_2H Firearm" icon=""/>
+        -->
 
         <!--===========
         = OTHER ITEMS =
         ============-->
 
-        <alias alias="I_GenericItem_weaponranged" icon="I_GenericWeapon_Bow"/>
         <!--
-        <alias alias="I_GenericItem_shield" icon=""/>
         <alias alias="I_GenericItem_armor" icon=""/>
         <alias alias="I_GenericItem_undergarment" icon=""/>
-        <alias alias="I_GenericItem_necklace" icon=""/>
         <alias alias="I_GenericItem_headjewelry" icon=""/>
         <alias alias="I_GenericItem_jewelry" icon=""/>
         <alias alias="I_GenericItem_miscjewelry" icon=""/>
@@ -413,5 +440,32 @@
         ==============-->
 
         <alias alias="TeaseXP" icon="I_Heart_Red"/>
+        <!-- Mastery icons: 'CombatMastery' + player.combatMastery[i].combat -->
+        <alias alias="CombatMastery" icon="I_GenericWeapon_Sword"/>
+        <alias alias="CombatMasteryFeral" icon="CombatMastery"/>
+        <alias alias="CombatMasteryGauntlet" icon="CombatMastery"/>
+        <alias alias="CombatMasteryDagger" icon="CombatMastery"/>
+        <alias alias="CombatMasterySword" icon="I_GenericWeapon_Sword"/>
+        <alias alias="CombatMasteryAxe" icon="CombatMastery"/>
+        <alias alias="CombatMasteryBludgeon" icon="CombatMastery"/>
+        <alias alias="CombatMasteryDueling" icon="CombatMastery"/>
+        <alias alias="CombatMasteryPolearm" icon="CombatMastery"/>
+        <alias alias="CombatMasterySpear" icon="CombatMastery"/>
+        <alias alias="CombatMasteryWhip" icon="CombatMastery"/>
+        <alias alias="CombatMasteryExotic" icon="CombatMastery"/>
+        <alias alias="CombatMasteryArchery" icon="I_GenericWeapon_Bow"/>
+        <alias alias="CombatMasteryThrowing" icon="I_GenericWeapon_Bow"/>
+        <alias alias="CombatMasteryFirearms" icon="I_GenericWeapon_Bow"/>
+        <alias alias="CombatMasteryDualSmall" icon="CombatMastery"/>
+        <alias alias="CombatMasteryDualNormal" icon="CombatMastery"/>
+        <alias alias="CombatMasteryDualLarge" icon="CombatMastery"/>
+        <alias alias="CombatMasteryDualFirearm" icon="CombatMastery"/>
+        <alias alias="CombatMasterySmall" icon="CombatMastery"/>
+        <alias alias="CombatMasteryNormal" icon="CombatMastery"/>
+        <alias alias="CombatMasteryLarge" icon="CombatMastery"/>
+        <alias alias="CombatMasteryMassive" icon="CombatMastery"/>
+        <alias alias="CombatMasteryRange" icon="I_GenericWeapon_Bow"/>
+        <alias alias="CombatMasteryUnarmed" icon="CombatMastery"/>
+        <alias alias="CombatMasteryDualMassive" icon="CombatMastery"/>
     </aliases>
 </icons>

--- a/res/icons.xml
+++ b/res/icons.xml
@@ -407,5 +407,11 @@
         <alias alias="A_Ranged" icon="I_GenericWeapon_Bow"/>
         <alias alias="A_Tease" icon="I_Heart_Red"/>
         <alias alias="A_Items" icon="I_Potion_Empty"/>
+
+        <!--=============
+        = NOTIFICATIONS =
+        ==============-->
+
+        <alias alias="TeaseXP" icon="I_Heart_Red"/>
     </aliases>
 </icons>


### PR DESCRIPTION
This update adds a pop-up notification panel below stats (on top of character model). Currently it displays a tease XP and combat mastery progress.
Notifications disappear after 5 seconds (by default) and can have icon and a progress bar (with highlighted increment).

Notifications are handled by component available as `notificationView` in scenes and `CoC.instane.mainView.notificationView` elsewhere.

Its methods to display notifications:
* `popupText(htmlText, [textFormat], [ttl])` - text only. ttl is 'time to live', default 5 seconds
* `popupIconText(iconId, htmlText, [textFormat], [ttl])` - icon and text
* `popupProgressBar(id, iconId, htmlLabel, progress, [barColor], [ttl])` - icon, progress bar, text
* `popupProgressBar(id, iconId, htmlLabel, progressStart, progressEnd, [barColorStart], [barColorEnd], [ttl])` - icon, progress bar with highlighted increment, text

For example:
```as
popupProgressBar2("popupxp", "XP", "Experience",
                  0.5, 0.75, "white", "blue")
```
will show white main bar from 0 to 50% and blue increment from 50% to 75%. It will have text "Experience", icon `"XP"`. `"popupxp"` is notification id, other notifications with same id will be removed.

Animations are done using SimpleTween class, extracted from DragButton and enhanced.