### PR TITLE
Exploration update and new merchant UI

### DIFF
--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -409,6 +409,8 @@ public class CoC extends MovieClip
         //setTimeout(this.run,0);
     }
     private function beforeEncounterSelect(pool:/*Encounter*/Array):void {
+        // Disabled - interferes with the new encounter system
+        /*
         while (true) {
             var tw:Number = 0;
             for each (var e:Encounter in pool) {
@@ -432,6 +434,7 @@ public class CoC extends MovieClip
             trace(strace);
             if (!hasSE) break; // somehow total chance is <=0 but there are no SimpleEncounters to work with
         }
+        */
     }
     private function adjustEncounterChance(pool:/*Encounter*/Array, e:Encounter, c:Number):Number {
         if (c === Encounters.ALWAYS) return c;
@@ -449,7 +452,9 @@ public class CoC extends MovieClip
         // Smaller - more randomness
         // Bigger - more predictability
         // Too big - all events fire one by one during first shuffle
-        if (pick is SimpleEncounter) (pick as SimpleEncounter).adjustment -= 0.1;
+        
+        // Disabled - interferes with the new encounter system
+        // if (pick is SimpleEncounter) (pick as SimpleEncounter).adjustment -= 0.1;
     }
 
     private function loadStory():void {

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -5594,6 +5594,16 @@ use namespace CoC;
 			}
 			return -1;
 		}
+		public function roomForItem(itype:ItemType):int {
+			var n:int = 0;
+			for (var i:int = 0; i<itemSlots.length; i++) {
+				var slot:ItemSlotClass = itemSlots[i];
+				if (!slot.unlocked) continue;
+				if (slot.itype == itype) n += slot.roomLeft();
+				if (slot.isEmpty()) n += itype.stackSize;
+			}
+			return n;
+		}
 
 		public function itemSlot(idx:int):ItemSlotClass
 		{

--- a/classes/classes/Scenes/API/Encounters.as
+++ b/classes/classes/Scenes/API/Encounters.as
@@ -44,9 +44,16 @@ public class Encounters {
 	 * Multiply encounter chance
 	 */
 	public static function wrap2(encounter:Encounter,whenFn:Function,chances:Array):Encounter {
-		if (chances.length==0) return encounter;
-		return new SimpleEncounter(encounter.encounterName(),whenFn,
-				fn.product(chances.concat([function():Number{return encounter.encounterChance();}])),
+		if (encounter is GroupEncounter) {
+			return (encounter as GroupEncounter).wrap(whenFn, chances);
+		} else if (encounter is SimpleEncounter) {
+			return (encounter as SimpleEncounter).wrap(whenFn, chances);
+		} else return new SimpleEncounter(
+				encounter.encounterName(),
+				whenFn,
+				(chances && chances.length > 0)
+						? fn.product(chances.concat([encounter.encounterChance]))
+						: encounter.encounterChance,
 				function():void{encounter.execEncounter()}// < wrap in case it uses `this`
 		);
 	}

--- a/classes/classes/Scenes/API/ExplorationEngine.as
+++ b/classes/classes/Scenes/API/ExplorationEngine.as
@@ -490,7 +490,7 @@ public class ExplorationEngine extends BaseContent {
 				b.show("Path " + (i + 1), curry(selectRoadAndExploreNext, i))
 			}
 		}
-		button(10).show("Inventory", inventory.inventoryMenu)
+		button(10).show("Inventory", curry(inventory.showInventoryMenu, doExplore))
 				  .hint("Use an item or manage your equipment.")
 				  .disableIf(!canInventory);
 		SceneLib.masturbation.masturButton(11).disableIf(!canMasturbate);

--- a/classes/classes/Scenes/API/ExplorationEngine.as
+++ b/classes/classes/Scenes/API/ExplorationEngine.as
@@ -41,7 +41,7 @@ public class ExplorationEngine extends BaseContent {
 	}
 	/** Encounter filter for last location on the road */
 	private function filterForEnd(e:SimpleEncounter):Boolean {
-		return (e.special || ['npc', 'item', 'boss', 'treasure', 'special'].indexOf(e.kind) >= 0) && filterUnique(e);
+		return (e.special || ['npc', 'item', 'boss', 'treasure', 'special', 'monster'].indexOf(e.getKind()) >= 0) && filterUnique(e);
 	}
 	private const filters:/*Function*/Array = [filterForStart, filterForMid, filterForEnd];
 	
@@ -431,6 +431,16 @@ public class ExplorationEngine extends BaseContent {
 		return map;
 	}
 	private function showUI():void {
+		var i:int;
+		for (i = 0; i < N; i++) {
+			// If there is an encounter with chance ALWAYS, stop the exploration and execute it immediately
+			if(flatList[i].encounter && !flatList[i].isDisabled && flatList[i].encounter.encounterChance() == Encounters.ALWAYS) {
+				stopExploring();
+				flatList[i].encounter.execEncounter();
+				return;
+			}
+		}
+		
 		// Buttons
 		// [Forward/Path 1] [Path 2] [Path 3] [Path 4] [Path 5]
 		// [              ] [      ] [      ] [      ] [      ]
@@ -441,7 +451,6 @@ public class ExplorationEngine extends BaseContent {
 		var overlust:int = camp.overLustCheck();
 		mainView.setCustomElement(createMap());
 		menu();
-		var i:int;
 		var next:ExplorationEntry = getNextEntry();
 		if (road) {
 			if (next) {

--- a/classes/classes/Scenes/API/ExplorationEngine.md
+++ b/classes/classes/Scenes/API/ExplorationEngine.md
@@ -173,9 +173,12 @@ Or to make an encounter repeatable/no longer reentrable.
 ---
 
 ```as
-explorer.getNextEntry()
+explorer.nextNodes
 ```
-On an exploration map UI, this is the next `ExplorationEntry` on a road. Inside the encounter, this is same as `getCurrentEntry()`. If the exploration was ended, or road isn't picked yet, return null.
+Array of next nodes.
+
+If exploration is ended, empty array.
+If road not picked, array of first nodes on the road. 
 
 ---
 

--- a/classes/classes/Scenes/API/ExplorationEngine.md
+++ b/classes/classes/Scenes/API/ExplorationEngine.md
@@ -10,9 +10,9 @@ Encounters on the map have 3 reveal stages:
 ## Updating encounter definition
 
 ExplorationEngine works with existing GroupEncounter, but they need to have extra fields:
-* `kind` (String, required). An encounter category, for example `"item"`, `"boss"`, or `"npc"`. See `ExplorationEntry.EncounterKinds` for full list.
-* `label` (String, optional). Map label - default is encounter `name` capitalized.
-* `hint` (String, optional). Displayed in the tooltip when hovering over the fully revealed encounter.
+* `kind` (String or function returning String, required). An encounter category, for example `"item"`, `"boss"`, or `"npc"`. See `ExplorationEntry.EncounterKinds` for full list.
+* `label` (String or function returning String, optional). Map label - default is encounter `name` capitalized.
+* `hint` (String or function returning String, optional). Displayed in the tooltip when hovering over the fully revealed encounter.
 * `special` (Boolean, optional). Encounter with `special: true` have priority to appear on the road end.
 * `unique` (Boolean, optional). Only one encounter with `unique: true` can appear on a map (but not guaranteed to).
 * `reenter` (Boolean, optional). You can re-enter the encounter after finishing it (until you go forward).

--- a/classes/classes/Scenes/API/ExplorationEntry.as
+++ b/classes/classes/Scenes/API/ExplorationEntry.as
@@ -1,7 +1,6 @@
 package classes.Scenes.API {
 import classes.CoC;
 import classes.Scenes.SceneLib;
-import classes.internals.Utils;
 
 import coc.view.Color;
 import coc.view.UIUtils;
@@ -88,7 +87,7 @@ public class ExplorationEntry {
 			text             : label,
 			defaultTextFormat: {
 				font : mainTextFormat.font,
-				size : Number(mainTextFormat.size || 12) - 2,
+				size : Number(mainTextFormat.size || 12) - 4,
 				color: mainTextFormat.color,
 				align: 'center'
 			}
@@ -145,7 +144,7 @@ public class ExplorationEntry {
 	}
 	public function revealKind():void {
 		revealLevel     = REVEAL_KIND;
-		var kind:String = encounter.kind as String;
+		var kind:String = encounter.getKind();
 		if (kind) {
 			if (kind in EncounterKinds) {
 				var entry:*   = EncounterKinds[kind];
@@ -180,9 +179,9 @@ public class ExplorationEntry {
 	public function revealFull():void {
 		revealKind();
 		revealLevel   = REVEAL_FULL;
-		label         = ('label' in encounter) ? encounter.label : Utils.capitalizeFirstLetter(encounter.encounterName());
-		tooltipHeader = label;
-		tooltipText   = ('hint' in encounter) ? encounter.hint : 'Trigger this encounter';
+		label         = encounter.getLabel();
+		tooltipHeader = encounter.getTooltipHeader();
+		tooltipText   = encounter.getTooltipHint();
 	}
 	
 	public function markCleared():void {

--- a/classes/classes/Scenes/API/ExplorationEntry.as
+++ b/classes/classes/Scenes/API/ExplorationEntry.as
@@ -54,16 +54,52 @@ public class ExplorationEntry {
 	public var isPlayerHere:Boolean;
 	public var revealLevel:int; // 0: not revealed, 1: kind, 2: full
 	public var reenter:Boolean;
+	public var x:Number;
+	public var y:Number;
+	public function get centerX():Number { return x + RADIUS; }
+	public function get centerY():Number { return y + RADIUS; }
+	public var sprite:Sprite;
+	public var tfLabel:TextField;
+	public var roadIndex:int;
+	public var roadPos:int;
+	public var nextNodes:/*ExplorationEntry*/Array = [];
 	
 	public function get isFullyRevealed():Boolean { return revealLevel == REVEAL_FULL }
 	public function get encounterName():String { return encounter ? encounter.encounterName() : "(null)"}
-	public function ExplorationEntry() {
+	public function ExplorationEntry(
+			roadIndex: int,
+			roadPos: int,
+			x: Number,
+			y: Number
+	) {
+		this.roadIndex = roadIndex;
+		this.roadPos = roadPos;
+		this.x = x;
+		this.y = y;
+		createUI();
 		setEmpty();
 	}
 	
-	public function render():Sprite {
-		var s:Sprite   = new Sprite();
-		var g:Graphics = s.graphics;
+	private function createUI():void {
+		sprite = new Sprite();
+		tfLabel         = UIUtils.newTextField({
+			x                : 0,
+			y                : 2 * RADIUS,
+			width            : 2 * RADIUS,
+			autoSize         : TextFieldAutoSize.CENTER
+		});
+//		tfLabel.filters       = [UIUtils.outlineFilter(LABEL_OUTLINE)];
+		sprite.addChild(tfLabel);
+		
+		sprite.mouseChildren = false;
+		sprite.addEventListener(MouseEvent.CLICK, onClick);
+		sprite.addEventListener(MouseEvent.ROLL_OVER, onHover);
+		sprite.addEventListener(MouseEvent.ROLL_OUT, onDim);
+		sprite.x = x;
+		sprite.y = y;
+	}
+	public function redraw():void {
+		var g:Graphics = sprite.graphics;
 		
 		var borderColor:uint = Color.convertColor32(
 				isPlayerHere ? BORDER_PLAYER
@@ -79,35 +115,19 @@ public class ExplorationEntry {
 		g.endFill();
 		
 		var mainTextFormat:TextFormat = CoC.instance.mainView.mainText.defaultTextFormat;
-		var tfLabel:TextField         = UIUtils.newTextField({
-			x                : 0,
-			y                : 2 * RADIUS,
-			width            : 2 * RADIUS,
-			autoSize         : TextFieldAutoSize.CENTER,
-			text             : label,
-			defaultTextFormat: {
-				font : mainTextFormat.font,
-				size : Number(mainTextFormat.size || 12) - 4,
-				color: mainTextFormat.color,
-				align: 'center'
-			}
+		tfLabel.defaultTextFormat = UIUtils.convertTextFormat({
+			font : mainTextFormat.font,
+			size : Number(mainTextFormat.size || 12) - 4,
+			color: mainTextFormat.color,
+			align: 'center'
 		});
-//		tfLabel.filters       = [UIUtils.outlineFilter(LABEL_OUTLINE)];
-		s.addChild(tfLabel)
+		tfLabel.text = label;
 		
-		s.mouseChildren = false;
-		if (isNext) {
-			s.buttonMode = true;
-			s.addEventListener(MouseEvent.CLICK, onClick);
-		}
-		s.addEventListener(MouseEvent.ROLL_OVER, onHover);
-		s.addEventListener(MouseEvent.ROLL_OUT, onDim);
-		
-		return s;
+		sprite.buttonMode = isNext;
 	}
 	
 	private function onClick(event:MouseEvent):void {
-		SceneLib.explorationEngine.entryClick(this);
+		if (encounter && !isDisabled) SceneLib.explorationEngine.entryClick(this);
 	}
 	private function onHover(event:MouseEvent):void {
 		if (!tooltipText && !tooltipHeader) return;
@@ -129,6 +149,12 @@ public class ExplorationEntry {
 		isPlayerHere  = false;
 		revealLevel   = REVEAL_NOT;
 		reenter       = false;
+	}
+	public function unlink():void {
+		nextNodes = [];
+	}
+	public function link(e:ExplorationEntry):void {
+		nextNodes.push(e);
 	}
 	
 	public function setupForEncounter(e:SimpleEncounter):void {
@@ -169,6 +195,7 @@ public class ExplorationEntry {
 			color         = COLOR_DEFAULT;
 			tooltipHeader = "Unknown Encounter";
 			tooltipText   = "Trigger this encounter";
+			redraw();
 		} else if (level == REVEAL_KIND) {
 			revealKind();
 		} else if (level == REVEAL_FULL) {
@@ -193,11 +220,16 @@ public class ExplorationEntry {
 		tooltipText   = "";
 	}
 	public function markDisabled():void {
+		if (!encounter) return;
 		color         = COLOR_DISABLED;
 		isDisabled    = true;
 		isNext        = false;
 		tooltipHeader = "";
 		tooltipText   = "";
+	}
+	public function toString():String {
+		if (roadIndex < 0) return "[Start]";
+		return "["+roadIndex+";"+roadPos+";"+encounterName+"]";
 	}
 }
 }

--- a/classes/classes/Scenes/API/GroupEncounter.as
+++ b/classes/classes/Scenes/API/GroupEncounter.as
@@ -61,8 +61,32 @@ public class GroupEncounter implements Encounter {
 
 	public function encounterChance():Number {
 		var sum:Number = 0;
-		for each (var encounter:Encounter in components) sum += encounter.encounterChance();
+		for each (var encounter:Encounter in components) {
+			var chance:Number = encounter.encounterChance();
+			if (chance >= Encounters.ALWAYS) return Encounters.ALWAYS;
+			if (chance > 0) sum += chance;
+		}
 		return sum;
+	}
+	
+	/**
+	 * Return a copy of this group encounter with extra condition and chance multipliers
+	 * @param when Extra condition. Can be null if not needed
+	 * @param chances Chance multipliers. Can be null or empty array if not needed
+	 * @return
+	 */
+	public function wrap(when:Function, chances:Array):GroupEncounter {
+		var result:GroupEncounter = new GroupEncounter(name,[]);
+		for each (var e:Encounter in components) {
+			result.components.push(Encounters.wrap2(e, when, chances));
+		}
+		return result;
+	}
+	public function withCondition(when:Function):GroupEncounter {
+		return wrap(when,null);
+	}
+	public function withChanceFactor(chance:*):GroupEncounter {
+		return wrap(null, [chance]);
 	}
 }
 }

--- a/classes/classes/Scenes/API/MerchantItem.as
+++ b/classes/classes/Scenes/API/MerchantItem.as
@@ -1,0 +1,65 @@
+package classes.Scenes.API {
+import classes.ItemType;
+import classes.internals.Utils;
+
+import coc.view.CoCButton;
+
+public class MerchantItem extends Utils {
+	internal var _menu:MerchantMenu;
+	internal var _item:ItemType;
+	internal var _amount:int;
+	internal var _price:int;
+	internal var _hint:String         = "";
+	internal var _disabled:Boolean    = false;
+	internal var _disabledHint:String = null;
+	internal var _hide:Boolean = false;
+	
+	public function MerchantItem(
+			menu:MerchantMenu,
+			item:ItemType,
+			price:int,
+			amount:int = -1
+	):void {
+		this._menu   = menu;
+		this._item   = item;
+		this._price  = price;
+		this._amount = amount;
+		this._hint   = item.description;
+		if (_hint.match(/Base value: \d+/)) _hint = _hint.replace(/Base value: \d+/, "Price: " + _price);
+		else _hint = _hint += "\nPrice: "+_price;
+	}
+	
+	public function hint(toolTipText:String):MerchantItem {
+		this._hint = toolTipText;
+		return this;
+	}
+	
+	public function applyToButton(button:CoCButton):void {
+		if (_item.isNothing) {
+			button.hide();
+			return;
+		}
+		if (_hide) {
+			button.showDisabled("???", _disabledHint);
+			return;
+		}
+		
+		button.showForItem(_item, curry(_menu.merchantItemClick, this));
+		
+		if (_amount >= 0) button.iconQty = String(_amount);
+		button.toolTipText = _hint;
+		if (_disabled) button.disable(_disabledHint ? _disabledHint + "\n" + button.toolTipText : null);
+		else if (_amount == 0) button.disable("<b>Out of stock!</b>\n\n" + button.toolTipText);
+		else if (_menu.getCurrencyFn() < _price) button.disable("<b>Can't afford!</b>\n\n" + button.toolTipText);
+	}
+	
+	public function disableIf(condition:Boolean, tooltipHint:String = null, hide:Boolean = false):MerchantItem {
+		if (!_disabled && condition) {
+			_disabled = true;
+			if (tooltipHint) _disabledHint = tooltipHint;
+			_hide = true;
+		}
+		return this;
+	}
+}
+}

--- a/classes/classes/Scenes/API/MerchantMenu.as
+++ b/classes/classes/Scenes/API/MerchantMenu.as
@@ -1,0 +1,272 @@
+package classes.Scenes.API {
+import classes.BaseContent;
+import classes.ItemSlotClass;
+import classes.ItemType;
+
+import coc.view.Block;
+import coc.view.CoCButton;
+
+public class MerchantMenu extends BaseContent {
+	public var items:/*MerchantItem*/Array = [];
+	/**
+	 * Player can sell items to this merchant
+	 */
+	public var playerCanSell:Boolean       = false;
+	/**
+	 * Buy items from player for (item value) * (sell factor) gems
+	 */
+	public var playerSellFactor:Number     = 0.5;
+	/**
+	 * Function `function(itype:ItemType):Boolean` to check if player can sell item.
+	 *
+	 * null - player can sell any item (if playerCanSell is true).
+	 */
+	public var playerSellFilter:Function = null;
+	/**
+	 * Default price = item value * price factor
+	 */
+	public var priceFactor:Number          = 1.0;
+	/**
+	 * `function(itype:ItemType, quantity:int, next:Function):void`
+	 *
+	 * Called after player purchases an item.
+	 *
+	 * To return to merchant interface, this function should call `next();`
+	 */
+	public var afterPurchase:Function = null;
+	/**
+	 * `function(itype:ItemType, quantity:int, slotIndex:int, next:Function):void`.
+	 *
+	 * Called after player sells an item.
+	 *
+	 * To return to merchant interface, this function should call `next();`
+	 */
+	public var afterPlayerSell:Function = null;
+	/**
+	 * `function(delta:int):void`
+	 */
+	public var modCurrencyFn:Function;
+	/**
+	 * `function():int`
+	 */
+	public var getCurrencyFn:Function;
+	/**
+	 * `function():void`
+	 *
+	 * Called after merchant interface is displayed. Can be used to add extra buttons.
+	 */
+	public var onShow:Function = null;
+	/**
+	 * Show [Inventory] button.
+	 */
+	public var canInventory:Boolean = true;
+	
+	private var grid:Block;
+	private var backButton:Function                   = camp.returnToCampUseOneHour;
+	private var playerInvButtons:/*CoCButton*/Array   = [];
+	private var playerPage:int                        = 0;
+	private var playerItemsPerPage:int                = 25;
+	private var playerPageMax:int                     = 0;
+	private var merchantInvButtons:/*CoCButton*/Array = [];
+	private var merchantPage:int                      = 0;
+	private var merchantItemsPerPage:int              = 25;
+	private var merchantPageMax:int                   = 0;
+	
+	public function MerchantMenu() {
+		useGemCurrency();
+	}
+	
+	public function useGemCurrency():void {
+		modCurrencyFn = function(delta:int):void {
+			player.gems += delta;
+			statScreenRefresh();
+		}
+		getCurrencyFn = function():int { return player.gems }
+	}
+	
+	public function addItem(
+			item:ItemType,
+			price:int  = -1,
+			amount:int = -1
+	):MerchantItem {
+		if (price == -1) price = Math.ceil(item.value * priceFactor);
+		var mi:MerchantItem = new MerchantItem(this, item, price, amount);
+		this.items.push(mi);
+		return mi;
+	}
+	/**
+	 * Add an empty (invisible) slot
+	 */
+	public function addSpacer():void {
+		addItem(ItemType.NOTHING);
+	}
+	/**
+	 * Add empty slots to ensure that next item will start on new line
+	 */
+	public function addLineBreak():void {
+		while (items.length % 5 > 0) addSpacer();
+	}
+	
+	public function merchantItemClick(mi:MerchantItem):void {
+		var amount:int = 1;
+		if (shiftKeyDown) {
+			amount = mi._item.stackSize;
+			if (mi._amount >= 0) amount = Math.min(amount, mi._amount);
+			amount = Math.min(amount, Math.max(1, player.roomForItem(mi._item)));
+		}
+		modCurrencyFn(-mi._price*amount);
+		if (mi._amount >= 0) mi._amount -= amount;
+		var n:int = amount;
+		var redraw:Boolean = false;
+		function addOneItem():void {
+			while (n-- > 0) {
+				if (inventory.tryAddItemToPlayer(mi._item) == 0) {
+					clearOutput();
+					inventory.takeItem(mi._item, addOneItem);
+					return;
+				}
+			}
+			if (afterPurchase != null) {
+				redraw = true;
+				afterPurchase(mi._item, amount, curry(addOneItem));
+			} else {
+				if (redraw) showScreen();
+				else update();
+			}
+		}
+		addOneItem();
+	}
+	public function playerItemClick(i:int):void {
+		sellPlayerItem(i, shiftKeyDown ? -1 : 1);
+	}
+	public function sellPlayerItem(slotIndex:int, quantity:int):void {
+		var itemSlot:ItemSlotClass = player.itemSlot(slotIndex);
+		var itype:ItemType         = itemSlot.itype;
+		if (itemSlot.isEmpty() || !canSell(itype)) return;
+		if (quantity < 0) quantity = itemSlot.quantity;
+		if (quantity > itemSlot.quantity) quantity = itemSlot.quantity;
+		if (quantity == 0) return;
+		var value:Number = sellPrice(itype) * quantity;
+		modCurrencyFn(+value);
+		itemSlot.quantity -= quantity;
+		update();
+		if (afterPlayerSell != null) afterPlayerSell(itype, quantity, slotIndex, showScreen);
+	}
+	public function sellAllClick():void {
+		for (var i:int = 0; i < player.itemSlotCount(); i++) {
+			if (player.itemSlot(i).unlocked) {
+				sellPlayerItem(i, -1);
+				if (mainView.getCustomElement() != grid) {
+					// If afterPlayerSell callback displayed own interface, halt
+					return;
+				}
+			}
+		}
+	}
+	public function canSell(itype:ItemType):Boolean {
+		return playerCanSell && !itype.isNothing && (playerSellFilter == null || playerSellFilter(itype));
+	}
+	public function sellPrice(itype:ItemType):int {
+		return Math.floor(itype.value * playerSellFactor);
+	}
+	
+	public function update():void {
+		var i:int, j:int, n:int;
+		j = playerPage * playerItemsPerPage;
+		n = player.itemSlotCount();
+		for (i = 0; i < playerInvButtons.length; i++, j++) {
+			if (j < n) {
+				var itemSlot:ItemSlotClass = player.itemSlot(j);
+				playerInvButtons[i].showForItemSlot(itemSlot, curry(playerItemClick, j))
+								   .disableIf(!playerCanSell);
+				if (canSell(itemSlot.itype)) playerInvButtons[i].toolTipText += "\nSell price: " + sellPrice(itemSlot.itype);
+			} else {
+				playerInvButtons[i].hide();
+			}
+		}
+		j = merchantPage * merchantItemsPerPage;
+		for (i = 0; i < merchantInvButtons.length; i++, j++) {
+			if (items[j]) items[j].applyToButton(merchantInvButtons[i]);
+			else merchantInvButtons[i].hide();
+		}
+		statScreenRefresh();
+	}
+	
+	public function show(backButton:Function):void {
+		this.backButton = backButton;
+		flushOutputTextToGUI();
+		show0();
+	}
+	private function showScreen():void {
+		clearOutput();
+		show0();
+	}
+	private function show0():void {
+		grid = new Block({
+			layoutConfig: {
+				type: "grid",
+				cols: 5
+			}
+		});
+		var i:int, n:int;
+		var btn:CoCButton;
+		// 5 rows: player inventory
+		// 1 row : player inventory pages
+		// 1 row : spacer
+		// 5 rows: merchant
+		// 1 row : merchant pages
+		n                       = 0;
+		var playerItemCount:int = player.itemSlotCount();
+		var playerItemRows:int  = Math.min(5, Math.ceil(playerItemCount / 5));
+		playerPage              = 0;
+		playerPageMax           = Math.ceil(playerItemCount / playerItemRows / 5);
+		playerItemsPerPage      = playerItemRows * 5;
+		playerInvButtons = [];
+		if (playerItemCount > 0) {
+			grid.addTextField({
+				htmlText         : "Your inventory: " + (playerCanSell ? " <i>(Click ot sell)</i>" : ""),
+				defaultTextFormat: mainView.mainText.defaultTextFormat
+			}, {colspan: 5})
+		}
+		for (i = 0; i < playerItemRows * 5; i++) {
+			btn = mainView.createActionButton(i);
+			grid.addElement(btn);
+			playerInvButtons.push(btn);
+		}
+		if (playerPageMax > 0) {
+			// todo @aimozg player inventory pagination
+		}
+		var merchantItemCount:int = items.length;
+		var merchantItemRows:int  = Math.min(5, Math.ceil(merchantItemCount / 5));
+		merchantPage              = 0;
+		merchantPageMax           = Math.ceil(merchantItemCount / merchantItemRows / 5);
+		merchantItemsPerPage      = merchantItemRows * 5;
+		merchantInvButtons = [];
+		if (merchantItemCount > 0) {
+			grid.addTextField({
+				htmlText         : "Merchant inventory: <i>(Click to buy)</i>",
+				defaultTextFormat: mainView.mainText.defaultTextFormat
+			}, {colspan: 5})
+		}
+		for (i = 0; i < merchantItemRows * 5; i++) {
+			btn = mainView.createActionButton(i);
+			grid.addElement(btn);
+			merchantInvButtons.push(btn);
+		}
+		if (playerPageMax > 0) {
+			// todo @aimozg merchant inventory pagination
+		}
+		update();
+		
+		mainView.setCustomElement(grid, true, true);
+		grid.doLayout();
+		menu();
+		if (playerCanSell) button(0).show("Sell All", sellAllClick);
+		if (canInventory) button(2).show("Inventory", curry(inventory.showInventoryMenu, showScreen));
+		button(14).show( "Back", backButton).icon("Back");
+		if (onShow != null) onShow();
+	}
+}
+}
+
+

--- a/classes/classes/Scenes/API/MerchantMenu.as
+++ b/classes/classes/Scenes/API/MerchantMenu.as
@@ -258,7 +258,7 @@ public class MerchantMenu extends BaseContent {
 		playerInvButtons        = [];
 		if (playerItemCount > 0) {
 			grid.addTextField({
-				htmlText         : "Your inventory: " + (playerCanSell ? " <i>(Click ot sell)</i>" : ""),
+				htmlText         : "Your inventory: " + (playerCanSell ? " <i>(Click to sell, Shift+click to sell all)</i>" : ""),
 				defaultTextFormat: mainView.mainText.defaultTextFormat
 			}, {colspan: 5})
 		}
@@ -286,7 +286,7 @@ public class MerchantMenu extends BaseContent {
 		merchantInvButtons        = [];
 		if (merchantItemCount > 1) {
 			grid.addTextField({
-				htmlText         : "Merchant inventory: <i>(Click to buy)</i>",
+				htmlText         : "Merchant inventory: <i>(Click to buy, Shift+click to buy max)</i>",
 				defaultTextFormat: mainView.mainText.defaultTextFormat
 			}, {colspan: 5})
 		}
@@ -314,9 +314,9 @@ public class MerchantMenu extends BaseContent {
 		if (playerCanSell) button(0).show("Sell All", sellAllClick);
 		if (canInventory) button(2).show("Inventory", curry(inventory.showInventoryMenu, showScreen));
 		if (CoC_Settings.mobileBuild) {
-			button(4).show("Buy 1", function ():void {
+			button(4).show("Buy/Sell: 1", function ():void {
 				shiftKeyDown = !shiftKeyDown;
-				button(4).text(shiftKeyDown ? "Buy max" : "Buy 1");
+				button(4).text(shiftKeyDown ? "Buy/Sell: Max" : "Buy/Sell: 1");
 			})
 		}
 		button(14).show("Back", backButton).icon("Back");

--- a/classes/classes/Scenes/API/SimpleEncounter.as
+++ b/classes/classes/Scenes/API/SimpleEncounter.as
@@ -60,8 +60,8 @@ public dynamic class SimpleEncounter implements Encounter {
 	 * @return
 	 */
 	public function wrap(whenFn:Function,chances:Array):SimpleEncounter {
-		if (whenFn) {
-			if (this._whenFn) whenFn = FnHelpers.FN.all(whenFn, this._whenFn)
+		if (whenFn != null) {
+			if (this._whenFn != null) whenFn = FnHelpers.FN.all(whenFn, this._whenFn)
 		} else whenFn = this._whenFn;
 		var result:SimpleEncounter = new SimpleEncounter(
 				name,

--- a/classes/classes/Scenes/API/SimpleEncounter.as
+++ b/classes/classes/Scenes/API/SimpleEncounter.as
@@ -14,7 +14,7 @@ public dynamic class SimpleEncounter implements Encounter {
 	
 	public function SimpleEncounter(name:String, whenFn:Function, weight:*, body:Function) {
 		if (!(weight is Function) && !(weight is Number)) {
-			CoC_Settings.error("Encounters.make(weight=" + (typeof weight) + ")");
+			CoC_Settings.error("Encounters.make(name="+name+", weight=" + (typeof weight) + ")");
 			weight = 100;
 		}
 		this.name = name;
@@ -30,7 +30,7 @@ public dynamic class SimpleEncounter implements Encounter {
 	}
 	
 	public function canHappen():Boolean {
-		return !(_whenFn is Function && !_whenFn());
+		return !(_whenFn is Function && !_whenFn()) && originalChance() > 0;
 	}
 	
 	public function adjustedChance():Number {
@@ -51,6 +51,52 @@ public dynamic class SimpleEncounter implements Encounter {
 
 	public function encounterName():String {
 		return name;
+	}
+	
+	/**
+	 * Return a copy of this encounter with extra condition and chance multipliers.
+	 * @param when Extra condition. Can be null if not needed
+	 * @param chances Chance multipliers. Can be null or empty array if not needed
+	 * @return
+	 */
+	public function wrap(whenFn:Function,chances:Array):SimpleEncounter {
+		if (whenFn) {
+			if (this._whenFn) whenFn = FnHelpers.FN.all(whenFn, this._whenFn)
+		} else whenFn = this._whenFn;
+		var result:SimpleEncounter = new SimpleEncounter(
+				name,
+				whenFn,
+				chances.length == 0 ? this._weight : FnHelpers.FN.product(chances.concat(this._weight)),
+				this._body
+		);
+		for (var key:String in this) {
+			if (!(key in result)) result[key] = this[key];
+		}
+		return result;
+	}
+	public function getKind():String {
+		var kind:* = null;
+		if ('kind' in this) kind = this['kind'];
+		if (kind is Function) kind = kind();
+		return String(kind).toLowerCase();
+	}
+	public function getLabel():String {
+		var label:* = getTooltipHeader();
+		if ('shortLabel' in this) label = this['shortLabel'];
+		if (label is Function) label = label();
+		return String(label);
+	}
+	public function getTooltipHint():String {
+		var hint:* = 'Trigger this encounter.';
+		if ('hint' in this) hint = this['hint'];
+		if (hint is Function) hint = hint();
+		return String(hint);
+	}
+	public function getTooltipHeader():String {
+		var hint:* = Utils.capitalizeFirstLetter(encounterName());
+		if ('label' in this) hint = this['label'];
+		if (hint is Function) hint = hint();
+		return String(hint);
 	}
 }
 }

--- a/classes/classes/Scenes/Areas/BattlefieldBoundary.as
+++ b/classes/classes/Scenes/Areas/BattlefieldBoundary.as
@@ -3,15 +3,13 @@
  * Area with lvl 6-29 group enemies. Good for PC focused on group fights.
  * Currently a Work in Progress
  */
-package classes.Scenes.Areas 
+package classes.Scenes.Areas
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
-import classes.CoC;
 import classes.Scenes.API.Encounters;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Battlefield.*;
-import classes.Scenes.Dungeons.DemonLab;
 import classes.Scenes.NPCs.EtnaFollower;
 import classes.Scenes.SceneLib;
 
@@ -98,12 +96,7 @@ use namespace CoC;
 				name: "ted",
 				call: SceneLib.tedScene.introPostHiddenCave,
 				when: SceneLib.tedScene.canEncounterTed
-			}, {
-				//General Golems, Goblin and Imp Encounters
-				name: "common",
-				chance: 0.4,
-				call: SceneLib.exploration.genericGolGobImpEncounters
-			}, {
+			}, SceneLib.exploration.commonEncounters.withChanceFactor(0.4), {
 				name: "zombies",
 				chance: 0.4,
 				call: battlefieldEnemiesScene.encounterZombies,

--- a/classes/classes/Scenes/Areas/BattlefieldInner.as
+++ b/classes/classes/Scenes/Areas/BattlefieldInner.as
@@ -3,15 +3,13 @@
  * Area with lvl 24-60 group enemies. Good for PC focused on group fights.
  * Currently a Work in Progress
  */
-package classes.Scenes.Areas 
+package classes.Scenes.Areas
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
-import classes.CoC;
 import classes.Scenes.API.Encounters;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Battlefield.*;
-import classes.Scenes.Dungeons.DemonLab;
 import classes.Scenes.NPCs.EtnaFollower;
 import classes.Scenes.SceneLib;
 
@@ -75,12 +73,7 @@ public class BattlefieldInner extends BaseContent
 			name: "ted",
 			call: SceneLib.tedScene.introPostHiddenCave,
 			when: SceneLib.tedScene.canEncounterTed
-		}, {
-			//General Golems, Goblin and Imp Encounters
-			name: "common",
-			chance: 0.4,
-			call: SceneLib.exploration.genericGolGobImpEncounters
-		}, {
+		}, SceneLib.exploration.commonEncounters.withChanceFactor(0.4), {
 			//General Golems, Goblin and Imp Encounters
 			name: "vengefulAparitions",
 			chance: 0.4,

--- a/classes/classes/Scenes/Areas/BattlefieldOuter.as
+++ b/classes/classes/Scenes/Areas/BattlefieldOuter.as
@@ -3,22 +3,20 @@
  * Area with lvl 24-53 group enemies. Good for PC focused on group fights.
  * Currently a Work in Progress
  */
-package classes.Scenes.Areas 
+package classes.Scenes.Areas
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
-import classes.CoC;
+import classes.Items.Vehicles;
 import classes.Scenes.API.Encounters;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Battlefield.*;
-import classes.Scenes.Dungeons.DemonLab;
 import classes.Scenes.NPCs.EtnaFollower;
 import classes.Scenes.NPCs.TyrantiaFollower;
 import classes.Scenes.SceneLib;
-import classes.Items.Vehicles;
 
 use namespace CoC;
-	
+
 public class BattlefieldOuter extends BaseContent
 {
 	public var battlefieldEnemiesScene:BattlefieldEnemiesScenes = new BattlefieldEnemiesScenes();
@@ -114,12 +112,7 @@ public class BattlefieldOuter extends BaseContent
 			name: "ted",
 			call: SceneLib.tedScene.introPostHiddenCave,
 			when: SceneLib.tedScene.canEncounterTed
-		}, {
-			//General Golems, Goblin and Imp Encounters
-			name: "common",
-			chance: 0.4,
-			call: SceneLib.exploration.genericGolGobImpEncounters
-		}, {
+		}, SceneLib.exploration.commonEncounters.withChanceFactor(0.4), {
 			name: "vengefulAparitions",
 			chance: 0.4,
 			call: battlefieldEnemiesScene.encounterVengefulApparitions

--- a/classes/classes/Scenes/Areas/Forest.as
+++ b/classes/classes/Scenes/Areas/Forest.as
@@ -92,18 +92,9 @@ use namespace CoC;
 		private function init():void {
             const fn:FnHelpers = Encounters.fn;
 			_forestOutskirtsEncounter = Encounters.group("outskirtsforest",
+					SceneLib.exploration.commonEncounters.withChanceFactor(0.4),
+					SceneLib.exploration.angelEncounters.wrap(fn.ifLevelMin(5), [0.05]),
 					{
-						//General Golems, Goblin, Angels and Imp Encounters
-						name: "common",
-						label: "Monsters",
-						kind: 'monster',
-						chance: 0.4,
-						call: function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							if (rand(10) == 0 && player.level > 5) SceneLib.exploration.genericAngelsEncounters();
-							else SceneLib.exploration.genericGolGobImpEncounters();
-						}
-					}, {
 						//Helia monogamy fucks
 						name  : "helcommon",
 						label : "Helia",
@@ -120,7 +111,6 @@ use namespace CoC;
 						night : false,
 						chance: 0.6,
 						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 							if (flags[kFLAGS.TAMANI_DAUGHTER_PREGGO_COUNTDOWN] == 0
 								&& flags[kFLAGS.TAMANI_NUMBER_OF_DAUGHTERS] >= 16 && flags[kFLAGS.SOUL_SENSE_TAMANI_DAUGHTERS] < 3) {
 								tamaniDaughtersScene.encounterTamanisDaughters();
@@ -140,10 +130,7 @@ use namespace CoC;
 						kind  : 'npc',
 						unique: true,
 						night : false,
-						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							encounterTamanisDaughtersFn();
-						},
+						call  : encounterTamanisDaughtersFn,
 						when  : function ():Boolean {
 							return player.gender > 0
 								&& player.hasCock()
@@ -160,10 +147,7 @@ use namespace CoC;
 						label : "Bee-girl",
 						kind  : 'monster',
 						night : false,
-						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							beeGirlScene.beeEncounter();
-						},
+						call  : beeGirlScene.beeEncounter,
 						chance: 0.20
 					}, {
 						name  : "werewolfFemale",
@@ -171,10 +155,7 @@ use namespace CoC;
 						kind : 'monster',
 						day : false,
 						when: fn.ifLevelMin(12),
-						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							SceneLib.werewolfFemaleScene.introWerewolfFemale();
-						},
+						call  : SceneLib.werewolfFemaleScene.introWerewolfFemale,
 						chance: 0.50
 					}, {
 						name  : "truffle",
@@ -268,22 +249,14 @@ use namespace CoC;
 						},
 						call: SceneLib.exploration.demonLabProjectEncounters
 					}*/);
-			_forestEncounter = Encounters.group("forest", {
-						//General Golems, Goblin and Imp Encounters
-						name: "common",
-						chance: 0.4,
-						call: function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							SceneLib.exploration.genericGolGobImpEncounters();
-						}
-					}, {
+			// TODO @aimozg 'plants' tag
+			_forestEncounter = Encounters.group("forest",
+					SceneLib.exploration.commonEncounters.withChanceFactor(0.4),
+					{
 						//Helia monogamy fucks
 						name  : "helcommon",
 						night : false,
-						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							SceneLib.helScene.helSexualAmbush();
-						},
+						call  : SceneLib.helScene.helSexualAmbush,
 						chance: forestChance2,
 						when  : SceneLib.helScene.helSexualAmbushCondition
 					}, {
@@ -841,7 +814,7 @@ use namespace CoC;
 		public function exploreForestOutskirts():void
 		{
 			explorer.prepareArea(forestOutskirtsEncounter);
-			explorer.setTags("forest","forestOutskirts");
+			explorer.setTags("forest","forestOutskirts","plants");
 			explorer.prompt = "You explore the forest outskirts.";
 			explorer.onEncounter = function(e:ExplorationEntry):void {
 				player.exploredForest++;

--- a/classes/classes/Scenes/Areas/Lake.as
+++ b/classes/classes/Scenes/Areas/Lake.as
@@ -8,7 +8,6 @@ import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.API.Encounters;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Lake.*;
-import classes.Scenes.Dungeons.DemonLab;
 import classes.Scenes.Holidays;
 import classes.Scenes.NPCs.BelisaFollower;
 import classes.Scenes.NPCs.EtnaFollower;
@@ -157,15 +156,9 @@ use namespace CoC;
 					return player.level >= 3
 				},
 				call: slimeOozeEncounterFn
-			}, {
-				name: "common",
-				when: function ():Boolean {
-					return player.level >= 3 && flags[kFLAGS.NEW_GAME_PLUS_LEVEL] > 0
-				},
-				chance: 0.5,
-				night: false,
-				call: SceneLib.exploration.genericGolGobImpEncounters
-			}, {
+			}, SceneLib.exploration.commonEncounters.wrap(function ():Boolean {
+				return player.level >= 3 && flags[kFLAGS.NEW_GAME_PLUS_LEVEL] > 0
+			}, [0.5]), {
 				//Helia monogamy fucks
 				name: "helcommon",
 				night : false,

--- a/classes/classes/Scenes/Areas/Mountain.as
+++ b/classes/classes/Scenes/Areas/Mountain.as
@@ -14,7 +14,6 @@ import classes.Scenes.API.FnHelpers;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.HighMountains.*;
 import classes.Scenes.Areas.Mountain.*;
-import classes.Scenes.Dungeons.DemonLab;
 import classes.Scenes.Monsters.LightElfScene;
 import classes.Scenes.NPCs.DivaScene;
 import classes.Scenes.NPCs.EtnaFollower;
@@ -59,15 +58,10 @@ public class Mountain extends BaseContent
 		}
 		private function init():void {
             const fn:FnHelpers = Encounters.fn;
-			_hillsEncounter = Encounters.group("hills", {
-				//General Angels, Golems, Goblin and Imp Encounters
-				name: "common",
-				chance: 0.5,
-				call: function ():void{
-					if (rand(10) == 0 && player.level > 5) SceneLib.exploration.genericAngelsEncounters();
-					else SceneLib.exploration.genericGolGobImpEncounters();
-				}
-			}, {
+			_hillsEncounter = Encounters.group("hills",
+					SceneLib.exploration.commonEncounters.withChanceFactor(0.4),
+					SceneLib.exploration.angelEncounters.wrap(fn.ifLevelMin(5), [0.05]),
+			{
 				//Helia monogamy fucks
 				name  : "helcommon",
 				night : false,

--- a/classes/classes/Scenes/Areas/Plains.as
+++ b/classes/classes/Scenes/Areas/Plains.as
@@ -5,12 +5,10 @@ package classes.Scenes.Areas
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
-import classes.CoC;
 import classes.Scenes.API.Encounters;
 import classes.Scenes.API.FnHelpers;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Plains.*;
-import classes.Scenes.Dungeons.DemonLab;
 import classes.Scenes.NPCs.EtnaFollower;
 import classes.Scenes.SceneLib;
 
@@ -38,16 +36,11 @@ use namespace CoC;
 
 		private function init():void {
 			const fn:FnHelpers = Encounters.fn;
-			explorationEncounter = Encounters.group(/*SceneLib.commonEncounters,*/ {
-				//General Golems, Goblin, Angels and Imp Encounters
-				name: "common",
-				chance: 0.5,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					if (rand(10) == 0) SceneLib.exploration.genericAngelsEncounters();
-					else SceneLib.exploration.genericGolGobImpEncounters();
-				}
-			}, {
+			// TODO @aimozg 'plants' tag
+			explorationEncounter = Encounters.group(/*SceneLib.commonEncounters,*/
+					SceneLib.exploration.commonEncounters.withChanceFactor(0.4),
+					SceneLib.exploration.angelEncounters.withChanceFactor(0.05),
+			{
 				//Helia monogamy fucks
 				name  : "helcommon",
 				night : false,

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -5,7 +5,6 @@ import classes.BodyParts.Arms;
 import classes.BodyParts.Eyes;
 import classes.BodyParts.Face;
 import classes.BodyParts.Hair;
-import classes.BodyParts.Horns;
 import classes.BodyParts.LowerBody;
 import classes.BodyParts.RearBody;
 import classes.BodyParts.Skin;
@@ -25,7 +24,6 @@ import classes.Scenes.NPCs.Holli;
 import classes.Scenes.NPCs.TyrantiaFollower;
 import classes.Scenes.Places.Mindbreaker;
 import classes.Scenes.Places.TelAdre.UmasShop;
-import classes.Scenes.SceneLib;
 import classes.Scenes.SceneLib;
 import classes.StatusEffects.VampireThirstEffect;
 
@@ -791,7 +789,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.GreenCovenant)) {
 				bd.disable("You already connected with nearby plants!");
 			}
-			else if(!player.hasStatusEffect(StatusEffects.NearbyPlants)) {
+			else if(!player.hasStatusEffect(StatusEffects.NearbyPlants) && !explorer.areaTags.plants) {
 				bd.disable("Green Covenant requires having plants nearby.");
 			}
 			else if(player.hasStatusEffect(StatusEffects.CooldownGreenCovenant)) {

--- a/classes/classes/Scenes/Combat/SpellsGreen/DeathBlossomSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/DeathBlossomSpell.as
@@ -1,12 +1,12 @@
-package classes.Scenes.Combat.SpellsGreen 
+package classes.Scenes.Combat.SpellsGreen
 {
 import classes.Monster;
 import classes.PerkLib;
 import classes.Scenes.Combat.AbstractGreenSpell;
 import classes.StatusEffects;
 
-	public class DeathBlossomSpell extends AbstractGreenSpell {
-		public function DeathBlossomSpell() 
+public class DeathBlossomSpell extends AbstractGreenSpell {
+		public function DeathBlossomSpell()
 		{
 			super("Death Blossom",
 			"Deliver deadly poison and strong aphrodisiac by causing nearby vegetation to bloom corrupted flowers which inflicts their poison each round for 3 rounds. Deals severe tease and poison damage over time intensifying every round by 20%.",
@@ -32,7 +32,7 @@ import classes.StatusEffects;
 		var uc:String = super.usabilityCheck();
 		if (uc) return uc;
 		
-		if (!player.hasStatusEffect(StatusEffects.NearbyPlants)) {
+		if (!player.hasStatusEffect(StatusEffects.NearbyPlants) && !explorer.areaTags.plants) {
 			return "Death Blossom require to have plants nearby.";
 		}
 		

--- a/classes/classes/Scenes/Combat/SpellsGreen/EntangleSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/EntangleSpell.as
@@ -38,7 +38,7 @@ public class EntangleSpell extends AbstractGreenSpell {
 		var uc:String = super.usabilityCheck();
 		if (uc) return uc;
 		
-		if (!player.hasStatusEffect(StatusEffects.NearbyPlants)) {
+		if (!player.hasStatusEffect(StatusEffects.NearbyPlants) && !explorer.areaTags.plants) {
 			return "Entangle require to have plants nearby.";
 		}
 		

--- a/classes/classes/Scenes/Combat/SpellsGreen/PlantGrowthSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/PlantGrowthSpell.as
@@ -53,7 +53,7 @@ public class PlantGrowthSpell extends AbstractGreenSpell {
 	
 	override protected function doSpellEffect(display:Boolean = true):void {
 		if (display) {
-			if (player.hasStatusEffect(StatusEffects.NearbyPlants)) {
+			if (player.hasStatusEffect(StatusEffects.NearbyPlants) || explorer.areaTags.plants) {
 				outputText("You focus your intent on the flora around you, infusing them with the power of your emotions. The onslaught of lust causes flowers to bloom into a pollen cloud as vine surges from the canopy and darts to your opponent.");
 				if (monster.lustVuln == 0) {
 					if (display) {

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -6,6 +6,10 @@ package classes.Scenes
 import classes.*;
 import classes.BodyParts.LowerBody;
 import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.API.Encounters;
+import classes.Scenes.API.ExplorationEntry;
+import classes.Scenes.API.FnHelpers;
+import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.DeepSea.Kraken;
 import classes.Scenes.Areas.Forest.AlrauneMaiden;
 import classes.Scenes.Areas.Forest.WapsHuntress;
@@ -36,6 +40,7 @@ public class Exploration extends BaseContent
 
 		public function Exploration()
 		{
+			onGameInit(init);
 		}
 
 		public function furriteMod():Number {
@@ -454,184 +459,83 @@ public class Exploration extends BaseContent
 			flags[kFLAGS.EXPLORATION_PAGE] = 5;
 			doExplore();
 		}
-
-		public function genericGolGobImpEncounters(even:Boolean = false):void {
-			var sss:Number = 3;
-			if (player.hasPerk(PerkLib.PiercedLethite)) sss += 1;
-			var ImpGobGol:Number = rand(sss);
-			if (ImpGobGol > 1) {
-				var ss:Number = 40;
-				if (player.level >= 8) ss += 20;
-				if (player.level >= 12) ss += 20;
-				if (player.level >= 16) ss += 20;
-				var impChooser:int = rand(ss);
-				//Imp Lord
-				if (impChooser >= 50 && impChooser < 70) {
-					if (flags[kFLAGS.GALIA_LVL_UP] > 0 && flags[kFLAGS.GALIA_LVL_UP] < 0.5) {
-						if (rand(4) == 0) SceneLib.impScene.impLordEncounter();
-						else SceneLib.impScene.impLordFeralEncounter();
-					}
-					else {
-						if (rand(4) == 0) SceneLib.impScene.impLordFeralEncounter();
-						else SceneLib.impScene.impLordEncounter();
-					}
-					spriteSelect(SpriteDb.s_imp);
-					return;
-				}
-				//Imp Warlord
-				else if (impChooser >= 70 && impChooser < 90) {
-					if (flags[kFLAGS.GALIA_LVL_UP] > 0 && flags[kFLAGS.GALIA_LVL_UP] < 0.5) {
-						if (rand(4) == 0) SceneLib.impScene.impWarlordEncounter();
-						else SceneLib.impScene.impWarlordFeralEncounter();
-					}
-					else {
-						if (rand(4) == 0) SceneLib.impScene.impWarlordFeralEncounter();
-						else SceneLib.impScene.impWarlordEncounter();
-					}
-					spriteSelect(SpriteDb.s_impWarlord);
-					return;
-				}
-				//Imp Overlord (Rare!)
-				else if (impChooser >= 90) {
-					SceneLib.impScene.impOverlordEncounter();
-					spriteSelect(SpriteDb.s_impOverlord);
-					return;
-				}
-				else {
-					clearOutput();
-					if (flags[kFLAGS.GALIA_LVL_UP] > 0 && flags[kFLAGS.GALIA_LVL_UP] < 0.5) {
-						if (rand(4) == 0) {
-							outputText("An imp wings out of the sky and attacks!");
-							camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_IMPS);
-							startCombat(new Imp());
-						}
-						else {
-							outputText("A feral imp wings out of the sky and attacks!");
-							camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_IMPS);
-							flags[kFLAGS.FERAL_EXTRAS] = 1;
-							startCombat(new FeralImps());
-						}
-					}
-					else {
-						if (rand(4) == 0 && (player.level >= 3 || player.statusEffectv2(StatusEffects.AdventureGuildQuests2) > 0)) {
-							outputText("A feral imp wings out of the sky and attacks!");
-							camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_IMPS);
-							flags[kFLAGS.FERAL_EXTRAS] = 1;
-							startCombat(new FeralImps());
-						}
-						else {
-							outputText("An imp wings out of the sky and attacks!");
-							camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_IMPS);
-							startCombat(new Imp());
-						}
-					}
-					spriteSelect(SpriteDb.s_imp);
-				}
-				return;
-			}
-			else if (ImpGobGol == 1) {
-				var sg:Number = 10;
-				if (player.level >= 12) sg += 10;
-				if (player.level >= 18) sg += 10;
-				if (player.level >= 24) sg += 10;
-				if (player.level >= 33) sg += 10;
-				if (player.level >= 42) sg += 10;
-				if (player.level >= 51) sg += 10;
-				var golemChooser:int = rand(sg);
-				clearOutput();
-				//Improved dummy golem
-				if (golemChooser >= 10 && golemChooser < 20) {
-					outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered improved dummy golem! You ready your [weapon] for a fight!");
-					startCombat(new GolemDummyImproved());
-					return;
-				}
-				//Advanced dummy golem or golems
-				if (golemChooser >= 20 && golemChooser < 30) {
-					if (rand(4) == 0) {
-						outputText("As you take a stroll, out of nearby bushes emerge group of golems. Looks like you have encountered advanced dummy golems! You ready your [weapon] for a fight!");
-						startCombat(new GolemsDummyAdvanced());
-						return;
-					}
-					else {
-						outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered advanced dummy golem! You ready your [weapon] for a fight!");
-						startCombat(new GolemDummyAdvanced());
-						return;
-					}
-				}
-				//Superior dummy golem or golems
-				if (golemChooser >= 30 && golemChooser < 40) {
-					if (rand(4) == 0) {
-						outputText("As you take a stroll, out of nearby bushes emerge group of golems. Looks like you have encountered superior dummy golems! You ready your [weapon] for a fight!");
-						startCombat(new GolemsDummySuperior());
-						return;
-					}
-					else {
-						outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered superior dummy golem! You ready your [weapon] for a fight!");
-						startCombat(new GolemDummySuperior());
-						return;
-					}
-				}
-				//Basic true golem or golems
-				if (golemChooser >= 40 && golemChooser < 50) {
-					if (rand(4) == 0) {
-						outputText("As you take a stroll, out of nearby bushes emerge group of golems. Looks like you have encountered basic true golems! You ready your [weapon] for a fight!");
-						startCombat(new GolemsTrueBasic());
-						return;
-					}
-					else {
-						outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered basic true golem! You ready your [weapon] for a fight!");
-						startCombat(new GolemTrueBasic());
-						return;
-					}
-				}
-				//Improved true golem or golems
-				if (golemChooser >= 50 && golemChooser < 60) {
-					if (rand(4) == 0) {
-						outputText("As you take a stroll, out of nearby bushes emerge group of golems. Looks like you have encountered improved true golems! You ready your [weapon] for a fight!");
-						startCombat(new GolemsTrueImproved());
-						return;
-					}
-					else {
-						outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered improved true golem! You ready your [weapon] for a fight!");
-						startCombat(new GolemTrueImproved());
-						return;
-					}
-				}
-				//Advanced true golem or golems
-				if (golemChooser >= 60) {
-					if (rand(4) == 0) {
-						outputText("As you take a stroll, out of nearby bushes emerge group of golems. Looks like you have encountered advanced true golems! You ready your [weapon] for a fight!");
-						startCombat(new GolemsTrueAdvanced());
-						return;
-					}
-					else {
-						outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered advanced true golem! You ready your [weapon] for a fight!");
-						startCombat(new GolemTrueAdvanced());
-						return;
-					}
-				}
-				//Dummy golem
-				else {
-					outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered dummy golem! You ready your [weapon] for a fight!");
-					camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_GOLEMS);
-					startCombat(new GolemDummy());
-					return;
-				}
-			}
-			else {
-				var gg:Number = 25;
-				if (player.level >= 8) gg += 25;
-				if (player.level >= 16) gg += 25;
-				if (player.level >= 24) gg += 25;
-				var goblinChooser:int = rand(gg);
-				if (goblinChooser >= 25 && goblinChooser < 50) SceneLib.goblinScene.goblinAssassinEncounter();
-				else if (goblinChooser >= 50 && goblinChooser < 75) SceneLib.goblinScene.goblinWarriorEncounter();
-				else if (goblinChooser >= 75) {
-					if (flags[kFLAGS.SOUL_SENSE_PRISCILLA] < 3 && rand(2) == 0) SceneLib.priscillaScene.goblinElderEncounter();
-					else SceneLib.goblinScene.goblinShamanEncounter();
-				}
-				else SceneLib.goblinScene.goblinEncounter();
-			}
+		
+		private function golemEncountBasic():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered dummy golem! You ready your [weapon] for a fight!");
+			camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_GOLEMS);
+			startCombat(new GolemDummy());
+		}
+		private function golemEncounterImproved():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered improved dummy golem! You ready your [weapon] for a fight!");
+			startCombat(new GolemDummyImproved());
+		}
+		private function golemEncounterAdvanced():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered advanced dummy golem! You ready your [weapon] for a fight!");
+			startCombat(new GolemDummyAdvanced());
+		}
+		private function golemEncounterAdvancedGroup():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge group of golems. Looks like you have encountered advanced dummy golems! You ready your [weapon] for a fight!");
+			startCombat(new GolemsDummyAdvanced());
+		}
+		private function golemEncounterSuperior():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered superior dummy golem! You ready your [weapon] for a fight!");
+			startCombat(new GolemDummySuperior());
+		}
+		private function golemEncounterSuperiorGroup():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge group of golems. Looks like you have encountered superior dummy golems! You ready your [weapon] for a fight!");
+			startCombat(new GolemsDummySuperior());
+		}
+		private function golemEncounterTrueBasic():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered basic true golem! You ready your [weapon] for a fight!");
+			startCombat(new GolemTrueBasic());
+		}
+		private function golemEncounterTrueBasicGroup():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge group of golems. Looks like you have encountered basic true golems! You ready your [weapon] for a fight!");
+			startCombat(new GolemsTrueBasic());
+		}
+		private function golemEncounterTrueImproved():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered improved true golem! You ready your [weapon] for a fight!");
+			startCombat(new GolemTrueImproved());
+		}
+		private function golemEncounterTrueImprovedGroup():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge group of golems. Looks like you have encountered improved true golems! You ready your [weapon] for a fight!");
+			startCombat(new GolemsTrueImproved());
+		}
+		private function golemEncounterTrueAdvanced():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge golem. Looks like you have encountered advanced true golem! You ready your [weapon] for a fight!");
+			startCombat(new GolemTrueAdvanced());
+		}
+		private function golemEncounterTrueAdvancedGroup():void {
+			clearOutput();
+			outputText("As you take a stroll, out of nearby bushes emerge group of golems. Looks like you have encountered advanced true golems! You ready your [weapon] for a fight!");
+			startCombat(new GolemsTrueAdvanced());
+		}
+		
+		private function feralImpEncounter():void {
+			clearOutput();
+			spriteSelect(SpriteDb.s_imp);
+			outputText("A feral imp wings out of the sky and attacks!");
+			camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_IMPS);
+			flags[kFLAGS.FERAL_EXTRAS] = 1;
+			startCombat(new FeralImps());
+		}
+		private function impEncounter():void {
+			clearOutput();
+			spriteSelect(SpriteDb.s_imp);
+			outputText("An imp wings out of the sky and attacks!");
+			camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_IMPS);
+			startCombat(new Imp());
 		}
 		public function genericGobImpAngEncounters(even:Boolean = false):void {
 			var gobImpAngChooser:int = rand(20);
@@ -760,33 +664,23 @@ public class Exploration extends BaseContent
 				else SceneLib.impScene.impPackEncounter2();
 			}
 		}
-		public function genericAngelsEncounters(even:Boolean = false):void {
-			var angelsChooser:int = rand(15);
-			//Limit chooser range
-			if (player.level < 6 && angelsChooser >= 5) angelsChooser = 4;
-			else if (player.level < 12 && angelsChooser >= 10) angelsChooser = 9;
+		private function angelEncounterLow():void {
 			clearOutput();
-			//Mid-rank Angel
-			if (angelsChooser >= 5 && angelsChooser < 10) {
-				outputText("A mid-ranked angeloid wings out of the sky and attacks!");
-				player.createStatusEffect(StatusEffects.AngelsChooser,2,0,0,0);
-				startCombat(new Angeloid());
-				return;
-			}
-			//High-rank Angel
-			else if (angelsChooser >= 10) {
-				outputText("A high-ranked angeloid wings out of the sky and attacks!");
-				player.createStatusEffect(StatusEffects.AngelsChooser,3,0,0,0);
-				startCombat(new Angeloid());
-				return;
-			}
-			//Low-rank Angel
-			else {
-				outputText("A low-ranked angeloid wings out of the sky and attacks!");
-				player.createStatusEffect(StatusEffects.AngelsChooser,1,0,0,0);
-				startCombat(new Angeloid());
-				return;
-			}
+			outputText("A low-ranked angeloid wings out of the sky and attacks!");
+			player.createStatusEffect(StatusEffects.AngelsChooser, 1, 0, 0, 0);
+			startCombat(new Angeloid());
+		}
+		private function angelEncounterMid():void {
+			clearOutput();
+			outputText("A mid-ranked angeloid wings out of the sky and attacks!");
+			player.createStatusEffect(StatusEffects.AngelsChooser, 2, 0, 0, 0);
+			startCombat(new Angeloid());
+		}
+		private function angelEncounterHigh():void {
+			clearOutput();
+			outputText("A high-ranked angeloid wings out of the sky and attacks!");
+			player.createStatusEffect(StatusEffects.AngelsChooser, 3, 0, 0, 0);
+			startCombat(new Angeloid());
 		}
 		public function demonLabProjectEncounters():void {
 			clearOutput();
@@ -842,37 +736,455 @@ public class Exploration extends BaseContent
 			}
 		}
 
+		public function impFactor():Number {
+			if (player.hasPerk(PerkLib.PiercedLethite)) return 2;
+			return 1;
+		}
+		public function feralImpFactor():Number {
+			if (flags[kFLAGS.GALIA_LVL_UP] > 0 && flags[kFLAGS.GALIA_LVL_UP] < 0.5) return 2;
+			return 1;
+		}
+		
+		private var _explorationEncounters:GroupEncounter = null;
+		private var _commonEncounters:GroupEncounter = null;
+		private var _angelEncounters:GroupEncounter = null;
+		public function get commonEncounters():GroupEncounter { return _commonEncounters }
+		public function get angelEncounters():GroupEncounter { return _angelEncounters }
+		private function init():void {
+			const fn:FnHelpers = Encounters.fn;
+			_angelEncounters = Encounters.group("angels",
+					{
+						name: "angel1",
+						label: "Angeloid I",
+						kind: "monster",
+						call: angelEncounterLow
+					}, {
+						name: "angel2",
+						label: "Angeloid II",
+						kind: "monster",
+						when: fn.ifLevelMin(6),
+						call: angelEncounterMid
+					} , {
+						name: "angel3",
+						label: "Angeloid III",
+						kind: "monster",
+						when: fn.ifLevelMin(12),
+						call: angelEncounterHigh
+					}
+			);
+			
+			_commonEncounters = Encounters.group("common",
+					{
+						name: "Imp",
+						kind: "monster",
+						mods: [impFactor],
+						call: impEncounter
+					}, {
+						name: "feralImp",
+						label: "Feral Imp",
+						kind: "monster",
+						when: function():Boolean {
+							return player.level >= 3 || player.statusEffectv2(StatusEffects.AdventureGuildQuests2) > 0
+						},
+						call: feralImpEncounter,
+						mods: [impFactor, feralImpFactor]
+					}, {
+						name: "impLord",
+						label: "Imp Lord",
+						kind: "monster",
+						chance: 0.5,
+						mods: [impFactor],
+						when: fn.ifLevelMin(8),
+						call: SceneLib.impScene.impLordEncounter
+					}, {
+						name: "feralImpLord",
+						label: "Feral Imp Lord",
+						shortLabel: "FI Lord",
+						kind: "monster",
+						chance: 0.5,
+						mods: [impFactor, feralImpFactor],
+						when: fn.ifLevelMin(8),
+						call: SceneLib.impScene.impLordFeralEncounter
+					}, {
+						name: "impWarlord",
+						label: "Imp Warlord",
+						kind: "monster",
+						chance: 0.5,
+						mods: [impFactor],
+						when: fn.ifLevelMin(12),
+						call: SceneLib.impScene.impWarlordEncounter
+					}, {
+						name: "feralImpWarlord",
+						label: "Feral Imp Warlord",
+						shortLabel: "FI Warlord",
+						kind: "monster",
+						chance: 0.5,
+						mods: [impFactor],
+						when: fn.ifLevelMin(12),
+						call: SceneLib.impScene.impWarlordFeralEncounter
+					}, {
+						name: "impOverlord",
+						label: "Imp Overlord",
+						kind: "monster",
+						chance: 0.25,
+						mods: [impFactor],
+						when: fn.ifLevelMin(16),
+						call: SceneLib.impScene.impOverlordEncounter
+					}, {
+						name: "goblin",
+						label: "Goblin",
+						kind: "monster",
+						call: SceneLib.goblinScene.goblinEncounter
+					}, {
+						name: "goblinAssassin",
+						label: "Goblin Assassin",
+						shortLabel: "Gob. Assassin",
+						kind: "monster",
+						when: fn.ifLevelMin(8),
+						call: SceneLib.goblinScene.goblinAssassinEncounter
+					}, {
+						name: "goblinWarrior",
+						label: "Goblin Warrior",
+						shortLabel: "Gob. Warrior",
+						kind: "monster",
+						when: fn.ifLevelMin(16),
+						call: SceneLib.goblinScene.goblinWarriorEncounter
+					}, {
+						name: "goblinShaman",
+						label: "Goblin Shaman",
+						shortLabel: "Gob. Shaman",
+						kind: "monster",
+						when: fn.ifLevelMin(24),
+						call: SceneLib.goblinScene.goblinShamanEncounter
+					}, {
+						name: "priscilla",
+						label: "Priscilla",
+						kind: "npc",
+						when: fn.ifLevelMin(24),
+						call: SceneLib.priscillaScene.goblinElderEncounter
+					}, {
+						name: "golem1",
+						label: "Dummy Golem",
+						shortLabel: "Golem I",
+						kind: "monster",
+						call: golemEncountBasic
+					}, {
+						name: "golem2",
+						label: "Improved Golem",
+						shortLabel: "Golem II",
+						kind: "monster",
+						when:fn.ifLevelMin(12),
+						call: golemEncounterImproved
+					}, {
+						name: "golem3",
+						label: "Advanced Golem",
+						shortLabel: "Golem III",
+						kind: "monster",
+						when:fn.ifLevelMin(18),
+						call: golemEncounterAdvanced
+					}, {
+						name: "golem3group",
+						label: "Advanced Golem Group",
+						shortLabel: "Golem III+",
+						kind: "monster",
+						when:fn.ifLevelMin(18),
+						chance: 0.25,
+						call: golemEncounterAdvancedGroup
+					}, {
+						name: "golem4",
+						label: "Superior Golem",
+						shortLabel: "Golem IV",
+						kind: "monster",
+						when:fn.ifLevelMin(24),
+						call: golemEncounterSuperior
+					}, {
+						name: "golem4group",
+						label: "Superior Golem Group",
+						shortLabel: "Golem IV+",
+						kind: "monster",
+						when:fn.ifLevelMin(18),
+						chance: 0.25,
+						call: golemEncounterSuperiorGroup
+					}, {
+						name: "golem5",
+						label: "Basic True Golem",
+						shortLabel: "Golem V",
+						kind: "monster",
+						when:fn.ifLevelMin(33),
+						call: golemEncounterTrueBasic
+					}, {
+						name: "golem5group",
+						label: "Basic True Golem Group",
+						shortLabel: "Golem V+",
+						kind: "monster",
+						when:fn.ifLevelMin(33),
+						chance: 0.25,
+						call: golemEncounterTrueBasicGroup
+					}, {
+						name: "golem6",
+						label: "Improved True Golem",
+						shortLabel: "Golem VI",
+						kind: "monster",
+						when:fn.ifLevelMin(42),
+						call: golemEncounterTrueImproved
+					}, {
+						name: "golem6group",
+						label: "Improved True Golem Group",
+						shortLabel: "Golem VI+",
+						kind: "monster",
+						when:fn.ifLevelMin(42),
+						chance: 0.25,
+						call: golemEncounterTrueImprovedGroup
+					}, {
+						name: "golem7",
+						label: "Advanced True Golem",
+						shortLabel: "Golem VII",
+						kind: "monster",
+						when:fn.ifLevelMin(51),
+						call: golemEncounterTrueAdvanced
+					}, {
+						name: "golem5group",
+						label: "Basic True Golem Group",
+						shortLabel: "Golem V+",
+						kind: "monster",
+						when:fn.ifLevelMin(33),
+						chance: 0.25,
+						call: golemEncounterTrueAdvancedGroup
+					}
+			);
+			
+			_explorationEncounters = Encounters.group("exploration",
+					{
+						name  : "Evangeline",
+						kind  : "npc",
+						unique: true,
+						chance: 2,
+						when  : function ():Boolean {
+							return player.level > 0 && (
+									EvangelineFollower.EvangelineAffectionMeter < 1
+									|| (EvangelineFollower.EvangelineAffectionMeter == 1 || EvangelineFollower.EvangelineAffectionMeter == 2) && player.statusEffectv1(StatusEffects.TelAdre) >= 1 && flags[kFLAGS.HEXINDAO_UNLOCKED] >= 1)
+						},
+						call  : function ():void {
+							if (EvangelineFollower.EvangelineAffectionMeter < 1) {
+								SceneLib.evangelineFollower.enterTheEvangeline();
+							} else {
+								SceneLib.evangelineFollower.alternativEvangelineRecruit();
+							}
+						}
+					}, {
+						name  : "Pearl",
+						kind  : "item",
+						unique: true,
+						chance: 1,
+						when  : function ():Boolean {
+							return player.level > 2 && player.hasKeyItem("Sky Poison Pearl") < 0 && flags[kFLAGS.SKY_POISON_PEARL] < 1;
+						},
+						call  : pearldiscovery
+					}, {
+						name  : "hiddencave",
+						label : "Hidden Cave",
+						kind  : "place",
+						unique: true,
+						when  : function ():Boolean {
+							return player.level > 5 && flags[kFLAGS.HIDDEN_CAVE_FOUND] < 1
+						},
+						call  : hiddencavediscovery
+					}, {
+						name  : "troll",
+						label : "Troll Village",
+						kind  : "place",
+						unique: true,
+						when  : function ():Boolean {
+							return flags[kFLAGS.FACTORY_SHUTDOWN] > 0 && TrollVillage.ZenjiVillageStage == 0
+						},
+						call  : SceneLib.trollVillage.FirstEncountersoftheTrollKind
+					}, {
+						name  : "pocketwatch",
+						label : "Pocket Watch",
+						kind  : "item",
+						unique: true,
+						when  : function ():Boolean {
+							return player.level >= 9 && player.hasKeyItem("Pocket Watch") < 0
+									&& (!player.hasStatusEffect(StatusEffects.PocketWatch) || player.superPerkPoints > 0)
+						},
+						call  : pocketwatchdiscovery
+					}, {
+						//Helia monogamy fucks
+						name  : "helcommon",
+						label : "Helia",
+						kind  : 'npc',
+						unique: true,
+						night : false,
+						call  : SceneLib.helScene.helSexualAmbush,
+						when  : SceneLib.helScene.helSexualAmbushCondition
+					}, {
+						name  : "Alvina",
+						kind  : "npc",
+						unique: true,
+						when  : function ():Boolean {
+							return flags[kFLAGS.ALVINA_FOLLOWER] < 1
+						},
+						call  : SceneLib.alvinaFollower.alvinaFirstEncounter
+					}, {
+						name  : "HeXinDao",
+						kind  : "place",
+						unique: true,
+						when  : function ():Boolean {
+							return flags[kFLAGS.HEXINDAO_UNLOCKED] < 1
+						},
+						call  : discoverHXD
+					}, {
+						name  : "Tel'Adre",
+						kind  : "place",
+						unique: true,
+						when  : function ():Boolean {
+							return !player.hasStatusEffect(StatusEffects.TelAdre);
+						},
+						call  : SceneLib.telAdre.discoverTelAdre
+					}, {
+						name  : "Bazaar",
+						kind  : "place",
+						unique: true,
+						when  : function ():Boolean {
+							return flags[kFLAGS.BAZAAR_ENTERED] == 0;
+						},
+						call  : SceneLib.bazaar.findBazaar
+					}, {
+						name  : "Forest",
+						kind  : "place",
+						unique: true,
+						chance: Encounters.ALWAYS,
+						when  : function ():Boolean {
+							return player.explored > 1 && player.exploredForest <= 0
+						},
+						call  : discoverForest
+					}, {
+						name  : "Lake",
+						kind  : "place",
+						unique: true,
+						chance: Encounters.ALWAYS,
+						when  : function ():Boolean {
+							return player.explored > 1 && player.exploredLake <= 0 && flags[kFLAGS.ALVINA_FOLLOWER] == 1
+						},
+						call  : discoverLake
+					}, {
+						name  : "Desert",
+						kind  : "place",
+						unique: true,
+						chance: Encounters.ALWAYS,
+						when  : function ():Boolean {
+							return player.exploredLake >= 1 && player.exploredDesert <= 0
+						},
+						call  : discoverDesert
+					}, {
+						name  : "Battlefield",
+						kind  : "place",
+						unique: true,
+						chance: Encounters.ALWAYS,
+						when  : function ():Boolean {
+							return player.exploredDesert >= 1 && flags[kFLAGS.DISCOVERED_BATTLEFIELD_BOUNDARY] <= 0 && (player.level + combat.playerLevelAdjustment()) >= 5
+						},
+						call  : disscoverBattlefield
+					}, {
+						name  : "Hills",
+						kind  : "place",
+						unique: true,
+						chance: Encounters.ALWAYS,
+						when  : function ():Boolean {
+							return flags[kFLAGS.DISCOVERED_BATTLEFIELD_BOUNDARY] > 0 && flags[kFLAGS.DISCOVERED_HILLS] <= 0 && (player.level + combat.playerLevelAdjustment()) >= 5
+						},
+						call  : discoverHills
+					}, {
+						name  : "Plains",
+						kind  : "place",
+						unique: true,
+						chance: Encounters.ALWAYS,
+						when  : function ():Boolean {
+							return flags[kFLAGS.DISCOVERED_HILLS] > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] <= 0 && (player.level + combat.playerLevelAdjustment()) >= 9
+						},
+						call  : discoverPlains
+					}, {
+						name  : "Swamp",
+						kind  : "place",
+						unique: true,
+						chance: Encounters.ALWAYS,
+						when  : function ():Boolean {
+							return flags[kFLAGS.TIMES_EXPLORED_SWAMP] <= 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && (player.level + combat.playerLevelAdjustment()) >= 13
+						},
+						call  : discoverSwamp
+					}, {
+						name  : "blightRidge",
+						label : "Blight Ridge",
+						kind  : "place",
+						unique: true,
+						chance: Encounters.ALWAYS,
+						when  : function ():Boolean {
+							return flags[kFLAGS.DISCOVERED_BLIGHT_RIDGE] <= 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && (player.level + combat.playerLevelAdjustment()) >= 21
+						},
+						call  : discoverBlightRidge
+					}, {
+						name  : "Beach",
+						kind  : "place",
+						unique: true,
+						chance: Encounters.ALWAYS,
+						when  : function ():Boolean {
+							return flags[kFLAGS.DISCOVERED_BEACH] <= 0 && flags[kFLAGS.DISCOVERED_BLIGHT_RIDGE] > 0 && (player.level + combat.playerLevelAdjustment()) >= 25
+						},
+						call  : discoverBeach
+					}, {
+						name  : "Caves",
+						kind  : "place",
+						unique: true,
+						chance: Encounters.ALWAYS,
+						when  : function ():Boolean {
+							return flags[kFLAGS.DISCOVERED_CAVES] <= 0 && flags[kFLAGS.DISCOVERED_BEACH] > 0 && (player.level + combat.playerLevelAdjustment()) >= 30
+						},
+						call  : discoverCave
+					}, {
+						name  : "Cathedral",
+						kind  : "place",
+						unique: true,
+						when  : function ():Boolean {
+							return flags[kFLAGS.FOUND_CATHEDRAL] != 1
+						},
+						call  : function ():void {
+							if (flags[kFLAGS.GAR_NAME] == 0) SceneLib.gargoyle.gargoylesTheShowNowOnWBNetwork();
+							else SceneLib.gargoyle.returnToCathedral();
+						}
+					}, {
+						name  : "Giacomo",
+						kind  : "npc",
+						unique: true,
+						call  : SceneLib.giacomoShop.giacomoEncounterSS
+					}, {
+						name  : "Dinah",
+						kind  : "npc",
+						unique: true,
+						when  : function ():Boolean {
+							return flags[kFLAGS.DINAH_LVL_UP] < 1
+						},
+						call  : SceneLib.dinahScene.DinahIntro1
+					}, {
+						name  : "Lumi",
+						kind  : "npc",
+						unique: true,
+						when  : function ():Boolean {
+							return flags[kFLAGS.LUMI_MET] == 0
+						},
+						call  : SceneLib.lumi.lumiEncounter
+					}, _commonEncounters
+			);
+		}
 		//Try to find a new location - called from doExplore once the first location is found
 		public function tryDiscover():void
 		{
-			if (player.level > 0 && EvangelineFollower.EvangelineAffectionMeter < 1 && rand(2) == 0) {
-				SceneLib.evangelineFollower.enterTheEvangeline();
-				return;
+			explorer.prepareArea(_explorationEncounters);
+			explorer.setTags("explore");
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				player.explored++;
 			}
-			if (player.level > 0 && (EvangelineFollower.EvangelineAffectionMeter == 1 || EvangelineFollower.EvangelineAffectionMeter == 2) && player.statusEffectv1(StatusEffects.TelAdre) >= 1 && flags[kFLAGS.HEXINDAO_UNLOCKED] >= 1 && rand(2) == 0) {
-				SceneLib.evangelineFollower.alternativEvangelineRecruit();
-				return;
-			}
-			if (player.level > 2 && player.hasKeyItem("Sky Poison Pearl") < 0 && flags[kFLAGS.SKY_POISON_PEARL] < 1 && rand(5) == 0) {
-				pearldiscovery();
-				return;
-			}
-			if (player.level > 5 && flags[kFLAGS.HIDDEN_CAVE_FOUND] < 1 && rand(10) == 0) {
-				hiddencavediscovery();
-				return;
-			}
-			if (flags[kFLAGS.FACTORY_SHUTDOWN] > 0 && TrollVillage.ZenjiVillageStage == 0 && rand(5) == 0) {
-				SceneLib.trollVillage.FirstEncountersoftheTrollKind();
-				return;
-			}
-			if (player.level >= 9 && player.hasKeyItem("Pocket Watch") < 0 && !player.hasStatusEffect(StatusEffects.PocketWatch) && rand(3) == 0) {
-				pocketwatchdiscovery();
-				return;
-			}
-			if (player.level >= 9 && player.hasKeyItem("Pocket Watch") < 0 && player.superPerkPoints > 0 && rand(5) == 0) {
-				pocketwatchdiscovery();
-				return;
-			}
+			explorer.skillBasedReveal(1, player.explored);
+			explorer.doExplore();
 /*			if (player.level > 5 && flags[kFLAGS.RYUBI_LVL_UP] < 1 && rand(4) == 0) {
 				ryubifirstenc();
 				return;
@@ -881,148 +1193,11 @@ public class Exploration extends BaseContent
 				ryubirepenc();
 				return;
 			}
-*/			if (flags[kFLAGS.PC_PROMISED_HEL_MONOGAMY_FUCKS] == 1 && flags[kFLAGS.HEL_RAPED_TODAY] == 0 && rand(5) == 0 && player.gender > 0 && !SceneLib.helFollower.followerHel() && !player.hasStatusEffect(StatusEffects.HeliaOff)) {
-				SceneLib.helScene.helSexualAmbush();
-				return;
-			}
-			if (flags[kFLAGS.ALVINA_FOLLOWER] < 1 && rand(4) == 0) {
-				SceneLib.alvinaFollower.alvinaFirstEncounter();
-				return;
-			}
-			if (flags[kFLAGS.HEXINDAO_UNLOCKED] < 1 && rand(4) == 0) {
-				clearOutput();
-				outputText("Against your better judgment, curiosity gets the better of you, and you find yourself walking into a strange area.");
-				outputText("\n\nNot long into your journey, you see a hooded figure looming across the landscape, moving at the same speed as it goes across the terrain. The odd creature captures your interest, and you start to follow it. You glance around, there's still no one else nearby, so you continue to tail the mysterious being.");
-				outputText("\n\nHalf an hour or so later, still following the cloaked figure, you begin to hear the sound of running water. Moving on, you eventually come across the source: a decently sized river flows across the land, populated by variously sized islands. Stopping for a second to take a look around, the hooded person seems to be moving towards one of the several islands. He? She? It is still oblivious to your presence.");
-				outputText("\n\nA voice rings from behind you, \"<i>Come to visit He'Xin'Dao, stranger?</i>\"");
-				outputText("\n\nTurning around, you see a few hooded figures similar to the one you have been following. You curse at the thought that someone could've ambushed you so easily without you noticing them sooner. You state that you've been exploring and found this place. The figure peers at you through the veiled hood.\n\n"
-					+ "\"<i>You seem lacking in soulforce, but luckily your soul is enough intact to allow future cultivation. So, since you are already here, what do you think about visiting our village? Maybe you would come more often to it in the future?</i>\"");
-				outputText("\n\nYou ponder for a moment over the offer. The hooded beings don't seem to carry any malice, given they haven't attacked you nor attempted rape. Perhaps it would be of interest to explore this place?  You decide to accept their offer as they lead you over the wide bridge to one of the islands.  Several heavily armored guards peer at you searchingly, to which one of your new companions state that you are a new guest.  The guard gives a stoic nod as they step aside, no longer barring you from entry.  Your hooded friends guide you to a small island to properly register you as a guest. They give you a small guide on a piece of parchment, telling you places of interest and instructions on how to find this place again.");
-				outputText("\n\nAfterwards, you're left alone.  You wander around, checking a few places of interest before you decide it's time to return to your camp.  With the guide in your hands, you're sure you'll find this place again with ease if you need to.");
-				outputText("\n\n\n<b>You have unlocked He'Xin'Dao in Places menu!</b>");
-				flags[kFLAGS.HEXINDAO_UNLOCKED] = 1;
-				doNext(camp.returnToCampUseTwoHours);
-				return;
-			}
-			if (!player.hasStatusEffect(StatusEffects.TelAdre) && rand(4) == 0) {
-				SceneLib.telAdre.discoverTelAdre();
-				return;
-			}
-			if (flags[kFLAGS.BAZAAR_ENTERED] == 0 && rand(4) == 0) {
-				SceneLib.bazaar.findBazaar();
-				return;
-			}
-			if (player.explored > 1) {
-				clearOutput();
-				if (player.exploredForest <= 0) {
-					outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old-looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You've discovered the Forest!</b>");
-					player.exploredForest = 1;
-					player.exploredForest++;
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				}
-				if (player.exploredLake <= 0 && flags[kFLAGS.ALVINA_FOLLOWER] == 1) {
-					outputText("Your wanderings take you far and wide across the barren wasteland that surrounds the portal, until the smell of humidity and fresh water alerts you to the nearby lake.  With a few quick strides, you find a lake so massive that the distant shore cannot be seen.  Grass and a few sparse trees grow all around it.\n\n<b>You've discovered the Lake!</b>");
-					player.exploredLake = 1;
-					player.explored++;
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				}
-				if (player.exploredLake >= 1 && rand(3) == 0 && player.exploredDesert <= 0) {
-					outputText("You stumble as the ground shifts a bit underneath you.  Groaning in frustration, you straighten up and discover the rough feeling of sand ");
-					if (player.lowerBody == LowerBody.HOOFED) outputText("in your hooves");
-					else if (player.lowerBody == LowerBody.DOG) outputText("in your paws");
-					else if (player.isNaga()) outputText("in your scales");
-					else outputText("inside your footwear, between your toes");
-					outputText(".\n\n<b>You've discovered the Desert (Outer)!</b>");
-					player.exploredDesert = 1;
-					player.explored++;
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				}
-				//Discover Battlefield Boundary
-				if (player.exploredDesert >= 1 && flags[kFLAGS.DISCOVERED_BATTLEFIELD_BOUNDARY] <= 0 && (player.level + combat.playerLevelAdjustment()) >= 5) {
-					flags[kFLAGS.DISCOVERED_BATTLEFIELD_BOUNDARY] = 1;
-					player.explored++;
-					clearOutput();
-					outputText("While exploring you run into the sight of endless field, littered with the remains of fallen soldiers from what appears to have been the demon war, this much do the horned skeletons tells. You can see some golem husk on the ground as well. It’s very plausible the war is still ongoing.\n\n<b>You've discovered the Battlefield (Boundary)!</b>");
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				}
-				if (flags[kFLAGS.DISCOVERED_BATTLEFIELD_BOUNDARY] > 0 && flags[kFLAGS.DISCOVERED_HILLS] <= 0 && (player.level + combat.playerLevelAdjustment()) >= 5) {
-					flags[kFLAGS.DISCOVERED_HILLS] = 1;
-					player.explored++;
-					clearOutput();
-					outputText("As you walk the large open wasteland of mareth you begin to notice an elevation in the ground. Far in the distance you can see a mountain chain but from where you stand is a hillside. Well you got tired of the monotony of the flat land anyway maybe going up will yield new interesting discoveries.\n\n<b>You found the Hills!</b>");
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				}
-				if (flags[kFLAGS.DISCOVERED_HILLS] > 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] <= 0 && (player.level + combat.playerLevelAdjustment()) >= 9) {
-					flags[kFLAGS.TIMES_EXPLORED_PLAINS] = 1;
-					player.explored++;
-					outputText("You find yourself standing in knee-high grass, surrounded by flat plains on all sides.  Though the mountain, forest, and lake are all visible from here, they seem quite distant.\n\n<b>You've discovered the plains!</b>");
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				}
-				//EXPLOOOOOOORE
-				if (flags[kFLAGS.TIMES_EXPLORED_SWAMP] <= 0 && flags[kFLAGS.TIMES_EXPLORED_PLAINS] > 0 && (player.level + combat.playerLevelAdjustment()) >= 13) {
-					flags[kFLAGS.TIMES_EXPLORED_SWAMP] = 1;
-					player.explored++;
-					clearOutput();
-					outputText("All things considered, you decide you wouldn't mind a change of scenery.  Gathering up your belongings, you begin a journey into the wasteland.  The journey begins in high spirits, and you whistle a little traveling tune to pass the time.  After an hour of wandering, however, your wanderlust begins to whittle away.  Another half-hour ticks by.  Fed up with the fruitless exploration, you're nearly about to head back to camp when a faint light flits across your vision.  Startled, you whirl about to take in three luminous will-o'-the-wisps, swirling around each other whimsically.  As you watch, the three ghostly lights begin to move off, and though the thought of a trap crosses your mind, you decide to follow.\n\n");
-					outputText("Before long, you start to detect traces of change in the environment.  The most immediate difference is the increasingly sweltering heat.  A few minutes pass, then the will-o'-the-wisps plunge into the boundaries of a dark, murky, stagnant swamp; after a steadying breath you follow them into the bog.  Once within, however, the gaseous balls float off in different directions, causing you to lose track of them.  You sigh resignedly and retrace your steps, satisfied with your discovery.  Further exploration can wait.  For now, your camp is waiting.\n\n");
-					outputText("<b>You've discovered the Swamp!</b>");
-					doNext(camp.returnToCampUseTwoHours);
-					return;
-				}
-				//Discover Blight Ridge
-				if (flags[kFLAGS.DISCOVERED_BLIGHT_RIDGE] <= 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && (player.level + combat.playerLevelAdjustment()) >= 21) {
-					flags[kFLAGS.DISCOVERED_BLIGHT_RIDGE] = 1;
-					player.explored++;
-					clearOutput();
-					outputText("You wander around the mountain area thinking over this whole ‘demonic’ realm affair.  You're not sure how widespread this entire thing is, everything seems to be isolated to certain areas, you've only really seen the demons in small groups or alone, and even then it's usually comprised of imps.  As far as you know it IS a demonic realm so there should be some area where demons live normally, they can't all be hold up in lethice's stronghold right?  You question whether or not the demons could even hold together a city long enough before 'water' damage ruined the place.");
-					if (flags[kFLAGS.BAZAAR_ENTERED] > 0) outputText("  Then again you have been to that Bizarre Bazaar, they seem to exist there to an extent without any trouble...");
-					outputText("  As you think the random topic over in your head you spy a path you've never noticed before.\n\n");
-					outputText("Being the adventurous champion you are you start down the path, as you walk down this sketchy path, carved through a section of the mountain a ridge comes into view.  Walking onwards until you're at the ridge a somewhat would-be beautiful sight lies before you.\n\n");
-					if (player.cor < 66) {
-						outputText("That would be if it wasn't corrupted to all hell, the scent of sweat, milk and semen invade your nose as you peer across the corrupted glade.  And you thought that the main forest was bad.");
-						if (flags[kFLAGS.MET_MARAE] >= 1) outputText("  Gods... If Marae could see this.");
-						outputText("\n\n");
-					}
-					else if (player.cor >= 66) {
-						outputText("And it is!  Lush fields of corrupted glades consume the land, giving the heavy scent of sweat, milk and semen as you take a deep breath.  Taking it all in and relishing in the corruption.  Truly this is how the world should be.");
-						if (flags[kFLAGS.MET_MARAE] >= 1) outputText("  Heh, if Marae could see this she'd flip her shit.");
-						outputText("\n\n");
-					}
-					outputText("<b>You've discovered the Blight Ridge!</b>");
-					doNext(camp.returnToCampUseTwoHours);
-					return;
-				}
-				//Discover Beach / Ocean / Deep Sea
-				if (flags[kFLAGS.DISCOVERED_BEACH] <= 0 && flags[kFLAGS.DISCOVERED_BLIGHT_RIDGE] > 0 && (player.level + combat.playerLevelAdjustment()) >= 25) {
-					flags[kFLAGS.DISCOVERED_BEACH] = 1;
-					player.explored++;
-					clearOutput();
-					outputText("You hear seagulls in the distance and run on the grass to look what is beyond. There is a few dunes of sand with patch of grass that you eagerly cross over as you discover what you hoped to find.");
-					outputText("\n\nFinally, after stepping over another dune, in the distance before you a shore of water spreads. Its surely way bigger than the lake you found some time ago. As far as you look to the side you can't see the shores end.  Mesmerized by the view you continue walking towards the ocean until you stand in the shallow water with waves passing by around your waist. Despite the corruption of Mareth this water turns out to be quite clear and who knows, maybe it’s not even that much tainted... yet. But that would probably require submerging deeper to check it out.");
-					outputText("\n\n<b>You've discovered the Beach and the Ocean!</b>");
-					doNext(camp.returnToCampUseTwoHours);
-					return;
-				}
-				//Discover Caves!
-				if (flags[kFLAGS.DISCOVERED_CAVES] <= 0 && flags[kFLAGS.DISCOVERED_BEACH] > 0 && (player.level + combat.playerLevelAdjustment()) >= 30) {
-					flags[kFLAGS.DISCOVERED_CAVES] = 1;
-					player.explored++;
-					clearOutput();
-					outputText("As you explore the area you run into a somewhat big hole in the landscape. You look inside unsure as it seems to lead into the depths of Mareth. Resolving yourself to chase the demons wherever they go you decide to still enter the hole discovering a full world of linked tunnels beneath Mareth ground.\n\n");
-					outputText("<b>You've discovered the Caves!</b>");
-					doNext(camp.returnToCampUseTwoHours);
-					return;
-				}/*
+*/
+				/*
 				//Discover Abyss
 				if (flags[kFLAGS.DISCOVERED_BLIGHT_RIDGE] > 0 && flags[kFLAGS.] <= 0 && (player.level + combat.playerLevelAdjustment()) >= 10) {
 					flags[kFLAGS.] = 1;
-					player.explored++;
 					clearOutput();
 					outputText("You walk \n\n");
 					outputText("<b>You've discovered the Abyss!</b>");
@@ -1032,7 +1207,6 @@ public class Exploration extends BaseContent
 				//Discover Pit
 				if (flags[kFLAGS.] > 0 && flags[kFLAGS.] <= 0 && ((rand(3) == 0 && player.level >= 16) || player.level >= 21)) {
 					flags[kFLAGS.] = 1;
-					player.explored++;
 					clearOutput();
 					outputText("You walk \n\n");
 					outputText("<b>You've discovered the Pit!</b>");
@@ -1040,52 +1214,112 @@ public class Exploration extends BaseContent
 					return;
 				}
 				*/
-				//Used for chosing 'repeat' encounters.
-				var choosey:Number = rand(5);
-				//2 (gargoyle) is never chosen once cathedral is discovered.
-				if(choosey == 2 && flags[kFLAGS.FOUND_CATHEDRAL] == 1)
-				{
-					choosey = rand(4);
-					if(choosey >= 2) choosey++;
-				}
-				if (choosey == 3)
-				{
-					choosey = rand(4);
-					if(choosey == 2) choosey += 2;
-					if(choosey >= 3) choosey++;
-				}
-				//Chance of encountering Giacomo!
-				if (choosey == 0) {
-					player.explored++;
-					if (flags[kFLAGS.SOUL_SENSE_GIACOMO] < 3 && rand(3) > 0) SceneLib.giacomoShop.giacomoEncounterSS();
-					else if (flags[kFLAGS.DINAH_LVL_UP] < 1) SceneLib.dinahScene.DinahIntro1();
-					else genericGolGobImpEncounters(true);
-					return;
-				}
-				else if (choosey == 1) {
-					player.explored++;
-					if (flags[kFLAGS.LUMI_MET] == 0) SceneLib.lumi.lumiEncounter();
-					else genericGolGobImpEncounters(true);
-					return;
-				}
-				else if (choosey == 2) {
-					player.explored++;
-					if (flags[kFLAGS.GAR_NAME] == 0) SceneLib.gargoyle.gargoylesTheShowNowOnWBNetwork();
-					else SceneLib.gargoyle.returnToCathedral();
-					return;
-				}
-				//Monster - 50/50 imp/gob split.
-				else {
-					player.explored++;
-					genericGolGobImpEncounters(true);
-					return;
-				}
-			}
-			player.explored++;
-			doNext(camp.returnToCampUseOneHour);
 		}
-
-		//Temporaly place of finding enemies for lvl between 31 and 49
+		
+		private function discoverCave():void {
+			flags[kFLAGS.DISCOVERED_CAVES] = 1;
+			clearOutput();
+			outputText("As you explore the area you run into a somewhat big hole in the landscape. You look inside unsure as it seems to lead into the depths of Mareth. Resolving yourself to chase the demons wherever they go you decide to still enter the hole discovering a full world of linked tunnels beneath Mareth ground.\n\n");
+			outputText("<b>You've discovered the Caves!</b>");
+			explorer.stopExploring();
+			doNext(camp.returnToCampUseTwoHours);
+		}
+		private function discoverBeach():void {
+			flags[kFLAGS.DISCOVERED_BEACH] = 1;
+			clearOutput();
+			outputText("You hear seagulls in the distance and run on the grass to look what is beyond. There is a few dunes of sand with patch of grass that you eagerly cross over as you discover what you hoped to find.");
+			outputText("\n\nFinally, after stepping over another dune, in the distance before you a shore of water spreads. Its surely way bigger than the lake you found some time ago. As far as you look to the side you can't see the shores end.  Mesmerized by the view you continue walking towards the ocean until you stand in the shallow water with waves passing by around your waist. Despite the corruption of Mareth this water turns out to be quite clear and who knows, maybe it’s not even that much tainted... yet. But that would probably require submerging deeper to check it out.");
+			outputText("\n\n<b>You've discovered the Beach and the Ocean!</b>");
+			explorer.stopExploring();
+			doNext(camp.returnToCampUseTwoHours);
+		}
+		private function discoverBlightRidge():void {
+			flags[kFLAGS.DISCOVERED_BLIGHT_RIDGE] = 1;
+			clearOutput();
+			outputText("You wander around the mountain area thinking over this whole ‘demonic’ realm affair.  You're not sure how widespread this entire thing is, everything seems to be isolated to certain areas, you've only really seen the demons in small groups or alone, and even then it's usually comprised of imps.  As far as you know it IS a demonic realm so there should be some area where demons live normally, they can't all be hold up in lethice's stronghold right?  You question whether or not the demons could even hold together a city long enough before 'water' damage ruined the place.");
+			if (flags[kFLAGS.BAZAAR_ENTERED] > 0) outputText("  Then again you have been to that Bizarre Bazaar, they seem to exist there to an extent without any trouble...");
+			outputText("  As you think the random topic over in your head you spy a path you've never noticed before.\n\n");
+			outputText("Being the adventurous champion you are you start down the path, as you walk down this sketchy path, carved through a section of the mountain a ridge comes into view.  Walking onwards until you're at the ridge a somewhat would-be beautiful sight lies before you.\n\n");
+			if (player.cor < 66) {
+				outputText("That would be if it wasn't corrupted to all hell, the scent of sweat, milk and semen invade your nose as you peer across the corrupted glade.  And you thought that the main forest was bad.");
+				if (flags[kFLAGS.MET_MARAE] >= 1) outputText("  Gods... If Marae could see this.");
+				outputText("\n\n");
+			} else if (player.cor >= 66) {
+				outputText("And it is!  Lush fields of corrupted glades consume the land, giving the heavy scent of sweat, milk and semen as you take a deep breath.  Taking it all in and relishing in the corruption.  Truly this is how the world should be.");
+				if (flags[kFLAGS.MET_MARAE] >= 1) outputText("  Heh, if Marae could see this she'd flip her shit.");
+				outputText("\n\n");
+			}
+			outputText("<b>You've discovered the Blight Ridge!</b>");
+			explorer.stopExploring();
+			doNext(camp.returnToCampUseTwoHours);
+		}
+		private function discoverSwamp():void {
+			flags[kFLAGS.TIMES_EXPLORED_SWAMP] = 1;
+			clearOutput();
+			outputText("All things considered, you decide you wouldn't mind a change of scenery.  Gathering up your belongings, you begin a journey into the wasteland.  The journey begins in high spirits, and you whistle a little traveling tune to pass the time.  After an hour of wandering, however, your wanderlust begins to whittle away.  Another half-hour ticks by.  Fed up with the fruitless exploration, you're nearly about to head back to camp when a faint light flits across your vision.  Startled, you whirl about to take in three luminous will-o'-the-wisps, swirling around each other whimsically.  As you watch, the three ghostly lights begin to move off, and though the thought of a trap crosses your mind, you decide to follow.\n\n");
+			outputText("Before long, you start to detect traces of change in the environment.  The most immediate difference is the increasingly sweltering heat.  A few minutes pass, then the will-o'-the-wisps plunge into the boundaries of a dark, murky, stagnant swamp; after a steadying breath you follow them into the bog.  Once within, however, the gaseous balls float off in different directions, causing you to lose track of them.  You sigh resignedly and retrace your steps, satisfied with your discovery.  Further exploration can wait.  For now, your camp is waiting.\n\n");
+			outputText("<b>You've discovered the Swamp!</b>");
+			explorer.stopExploring();
+			doNext(camp.returnToCampUseTwoHours);
+		}
+		private function discoverPlains():void {
+			clearOutput();
+			flags[kFLAGS.TIMES_EXPLORED_PLAINS] = 1;
+			outputText("You find yourself standing in knee-high grass, surrounded by flat plains on all sides.  Though the mountain, forest, and lake are all visible from here, they seem quite distant.\n\n<b>You've discovered the plains!</b>");
+			endEncounter();
+		}
+		private function discoverHills():void {
+			flags[kFLAGS.DISCOVERED_HILLS] = 1;
+			clearOutput();
+			outputText("As you walk the large open wasteland of mareth you begin to notice an elevation in the ground. Far in the distance you can see a mountain chain but from where you stand is a hillside. Well you got tired of the monotony of the flat land anyway maybe going up will yield new interesting discoveries.\n\n<b>You found the Hills!</b>");
+			endEncounter();
+		}
+		private function disscoverBattlefield():void {
+			flags[kFLAGS.DISCOVERED_BATTLEFIELD_BOUNDARY] = 1;
+			clearOutput();
+			outputText("While exploring you run into the sight of endless field, littered with the remains of fallen soldiers from what appears to have been the demon war, this much do the horned skeletons tells. You can see some golem husk on the ground as well. It’s very plausible the war is still ongoing.\n\n<b>You've discovered the Battlefield (Boundary)!</b>");
+			endEncounter();
+		}
+		private function discoverDesert():void {
+			clearOutput();
+			outputText("You stumble as the ground shifts a bit underneath you.  Groaning in frustration, you straighten up and discover the rough feeling of sand ");
+			if (player.lowerBody == LowerBody.HOOFED) outputText("in your hooves");
+			else if (player.lowerBody == LowerBody.DOG) outputText("in your paws");
+			else if (player.isNaga()) outputText("in your scales");
+			else outputText("inside your footwear, between your toes");
+			outputText(".\n\n<b>You've discovered the Desert (Outer)!</b>");
+			player.exploredDesert = 1;
+			endEncounter();
+		}
+		private function discoverLake():void {
+			clearOutput();
+			outputText("Your wanderings take you far and wide across the barren wasteland that surrounds the portal, until the smell of humidity and fresh water alerts you to the nearby lake.  With a few quick strides, you find a lake so massive that the distant shore cannot be seen.  Grass and a few sparse trees grow all around it.\n\n<b>You've discovered the Lake!</b>");
+			player.exploredLake = 1;
+			endEncounter();
+		}
+		private function discoverForest():void {
+			clearOutput();
+			outputText("You walk for quite some time, roaming the hard-packed and pink-tinged earth of the demon-realm.  Rust-red rocks speckle the wasteland, as barren and lifeless as anywhere else you've been.  A cool breeze suddenly brushes against your face, as if gracing you with its presence.  You turn towards it and are confronted by the lush foliage of a very old-looking forest.  You smile as the plants look fairly familiar and non-threatening.  Unbidden, you remember your decision to test the properties of this place, and think of your campsite as you walk forward.  Reality seems to shift and blur, making you dizzy, but after a few minutes you're back, and sure you'll be able to return to the forest with similar speed.\n\n<b>You've discovered the Forest!</b>");
+			player.exploredForest = 1;
+			player.exploredForest++;
+			endEncounter();
+		}
+		private function discoverHXD():void {
+			clearOutput();
+			outputText("Against your better judgment, curiosity gets the better of you, and you find yourself walking into a strange area.");
+			outputText("\n\nNot long into your journey, you see a hooded figure looming across the landscape, moving at the same speed as it goes across the terrain. The odd creature captures your interest, and you start to follow it. You glance around, there's still no one else nearby, so you continue to tail the mysterious being.");
+			outputText("\n\nHalf an hour or so later, still following the cloaked figure, you begin to hear the sound of running water. Moving on, you eventually come across the source: a decently sized river flows across the land, populated by variously sized islands. Stopping for a second to take a look around, the hooded person seems to be moving towards one of the several islands. He? She? It is still oblivious to your presence.");
+			outputText("\n\nA voice rings from behind you, \"<i>Come to visit He'Xin'Dao, stranger?</i>\"");
+			outputText("\n\nTurning around, you see a few hooded figures similar to the one you have been following. You curse at the thought that someone could've ambushed you so easily without you noticing them sooner. You state that you've been exploring and found this place. The figure peers at you through the veiled hood.\n\n"
+					+ "\"<i>You seem lacking in soulforce, but luckily your soul is enough intact to allow future cultivation. So, since you are already here, what do you think about visiting our village? Maybe you would come more often to it in the future?</i>\"");
+			outputText("\n\nYou ponder for a moment over the offer. The hooded beings don't seem to carry any malice, given they haven't attacked you nor attempted rape. Perhaps it would be of interest to explore this place?  You decide to accept their offer as they lead you over the wide bridge to one of the islands.  Several heavily armored guards peer at you searchingly, to which one of your new companions state that you are a new guest.  The guard gives a stoic nod as they step aside, no longer barring you from entry.  Your hooded friends guide you to a small island to properly register you as a guest. They give you a small guide on a piece of parchment, telling you places of interest and instructions on how to find this place again.");
+			outputText("\n\nAfterwards, you're left alone.  You wander around, checking a few places of interest before you decide it's time to return to your camp.  With the guide in your hands, you're sure you'll find this place again with ease if you need to.");
+			outputText("\n\n\n<b>You have unlocked He'Xin'Dao in Places menu!</b>");
+			flags[kFLAGS.HEXINDAO_UNLOCKED] = 1;
+			explorer.stopExploring();
+			doNext(camp.returnToCampUseTwoHours);
+		}
+//Temporaly place of finding enemies for lvl between 31 and 49
 		public function tryDiscoverLL():void {
 			clearOutput();
 			if (rand(4) == 0) {
@@ -1232,7 +1466,7 @@ public class Exploration extends BaseContent
 			flags[kFLAGS.SKY_POISON_PEARL] = 1;
 			clearOutput();
 			outputText("While exploring, you feel something is off.  Wary of meeting new things in this world after your previous experiences, you decide to cautiously locate the source of this feeling.  Soon the object comes into view and you can see that it is an ordinary looking pearl.  Knowing that it may be more then it looks to be you check the suroundings next to it for a while before deciding to touch it.  Nothing happens so since it somehow attracted your attention you pocket this pearl.\n\n");
-			inventory.takeItem(consumables.SPPEARL, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.SPPEARL, explorer.done);
 		}
 
 		public function hiddencavediscovery():void {
@@ -1257,12 +1491,12 @@ public class Exploration extends BaseContent
 			player.createKeyItem("Pocket Watch", 0, 0, 0, 0);
 			player.createStatusEffect(StatusEffects.MergedPerksCount, 0, 0, 0, 0);
 			if (player.hasStatusEffect(StatusEffects.PocketWatch)) player.removeStatusEffect(StatusEffects.PocketWatch);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function pocketwatchdiscoveryNo():void {
 			outputText("No you do not want to sacrifice anything. Leaving the watch behind, you return to the camp.\n\n");
 			player.createStatusEffect(StatusEffects.PocketWatch, 0, 0, 0, 0);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function ryubifirstenc():void {
@@ -1391,8 +1625,8 @@ public class Exploration extends BaseContent
 			else outputText("  You struggle and push with your [legs] as hard as you can, but it's no use.  You do the only thing you can and begin stroking your [cocks] with as much vigor as you can muster.  Eventually your body tenses and a light load of jizz erupts from your body, but the orgasm is truly mild compared to what you need.  You're simply too weary from struggling to give yourself the masturbation you truly need, but you continue to try.  Nearly an hour later " + sMultiCockDesc() + " softens enough to allow you to stand again, and you make your way back to camp, still dragging your genitals across the warm sand.");
 			dynStats("lus", 25 + rand(player.cor / 5), "scale", false);
 			fatigue(5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 	}
-}
+}

--- a/classes/classes/Scenes/Explore/Giacomo.as
+++ b/classes/classes/Scenes/Explore/Giacomo.as
@@ -1,5 +1,5 @@
 /*
- LICENSE 
+ LICENSE
  
 This license grants Fenoxo, creator of this game usage of the works of
 Dxasmodeus in this product. Dxasmodeus grants Fenoxo and the coders assigned by him to this project permission to alter the text to conform with current and new game functions, only. Dxasmodeus retains exclusive rights to alter or change the core contents of the events and no other developer may alter, change or use the events without permission from dxasmodeus. Fenoxo agrees to include Dxasmodeus' name in the credits with indications to the specific contribution made to the licensor. This license must appear
@@ -26,10 +26,10 @@ For further information and license requests, Dxasmodeus may be contacted throug
 package classes.Scenes.Explore {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Camp.Garden;
 import classes.Scenes.Crafting;
 import classes.Scenes.Holidays;
 import classes.Scenes.SceneLib;
-import classes.Scenes.Camp.Garden;
 import classes.display.SpriteDb;
 
 public class Giacomo extends BaseContent implements TimeAwareInterface {
@@ -114,7 +114,7 @@ public class Giacomo extends BaseContent implements TimeAwareInterface {
 			addButton(2, "Erotica", eroticaMenu);
 			addButton(3, "Misc", miscMenu);
 			if (player.hasStatusEffect(StatusEffects.WormOffer) && player.hasStatusEffect(StatusEffects.Infested)) addButton(5, "Worm Cure", wormRemovalOffer);
-			addButton(14, "Leave", camp.returnToCampUseOneHour);
+			addButton(14, "Leave", explorer.done);
 			statScreenRefresh();
 		}
 		
@@ -1011,7 +1011,7 @@ public class Giacomo extends BaseContent implements TimeAwareInterface {
 			player.buff("Infested").remove();
 			dynStats("lus", -99, "cor", -4);
 			player.gems -= 175;
-			inventory.takeItem(consumables.VITAL_T, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.VITAL_T, explorer.done);
 		}
 		
 		private function wormRemovalOffer():void {

--- a/classes/classes/Scenes/Explore/Giacomo.as
+++ b/classes/classes/Scenes/Explore/Giacomo.as
@@ -26,6 +26,7 @@ For further information and license requests, Dxasmodeus may be contacted throug
 package classes.Scenes.Explore {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.API.MerchantMenu;
 import classes.Scenes.Camp.Garden;
 import classes.Scenes.Crafting;
 import classes.Scenes.Holidays;
@@ -113,6 +114,7 @@ public class Giacomo extends BaseContent implements TimeAwareInterface {
 			addButton(1, "Books", bookMenu);
 			addButton(2, "Erotica", eroticaMenu);
 			addButton(3, "Misc", miscMenu);
+			addButton(4, "Trade", tradeMenu);
 			if (player.hasStatusEffect(StatusEffects.WormOffer) && player.hasStatusEffect(StatusEffects.Infested)) addButton(5, "Worm Cure", wormRemovalOffer);
 			addButton(14, "Leave", explorer.done);
 			statScreenRefresh();
@@ -129,6 +131,30 @@ public class Giacomo extends BaseContent implements TimeAwareInterface {
 			flags[kFLAGS.GIACOMO_MET] = 1;
 		}
 		
+		private function tradeMenu():void {
+			spriteSelect(SpriteDb.s_giacomo);
+			clearOutput();
+			menu();
+			var merchantMenu:MerchantMenu = new MerchantMenu();
+			merchantMenu.addItem(consumables.MANUP_B, 15);
+			merchantMenu.addItem(consumables.VITAL_T, 15);
+			merchantMenu.addItem(consumables.SMART_T, 15);
+			merchantMenu.addItem(consumables.CERUL_P, 75);
+			merchantMenu.addLineBreak();
+			merchantMenu.addItem(consumables.SAPILL_);
+			merchantMenu.addItem(consumables.MAPILL_).disableIf(player.level < 24, "Req. lvl 24+", true);
+			merchantMenu.addItem(consumables.BAPILL_).disableIf(player.level < 42, "Req. lvl 42+", true);
+			merchantMenu.addItem(useables.CONDOM, 10);
+			merchantMenu.addLineBreak();
+			merchantMenu.addItem(consumables.W__BOOK, 100);
+			merchantMenu.addItem(consumables.G__BOOK, 500);
+			merchantMenu.addItem(consumables.B__BOOK, 100);
+			merchantMenu.addItem(consumables.RMANUSC, 125);
+			merchantMenu.addItem(weaponsrange.E_TOME_, 1000);
+			merchantMenu.addItem(consumables.CRIMS_J, 125);
+			merchantMenu.show(giacomoEncounter);
+		}
+	
 		private function potionMenu():void {
 			spriteSelect(SpriteDb.s_giacomo);
 			clearOutput();

--- a/classes/classes/Scenes/Monsters/ImpScene.as
+++ b/classes/classes/Scenes/Monsters/ImpScene.as
@@ -1648,6 +1648,7 @@ use namespace CoC;
 		//IMP LORD
 		public function impLordEncounter():void {
 			clearOutput();
+			spriteSelect(SpriteDb.s_imp);
 			if (flags[kFLAGS.IMP_LORD_MALEHERM_PROGRESS] != 1) {
 				outputText("A large corrupted imp crosses your path. He flashes a cruel smile your way.  No way around it, you ready your [weapon] for the fight.");
 				camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_IMPS);
@@ -1665,6 +1666,7 @@ use namespace CoC;
 
 		//IMP WARLORD
 		public function impWarlordEncounter():void {
+			spriteSelect(SpriteDb.s_impWarlord);
 			clearOutput();
 			outputText("A large corrupted imp crosses your path.  He is wearing armor, unlike most of the imps.  He is also wielding a sword in his right hand.  He flashes a cruel smile your way.  No way around it, you ready your [weapon] for the fight.");
 			flags[kFLAGS.TIMES_ENCOUNTERED_IMP_WARLORD]++;
@@ -1675,6 +1677,7 @@ use namespace CoC;
 
 		//IMP OVERLORD
 		public function impOverlordEncounter():void {
+			spriteSelect(SpriteDb.s_impOverlord);
 			clearOutput();
 			outputText("A large corrupted imp crosses your path but he is no ordinary imp.  Glowing veins line his body.  He is clad in bee-chitin armor and he's wearing a shark-tooth necklace.  He is also wielding a scimitar in his right hand.  He must be an Imp Overlord!  He flashes a cruel smile your way.  No way around it, you ready your [weapon] for the fight.");
 			flags[kFLAGS.TIMES_ENCOUNTERED_IMP_OVERLORD]++;
@@ -1686,6 +1689,7 @@ use namespace CoC;
 		//FERAL IMP LORD
 		public function impLordFeralEncounter():void {
 			clearOutput();
+			spriteSelect(SpriteDb.s_imp);
 			outputText("A large corrupted feral imp crosses your path. He flashes a cruel smile your way while flexing his massive muscles.  No way around it, you ready your [weapon] for the fight.");
 			camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_IMPS);
 			flags[kFLAGS.FERAL_EXTRAS] = 2;
@@ -1694,6 +1698,7 @@ use namespace CoC;
 
 		//FERAL IMP WARLORD
 		public function impWarlordFeralEncounter():void {
+			spriteSelect(SpriteDb.s_impWarlord);
 			clearOutput();
 			outputText("A large corrupted feral imp crosses your path.  He is wearing armor, unlike most of the imps.  He is also wielding a sword in his right hand.  He flashes a cruel smile your way while flexing his massive muscles.  No way around it, you ready your [weapon] for the fight.");
 			flags[kFLAGS.TIMES_ENCOUNTERED_IMP_WARLORD]++;

--- a/classes/classes/Scenes/NPCs/DinahFollower.as
+++ b/classes/classes/Scenes/NPCs/DinahFollower.as
@@ -2,7 +2,7 @@
  * ...
  * @author Ormael
  */
-package classes.Scenes.NPCs 
+package classes.Scenes.NPCs
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
@@ -75,12 +75,12 @@ public class DinahFollower extends NPCAwareContent// implements TimeAwareInterfa
 			flags[kFLAGS.DINAH_LVL_UP] = 1;
 			flags[kFLAGS.DINAH_DEFEATS_COUNTER] = 0;
 			flags[kFLAGS.DINAH_AFFECTION] = 0;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function DinahMoveDecline():void {
 			clearOutput();
 			outputText("They wheeze out an exaggerated sigh.\n\n\"<i>So much of letdown.</i>\" they mutter, as they pack up their goods to travel toward the horizon.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function DinahIntro2():void {
 			clearOutput();//camp intro
@@ -120,7 +120,7 @@ public class DinahFollower extends NPCAwareContent// implements TimeAwareInterfa
 			}
 			else {
 				if (flags[kFLAGS.DINAH_LVL_UP] >= 0.5) addButton(13, "Inv2Camp", DinahMoveToCamp);
-				addButton(14, "Leave", camp.returnToCampUseOneHour);
+				addButton(14, "Leave", explorer.done);
 			}
 		}
 		

--- a/classes/classes/Scenes/NPCs/HelScene.as
+++ b/classes/classes/Scenes/NPCs/HelScene.as
@@ -1,7 +1,6 @@
 package classes.Scenes.NPCs{
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
-import classes.Scenes.Holidays;
 import classes.Scenes.SceneLib;
 import classes.display.SpriteDb;
 
@@ -1772,9 +1771,10 @@ private function satisfyHelSoSheStopsMinoFucking():void {
 
 	public function helSexualAmbushCondition():Boolean {
 		return flags[kFLAGS.PC_PROMISED_HEL_MONOGAMY_FUCKS] == 1
-			   && flags[kFLAGS.HEL_RAPED_TODAY] == 0
-			   && player.gender > 0
-			   && !followerHel();
+				&& flags[kFLAGS.HEL_RAPED_TODAY] == 0
+				&& player.gender > 0
+				&& !followerHel()
+				&& !player.hasStatusEffect(StatusEffects.HeliaOff);
 	}
 //Hel Sexual Ambush
 //(Proc's once per day when [Exploring] anywhere)

--- a/classes/classes/Scenes/Places/TelAdre.as
+++ b/classes/classes/Scenes/Places/TelAdre.as
@@ -2,6 +2,7 @@
 import classes.*;
 import classes.GlobalFlags.kACHIEVEMENTS;
 import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.API.MerchantMenu;
 import classes.Scenes.NPCs.JojoScene;
 import classes.Scenes.Places.TelAdre.*;
 import classes.Scenes.SceneLib;
@@ -308,15 +309,15 @@ public function oswaldPawn():void {
 		outputText("\n\nIn passing, you mention that you're looking for a carrot.\n\nOswald's tophat tips precariously as his ears perk up, and he gladly announces, \"<i>I happen to have come across one recently - something of a rarity in these dark times, you see.  I could let it go for 500 gems, if you're interested.</i>\"");
 		if (player.gems < 500) {
 			outputText("\n\n<b>You can't afford that!</b>");
-			oswaldPawnMenu(); //eventParser(1065);
+			oswaldPawnMenuNew(); //eventParser(1065);
 		}
 		else {
 			menu();
-			addButton(0, "Sell", oswaldPawnMenu);
+			addButton(0, "Sell", oswaldPawnMenuNew);
 			addButton(1, "BuyCarrot", buyCarrotFromOswald);
 		}
 	}
-	else oswaldPawnMenu(); //eventParser(1065);
+	else oswaldPawnMenuNew(); //eventParser(1065);
 }
 
 private function buyCarrotFromOswald():void {
@@ -329,7 +330,22 @@ private function buyCarrotFromOswald():void {
 	addButton(0,"Next",oswaldPawn);
 }
 
-private function oswaldPawnMenu(page:int = 1, refresh:Boolean = false):void { //Moved here from Inventory.as
+	private function oswaldPawnMenuNew():void {
+		clearOutput();
+		outputText("You see Oswald fiddling with a top hat as you approach his stand again.  He looks up and smiles, padding up to you and rubbing his furry hands together.  He asks, \"<i>Have any merchandise for me " + player.mf("sir","dear") + "?</i>\"\n\n");
+		var merchantMenu:MerchantMenu = new MerchantMenu();
+		merchantMenu.playerCanSell = true;
+		merchantMenu.playerSellFactor = 0.5;
+		if (player.hasPerk(PerkLib.Greedy) || player.hasPerk(PerkLib.TravelingMerchantOutfit)) {
+			outputText("Thanks to a little magic and a lot of hard bargaining you managed to sell your items for more than normal. ");
+			merchantMenu.playerSellFactor = 1.0;
+		}
+		merchantMenu.onShow = function():void {
+			button(10).show("Misc", oswaldPawnMenu2);
+		}
+		merchantMenu.show(telAdreMenu);
+	}
+private function oswaldPawnMenu(page:int = 1, refresh:Boolean = true):void { //Moved here from Inventory.as
 	var slot:int;
 	spriteSelect(SpriteDb.s_oswald);
 	if (refresh) {
@@ -359,7 +375,7 @@ private function oswaldPawnMenu(page:int = 1, refresh:Boolean = false):void { //
 			}
 		}
 		addButton(12, "Prev", oswaldPawnMenu, page - 1, refresh = true);
-		if (inventory.getMaxSlots() > 20) addButton(13, "Next", oswaldPawnMenu, page + 1, refresh = true);
+		if (inventory.getMaxSlots() > 20) addButton(13, "Next", oswaldPawnMenu, page + 1, true);
 	}
 	if (page == 3) {
 		for (slot = 20; slot < 30; slot++) {

--- a/classes/coc/view/Block.as
+++ b/classes/coc/view/Block.as
@@ -99,7 +99,7 @@ public class Block extends Sprite {
 			}
 			if (!grid[row]) grid[row] = [];
 			grid[row][col] = child;
-			col++;
+			col += ('colspan' in hint) ? hint['colspan'] : 1;
 			if (col >= cols) {
 				col = 0;
 				row++;
@@ -110,16 +110,20 @@ public class Block extends Sprite {
 			if (!grid[row]) continue;
 			var h:Number = 0;
 			var x:Number = paddingLeft;
-			for (col = 0; col < columns.length; col++) {
+			for (col = 0; col < columns.length;) {
+				var colspan:int = 1;
 				child = grid[row][col];
 				if (child) {
 					if (debug) trace("[" + row + "][" + col + "] x="+(x|0)+" y="+(y|0)+" w="+(columns[col]|0)+" h="+(cellh|0)+" "+child);
 					var setw:Boolean = 'setWidth' in hint ? hint['setWidth'] : setcw;
 					var seth:Boolean = 'setHeight' in hint ? hint['setHeight'] : setch;
+					colspan = 'colspan' in hint ? hint['colspan'] : 1;
 					child.x          = x + gap / 2;
 					child.y          = y;
 					if (setw) {
-						child.width = columns[col];
+						var cw:Number = columns[col];
+						for (i = 1; i < colspan; i++) cw += gap + columns[col+i];
+						child.width = cw;
 					}
 					if (seth) {
 						child.height = cellh;
@@ -127,7 +131,10 @@ public class Block extends Sprite {
 					if (debug) trace(""+child.x+" "+child.y+" "+child.width+" "+child.height);
 					h = Math.max(h, child.height);
 				}
-				x += columns[col]+gap;
+				while (colspan-->0 && col < columns.length) {
+					x += columns[col] + gap;
+					col++;
+				}
 			}
 			y += h+gap;
 		}

--- a/classes/coc/view/CoCButton.as
+++ b/classes/coc/view/CoCButton.as
@@ -317,7 +317,7 @@ public class CoCButton extends Block {
 		return this;
 	}
 	
-	public function color(rgb:String):CoCButton {
+	public function color(rgb:*):CoCButton {
 		this._labelField.textColor = Color.convertColor(rgb);
 		return this;
 	}
@@ -367,7 +367,20 @@ public class CoCButton extends Block {
 		return this;
 	}
 	public function showForItemSlot(slot:ItemSlotClass, callback:Function):CoCButton {
-		show(slot.itype.shortName, callback);
+		if (slot.isEmpty()) {
+			showDisabled("Empty");
+			hint("");
+			color(DEFAULT_COLOR);
+			iconId = null;
+			iconQty = "";
+			return this;
+		}
+		showForItem(slot.itype, callback);
+		if (slot.itype.stackSize > 1 || slot.quantity > 1) {
+			iconQty = String(slot.quantity);
+		} else {
+			iconQty = "";
+		}
 		itemSlotTexts(slot);
 		return this;
 	}

--- a/classes/coc/view/MainView.as
+++ b/classes/coc/view/MainView.as
@@ -845,7 +845,9 @@ public class MainView extends Block {
 			element.height = mainText.y + mainText.height - element.y;
 		}
 	}
-	
+	public function getCustomElement():DisplayObject {
+		return customElement;
+	}
 
 	public function appendOutputText(text:String):void {
 		var fmt:TextFormat = this.mainText.defaultTextFormat;

--- a/classes/coc/view/MainView.as
+++ b/classes/coc/view/MainView.as
@@ -191,7 +191,7 @@ public class MainView extends Block {
 	internal static const COLUMN_1_W:Number      = Math.max(STATBAR_W, CHARVIEW_W);
 	internal static const COLUMN_1_RIGHT:Number  = COLUMN_1_X + COLUMN_1_W;
 	// Column 2 core
-	internal static const TEXTZONE_W:Number      = 770;
+	public static const TEXTZONE_W:Number      = 770;
 	internal static const COLUMN_2_X:Number      = COLUMN_1_RIGHT + GAP;
 	internal static const COLUMN_2_W:Number      = TEXTZONE_W;
 	internal static const COLUMN_2_RIGHT:Number  = COLUMN_2_X + COLUMN_2_W;

--- a/res/icons.xml
+++ b/res/icons.xml
@@ -90,7 +90,7 @@
             <icon>Potion_Unknown</icon>
             <icon>ManUp B</icon>
             <icon>Vital T</icon>
-            <icon>Agil.E</icon>
+            <icon>Agil.E.</icon>
             <icon>IncOIns</icon>
             <icon>Smart T</icon>
             <icon>Vixen T</icon>


### PR DESCRIPTION
* Converted common exploration to new engine.
* Exploration nodes can branch.
* Generic goblin/golem/imp encounters are separated
* Disabled encounter chance adjustment, as it interferes with new system.
* Encounter node label font size reduced.
* New merchant UI.
* Converted Giacomo and Oswald to new UI.

Code changes:
* Abilities using `PlantsNearby` effect also check `explorer.areaTags.plants`.
* Added "plants" to Forest (O) area tags.
* Removed PlantsNearby effect in Forest (O).
* New encounter property 'shortLabel'. Default same as 'label'. 'shortLabel' is displayed on map, 'label' - on tooltip
* Encounter node properties - kind, label, shortLabel, hint - can be functions. For example, encounter kind can switch between NPC and monster depending on flag.
* Encounters with chance = ALWAYS stop the exploration and are executed immediately.
* More utility functions to manage encounters