### PR TITLE
Forest(I) and Deepwoods map exploration

### DIFF
--- a/classes/classes/Scenes/Areas/Forest.as
+++ b/classes/classes/Scenes/Areas/Forest.as
@@ -864,13 +864,6 @@ use namespace CoC;
 			}*/);
 		}
 
-		public function exploreDeepwoods():void {
-			clearOutput();
-			player.addStatusValue(StatusEffects.ExploredDeepwoods, 1, 1);
-			//player.createStatusEffect(StatusEffects.GnomeHomeBuff,1,0,0,0);
-			deepwoodsEncounter.execEncounter();
-		}
-
 		public function forestChance():Number {
 			var temp:Number = 0.5;
 			temp *= player.npcChanceToEncounter();
@@ -961,14 +954,28 @@ use namespace CoC;
 		}
 		public function exploreForest():void
 		{
-			clearOutput();
-			doNext(camp.returnToCampUseOneHour);
-			//Increment forest exploration counter.
-			player.exploredForest++;
-//			forestStory.execute();
-			forestEncounter.execEncounter();
-			flushOutputTextToGUI();
+			explorer.prepareArea(forestEncounter);
+			explorer.setTags("forest","forestInner","plants");
+			explorer.prompt = "You explore the forest.";
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				player.exploredForest++;
+			}
+			explorer.leave.hint("Leave the forest");
+			explorer.skillBasedReveal(3, player.exploredForest);
+			explorer.doExplore();
 		}
+		public function exploreDeepwoods():void {
+			explorer.prepareArea(deepwoodsEncounter);
+			explorer.setTags("forest","deepwoods","plants");
+			explorer.prompt = "You explore the deepwoods.";
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				player.addStatusValue(StatusEffects.ExploredDeepwoods, 1, 1);
+			}
+			explorer.leave.hint("Leave the deepwoods");
+			explorer.skillBasedReveal(7, player.statusEffectv1(StatusEffects.ExploredDeepwoods));
+			explorer.doExplore();
+		}
+		
 		//[FOREST]
 //[RANDOM SCENE IF CHARACTER HAS AT LEAST ONE COCK LARGER THAN THEIR HEIGHT, AND THE TOTAL COMBINED WIDTH OF ALL THEIR COCKS IS TWELVE INCHES OR GREATER]
 		public function bigJunkForestScene(lake:Boolean = false):void

--- a/classes/classes/Scenes/Areas/Forest.as
+++ b/classes/classes/Scenes/Areas/Forest.as
@@ -288,7 +288,6 @@ use namespace CoC;
 						night : false,
 						chance: 0.6,
 						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 							if (flags[kFLAGS.TAMANI_DAUGHTER_PREGGO_COUNTDOWN] == 0
 								&& flags[kFLAGS.TAMANI_NUMBER_OF_DAUGHTERS] >= 16 && flags[kFLAGS.SOUL_SENSE_TAMANI_DAUGHTERS] < 3) {
 								tamaniDaughtersScene.encounterTamanisDaughters();
@@ -308,10 +307,7 @@ use namespace CoC;
 						kind  : 'npc',
 						unique: true,
 						night : false,
-						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							encounterTamanisDaughtersFn();
-						},
+						call  : encounterTamanisDaughtersFn,
 						when  : function ():Boolean {
 							return player.gender > 0
 								&& player.hasCock()
@@ -320,7 +316,9 @@ use namespace CoC;
 						}
 					}, {
 						name  : "Jojo",
-						label : "JoJo",
+						label : function():String {
+							return silly() ? "JoJo" : "Jojo"
+						},
 						kind  : 'npc',
 						unique: true,
 						night : false,
@@ -343,10 +341,7 @@ use namespace CoC;
 						name  : "tentaBeast",
 						label : "Tentacle Beast",
 						kind  : 'monster',
-						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							tentacleBeastEncounterFn();
-						},
+						call  : tentacleBeastEncounterFn,
 						when  : fn.ifLevelMin(3),
 						chance: 0.80
 					}, corruptedGlade.encounter, {
@@ -354,10 +349,7 @@ use namespace CoC;
 						label : "Bee-girl",
 						kind  : 'monster',
 						night : false,
-						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							beeGirlScene.beeEncounter();
-						},
+						call  : beeGirlScene.beeEncounter,
 						chance: 1.0
 					}, {
 						name  : "WoodElf",

--- a/classes/classes/Scenes/Areas/Forest/AkbalScene.as
+++ b/classes/classes/Scenes/Areas/Forest/AkbalScene.as
@@ -7,7 +7,6 @@ import classes.*;
 import classes.BodyParts.Tail;
 import classes.GlobalFlags.kFLAGS;
 import classes.Items.Armors.LustyMaidensArmor;
-import classes.Scenes.SceneLib;
 import classes.display.SpriteDb;
 
 public class AkbalScene extends BaseContent {
@@ -638,7 +637,7 @@ public class AkbalScene extends BaseContent {
 
 			outputText("The aura pouring forth from this 'Akbal' is anything but god-like; you recognize the demon for what it truly is.  Yet its ivory teeth and sharp claws prove to you that it can make good on its threat.  What do you do?");
 			//Talk / Fight / Run
-			simpleChoices("Talk", superAkbalioTalk, "Fight", startuAkabalFightomon, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+			simpleChoices("Talk", superAkbalioTalk, "Fight", startuAkabalFightomon, "", null, "", null, "Leave", explorer.done);
 		}
 
 		//[Talk]
@@ -667,7 +666,7 @@ public class AkbalScene extends BaseContent {
 			clearOutput();
 			outputText("You shake your head and rub the lust-filled jaguar behind the ear as you tell him you're busy.  The demon's eyes roll, and he licks your [leg] before his eyes find an imp in the trees above the two of you.\n\n");
 			outputText("Knowing he's found a new toy, Akbal allows you to leave unmolested.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//[Encounter if previously fought and won/raped him]
@@ -680,7 +679,7 @@ public class AkbalScene extends BaseContent {
 			else
 				outputText("dodging roll places you a good distance away from him.  Do you fight or flee?\n\n");
 			//Fight / Flee
-			simpleChoices("Fight", startuAkabalFightomon, "", null, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+			simpleChoices("Fight", startuAkabalFightomon, "", null, "", null, "", null, "Leave", explorer.done);
 		}
 
 		//[Encounter if previously fought and lost]
@@ -690,7 +689,7 @@ public class AkbalScene extends BaseContent {
 			outputText("A chorus of laughter sounds inside your mind as the jaguar demon, Akbal, drops to the ground in front of you.  His masculine voice says, \"<i>Well, if it isn't the defiant welp who, in all their great idiocy, has wandered into my territory again.  Will you submit, or do I have to teach you another harsh lesson?</i>\"\n\n");
 
 			//Submit / Fight / Run
-			simpleChoices("Submit", akbalSubmit, "Fight", startuAkabalFightomon, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+			simpleChoices("Submit", akbalSubmit, "Fight", startuAkabalFightomon, "", null, "", null, "Leave", explorer.done);
 		}
 
 		//[Fight]
@@ -772,6 +771,7 @@ public class AkbalScene extends BaseContent {
 					player.butt.type++;
 				}
 				player.createStatusEffect(StatusEffects.PostAkbalSubmission, 0, 0, 0, 0);
+				explorer.stopExploring();
 				doNext(camp.returnToCampUseEightHours);
 				return;
 			}
@@ -845,6 +845,7 @@ public class AkbalScene extends BaseContent {
 					player.butt.type++;
 				}
 				player.createStatusEffect(StatusEffects.PostAkbalSubmission, 0, 0, 0, 0);
+				explorer.stopExploring();
 				doNext(camp.returnToCampUseEightHours);
 				return;
 			}
@@ -919,6 +920,7 @@ public class AkbalScene extends BaseContent {
 				player.butt.type++;
 			}
 			player.createStatusEffect(StatusEffects.PostAkbalSubmission, 0, 0, 0, 0);
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 
@@ -1031,6 +1033,7 @@ public class AkbalScene extends BaseContent {
 			player.sexReward("cum", "Anal");
 			dynStats("cor", 5);
 			player.createStatusEffect(StatusEffects.PostAkbalSubmission, 0, 0, 0, 0);
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 
@@ -1061,7 +1064,7 @@ public class AkbalScene extends BaseContent {
 			outputText("You turn back, allowing the demon to finish cleaning himself and thankful he didn’t ambush you this time.");
 			if (player.lust < 33)
 				outputText("  Besides, you aren't aroused right now, anyway.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//{Choose Rape}
@@ -1174,7 +1177,7 @@ public class AkbalScene extends BaseContent {
 
 				player.sexReward("no", "Dick");
 				dynStats("cor", 3);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 
 			function vagF():void {
@@ -1233,7 +1236,7 @@ public class AkbalScene extends BaseContent {
 				player.sexReward("cum", "Vaginal");
 				dynStats("cor", 3);
 				if (player.hasVagina() && !player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP, 101);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -1305,7 +1308,7 @@ public class AkbalScene extends BaseContent {
 					outputText("\n\nYou stand and Akbal’s legs flop from where you had them pinned to his chest.  You gather your [armor] and dress before aiming a wicked slap at Akbal’s tender cheeks and leaving him tied up for the imps and goblins you spy watching the two of you from the trees.\n\nYou tell him he is all theirs and share a conspiratorial grin as you head back to camp.");
 				player.sexReward("no", "Dick");
 				dynStats("cor", 3);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 
 			function vagF():void {
@@ -1359,7 +1362,7 @@ public class AkbalScene extends BaseContent {
 				player.sexReward("cum", "Dick");
 				dynStats("cor", 3);
 				if (player.hasVagina() && !player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP, 101);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -1403,7 +1406,7 @@ public class AkbalScene extends BaseContent {
 				outputText("\n\nAkbal lies on the ground, shivering as he rolls over.  The tied up demon jaguar’s stomach, and the forest floor are covered in a thick coating of jizz, sticky strings even connect the demon’s chest to the puddle.  With heaving breath, the demon falls asleep as you gather your [armor] and leave.");
 				player.sexReward("no", "Dick");
 				dynStats("cor", 3);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 
 			function vagF():void {
@@ -1457,7 +1460,7 @@ public class AkbalScene extends BaseContent {
 				if (player.hasVagina()) player.sexReward("cum", "Vaginal");
 				else player.sexReward("cum", "Anal");
 				dynStats("cor", 3);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -1601,7 +1604,7 @@ public class AkbalScene extends BaseContent {
 			if (player.hasVagina()) player.sexReward("cum", "Vaginal");
 			else player.sexReward("cum", "Anal");
 			dynStats("cor", 3);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 	}
 }

--- a/classes/classes/Scenes/Areas/Forest/ErlKingScene.as
+++ b/classes/classes/Scenes/Areas/Forest/ErlKingScene.as
@@ -221,8 +221,8 @@ public class ErlKingScene extends BaseContent
 			fatigue(10);
 
 			if (waited)
-				inventory.takeItem(consumables.CANINEP, camp.returnToCampUseOneHour);
-			else inventory.takeItem(consumables.FOXBERY, camp.returnToCampUseOneHour);
+				inventory.takeItem(consumables.CANINEP, explorer.done);
+			else inventory.takeItem(consumables.FOXBERY, explorer.done);
 		}
 
 		public function repeatWildHuntEncounter():void
@@ -270,7 +270,7 @@ public class ErlKingScene extends BaseContent
 			outputText("It seems the Erlking has no interest in chasing prey that won’t run.\n\n");
 
 			if (player.inte < 80) dynStats("int+", 1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		protected function repeatWildHuntChase():void
@@ -300,7 +300,7 @@ public class ErlKingScene extends BaseContent
 				if (rand(2) == 0) dynStats("tou+", 1);
 				else dynStats("spe+", 1);
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		protected function mockSlow():void {
@@ -399,7 +399,7 @@ public class ErlKingScene extends BaseContent
 			player.gems -= gemLoss;
 
 			outputText("<b>You’ve lost " + gemLoss + " gems.</b>\n\n");
-			inventory.takeItem(consumables.CANINEP, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.CANINEP, explorer.done);
 			dynStats("sen-", 2, "lib+", 2, "cor+", 1, "lus=", 0);
 			fatigue(10);
 			player.sexReward("cum");
@@ -451,10 +451,10 @@ public class ErlKingScene extends BaseContent
 			player.gems += gemFind;
 			var selector:int = rand(4);
 
-			if (selector == 0) inventory.takeItem(consumables.CANINEP, camp.returnToCampUseOneHour);
-			if (selector == 1) inventory.takeItem(consumables.FOXBERY, camp.returnToCampUseOneHour);
-			if (selector == 2) inventory.takeItem(consumables.NPNKEGG, camp.returnToCampUseOneHour);
-			if (selector == 3) inventory.takeItem(consumables.GLDRIND, camp.returnToCampUseOneHour);
+			if (selector == 0) inventory.takeItem(consumables.CANINEP, explorer.done);
+			if (selector == 1) inventory.takeItem(consumables.FOXBERY, explorer.done);
+			if (selector == 2) inventory.takeItem(consumables.NPNKEGG, explorer.done);
+			if (selector == 3) inventory.takeItem(consumables.GLDRIND, explorer.done);
 		}
 
 		protected function stopTheMadness():void
@@ -475,7 +475,7 @@ public class ErlKingScene extends BaseContent
 			outputText("\"<i>As you wish,</i>\" says the Erlking.  The fog rolls in once more, engulfing the Erlking and his steed.  It clears a moment later, leaving you alone in the forest.\n\n");
 
 			outputText("You get the feeling you won’t be seeing him anymore.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		protected function surrenderToTheHounds():void
@@ -686,7 +686,7 @@ public class ErlKingScene extends BaseContent
 				//[+10 Fatigue, +1 Toughness / +1 Strength, 100 hp healed]
 				if (player.tou < player.str) dynStats("toughness+", 1, "fatigue+", 10, "health+", 100, "lust=", 0);
 				else (dynStats("strength+", 1, "fatigue+", 10, "health+", 100, "lust=", 0));
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -772,10 +772,10 @@ public class ErlKingScene extends BaseContent
 					player.sexReward("no");
 					dynStats("lust=", 0);
 					if (flags[kFLAGS.ERLKING_CANE_OBTAINED] == 0) {
-						inventory.takeItem(weapons.HNTCANE, camp.returnToCampUseOneHour);
+						inventory.takeItem(weapons.HNTCANE, explorer.done);
 						flags[kFLAGS.ERLKING_CANE_OBTAINED] = 1;
 					}
-					else doNext(camp.returnToCampUseOneHour);
+					else endEncounter();
 				}
 				else doNext(recallWakeUp);
 			}
@@ -831,7 +831,7 @@ public class ErlKingScene extends BaseContent
 			}
 			addButton(3, "Milk Dick", gwynnGetsDickmilked);
 			addButton(4, "Gifts", gwynnGibsGifts);
-			addButton(14, "Leave", camp.returnToCampUseOneHour);
+			addButton(14, "Leave", explorer.done);
 		}
 
 		protected function gwynnSucksDicks():void
@@ -855,7 +855,7 @@ public class ErlKingScene extends BaseContent
 			//[Libido + 2]
 			dynStats("lib+", 2, "lus=", 0);
 			player.sexReward("Default","Default",true,false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		protected function gwynnGetsButtfuxed():void
@@ -880,7 +880,7 @@ public class ErlKingScene extends BaseContent
 			//[Sensitivity -2]
 			dynStats("sen-", 2, "lus=", 0);
 			player.sexReward("Default","Default",true,false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		protected function gwynnNomsDaCunts():void
@@ -905,7 +905,7 @@ public class ErlKingScene extends BaseContent
 			//[Sensitivity -2, Libido +2]
 			dynStats("sen-", 2, "lib+", 2, "lus=", 0);
 			player.sexReward("Default","Default",true,false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		protected function gwynnGetsDickmilked():void
@@ -937,7 +937,7 @@ public class ErlKingScene extends BaseContent
 
 			//[Lust +20, Libido +2]
 			dynStats("lus+", 20, "lib+", 2);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		protected function gwynnGibsGifts():void
@@ -956,14 +956,14 @@ public class ErlKingScene extends BaseContent
 
 			outputText("Before you can stop her, she’s gone, and you pocket the small bottle for later.\n\n");
 
-			if (rand(4) > 0) inventory.takeItem(consumables.PRNPKR, camp.returnToCampUseOneHour);
+			if (rand(4) > 0) inventory.takeItem(consumables.PRNPKR, explorer.done);
 			else inventory.takeItem(consumables.PRNPKR, goldenRindBonus);
 		}
 
 		private function goldenRindBonus():void {
 			clearOutput();
 			outputText("\"<i>Oh, I also had this left over from brewing my Pucker,</i>\" she says, popping out of the brush behind you.  You yelp in surprise.  She’d vanished into the forest in front of you a moment ago.  How did she move so quickly?  \"<i>Here you go!</i>\" she pipes up, depositing a small item in your hand before disappearing back into the woods.  If she can move that quickly and quietly through the woods, it’s pretty likely that her falling prey to the forest predators has been entirely voluntary.\n\n");
-			inventory.takeItem(consumables.GLDRIND, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.GLDRIND, explorer.done);
 		}
 
 		public function deerTFs():void {

--- a/classes/classes/Scenes/Areas/Forest/Faerie.as
+++ b/classes/classes/Scenes/Areas/Forest/Faerie.as
@@ -1,9 +1,5 @@
 ﻿package classes.Scenes.Areas.Forest{
 import classes.*;
-import classes.BodyParts.Arms;
-import classes.BodyParts.LowerBody;
-import classes.BodyParts.Tail;
-import classes.BodyParts.Wings;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.SceneLib;
 import classes.display.SpriteDb;
@@ -51,7 +47,7 @@ public function encounterFaerie():void {
 			player.orgasm();
 		}
 		else outputText("\n\nYou try in vain to jump and catch her, but she's too high above you and much too fast.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		return;
 	}
 	outputText("The faerie slows the beating of her wings and hovers towards you. You dismiss your fearful notions, certain a small faerie is quite harmless to you.\n\n");
@@ -158,14 +154,14 @@ private function faerieRAEP():void {
 	}
 	player.orgasm();
 	dynStats("lib", -2, "cor", .5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function faerieShooAway():void {
 	spriteSelect(SpriteDb.s_faerie);
 	clearOutput();
 	outputText("You shake your hands, shooing away the tiny faerie.  She's clearly been touched by the magics of this land, and you want nothing to do with her. With a pouting look, she turns and buzzes away.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function faerieDoNothing():void {
@@ -186,7 +182,7 @@ private function faerieDoNothing():void {
 		if(player.biggestLactation() > 1.5) outputText("\n\nA copious gout of your milk escapes her rosy folds.");
 		player.orgasm();
 		dynStats("lib", -2);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else if (clitOK) {
 		outputText("A smile crosses her face, and she flutters down to your crotch. She starts by scissoring you despite the size difference, driving your clit into her despite its erect state. Compared to her, it looks massive. She swings one leg over it and starts impaling herself on it. Your taut clitoris barely fits inside her, and the tight confines on your sensitive nub are enough to make you weak in the knees. Staggering to the ground, you grab hold of her frail body in your fist and thrust her roughly on your engorged button. She wails in both pain and pleasure, being crushed and stretched open at once. Her cries of pain combined with the intense stimulation on your most sensitive part bring you to a quick orgasm.\n\n");
@@ -195,7 +191,7 @@ private function faerieDoNothing():void {
 		outputText("Time skips a beat, and you eventually come down, gently relaxing your grip and disengaging the worn out faerie from your softening female parts. The faerie regains consciousness slowly and thanks you before flying off.");
 		player.orgasm();
 		dynStats("lib", -1);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else if (nippleSmall) {
 		outputText("The faerie flies close to your nipple and sucks it gingerly.  You pant in pleasure as you feel it pucker tight in her mouth, tingling with her saliva.  She lets it pop free, swollen with arousal.  Her hand flicks it playfully, the sudden sensation fluttering through you as you close your eyes in pleasure.  You recover and find she has flown high into the trees, waving playfully as she escapes.\n\nYou frown and begin to dress yourself, flushing irritably as your nipples protrude further into your clothes than you remember.");
@@ -205,12 +201,12 @@ private function faerieDoNothing():void {
 			player.nippleLength -= .25;
 		}
 		dynStats("sen", 1, "lus", 5);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else {
 		outputText("The faerie flies close to your ear and speaks in a volume that would be a whisper from another human, \"You've got some sexy parts girl, but you're too big for me. I hope you find someone to get you off, so I can watch.\" Then she flies in front of you, cutely kisses the bridge of your nose, and flies off.");
 		dynStats("lus", 5, "scale", false);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 
@@ -219,7 +215,7 @@ private function letFaerieGo():void {
 	spriteSelect(SpriteDb.s_faerie);
 	clearOutput();
 	outputText("You apologize and release her, letting her fly away on gossamer wings.  She thanks you, buzzing up to your lips and planting a chaste kiss on your mouth.  She zips away into the woods without a glance back...");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Disable Faerie encounter
 private function disableFaerieEncounterForGood():void {
@@ -228,7 +224,7 @@ private function disableFaerieEncounterForGood():void {
 	outputText("You apologize and release her, letting her fly away on gossamer wings.  She thanks you, buzzing up to your lips and planting a chaste kiss on your mouth.  She zips away into the woods without a glance back...");
 	outputText("\n\nYou make a mental note and resolve to never catch her again.");
 	flags[kFLAGS.FAERIE_ENCOUNTER_DISABLED] = 1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[YES] *make her pleasure you
@@ -302,7 +298,7 @@ private function faerieCaptureHJ():void {
             SceneLib.valeria.feedValeria(player.cumQ() / 10);
         }
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function encounterFaerieDragon():void {
 	spriteSelect(SpriteDb.s_faerie);
@@ -341,7 +337,7 @@ private function encounterFaerieDragonStoryNo():void {
 	spriteSelect(SpriteDb.s_faerie);
 	clearOutput();
 	outputText("You excuse yourself, saying that you like yourself the way you are. Then you turn back, making your way back to camp.\n\n");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 private function encounterFaerieDragonStoryYes():void {
 	spriteSelect(SpriteDb.s_faerie);
@@ -357,7 +353,7 @@ private function encounterFaerieDragonStoryYes():void {
 	transformations.ArmsFeyDraconic.applyEffect(false);
 	transformations.LowerBodyFeyDraconic(player.legCount).applyEffect(false);
 	if (!player.hasPerk(PerkLib.DragonFaerieBreath)) player.createPerk(PerkLib.DragonFaerieBreath, 0, 0, 0, 0);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 }
 }

--- a/classes/classes/Scenes/Areas/Forest/KitsuneScene.as
+++ b/classes/classes/Scenes/Areas/Forest/KitsuneScene.as
@@ -149,7 +149,7 @@ public class KitsuneScene extends BaseContent
 			outputText("There's no way you're going to go gallivanting off into the woods after some flame.  You shake your head to clear your thoughts, and warily turn away to head back toward camp.  You could almost swear for a moment the flame looked disappointed, and you chuckle lightly at such a silly thought.");
 			//Advance time 1 hour, return to camp.
             if (CoC.instance.inCombat) cleanupAfterCombat();
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
 		}
 
 //[Follow] (C)
@@ -237,7 +237,7 @@ public class KitsuneScene extends BaseContent
 			}
 			else {
 				//add Kitsune's Gift to inventory
-				inventory.takeItem(consumables.KITGIFT, camp.returnToCampUseOneHour);
+				inventory.takeItem(consumables.KITGIFT, explorer.done);
 			}
 		}
 
@@ -678,7 +678,7 @@ public class KitsuneScene extends BaseContent
 			CoC.instance.timeQ = 0;
 			player.addCurse("tou", 2, 2);
 			if (!CoC.instance.inCombat)
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			else cleanupAfterCombat();
 		}
 
@@ -2193,7 +2193,7 @@ public class KitsuneScene extends BaseContent
 					outputText("<b>You can now visit the forest shrine at will.</b>");
 					flags[kFLAGS.KITSUNE_SHRINE_UNLOCKED] = 1;
 					flags[kFLAGS.AYANE_FOLLOWER] = 0;
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 					return;
 				}
 				else outputText("You find your way to the abandoned kitsune shrine again.  The place is full of rotten timber, but it has a bookcase stuffed with well-maintained tomes.  The remains of a camp are in here as well, though the owner is curiously absent.  Judging by the layer of dust on everything, whoever lived here hasn't been around in quite some time.  You're sure they wouldn't mind if you helped yourself to some of those books - you might just learn a thing or two.");
@@ -2226,7 +2226,7 @@ public class KitsuneScene extends BaseContent
 				addButton(6, "Servant", AyaneServant);
 			}
 			if (player.hasPerk(PerkLib.CorruptedNinetails) && player.inte >= 100 && player.wis >= 100 && player.cor >= 50 && flags[kFLAGS.KITSUNE_SHRINE_UNLOCKED] > 0 && flags[kFLAGS.AYANE_FOLLOWER] < 2) addButton(7, "Slave", AyaneSlave);
-			addButton(14, "Leave", camp.returnToCampUseOneHour);
+			addButton(14, "Leave", explorer.done);
 		}
 
 //[Read Books]
@@ -2242,20 +2242,20 @@ public class KitsuneScene extends BaseContent
 				dynStats("int", 2);
 				player.KnowledgeBonus("int",2);
 				player.KnowledgeBonus("wis", 2);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else if (choice == 1) {
 				outputText("It seems to be a religious text of some sort.  As you flip through the pages, you read about various rituals and scriptures, familiarizing yourself with the spirits and gods of this land.  You close the tome at last, setting it reverently back on the shelf and reflecting upon the teachings housed within.");
 				//-1 COR, Advance 1hr and return to camp
 				dynStats("cor", -1);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else {
 				outputText("You start to flip through the pages, a deep blush slowly forming on your cheeks the further you read into what is clearly an erotic novella of some form.  Graphic descriptions of women being violated by tentacle beasts abound on almost every page, " + ((player.lib < 50) ? "and you slam the book shut before reading further, already feeling a heat building in your groin." : "and you lick your lips hungrily, poring over every line and word of lascivious prose."));
 				//+ 1 LIB, + 5 LUST, Advance 1hr and return to camp
 				dynStats("lib", 1, "lus", 5);
 				player.KnowledgeBonus("lib",1);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -2266,7 +2266,7 @@ public class KitsuneScene extends BaseContent
 			outputText("You leave a generous offering of gems at the shrine of Taoth and pray to the fox god for his support in your quest. Light falls from the sky and seems to condense in your star sphere, as you feel your kitsune powers increasing. When you look down to the offering bowl, you discover it is now empty.\n\n");
 			player.addPerkValue(PerkLib.StarSphereMastery, 1, 1);
 			player.gems -= 1000;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//[Meditate]
@@ -2287,7 +2287,7 @@ public class KitsuneScene extends BaseContent
 					player.createPerk(PerkLib.StarSphereMastery, 1, 0, 0, 0);
 					player.createKeyItem("Kitsune Star Sphere", 0, 0, 0, 0);
 					player.consumeItem(consumables.FOXJEWL);
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 				} else if (player.tailCount == 8 && player.level >= 42 && player.inte >= 120 && player.wis >= 120 && notANineTail) {
 					outputText("Nearing the end of your meditation, you are inexplicably compelled to reach into your bag and pull out the small teardrop-shaped jewel you were carrying.  As you stare past the translucent surface of the bead and into the dancing fire within, the jewel begins to dissolve in your hand, the pale flames within spilling out and spreading over your body.\n\n");
 					//Apply Nine-Tails perk if applicable.
@@ -2341,7 +2341,7 @@ public class KitsuneScene extends BaseContent
 					player.statStore.replaceBuffObject({"wis.mult":0.10,"int.mult":0.10}, "KitsuneShrine",{text:"Kitsune shrine Meditation", rate:Buff.RATE_DAYS, tick:7});
 					dynStats("wis", 5,"int", 5, "lus", -50, "cor", -5);
 					player.consumeItem(consumables.FOXJEWL);
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 				} else if (player.tailCount == 6 && player.level >= 30 && player.inte >= 90 &&  player.wis >= 90 && notANineTail && (!player.hasPerk(PerkLib.CorruptedKitsune) || player.perkv4(PerkLib.CorruptedKitsune) > 0)) {
 					outputText("Nearing the end of your meditation, you are inexplicably compelled to reach into your bag and pull out the small teardrop-shaped jewel you were carrying.  As you stare past the translucent surface of the bead and into the dancing fire within, the jewel begins to dissolve in your hand, the pale flames within spilling out and spreading over your body.\n\n");
 					//Apply Kitsune perk if applicable.
@@ -2387,13 +2387,13 @@ public class KitsuneScene extends BaseContent
 				player.createPerk(PerkLib.StarSphereMastery, 1, 0, 0, 0);
 				player.createKeyItem("Kitsune Star Sphere", 0, 0, 0, 0);
 				player.consumeItem(consumables.RUBYCRY);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			} else {
 				//Normal:
 				outputText("As you open your eyes again, you feel as if a great burden has been lifted from your shoulders.\n\nWith a renewed vigor for your quest, you stand up and set off for camp.");
 				player.statStore.replaceBuffObject({"wis.mult":0.10,"int.mult":0.10}, "KitsuneShrine",{text:"Kitsune shrine Meditation", rate:Buff.RATE_DAYS, tick:7});
 				dynStats("wis", 5,"int", 5, "lus", -50, "cor", -2);
-				//doNext(camp.returnToCampUseOneHour);
+				//endEncounter();
 			}
 			var tailzAfter:int = player.tail.count;
 			if (player.tailType == Tail.FOX) return tailzAfter;
@@ -2411,7 +2411,7 @@ public class KitsuneScene extends BaseContent
 				outputText("\n\nDo you take her as your attendant?");
 				doYesNo(AyaneCome2Camp, AyaneStayAtShrine);
 			} else {
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 		private function AyaneCome2Camp():void {
@@ -2426,13 +2426,13 @@ public class KitsuneScene extends BaseContent
 			else player.createKeyItem("Radiant shard", 1,0,0,0);
 			outputText("\n\n\"<i>Please take it as my first of many tribute to you my " + player.mf("lord", "lady") + ".</i>\"");
 			flags[kFLAGS.AYANE_FOLLOWER] = 2;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function AyaneStayAtShrine():void {
 			clearOutput();
 			outputText("\n\nAyane looks disappointed but nods regardless. \"<i>I accept your choice... maybe I was too hasty. Come back and see me again, should you be in need of counsel or a servant, my " + player.mf("lordship", "ladyship") + ".</i>\"");
 			flags[kFLAGS.AYANE_FOLLOWER] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function AyaneServant():void {
 			clearOutput();
@@ -2452,7 +2452,7 @@ public class KitsuneScene extends BaseContent
 			player.createKeyItem("Ayane Star Sphere", 0, 0, 0, 0);
 			//dynStats("cor", 10); - dodawać czy nie to?
 			flags[kFLAGS.AYANE_FOLLOWER] = 2;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //[Steal Statue]
@@ -2479,7 +2479,7 @@ public class KitsuneScene extends BaseContent
 			outputText("The thought of how many gems you'll be able to get for it is enough to quickly suppress those feelings, avarice winning out over guilt.");
 			//+10 COR, add Gold Statue to inventory, Advance 1hr and return to camp
 			dynStats("lus", 10, "scale", false);
-			inventory.takeItem(useables.GLDSTAT, camp.returnToCampUseOneHour);
+			inventory.takeItem(useables.GLDSTAT, explorer.done);
 			flags[kFLAGS.TOOK_KITSUNE_STATUE] = 1;
 		}
 
@@ -2491,7 +2491,7 @@ public class KitsuneScene extends BaseContent
 			//Advance 1hr and return to camp.
 			flags[kFLAGS.TOOK_KITSUNE_STATUE] = 0;
 			player.consumeItem(useables.GLDSTAT);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //Use:

--- a/classes/classes/Scenes/Areas/Forest/NightmareScene.as
+++ b/classes/classes/Scenes/Areas/Forest/NightmareScene.as
@@ -19,7 +19,7 @@ public class NightmareScene extends BaseContent
 			outputText("As you explore the deepwoods, you come upon a particularly corrupted grove. At the center of it you see many demons busy fucking each other, some of them wearing armors and weapons. The demons could’ve been a concern if not for an even bigger threat looming at the epicenter of this scene of utter decadence. At the middle of a grove a centauress is busy fucking what seems to be a dog morph. ");
 			if (sceneHunter.other) {
 				outputText("\n\nSeems like it's the creature the unicorn told you about...\n\n<b>The events can take a sharp turn if you don't run away right now... do you still want to aproach?</b>\n\n");
-				doYesNo(intro2, camp.returnToCampUseOneHour);
+				doYesNo(intro2, explorer.done);
 			} else intro2();
 		}
 
@@ -215,7 +215,10 @@ public class NightmareScene extends BaseContent
 				outputText("You nod weakly with a confused lust addled expression. Yea, whatever she says... You don’t care, you're in nirvana, trying to reconnect with your body right now, and so your vision fades to black.\n\n");
 				if (player.isGargoyle()) {
 					outputText("You wake up your alone in the clearing. Seems everyone left while you were sleeping. Guess you will have to try again.");
-					if (!recalling) doNext(camp.returnToCampUseFourHours);
+					if (!recalling) {
+						explorer.stopExploring();
+						doNext(camp.returnToCampUseFourHours);
+					}
 				}
 				else {
 					outputText("You wake up your alone in the clearing. Seems everyone left while you were sleeping. You feel horribly aroused by your defiled body and all the more by the powerful black magic you are permeated with. Somehow the centauress permanently desecrated your body with her energy, and you can feel this \"blessing\" resonating with your newfound corruption.\n\n");
@@ -235,6 +238,7 @@ public class NightmareScene extends BaseContent
 				if (!recalling) {
 					player.sexReward("cum", "Oral");
 					player.sexReward("cum", "Anal");
+					explorer.stopExploring();
 					doNext(camp.returnToCampUseFourHours);
 					return;
 				}

--- a/classes/classes/Scenes/Areas/Forest/TamainsDaughtersScene.as
+++ b/classes/classes/Scenes/Areas/Forest/TamainsDaughtersScene.as
@@ -161,7 +161,7 @@ private function playDumbToTamanisDaughters():void {
 	if(player.inte/2 + 25 > rand(75)) {
 		outputText("The leader looks you up and down for a moment.  Her face slowly contorts to puzzlement, then rage, \"<i>Tammi you ditz!  I thought you said this was his trail?  Come on girls, we've got a dad to hunt.</i>\"\n\n");
 		if(flags[kFLAGS.TIMES_ENCOUNTED_TAMANIS_DAUGHTERS] > 1) outputText("They really must not be paying much attention to what you look like.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		return;
 	}
 	outputText("The leader stamps her foot in a fit of rage.  It would be more imposing if she wasn't three feet tall... Her eyes lock onto your crotch and she says, \"<i>Last chance.   We're getting our ");
@@ -376,6 +376,7 @@ private function fuckYoDaughtersHomie():void {
 		if (tamaniPresent) SceneLib.forest.tamaniScene.tamaniKnockUp(); //If she wasn't pregnant she will be now
 		knockUpDaughters();
 		player.cumMultiplier += .3;
+		explorer.stopExploring();
 		if (CoC.instance.inCombat) cleanupAfterCombat();
 		else doNext(camp.returnToCampUseFourHours);
 	}
@@ -738,6 +739,7 @@ private function legTamanisDaughtersRAEPYou():void {
 		dynStats("str", -.5,"int", -.5, "lib", 1, "cor", 1);
 		if (tamaniPresent) SceneLib.forest.tamaniScene.tamaniKnockUp(); //If she wasn't pregnant she will be now
 		knockUpDaughters();
+		explorer.stopExploring();
 		if (CoC.instance.inCombat) cleanupAfterCombat();
 		else doNext(camp.returnToCampUseFourHours);
 	}
@@ -1045,7 +1047,7 @@ private function loseToDaughtersWithTamaniThere():void {
 		player.sexReward("vaginalFluids")
 		dynStats("str", -.5,"int", -.5, "lib", 1, "sen", 1, "cor", 1);
 		if (CoC.instance.inCombat) cleanupAfterCombat();
-		else doNext(camp.returnToCampUseOneHour);
+		else endEncounter();
 	}
 }
 

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -72,14 +72,23 @@ public class Camp extends NPCAwareContent{
 	}
 
 	public function returnToCamp(timeUsed:int):void {
-		if (explorer.inEncounter && timeUsed == 1) {
-			clearOutput();
-			outputText("Encounter '"+explorer.getCurrentEntry().encounterName+"' does not end with 'endEncounter()'. This is a bug.");
-			endEncounter();
-			return;
+		clearOutput();
+		if (explorer.inEncounter) {
+			if (timeUsed == 1) {
+				// Encounter ended with returnToCampUsingOneHour.
+				// Report a bug and continue exploration.
+				// To actually return to camp, call explorer.stopExploring() before return
+				outputText("Encounter '" + explorer.getCurrentEntry().encounterName + "' does not end with 'endEncounter()'. This is a bug.");
+				endEncounter();
+				return;
+			} else {
+				// Encounter ended with returnToCampUsing<MoreThan1>Hours.
+				// Should have had `explorer.stopExploring();`
+				outputText("Encounter '"+explorer.getCurrentEntry().encounterName+"' does not end with 'explorer.stopExploring()'. This is a bug.\n\n");
+				explorer.stopExploring();
+			}
 		}
 		explorer.clear();
-		clearOutput();
 		if (timeUsed == 1)
 			outputText("An hour passes...\n");
 		else outputText(Num2Text(timeUsed) + " hours pass...\n");

--- a/classes/classes/Scenes/Dungeons/DeepCave.as
+++ b/classes/classes/Scenes/Dungeons/DeepCave.as
@@ -39,7 +39,7 @@ use namespace CoC;
 			inDungeon = false;
 			clearOutput();
 			outputText("You leave the cave behind and take off through the deepwoods back towards camp.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function checkDoor1():void {

--- a/classes/classes/Scenes/Holidays.as
+++ b/classes/classes/Scenes/Holidays.as
@@ -129,9 +129,9 @@ public class Holidays extends BaseContent {
         //If PC has neither
         if (player.gender == 0) {
             outputText("\n\nOdd as it is, it doesn't seem to react as you look it over.  You avoid it, for now.");
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
-        simpleChoices("Fuck It", fuck, "Mount It", mount, "", null, "", null, "No Way", SceneLib.camp.returnToCampUseOneHour);
+        simpleChoices("Fuck It", fuck, "Mount It", mount, "", null, "", null, "No Way", explorer.done);
 
         //[HOLY SHIT YOU BE FUCKING A PUMPKIN]
         function pumpkinFuck():void {
@@ -160,7 +160,7 @@ public class Holidays extends BaseContent {
                 outputText("\n\nAll too soon, you finish and step away, satisfied.  The pumpkin's pussy seals closed slowly, cutting off the worst of the slime-flow.  You get dressed, but the plant's tendrils no longer bother you.  They lie still and flat, and even the perverse sweating comes to an end.  Whatever fel magic was behind this, it seems to have settled after the salty snack you gave it.  You get dressed and walk back to camp with a spring in your step.");
                 player.orgasm();
                 player.dynStats("cor", 2);
-                doNext(SceneLib.camp.returnToCampUseOneHour);
+                doNext(explorer.done);
             } else {
                 outputText("\n\nOver and over you empty your [balls] into the growing gourd, inflating it larger and larger, passionately giving up every drop of sperm to fuel its unnatural growth.  Even once you feel empty, your [cock biggest] continues to clench and pump, firing blanks in an effort to feed EVERYTHING to the semen-hungry plant.  Still, even your prodigious virility can only take so much, and once your dick starts to go soft inside the massive cunt, it releases you, allowing you to ride out the rest of your orgasm, below, on the ground.  Your descent is graceless, a lazy slide down the orange rind.  Were it not for the gentle slope, it would be a dangerous six-foot fall."
                     + "\n\nYou thank the gods for that small mercy as you calm down and climb to your feet, beholding the sudden gargantuan growth as if for the first time.  That pumpkin is at least six feet tall, and the swollen pussy that devoured your cum?  It has grown with it, now a gash big enough to devour a man.  A few strings of semen trail from the labia to the ground, but it looks like most of your cum is vanishing into the pumpkin's depths, drank down for some purpose only the demons would know."
@@ -223,7 +223,7 @@ public class Holidays extends BaseContent {
                 player.createPerk(PerkLib.FerasBoonAlpha, 0, 0, 0, 0);
                 player.dynStats("cor", 30);
             }
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         function mountPumpkin():void {
@@ -240,7 +240,7 @@ public class Holidays extends BaseContent {
                     + "\n\nWet slapping noises ring out as you piston faster and faster, violently plowing the plant-cock into your [vagina] in a rutting, mating frenzy.  Your eyes are repeatedly drawn downward to the slimy shaft each time you pull up, the ooze keeping your [vagina] well lubricated.  The green shaft seems even larger than before, the phallus stretching you wider and longer each time you slam down on it as you ride the pumpkin into orgasm.  You feel a strange compulsion to let it cum inside, to flood your womb with pie goop until you appear immensely pregnant and the overflow is spraying out around your legs."
                     + "\n\nWith a triumphant roar, you climax and mash yourself against the pumpkin, slamming your [hips] hard enough onto the hard green shaft, that you could almost swear your cervix was penetrated.  You don't care, your vagina is clenching, the stem is flexing, and the pumpkin's ooze is gushing out, flooding your innards with pumpkin seed as you flood the pumpkin's surface with your female juices in turn.  Clenching tightly, your muscles lock, working in perfect concert with one goal; filling you up with fruity cum.  The pumpkin's thick load floods your inner folds, a deluge of sweet-smelling goop squirting deep into your [vagina], inflating you and then squirting back out mixed with your own juices.  The mixed juices are absorbed into the plant's rind almost as fast as they exit your body, though you can see a bit of glistening moisture around the base of the stem."
                     + "\n\nAll too soon, you finish and step away, satisfied.  The pumpkin's stem slowly stops pulsing, cutting off the worst of the slime-flow.  You get dressed, but the plant's tendrils no longer bother you.  They lie still and flat, and even the perverse sweating comes to an end.  Whatever fell magic was behind this, it seems to have settled after the pressure you relieved it of.  You get dressed and walk back to camp with a spring in your step.");
-                doNext(SceneLib.camp.returnToCampUseOneHour);
+                doNext(explorer.done);
             }
             //Female characters don't have an easy analogue to cum production unless we count milk production, and female gender doesn't require either breasts or lactation to play.  So I just went for high vaginal wetness, not pregnant, and likely to become pregnant if she had sex with a male creature.  I hope that works out OK.
             else {
@@ -299,7 +299,7 @@ public class Holidays extends BaseContent {
                 player.createPerk(PerkLib.FerasBoonBreedingBitch, 0, 0, 0, 0);
                 player.dynStats("cor", 30);
             }
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
     }
 
@@ -328,7 +328,7 @@ public class Holidays extends BaseContent {
             clearOutput();
             outputText("Nah, that whole place is probably some kind of giant venus fly trap. Fuck that.");
             flags[kFLAGS.FERAS_GLADE_EXPLORED_YEAR] = date.fullYear;
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //Explore Das Trees
@@ -350,7 +350,7 @@ public class Holidays extends BaseContent {
             else {
                 outputText("\n\nWell, that was nice, but you don't see much reason to stick around.  You head back to camp with a wistful look over your shoulder.");
                 player.dynStats("lib", 1, "lus", 20, "cor", 1);
-                doNext(SceneLib.camp.returnToCampUseOneHour);
+                doNext(explorer.done);
                 return;
             }
 
@@ -380,7 +380,7 @@ public class Holidays extends BaseContent {
         function leaveAfterFlowerHuffing():void {
             clearOutput();
             outputText("The farther you get from that glade, the more your head clears and the more you realize how close you came to disaster.  You resolve to avoid it in the future, lest you fall prey to that entrancing pollen and the hypnotic petals once more.");
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //Fuck the Lips
@@ -494,6 +494,7 @@ public class Holidays extends BaseContent {
             //Add ten more corruption.
             //Add 50 lust.
             player.dynStats("lus", 25, "cor", 10, "scale", false);
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseFourHours);
         }
 
@@ -594,6 +595,7 @@ public class Holidays extends BaseContent {
             //Add ten more corruption.
             player.dynStats("lus", 20, "cor", 10, "scale", false);
             player.buff("FeraBlessing").setStat("lib.mult", 0.10).withText("Fera Blessing");
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseFourHours);
         }
 
@@ -648,6 +650,7 @@ public class Holidays extends BaseContent {
                 + "\n\nAs you head back to camp to prepare for your next adventure, you realize that you had some really, really fucked up dreams.  You hope you have more tomorrow night.");
             player.dynStats("lus", 20, "cor", 10, "scale", false);
             player.buff("FeraBlessing").setStat("lib.mult", 0.10).withText("Fera Blessing");
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseFourHours);
             //Add ten more corruption.
         }
@@ -688,6 +691,7 @@ public class Holidays extends BaseContent {
             //Add 50 lust.
             player.dynStats("lus", 20, "cor", 10);
             player.buff("FeraBlessing").setStat("lib.mult", 0.10).withText("Fera Blessing");
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseFourHours);
         }
     }
@@ -708,7 +712,7 @@ public class Holidays extends BaseContent {
         function leavePonies():void {
             clearOutput();
             outputText("Deciding it must be some demonic trick, you decide to retreat from the scene before they notice your presence.");
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         function approachPonies():void {
@@ -734,7 +738,7 @@ public class Holidays extends BaseContent {
         function derpPolitely():void {
             clearOutput();
             outputText("You hold out your arms and stop the ponies.  Once you have their attention you let them know you have something important you need to do for now, but will come back soon.  With a wave you turn and walk back into the trees to a chorus of disappointed \"<i>ahhhs</i>\", mostly from the pink one.");
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         function derpCreepy():void {
@@ -742,7 +746,7 @@ public class Holidays extends BaseContent {
             outputText("Cocks, horns and slavering vaginas is one thing, but this is almost too much cute to process.  You determine to leave this grove and never EVER come back again.  Still disturbed by the mental images running through your head, as you make your way back to camp, you callously slaughter an imp. Yeah, that feels better.\n\n(+10 XP!  +5 Gems!)");
             player.XP += 10;
             player.gems += 5;
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         function derpyParty():void {
@@ -752,6 +756,7 @@ public class Holidays extends BaseContent {
                 + "Your strong lower body has shrunk, the firm musculature replaced by an oddly cartoonish looking form.  In fact, from the waist down you look just like one of the ponies!  Everything looks to still be in the same general place, and a quick test of your new lower body proves it still functions somewhat the same. The new shape of your hooves takes a little while to get used to, but other than that you get used to your new lower body almost with no effort\n\n(<i>*Note:You should really check the character viewer</i>)");
             player.lowerBody = LowerBody.PONY;
             player.legCount = 4;
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseEightHours);
         }
     }
@@ -843,6 +848,7 @@ public class Holidays extends BaseContent {
         function noThanksTurkeyGal():void {
             clearOutput();
             outputText("You reluctantly push her away.  You've no need to ram your dick down some new monstrosity's gullet.  The girl forlornly gobbles one last time, then prances off into the fading evening light, globular ass jiggling.");
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
 
@@ -918,6 +924,7 @@ public class Holidays extends BaseContent {
                 player.createPerk(PerkLib.PilgrimsBounty, 0, 0, 0, 0);
                 outputText("\n\n(<b>Perk Gained: Pilgrim's Bounty - Lower lust values no longer reduce the size of your orgasm.</b>)");
             }
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
 
@@ -996,6 +1003,7 @@ public class Holidays extends BaseContent {
             //HP set to full, fatigue to 0?
             fatigue(-100);
             HPChange(3000, false);
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
 
@@ -1145,6 +1153,7 @@ public class Holidays extends BaseContent {
                 + "\n\n\"<i>Gobble,</i>\" you agree, wrapping the giddy turkey up in your arms and planting one last kiss on her big ol' boob.  She stares sedately at you with big, blue eyes, a cute little smile on her lips as you withdraw from her, wiping the last of your spunk on her feathery thigh.  Running your hand through the turkey-girl’s hair, you whisper what a good little cockgobbler she is.  However, you soon find that the poor thing’s passed out, your rut finally over with.  Still, she's left you with a nice soft tit-pillow to lay your head down upon as you pick up the lunch you’d been preparing to eat before the eager slut arrived."
                 + "\n\n\"<i>That’ll do, turkey,</i>\" you say, patting her jiggling tit and scraping some of the excess gravy out of your lunch.  \"<i>That’ll do.</i>\"");
             player.orgasm();
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
     }
@@ -1343,6 +1352,7 @@ public class Holidays extends BaseContent {
             outputText("\n\nYou sigh");
             if (changed) outputText(", feeling your body expand as you waddle out back towards camp with belly full of sweet syrup");
             outputText(". For only one gem, that was a pretty good time...");
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
     }
@@ -1385,7 +1395,7 @@ public class Holidays extends BaseContent {
         function leaveValentinesDayForever():void {
             clearOutput();
             outputText("Ultimately, this is not worth your time.  You wish Scylla good luck, but tell her you won't help her make the holiday more popular in Tel'Adre, as you have other things to do.  Her expression turns sad and she nods in understanding as you turn away and go back into the streets of Tel'Adre.");
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //[next]
@@ -1429,6 +1439,7 @@ public class Holidays extends BaseContent {
             //With no other things to do, you go back to camp to rest.
             //{Small Lust Increase, return to camp, go to sleep}
             player.dynStats("lus", 10, "scale", false);
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
 
@@ -1485,6 +1496,7 @@ public class Holidays extends BaseContent {
                 outputText("\n\n(<b>You have gained the Pure and Loving perk!</b>");
                 player.createPerk(PerkLib.PureAndLoving, 0, 0, 0, 0);
             }
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
 
@@ -1535,7 +1547,7 @@ public class Holidays extends BaseContent {
                 outputText("\n\n(<b>You have gained the Sensual Lover perk!</b>)");
                 player.createPerk(PerkLib.SensualLover, 0, 0, 0, 0);
             }
-
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
 
@@ -1550,6 +1562,7 @@ public class Holidays extends BaseContent {
                 outputText("\n\n(<b>You have gained the One Track Mind perk.</b>");
                 player.createPerk(PerkLib.OneTrackMind, 0, 0, 0, 0);
             }
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
 
@@ -1619,6 +1632,7 @@ public class Holidays extends BaseContent {
 
             player.orgasm();
             player.dynStats("sen", -3);
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
 
@@ -1647,6 +1661,7 @@ public class Holidays extends BaseContent {
             }
 
             player.dynStats("lus", 80, "scale", false);
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
 
@@ -1666,6 +1681,7 @@ public class Holidays extends BaseContent {
                 if (player.hasVagina()) addButton(3, "Pussy", pastieValentineIntro, "vag");
             } else {
                 outputText("\n\nYou tell Pastie that, regrettably, you only have what she sees.  She nods and says, \"<i>Too bad.  I think I'll better get going, then.  It's been somewhat fun, and I finally get a chance to go to sleep sober and wake up without a hangover.\"</i>");
+                explorer.stopExploring();
                 doNext(SceneLib.camp.returnToCampUseTwoHours);
             }
         }
@@ -1768,6 +1784,7 @@ public class Holidays extends BaseContent {
             }
             player.orgasm();
             player.dynStats("sen", -2);
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
 
@@ -1800,6 +1817,7 @@ public class Holidays extends BaseContent {
             }
             player.orgasm();
             player.dynStats("sen", -2);
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
 
@@ -1831,6 +1849,7 @@ public class Holidays extends BaseContent {
 
             player.orgasm();
             player.dynStats("sen", -2);
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseTwoHours);
         }
     }
@@ -2130,7 +2149,7 @@ public class Holidays extends BaseContent {
                 + "\n\nIt's certainly warmer there.");
             //turn dat shit off
             flags[kFLAGS.GATS_ANGEL_DISABLED] = .5;
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //ii. Yes
@@ -2180,7 +2199,7 @@ public class Holidays extends BaseContent {
                 flags[kFLAGS.GATS_ANGEL_TIME_TO_FIND_KEY] = 1;
             }
             flags[kFLAGS.GATS_ANGEL_QUEST_BEGAN] = 1;
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //5. Solution
@@ -2199,7 +2218,7 @@ public class Holidays extends BaseContent {
                 + "\n\nOne surprise leads to another when a warm glow breaks free from between your hands.  A swirling of green and red mist is concentrated within the frame of your prize, glowing brightly as they swim endlessly through the key's curves at a variety of velocities.  It's plain to see that this little treasure was the cause for the cave's unnatural brilliance.  You're a little ashamed to rob it of its power source... but not enough to give it a second thought as you crawl back down to the entrance only a few feet away.  The last thing you want is for your magical lantern to dull and leave your naked body blind in this hazard-filled hole."
                 + "\n\nYou carefully re-enter the flooded tunnel, unsure how the supposed key will take to water.  It makes little impact as you submerge it, though the glowing light looks lovely on the pitch black tunnel.  The sight reinvigorates you slightly, though the warmer waters are probably more to blame.  Chalking up yet another simple retrieval asked of your person, you surface back outside, eager to get back into your [armor] and return to the high mountains.");
             player.createKeyItem("North Star Key", 0, 0, 0, 0);
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //ii. Bringing the Key Back
@@ -2234,7 +2253,7 @@ public class Holidays extends BaseContent {
                     + "\n\nThe air remains cold and merciless, and regardless of what you do it would be difficult to stay for much longer.  Turning away, you trot silently back to your camp, wondering how things would've gone - if only you were quicker.");
                 //[BAD END, Can no longer see the Old Woman or this series of events]
                 flags[kFLAGS.GATS_ANGEL_DISABLED] = 1;
-                doNext(SceneLib.camp.returnToCampUseOneHour);
+                doNext(explorer.done);
             }
             //player.removeKeyItem("North Star Key");
         }
@@ -2286,7 +2305,7 @@ public class Holidays extends BaseContent {
             //[if (corruption > 49)
             if (player.cor > 49) outputText("  More importantly, you have some unsatisfied, pent up lust that you'd like to expend.");
             player.dynStats("lus", 2 + player.lib / 10 + player.cor / 10, "cor", 10, "scale", false);
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
             flags[kFLAGS.GATS_ANGEL_DISABLED] = 1;
             player.removeKeyItem("North Star Key");
         }
@@ -2358,7 +2377,7 @@ public class Holidays extends BaseContent {
             flags[kFLAGS.GATS_ANGEL_DISABLED] = 1;
             player.orgasm();
             player.dynStats("cor", 10);
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //8. Good End
@@ -2464,7 +2483,7 @@ public class Holidays extends BaseContent {
             if (flags[kFLAGS.PC_ENCOUNTERED_CHRISTMAS_ELF_BEFORE] == 0) outputText("\n\nYou have no idea what that is.");
             awardAchievement("A Christmas Carol", kACHIEVEMENTS.HOLIDAY_CHRISTMAS_II);
             flags[kFLAGS.GATS_ANGEL_GOOD_ENDED] = 1;
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
     }
@@ -2497,7 +2516,7 @@ public class Holidays extends BaseContent {
                 + "\n\n\"<i>Pity... well, if you'll excuse me, this mountain ain't snowy enough just yet!</i>\"  He resumes his furious masturbation, spraying another gush of snow on the side of the mountain."
                 + "\n\nSeeing no reason to linger, you return to your camp.");
             flags[kFLAGS.JACK_FROST_YEAR] = date.fullYear;
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //[=Yes=]
@@ -2507,7 +2526,7 @@ public class Holidays extends BaseContent {
                 + "\n\nYou thank him for the surprisingly kind gesture, and start to head back down to camp.  Even as you go, you can see the first huge jet of snow arcing its way across the sky...");
             flags[kFLAGS.JACK_FROST_YEAR] = date.fullYear;
             flags[kFLAGS.JACK_FROST_PROGRESS] = 1;
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
     }
 
@@ -2531,6 +2550,7 @@ public class Holidays extends BaseContent {
             flags[kFLAGS.JACK_FROST_PROGRESS] = 0;
             HPChange(player.maxHP(), false);
             fatigue(-100);
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseEightHours);
         }
         //Rathazul
@@ -2897,6 +2917,7 @@ public class Holidays extends BaseContent {
             HPChange(player.maxHP(), false);
             fatigue(-100);
             flags[kFLAGS.JACK_FROST_PROGRESS] = 0;
+            explorer.stopExploring();
             doNext(SceneLib.camp.returnToCampUseEightHours);
         }
         //[=Fuck Her=]
@@ -3075,7 +3096,7 @@ public class Holidays extends BaseContent {
             outputText("You're not willing to run the risk of getting a foreign cock stuffed up your [butt].");
             //(If corruption or libido>50)
             if (player.cor > 50 || player.lib > 50) outputText("  At least not right now.  You turn back, navigating your way back to your camp.");
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //INVESTIGATE
@@ -3114,7 +3135,7 @@ public class Holidays extends BaseContent {
             function declineCandyCaneCawks():void {
                 clearOutput();
                 outputText("Turning around a tad awkwardly, you stumble out of the glade.  Tempting as he is, you don't have time to help the random bunny orgasm.");
-                doNext(SceneLib.camp.returnToCampUseOneHour);
+                doNext(explorer.done);
             }
 
             //YES
@@ -3138,7 +3159,7 @@ public class Holidays extends BaseContent {
                 else outputText("  Despite your rising urge to take advantage of the unknowing bunny, you decide to retire and return to camp.");
                 //(Lust set to 100, hour passes.)
                 player.dynStats("lib", 1, "sen", 1, "lus=", 100, "cor", -5, "scale", false);
-                doNext(SceneLib.camp.returnToCampUseOneHour);
+                doNext(explorer.done);
             }
         }
     }
@@ -3157,7 +3178,7 @@ public class Holidays extends BaseContent {
         function leaveXmasChicken():void {
             clearOutput();
             outputText("Too exasperated by the plain absurdity of the situation to deal with it, you bury your face in your hands and decide to leave her to it.  Maybe some imps will shut her up for you.  You head back to camp with her piercing cries following you all the way, and prepare for the day ahead.  Her cries fade a while later; the snow thaws and the air warms soon after.");
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //[Talk]
@@ -3313,7 +3334,7 @@ public class Holidays extends BaseContent {
             outputText("You politely decline Kami's sexual advances, apologizing before making a turn for the door. You begin to wonder why you didn't buy anything at the bakery.");
             //[Return to Tel Adre, KamiEnc = 1]
             flags[kFLAGS.KAMI_ENCOUNTER] = 1;
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //[Player chooses 'Let's go!']
@@ -3356,7 +3377,7 @@ public class Holidays extends BaseContent {
             flags[kFLAGS.KAMI_ENCOUNTER] = 1;
             player.orgasm();
             player.dynStats("sen", -2);
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //[Player selects 'Receive Anal']
@@ -3390,7 +3411,7 @@ public class Holidays extends BaseContent {
             //[Player heads back to camp, An hour passes, Asshole tightness is reduced, Lust is reduced to zero and KamiEnc = 1]
             player.orgasm();
             player.dynStats("sen", 1);
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
             flags[kFLAGS.KAMI_ENCOUNTER] = 1;
         }
 
@@ -3408,7 +3429,7 @@ public class Holidays extends BaseContent {
             player.dynStats("lus", 20 + player.lib / 10 + player.sens / 10, "scale", false);
             //[Player heads back to camp, An hour passes, Lust = + 40 and KamiEnc = 1]
             flags[kFLAGS.KAMI_ENCOUNTER] = 1;
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         function KamiDoubleDickFuck():void {
@@ -3427,7 +3448,7 @@ public class Holidays extends BaseContent {
             player.orgasm();
             player.dynStats("sen", -3);
             flags[kFLAGS.KAMI_ENCOUNTER] = 1;
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
     }
 
@@ -3502,7 +3523,7 @@ public class Holidays extends BaseContent {
             //end encounter
             //Receive \"<i>Peppermint White</i>\"
             player.orgasm();
-            SceneLib.inventory.takeItem(consumables.PEPPWHT, SceneLib.camp.returnToCampUseOneHour);
+            SceneLib.inventory.takeItem(consumables.PEPPWHT, explorer.done);
         }
 
         //Leave
@@ -3511,7 +3532,7 @@ public class Holidays extends BaseContent {
             outputText("You've decided not to trust the stranger, with a nod of your head you walk away from the man.  \"<i>Wait!  Before you go...</i>\" he speaks as he moves his massive sack in front of himself with a huff.  He leans forward, his upper body rummaging through the sack before reappearing.  He hands you a brightly wrapped gift."
                 + "\n\n\"<i>A little something from me,</i>\" he says with a bright smile.  Despite your hesitation, something about this gesture seems genuine.  You nod your head taking the gift from him and leaving after a simple word of thanks.  You unwrap the gift after returning to a normal climate, inside you find a small crystal bottle filled with a white liquid that looks strangely familiar.  Popping the cork and smelling the contents fills your nose with the refreshing scent of mint. It smells delicious, though you resist the temptation and cork the bottle again.  You take it with you back to camp.\n\n");
             //Receive \"<i>Peppermint White</i>\"
-            SceneLib.inventory.takeItem(consumables.PEPPWHT, SceneLib.camp.returnToCampUseOneHour);
+            SceneLib.inventory.takeItem(consumables.PEPPWHT, explorer.done);
         }
 
         flags[kFLAGS.POLAR_PETE_YEAR_MET] = date.fullYear;
@@ -3569,7 +3590,7 @@ public class Holidays extends BaseContent {
             menu();
             if (player.hasItem(consumables.COAL___)) addButton(0, "Coal", nieveCoalEyes);
             addButton(1, "Gems", nieveGemEyes);
-            addButton(4, "Back", SceneLib.camp.returnToCampUseOneHour);
+            addButton(4, "Back", explorer.done);
         }
         //Fourth Step: The Nose
         else if (flags[kFLAGS.NIEVE_STAGE] == 3) {
@@ -3586,10 +3607,10 @@ public class Holidays extends BaseContent {
             else {
                 outputText("Unfortunately, you've yet to find one in your adventures.  You suppose you'll have to look more carefully.  Who knows, there might be a farm right under your nose.");
             }
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         } else {
             outputText("Your snowman is done!  There's nothing more to add to it.  It looks mighty fine however, and just looking at it brings a nostalgia-fueled smile to your lips.");
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //Coal
@@ -3601,7 +3622,7 @@ public class Holidays extends BaseContent {
                 + "\n\nYou split the coal into smaller chunks, and place them evenly around the Snowman's face, creating a nice, vacant smile.  It still needs a nose, however, and for that, you'll need a carrot.  Perhaps there's a farm nearby, or maybe you could buy one somewhere?");
             flags[kFLAGS.NIEVE_MOUTH] = "coal";
             flags[kFLAGS.NIEVE_STAGE] = 3;
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //Gems
@@ -3619,7 +3640,7 @@ public class Holidays extends BaseContent {
             else {
                 outputText("You open up your pouch, and frown.  Unfortunately, you don't have enough gems to create the eyes and mouth. With a sigh you march your broke ass back to camp.");
             }
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //Snowwoman
@@ -3628,7 +3649,7 @@ public class Holidays extends BaseContent {
             //Add to existing text if possible, rather than a new window?
             outputText("You grin mischievously to yourself and set about making two more balls of powdery snow.  It takes less time than any of the others, and before you know it you've attached two icy-breasts to the snowman.  They aren't terribly big, any heavier and you're sure they'd fall off, but they get the point across."
                 + "\n\nYour snowwoman still needs a face, of course, but you'll leave that until later.  For now, you head back into the main part of camp.");
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
             flags[kFLAGS.NIEVE_STAGE] = 2;
             flags[kFLAGS.NIEVE_GENDER] = 2;
         }
@@ -3639,7 +3660,7 @@ public class Holidays extends BaseContent {
             clearOutput();
             outputText("You decide to leave it as is. Not everything has to have breasts, of course, even in Mareth."
                 + "\n\nYour snowman still needs a face, of course, but you'll leave that until later.  For now, you head back into the main part of camp.");
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
             flags[kFLAGS.NIEVE_STAGE] = 2;
             flags[kFLAGS.NIEVE_GENDER] = 1;
         }
@@ -3652,7 +3673,7 @@ public class Holidays extends BaseContent {
             + "\n\nYou stash the carrot away with a smile.  You've got a nose for your snowman!");
         outputText("\n\n(Gained Key Item: Carrot)");
         player.createKeyItem("Carrot", 0, 0, 0, 0);
-        doNext(SceneLib.camp.returnToCampUseOneHour);
+        doNext(explorer.done);
     }
 
     public static function nieveMF(Man:String = "", Woman:String = ""):String {
@@ -3698,7 +3719,7 @@ public class Holidays extends BaseContent {
             outputText("  " + nieveMF("He", "She") + " doesn't seem to be a threat, and indeed seems sincere in the fact that " + nieveMF("he", "she") + " was sent here to be your lover."
                 + "\n\nNieve beams at you, \"<i>You won't regret it, [name]!  Just give me a little while to set up a cozy place here... then we can get cozy.</i>\""
                 + "\n\nYou return to your camp proper with a goofy smirk on your face.\n\n(<b>Nieve is now available in the Lovers menu.</b>)");
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
 
         //No, because I'm an idiot.
@@ -3710,7 +3731,7 @@ public class Holidays extends BaseContent {
             flags[kFLAGS.NIEVE_STAGE] = -1;
             flags[kFLAGS.NIEVE_GENDER] = 0;
             flags[kFLAGS.NIEVE_MOUTH] = "";
-            doNext(SceneLib.camp.returnToCampUseOneHour);
+            doNext(explorer.done);
         }
     }
 
@@ -3864,7 +3885,7 @@ public class Holidays extends BaseContent {
                         + "\n\nBoth of you thoroughly flustered, Nieve returns to the winter paradise and you go back to your duties.");
                     player.dynStats("lus", -5 - player.sens / 5, "scale", false);
                 }
-                doNext(SceneLib.camp.returnToCampUseOneHour);
+                doNext(explorer.done);
             }
 
             //Suck Him by Kinathis
@@ -3881,7 +3902,7 @@ public class Holidays extends BaseContent {
                     + "\n\nSucking as hard as you can, you slither your tongue around the length inside your mouth, licking everywhere you can in spite of having your mouth full already.  Cupping those swollen balls in your hands you gently fondle them, massaging them tenderly even as they lurch and swell, their icy payload ready to burst and gush into your mouth already.  Giving you only seconds notice, the pleasure filed gasps warn you of the impending orgasm.  Letting out a long moan of pure ecstasy Nieve blows his minty load inside your mouth.  Pulse after pulse, burst after thick burst of creamy minty cum flows over your tongue and down your throat.  With each gush your tongue is overwhelmed by the strong minty flavor, the thick stuff gushing down your throat to pool inside your stomach.  With his body presumably made from ice and snow, you're unsure as to where he is keeping all this minty cream, more and more gushing until your belly swells just a little under the chilling amount.  Shivering from the icy cum in your tummy you slowly pull back, sucking the last streams of pearly seed from your wintery lover before popping off."
                     + "\n\nLetting out a deep sigh you grin and look up, wanting to see the look on Nieve's face.  The iceborn man looks like he couldn't be happier, a silly smile on his face as he looks down at you.  \"<i>Oh [Master]... that was amazing, I've never met someone so skilled before.  I hope you're not too cold now,</i>\" he says with a hint of worry, knowing that his body and by extension, his cum, must be quite cold.  Reassuring him you tell your frosty friend you're fine and that he actually tasted pretty good. Looking quite pleased Nieve helps you up before sweeping you up into a squeezing hug.  \"<i>Thank you so much for this, but next time let me do you though, you need to be pleasured as well,</i>\" the elemental spirit says gently before helping you get cleaned up and ready for your adventures.");
                 player.dynStats("lus", 10 + player.lib / 10, "scale", false);
-                doNext(SceneLib.camp.returnToCampUseOneHour);
+                doNext(explorer.done);
             }
 
             function fuckNieve_router():void {
@@ -4024,7 +4045,7 @@ public class Holidays extends BaseContent {
                     + "\n\n\"<i>So messy, [Master],</i>\" she notes with a smile.  \"<i>Allow me to clean you up.</i>\"  Her cool mouth descends on your member, licking and sucking away all of your juices and hers, leaving you spotless.  She seems to delight in the flavor, and once she's done, she leans in and gives you a big, sloppy kiss that tastes more like mint than anything else.  She then cuddles up next to you, her cold body somehow comforting, until you've recuperated enough to head back to the camp proper.");
                 player.orgasm();
                 player.dynStats("sen", -2);
-                doNext(SceneLib.camp.returnToCampUseOneHour);
+                doNext(explorer.done);
             }
 
             //Get Fucked by Gurumash
@@ -4087,7 +4108,7 @@ public class Holidays extends BaseContent {
                         + "\n\nYou both rest in that position, Nieve still trickling cum into you even though he stopped moving minutes ago.  You turn your head to look at him and notice his face a few inches from yours.  It's clear that at the moment he's barely conscious, and you shift a bit to kiss him, thanking him for a job well done.  After a little while you both recover, redress, and silently go back to business.  Looking back at him as you leave, you know you want to do it again real soon.");
                     player.orgasm();
                     player.dynStats("sen", -2);
-                    doNext(SceneLib.camp.returnToCampUseOneHour);
+                    doNext(explorer.done);
                 }
 
                 //Vaginal
@@ -4116,7 +4137,7 @@ public class Holidays extends BaseContent {
                         + "\n\nAnother hour passes and you wake up clean and dressed, laying next to Nieve.  You noticed he's probably been watching you for the last several minutes.  You get up, pat yourself off, then with one hand tussle his snow-white hair, while uttering the words, \"<i>Good boy.</i>\"");
                     player.orgasm();
                     player.dynStats("sen", -2);
-                    doNext(SceneLib.camp.returnToCampUseOneHour);
+                    doNext(explorer.done);
                 }
             }
 
@@ -4211,9 +4232,9 @@ public class Holidays extends BaseContent {
                     + "\n\n\"<i>I... I can still only stay the winter, at least for now, but it's something, right?</i>\" the snow spirit says, clasping your hand in theirs."
                     + "\n\nYou nod.  You'll take what you can get, even if it is such a brief moment.  The two of you share stories, well, you share stories while Nieve listens with rapt attention, for the next hour or so.  It's been a long time since you've seen each other, and there's a lot to catch up on...");
                 flags[kFLAGS.NIEVE_STAGE] = 5;
-                doNext(SceneLib.camp.returnToCampUseOneHour);
+                doNext(explorer.done);
             }
         }
     }
 }
-}
+}

--- a/classes/classes/Scenes/Monsters/IvorySuccubusScene.as
+++ b/classes/classes/Scenes/Monsters/IvorySuccubusScene.as
@@ -7,8 +7,8 @@
 package classes.Scenes.Monsters
 {
 import classes.BaseContent;
-import classes.display.SpriteDb;
 import classes.StatusEffects;
+import classes.display.SpriteDb;
 
 public class IvorySuccubusScene extends BaseContent
 {
@@ -85,6 +85,7 @@ public class IvorySuccubusScene extends BaseContent
         }
         dynStats("cor", 3);
         player.addCurse("lib", 2, 2);
+        explorer.stopExploring();
         if (fromBattle)
             cleanupAfterCombat();
         else

--- a/classes/classes/Scenes/Monsters/MimicScene.as
+++ b/classes/classes/Scenes/Monsters/MimicScene.as
@@ -42,7 +42,7 @@ public class MimicScene extends BaseContent {
             else if (mimicAppearance == 3) outputText("While a huge penis ");
             else outputText("While what is clearly a treasure chest ");
             outputText("certainly warrants further investigation, you aren’t absolutely sure that this is the best idea. Do you choose to investigate? ");
-            doYesNo(mimicTentacle1, camp.returnToCampUseOneHour); //call mimicTentacle1() or return to main screen
+            doYesNo(mimicTentacle1, explorer.done); //call mimicTentacle1() or return to main screen
         }
     }
 
@@ -75,7 +75,7 @@ public class MimicScene extends BaseContent {
                     player.createStatusEffect(StatusEffects.KnockedBack, 0, 0, 0, 0);
                     startCombat(new Mimic(mimicAppearance));
                 });
-                addButton(14, "Leave", camp.returnToCampUseOneHour);
+                addButton(14, "Leave", explorer.done);
             }
         } else { //if you're dumb or fail, FIGHT!
             outputText("and slowly reach out to touch it with one hand. You get a sense that something is terribly wrong when you realize that your hand is stuck fast to the ");
@@ -103,10 +103,10 @@ public class MimicScene extends BaseContent {
         if (itemRoll == 2) outputText("bottle ");
         if (itemRoll == 3) outputText("jar ");
         outputText("and leave the monster to its slumber. ");
-        if (itemRoll == 0) inventory.takeItem(consumables.PPHILTR, camp.returnToCampUseOneHour); //find purity philter
+        if (itemRoll == 0) inventory.takeItem(consumables.PPHILTR, explorer.done); //find purity philter
         if (itemRoll == 1) findSomeGems(); //find bag o gems
-        if (itemRoll == 2) inventory.takeItem(consumables.NUMBOIL, camp.returnToCampUseOneHour); //find numbing oil
-        if (itemRoll == 3) inventory.takeItem(consumables.HUMMUS_, camp.returnToCampUseOneHour); //find Hummanus
+        if (itemRoll == 2) inventory.takeItem(consumables.NUMBOIL, explorer.done); //find numbing oil
+        if (itemRoll == 3) inventory.takeItem(consumables.HUMMUS_, explorer.done); //find Hummanus
     }
 
     public function attackIt():void {
@@ -453,7 +453,7 @@ public class MimicScene extends BaseContent {
         var quantity:int = (rand(30) + 10 + player.level) * (1 + (player.perkv1(PerkLib.AscensionFortune) * 0.1));
         player.gems += quantity;
         outputText("Upon opening the small bag, you find " + quantity + " gems inside!");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 }
 

--- a/classes/classes/Scenes/NPCs/AikoScene.as
+++ b/classes/classes/Scenes/NPCs/AikoScene.as
@@ -125,7 +125,7 @@ public function encounterAiko():void {
 		+"<i>\"H-how long were you… I uh… I left the stove on BYE!!\"</i>\n\n"
 		+"Before you can say another word, she dashes off into the forest, trying to hide the deep crimson blush on her face.");
 		flags[kFLAGS.AIKO_HOT_BLOOD]++;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	// Second encounter with Aiko
 	else if (flags[kFLAGS.AIKO_TIMES_MET] == 2) {
@@ -219,7 +219,7 @@ public function encounterAiko():void {
 		+"You smile and congratulate the now eight-tails as she tries to hide a deep crimson blush on her face. She seems to be really convinced to become a nine-tails and you are very happy that she is making it a reality. You spend the remaining time happily chatting with your kitsune girl.\n\n"
 		+"<i>\"See you around, [name].\"</i> She lets you go after a quick peck on the cheek. As you see her rush away, you notice she still has Yamata's Muramasa katana tied to her hip. The blade's corruption is as strong as ever, but it seems that Aiko is as yet unaffected. Her magic has however grown very strong indeed. Still, you are worried, you better keep an eye on her state from now on, lest she become corrupted like her half-sister.");
 		flags[kFLAGS.AIKO_BOSS_OUTRO] = 1;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else if (flags[kFLAGS.AIKO_BOSS_COMPLETE] ==0 && player.level >= 25 && flags[kFLAGS.AIKO_AFFECTION] > 90 && flags[kFLAGS.AIKO_TIMES_MET] > 3) {
 		if (flags[kFLAGS.AIKO_BOSS_INTRO] > 0) {
@@ -376,7 +376,7 @@ private function leave():void
 		player.removeStatusEffect(StatusEffects.DomFight);
 	}
 	cleanupAfterCombat();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 /////////////////////////////////////////////////////////////////////
@@ -474,7 +474,7 @@ private function aikoE1Riches():void {
 	flags[kFLAGS.AIKO_BALL_RETURNED] = 1;
 	flags[kFLAGS.AIKO_FIRST_CHOICE] = 1;
 	flags[kFLAGS.AIKO_AFFECTION]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function aikoE1Power():void {
@@ -493,7 +493,7 @@ private function aikoE1Power():void {
 	flags[kFLAGS.AIKO_BALL_RETURNED] = 1;
 	flags[kFLAGS.AIKO_FIRST_CHOICE] = 2;
 	flags[kFLAGS.AIKO_AFFECTION]++;
-	inventory.takeItem(weapons.PIPE, camp.returnToCampUseOneHour);
+	inventory.takeItem(weapons.PIPE, explorer.done);
 }
 
 private function aikoE1SexPart1():void {
@@ -538,7 +538,7 @@ private function applyAikoLustPrankEffect():void
 {
 	player.createStatusEffect(StatusEffects.AikoLustPrank, rand(48)+24, 0, 0, 0);
 	dynStats("sen", 35);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function aikoE1Nothing():void {
@@ -575,7 +575,7 @@ private function aikoE1Nothing():void {
 	flags[kFLAGS.AIKO_BALL_RETURNED] = 1;
 	flags[kFLAGS.AIKO_FIRST_CHOICE] = 4;
 	flags[kFLAGS.AIKO_AFFECTION] += 5;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function aikoTouchFluffTail():void {
@@ -610,7 +610,7 @@ private function aikoTouchFluffTail():void {
 	flags[kFLAGS.AIKO_FIRST_CHOICE] = 6;
 	flags[kFLAGS.AIKO_AFFECTION] += 15;
 	player.dynStats("lus", 10+rand(11), "cor", -5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 internal function aikoLosesIntro():void {
@@ -704,7 +704,7 @@ private function aikoTalkE2():void {
 	flags[kFLAGS.AIKO_AFFECTION] += 3;
 	if (flags[kFLAGS.AIKO_CORRUPTION_ACTIVE]==1) flags[kFLAGS.AIKO_CORRUPTION] -= 5;
 	if (flags[kFLAGS.AIKO_CORRUPTION]<0) flags[kFLAGS.AIKO_CORRUPTION] = 0;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function aikoSexE2():void {
@@ -756,7 +756,7 @@ private function aikoApologySincere():void {
 	flags[kFLAGS.AIKO_AFFECTION] = 50;
 	if (flags[kFLAGS.AIKO_CORRUPTION_ACTIVE]==1) flags[kFLAGS.AIKO_CORRUPTION] -= 5;
 	if (flags[kFLAGS.AIKO_CORRUPTION]<0) flags[kFLAGS.AIKO_CORRUPTION] = 0;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function aikoApologyTrick():void {
@@ -846,7 +846,7 @@ private function aikoTalkE3():void {
 	flags[kFLAGS.AIKO_AFFECTION] += 3;
 	if (flags[kFLAGS.AIKO_CORRUPTION_ACTIVE]==1) flags[kFLAGS.AIKO_CORRUPTION] -= 5;
 	if (flags[kFLAGS.AIKO_CORRUPTION]<0) flags[kFLAGS.AIKO_CORRUPTION] = 0;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function aikoApologize2():void {
@@ -910,7 +910,7 @@ private function  talkBees():void {
 		doNext(aikoSex);
 	} else {
 		outputText("You say that that’s alright, thanking her for her time, and tell her that you should be heading back to camp anyway.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 private function  talkTentacles():void {
@@ -933,7 +933,7 @@ private function  talkTentacles():void {
 		doNext(aikoSex);
 	} else {
 		outputText("Finally, you bid her farewell, telling her that you have to check in on your camp.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 private function  talkGoblins():void {
@@ -949,7 +949,7 @@ private function  talkGoblins():void {
 		doNext(aikoSex);
 	} else {
 		outputText("bid her farewell, telling her you should be checking in on your camp again soon.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 private function  talkAkbal():void {
@@ -965,7 +965,7 @@ private function  talkAkbal():void {
 		doNext(aikoSex);
 	} else {
 		outputText("Thanking her for her time, you tell her that you have to go check back on your camp.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 private function talkCulture():void {
@@ -992,7 +992,7 @@ private function talkCulture():void {
 		doNext(aikoSex);
 	} else {
 		outputText("While the experience has been educational, you should be heading back to check on your camp now.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 private function  talkAiko():void {
@@ -1018,7 +1018,7 @@ private function  talkAiko():void {
 		doNext(aikoSex);
 	} else {
 		outputText("; you really should be heading back to check on your camp.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 private function  talkMansionSisters():void {
@@ -1037,7 +1037,7 @@ private function  talkMansionSisters():void {
 		doNext(aikoSex);
 	} else {
 		outputText("Unfortunately, you’ve been away from camp for too long, and you should probably return to check up on it.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 private function  talkNineTails():void {
@@ -1061,7 +1061,7 @@ private function  talkNineTails():void {
 		doNext(aikoSex);
 	} else {
 		outputText("Thanking her for her time, you tell her that you have to go check back on your camp. <i>\"Sayonara, [name].\"</i>");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 private function  talkFamily():void {
@@ -1083,7 +1083,7 @@ private function  talkFamily():void {
 	} else {
 		outputText("saying that you should be heading back to camp anyway.\n\n"
 		+"<i>\"Yeah, I'd prefer it that way, thanks.\"</i>");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 private function  talkArchery():void {
@@ -1141,7 +1141,7 @@ private function  talkArchery():void {
 		doNext(aikoSex);
 	} else {
 		outputText(", but unfortunately, you should be getting back to camp now.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 
@@ -1543,7 +1543,7 @@ private function aikoSexMissionary():void {
 			player.removeStatusEffect(StatusEffects.DomFight);
 		cleanupAfterCombat();
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function aikoSexDoggy():void {
@@ -1582,7 +1582,7 @@ private function aikoSexDoggy():void {
 			player.removeStatusEffect(StatusEffects.DomFight);
 		cleanupAfterCombat();
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function aikoSexBJ():void {
@@ -1632,7 +1632,7 @@ private function aikoSexBJscene(x:int):void {
 			player.removeStatusEffect(StatusEffects.DomFight);
 		cleanupAfterCombat();
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function aikoSexCunni():void {
@@ -1660,7 +1660,7 @@ private function aikoSexCunni():void {
 			player.removeStatusEffect(StatusEffects.DomFight);
 		cleanupAfterCombat();
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function aikoSexTailjob():void {
@@ -1692,7 +1692,7 @@ private function aikoSexTailjob():void {
 			player.removeStatusEffect(StatusEffects.DomFight);
 		cleanupAfterCombat();
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 private function aikoSexKitsuneTailjob():void {
 	clearOutput();
@@ -1728,7 +1728,7 @@ private function aikoSexKitsuneTailjob():void {
 			player.removeStatusEffect(StatusEffects.DomFight);
 		cleanupAfterCombat();
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 private function submitToAiko():void {
 	clearOutput();
@@ -1738,7 +1738,7 @@ private function submitToAiko():void {
 	+"You are worried she won’t take no for an answer, but thankfully she drops her billhook and walks up to you[if ("+"[hasweapon]"+"), gently taking your "+"[weapon]"+" from you and tossing it aside.] <i>\"But I suppose it can’t be helped...\"</i>");
 	if (player.gender == 0) {
 		outputText("Wait a minute! How am I supposed to have sex with you when you don't have any of the tools needed to even have sex?! Fuck off!");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	} else sceneHunter.selectLossMenu([
 		[0, "Footjob", aikoFootjob, "Req. a cock.", player.hasCock()],
 		[1, "Whipping", aikoWhipping, "Req. a vagina.", player.hasVagina()],
@@ -1771,7 +1771,7 @@ private function aikoFootjob():void
 		postSexUpdate();
 	}
 	flags[kFLAGS.AIKO_SEXED]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function aikoWhipping():void {
@@ -1809,7 +1809,7 @@ private function aikoWhipping():void {
 		postSexUpdate();
 	}
 	flags[kFLAGS.AIKO_SEXED]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 /////////////////////////////////////////////////////////////////////
@@ -1841,7 +1841,7 @@ private function yamataPrepare():void {
 	clearOutput();
 	spriteSelect(SpriteDb.s_aiko);
 	outputText("You tell Aiko that you still need time to prepare, her half-sister is quite the adversary from how she described Yamata. You return to camp to continue preparations for the huge battle to come.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function yamataStart():void {
@@ -1978,6 +1978,7 @@ private function yamataAftermath():void {
 	+"After some time, you help Aiko free the townsfolk from Yamata's chains and bondage devices and twisted torture contraptions, everyone hailing you as a hero for the service done to the village. Some Kitsune even tempt you with their bodies, showing off her large breasts and seductive hips. It has been a long day and you remember that your camp is waiting. You kiss Aiko goodbye, promising to check on her later, but are stopped before you can leave by a nine-tailed kitsune who materializes before you. She is an absolute beauty, and has more than a few similarities with Aiko, albeit with more matured features.\n\n"
 	+"<i>\"Brave Champion, we thank you for the service done to our race... In the name of all of our village, you'll always be kept in the highest regards should you choose to return. I thank you, both as an elder and as a mother. Aiko seems to have found happiness with you, you have my thanks.\"</i> Politely, the kitsune elder bows before you and then disappears seemingly into nothingness. You widen your eyes and recall Aiko's mention of her mother. No wonder Aiko is as beautiful as she is, having seen her mother."
 	+"\n\nYou return to camp after an exhaustive day.");
+	explorer.stopExploring();
 	cleanupAfterCombat(camp.returnToCampUseFourHours);
 }
   }

--- a/classes/classes/Scenes/NPCs/AyaneFollower.as
+++ b/classes/classes/Scenes/NPCs/AyaneFollower.as
@@ -2,7 +2,7 @@
  * ...
  * @author Liadri
  */
-package classes.Scenes.NPCs 
+package classes.Scenes.NPCs
 {
 import classes.*;
 import classes.GlobalFlags.*;
@@ -20,7 +20,7 @@ import classes.display.SpriteDb;
 public class AyaneFollower extends NPCAwareContent implements TimeAwareInterface
 	{
 		public var pregnancy:PregnancyStore;
-		public function AyaneFollower() 
+		public function AyaneFollower()
 		{
 			pregnancy = new PregnancyStore(kFLAGS.AYANE_PREGNANCY_TYPE, kFLAGS.AYANE_INCUBATION, 0, 0);
 			pregnancy.addPregnancyEventSet(PregnancyStore.PREGNANCY_PLAYER, 310, 270, 200, 180, 100, 75, 48, 15);
@@ -138,8 +138,8 @@ public function ayaneShop():void {
 			outputText("You tell Ayane you could use some items from her shop, and she displays her inventory for you to browse.\n\n");
 		}
 		else{
-			outputText("Ayane gives you a mischievous grin as you approach the shrine's shop stall.\n\n");			
-			outputText("\"<i>You want to buy some nice clothes and gear to look the part and do better tricks? Sure, I’ve got a few useful items I can spare, for you that is. What do you need?</i>\"");			
+			outputText("Ayane gives you a mischievous grin as you approach the shrine's shop stall.\n\n");
+			outputText("\"<i>You want to buy some nice clothes and gear to look the part and do better tricks? Sure, I’ve got a few useful items I can spare, for you that is. What do you need?</i>\"");
 		}
 		menu();
 		addButton(0, armors.WKIMONO.shortName, sellItem, armors.WKIMONO);
@@ -248,7 +248,7 @@ public function ayaneWorship():void
 		outputText("\"<i>Wait a minute, is this some cruel joke?</i>\" She looks at you with a puzzled expression while your gaze is fixed down at her. \"<i>Why...Why don't you have anything down here?</i>\"\n\n");
 		outputText("You can feel her rising disapointment in her voice as she begins to back off, you don't even need to say anything about your genderless nature as she gets up and looks over you in barely veiled disgust.");
 		outputText("\"<i>Next time you want to play a cruel joke on somebody, at least don't pick me!</i>\" She turns around and runs off, leaving you alone.\n\n");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 
@@ -268,7 +268,7 @@ public function ayaneCockWorship():void
 	}
 	else if (pregnancy.isPregnant) {
 		if (debug) outputText("\n\n<b>DEBUG: Ayane impregnation check skipped.</b>");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 private function breedayaneweneedallthefoxes():void
@@ -283,19 +283,19 @@ private function breedayaneweneedallthefoxes():void
 		pregnancy.knockUp(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.INCUBATION_AYANE); //Will always impregnate unless contraceptives are in use
 		if (debug) outputText("\n\n<b>DEBUG: Ayane pregcheck returned good.</b>");
 		trace("Ayane got PREGNANT!");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else if (rand(100) < Math.sqrt(player.cumQ())) {
 		trace("Ayane got random chance PREGNANT!");
 		if (debug) outputText("\n\n<b>DEBUG: Ayane chance pregcheck returned good.</b>");
 		pregnancy.knockUpForce(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.INCUBATION_AYANE); //Will always impregnate unless contraceptives are in use
 		if (flags[kFLAGS.SCENEHUNTER_PRINT_CHECKS]) outputText("\n<b>Ayane is pregnant!</b>");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else {
 		if (debug) outputText("\n\n<b>DEBUG: Ayane pregcheck returned as skipped.</b>");
 		trace("Ayane pregcheck failed (not in heat and bad cum volume)");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 
@@ -308,7 +308,7 @@ public function ayaneVaginalWorship():void
 	outputText("\"<i>Is " + player.mf("milord", "milady") + " satisfied?</i>\"\n\n");
 	outputText("You reply that Ayane is doing a wonderful job and that you are indeed quite satisfied by her worship. A few minutes later both of you start redressing, ready to continue on your journey.");
 	player.sexReward("saliva","Vaginal");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function ayaneAnal():void
@@ -324,7 +324,7 @@ public function ayaneAnal():void
 	outputText("\"<i>Ahh... So wonderful... To be filled with your seed is a blessing...</i>\"\n\n");
 	outputText("You clean your cock on one of her silky white tails, making her gasp, as both of you slowly proceed to redress.");
 	player.sexReward("Default","Default",true,false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function ayaneTribadism():void {
@@ -361,7 +361,7 @@ public function ayaneTribadism():void {
 		+ "\n"
 		+ "As your climax begins to ebb, you slump downward, sliding off of her in satisfaction and panting on the grass. You lie head to toe with her, legs spread apart, breathing in deeply in an attempt to catch your breath. Your eyes close, a contented sigh issuing from your lips as Ayane move to rest on your chest. The both of you wake up later and redress ready for adventuring.");
 	player.sexReward("vaginalFluids", "Vaginal");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function ayaneCuringCurse():void {
@@ -380,7 +380,7 @@ public function ayaneCuringCurse():void {
 			player.removeCurse(stat+".mult", 0.05,3);
 		}
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function ayaneGivesBirth():void {
@@ -423,13 +423,13 @@ public function ayanePregUpdate():Boolean
 		case 4: outputText("\nAyane's belly has grown quite a bit.  Anyone can tell she's pregnant with a single glance.  ");
 				outputText("Ayane catches you looking and blushes <i>W-what is it?</i> You reply merely that she carries a baby bump very well; she looks good pregnant. \n<i>Oh, uh...  Thanks I guess?</i> she replies, looking away nervously.\n");
 				return true;
-		case 5: 
+		case 5:
 				outputText("\nAyane is sitting down with a smile, rubbing her belly; you approach and ask if she's feeling well.\n\n\"<i>Yes, both of us are.  I can already feel our baby starting to move.  Do you want to feel it too?</i>\"  You respond that you do, and gently approach her, reaching out to stroke her gravid stomach, feeling the skin already stretched taut over her burgeoning womb.\n\nYou feel what seems to be a small kick under your hand.  A faint hint of paternal pride fills you, and you can't resist rubbing the spot where the baby kicked.  Ayane sighs and lets you rub her belly to your heart's content.  Unfortunately duty calls, so you bid Ayane farewell and return to your duties.\n");
 				return true;
-		case 6: 
+		case 6:
 				outputText("\nAyane's been getting as moody as her belly is big lately.  She constantly grumbles at anyone and anything that may approach her, even harmless bugs.  You decide to watch your step around her - pregnant women were scary enough back in Ingnam,.\n\n\"<i>Something wrong!?</i>\" Ayane questions you, glaring at you.  Your point proven, you tell her it's nothing, you were merely thinking of your former home.\n\n\"<i>Well if you have enough time to be reminiscing your past, how about you get over here and give me a hand instead!?  You're responsible for this, after all.</i>\"\n\nYou hasten to help her with whatever minor tasks she thinks she needs you for, until she promptly dismisses you.\n");
 				return true;
-		case 7: 
+		case 7:
 				outputText("\nAyane's been much less active nowadays, and a single look at her heavily pregnant belly lets you know why.  She is huge!  You're surprised she can even move about with a belly as big as that.  Upon closer inspection you're pretty sure you can see it squirm as the little fox rolls itself over inside her.\n\n\"<i>Hey, [name]. Fetch me some water will you?</i>\"\n\nYou decide to be generous and fetch it for her - you wouldn't be surprised if she's too heavy to get to the stream by herself.  You promptly return with a full skin and present it to her so that she can slake her thirst.\n\nAyane takes the skin off your hands and chugs it down unceremoniously, sighing in relief once she's done.  \"<i>Ahhh, that hit the spot, thanks.</i>\"  You check to see if there's anything else she needs, but when she confirms she's fine, you nod your head, sneak a quick caress of her swollen stomach, then leave her alone.\n");
 				return true;
 		case 8:
@@ -465,7 +465,7 @@ public function randomEncounter():void {
 		+ "It seems to be beckoning you to follow it.");
 	if (flags[kFLAGS.AYANE_FOUGHT]) {
 		outputText("\n\nSeems like " + ayaName("Ayane", "the kitsune") + " is messing with you again. Will you follow the flame?");
-		doYesNo(followFlame, camp.returnToCampUseOneHour);
+		doYesNo(followFlame, explorer.done);
 	} else doNext(followFlame);
 }
 

--- a/classes/classes/Scenes/NPCs/CelessScene.as
+++ b/classes/classes/Scenes/NPCs/CelessScene.as
@@ -177,7 +177,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 	public override function campInteraction():void {
 		celessSprite();
 		clearOutput();
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		outputText(_name + " sees you coming over, and smiles. She trots over happily, horn almost glowing.\n\n<i>\""+
 				player.mf("Dad", "Mom") +
 				", did you come over to see me?!\"</i>");
@@ -251,7 +251,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 					"As innocent as a day can be in Mareth, even if you had to force the issue. But if it’s for the sake of your daughter having a happy childhood, you would gladly beat this whole crazy realm into submission.")
 		}
 		_age+=72;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 
@@ -274,7 +274,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 				"As her erection finally dies down, you feel something change in you as the cum reaches your stomach.");
 		doHeatOrRut();
 		pureChildCorruption();
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 		//region INTERFACE classes.TimeAwareInterface
@@ -352,6 +352,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		outputText("<i>\""+ player.mf("Dad", "Mom") +", is something wrong?\"</i>\n" +
 		"You reply that no… Although you wistfully hope she will stay cute like this forever, despite knowing perfectly well that she will not.\n" +
 		"While you would like to spend more time enjoying your role as a parent you still have a lot of things to do, so you simply tell her to stay at camp for now whenever you're not here for her safety.");
+		explorer.stopExploring();
 		doNext(camp.returnToCampUseFourHours);
 	}
 
@@ -440,7 +441,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		else player.addKeyValue("Radiant shard",1,-3);
 		player.gems -= 20000;
 		player.destroyItems(from, 1);
-		SceneLib.inventory.takeItem(item, SceneLib.camp.returnToCampUseOneHour);
+		SceneLib.inventory.takeItem(item, explorer.done);
 	}
 
 	public function AboutRadiantShard():void {
@@ -454,14 +455,14 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		spriteSelect(SpriteDb.s_celessWhite);
 		if (player.hasPerk(PerkLib.BicornBlessing)) {
 			outputText("No matter how much you try, you cannot find the grove where the holy shield rest. It seems that the barriers are keeping you at bay now.");
-			doNext(camp.returnToCampUseOneHour);	
+			endEncounter();
 			return;
 		}
 		if (player.hasStatusEffect(StatusEffects.CanMeetNightmare)) {
 			outputText("You manage to find your way back to the sacred grove. As expected the guardian is swift to show, blocking your path to the shield, her tall frame acting like a pure, furry wall.\n\n"+
 			"<i>\"Sorry, but until you have proven yourself I cannot allow you any further.\"</i>")
 			menu();
-			addButton(0, "Back", camp.returnToCampUseOneHour);
+			addButton(0, "Back", explorer.done);
 			if (player.hasKeyItem("Nightmare Horns") >= 0) addButton(1, "Show proof", celessUnicornIntro2);
 			else addButtonDisabled(1, "Show proof", "Req. to have Nightmare Horns.");
 			return;
@@ -528,12 +529,12 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 					"On these words you leave, better seek out this creature as fast as possible.");
 					player.createStatusEffect(StatusEffects.CanMeetNightmare,0,0,0,0);
 					_age = _ageCanMeetNightmare;
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 				}
 				break;
 			case 1:
 				celessGuardNoWay();
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				break;
 			case 2:
 				celessGuardOkayMale();
@@ -546,7 +547,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 				player.createPerk(PerkLib.UnicornBlessing, 0, 0, 0, 0);
 				player.cor = 0;
 				player.knockUp(PregnancyStore.PREGNANCY_CELESS, PregnancyStore.INCUBATION_CELESS, 1, 1);
-				inventory.takeItem(shields.SANCTYN, camp.returnToCampUseOneHour);
+				inventory.takeItem(shields.SANCTYN, explorer.done);
 				_age = _ageDidPregnancy;
 				_questFinished = _finishedUnicorn;
 				break;
@@ -575,7 +576,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 				outputText("You give her the same answer you gave all others, a flat \"No\" that leaves no room for negotiation");
 				if (silly()) outputText(", followed by singing <i>\"nope, nope, nope, fuck this shit, I’m out!\" </i>, ");
 				outputText(" as you turn around and leave. You fought hard to keep your virginity, no amount of loot is going to tempt you.");
-				doNext(recalling ? recallWakeUp : camp.returnToCampUseOneHour);
+				doNext(recalling ? recallWakeUp : explorer.done);
 				break;
 			case 2:
 				celessGuardOkayMale();
@@ -585,7 +586,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 				} else if (!recalling) {
 					if (player.hasKeyItem("Nightmare Horns") >= 0) player.removeKeyItem("Nightmare Horns");
 					findArmor();
-					inventory.takeItem(shields.SANCTYN, camp.returnToCampUseOneHour);
+					inventory.takeItem(shields.SANCTYN, explorer.done);
 				} else recallWakeUp();
 				break;
 			case 3:
@@ -595,7 +596,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 					player.createPerk(PerkLib.UnicornBlessing, 0, 0, 0, 0);
 					player.cor = 0;
 					if (player.canGetPregnant()) player.knockUp(PregnancyStore.PREGNANCY_CELESS, PregnancyStore.INCUBATION_CELESS, 1, 1);
-					inventory.takeItem(shields.SANCTYN, camp.returnToCampUseOneHour);
+					inventory.takeItem(shields.SANCTYN, explorer.done);
 					_age = _ageDidPregnancy;
 					_questFinished = _finishedUnicorn;
 				} else doNext(recallWakeUp);
@@ -733,7 +734,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		if (!recalling) {
 			if (player.hasKeyItem("Nightmare Horns") >= 0) player.removeKeyItem("Nightmare Horns");
 			findArmor();
-			inventory.takeItem(shields.SANCTYN, camp.returnToCampUseOneHour);
+			inventory.takeItem(shields.SANCTYN, explorer.done);
 			if (sceneHunter.other) flags[kFLAGS.HACK_CELESS_INCUBATION] = PregnancyStore.INCUBATION_CELESS / 2; //make the same shit, but shorter.
 		} else doNext(recallWakeUp);
 	}
@@ -762,7 +763,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		"It has plated barding and a skirt fit for a horse's body, it even comes with matching horseshoes."+
 		"While clearly made like a full plate, it is surprisingly flexible, allowing for maneuverability similar to that of light armor, which is rather unusual.");
 		findArmor();
-		inventory.takeItem(armors.CTPALAD, camp.returnToCampUseOneHour);
+		inventory.takeItem(armors.CTPALAD, explorer.done);
 	}
 	
 	public function nightmareDefeated():void {
@@ -848,7 +849,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 			}
 		}
 		else{
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 	}
 
@@ -862,7 +863,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		"You suck on her cock until she finally orgasms, the sweet cum flooding your throat.\n\n"+
 		"Weirdly enough, you feel something change in you as the corrupted cum reaches your stomach.");
 		doHeatOrRut();
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function incestGetFucked():void{
@@ -882,7 +883,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		"By now you already figured this is a common thing among unicorns.");
 		outputText("You feel something change in you as the corrupted cum reaches your womb.");
 		doHeatOrRut();
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 
@@ -901,13 +902,13 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		"You lick the flared tip to get a taste. Satisfied with it, you then proceed to put the thing in your mouth proper. " + _name + " moans as her horse dong throbs in appreciation for the attention you’re giving it.\n"+
 		"You suck on her cock until she finally orgasms, the sweet cum flooding your throat.");
 		outputText("\t\t\t\tWeirdly enough, you feel something change in you as the corrupted cum reaches your stomach. ");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function incestMasturbate():void{
 		clearOutput();
 		outputText("You simply help her by masturbating her horse dong to satisfaction. " + _name + " thanks you afterward and goes to sit in a corner to rest.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function incestFuckCorrupt():void{
@@ -936,13 +937,13 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		"As expected, nothing spills out of her pussy, even after both of you lay down in the grass to rest.\n\n" +
 		"You snuggle for a time with "+ _name +" then head back to your daily routine. ");
 		doHeatOrRut();
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function incestCentaurToys():void{
 		outputText("\n\nYou point at the centaur toys and she swiftly gallops to them with a clear idea of how to use them.\n"+
 		"Well that's one problem solved.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function doHeatOrRut():void{
@@ -954,7 +955,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		else if (!player.inRut && player.goIntoRut(false)) {	//This is based on the original.xml source.
 			outputText("\nYou are now in Rut!");
 		}
-		//doNext(camp.returnToCampUseOneHour);
+		//endEncounter();
 	}
 
 	private function celessChildAppearance():void{
@@ -1001,7 +1002,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 				outputText("Just as you're about to go, however, you catch a glimpse of " + _name +"’s horse dong as it resumes acting up, just as you wanted. " +
 						"You’ll need to keep her constantly aroused to educate her properly and set her on the path to depravity if she's to become a proper daughter of yours.");
 				dynStats("cor", -1);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 	}

--- a/classes/classes/Scenes/NPCs/DianaFollower.as
+++ b/classes/classes/Scenes/NPCs/DianaFollower.as
@@ -66,7 +66,7 @@ public function postNameEncSure():void {
 }
 public function postNameEncNotNow():void {
 	outputText("You don’t have time for sparring right now. Diana looks slightly disappointed, but she nods respectfully as you head out back to camp.\n\n");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function wonOverDiana():void {
@@ -791,7 +791,7 @@ public function SexMenuBreeding():void {
 	outputText("When it will be ready.\n\n");
 	outputText("\"<i>Please hurry, I can’t wait!</i>\" Diana begs you, still hugging your head.\n\n");
 	player.sexReward("vaginalFluids","Dick");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 */
 
@@ -816,7 +816,7 @@ public function SexMenuVaginal():void {
 		outputText("Diana pouts a bit before you both say your goodbyes, and then you head off.\n\n");
 	//}
 	player.sexReward("vaginalFluids","Dick");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function SexMenuAnal():void {
 	clearOutput();
@@ -854,7 +854,7 @@ public function SexMenuAnal():void {
 		}
 	//}
 	player.sexReward("no", "Dick");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function SexMenuTitsfuck():void {
 	clearOutput();
@@ -927,7 +927,7 @@ public function SexMenuTitsfuck():void {
 		}
 	//}
 	player.sexReward("no", "Dick");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function BelisaDianaTalk():void {
@@ -946,7 +946,7 @@ private function BelisaDianaTalk():void {
 	outputText("Nearly an hour later, Belisa’s home bobs to the surface, and Diana walks up onto the beach, a smile on her face. You ask her how it went, and she nods once.\n\n");
 	outputText("\"<i>Your friend is going to be just fine. She’s going to be very sore in the mouth for a few days, but the curse is gone, and her fang has been regrown.</i>\" Diana sighs. \"<i>Please take me back to camp, my stallion…That curse was quite draining on me. Whoever did it wasn’t skilled at all, but had a lot of power behind them.</i>\" You half-carry your mare back to camp, and she’s out cold once she hits her bed. You make a mental note to thank Diana sometime soon.\n\n");
 	BelisaFollower.BelisaQuestComp = true;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 	}
 }

--- a/classes/classes/Scenes/NPCs/ElectraFollower.as
+++ b/classes/classes/Scenes/NPCs/ElectraFollower.as
@@ -88,7 +88,7 @@ public function repeatEncAsRaijuPC():void {
 }
 public function repeatEncAsRaijuPCNoThanks():void {
 	outputText("Can’t get her charge out? Too bad, because you have enough of yours to manage as it is. You bid her good luck then head back to camp.\n\n");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function repeatEncAsRaijuPCRelieveHer():void {
 	outputText("You don’t exactly find her bad on the eyes for a kinswoman so why not help her? You offer to draw out her discharge for her. The raiju lights up, teary eyed at your offer and very appreciative.\n\n");
@@ -151,7 +151,7 @@ public function ElectraRecruitingNah():void {
 	outputText("You apologize to her but for now you aren't exactly ready to make space for someone in your life. Electra nods. She's on the verge of tears but accepts your decision to turn her down, walking away.\n\n");
 	flags[kFLAGS.ELECTRA_FOLLOWER] = 1;
 	electraAffection(-100);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function ElectraRecruitingAgain():void {
 	spriteSelect(SpriteDb.s_electra);
@@ -444,8 +444,8 @@ public function ElectraSeXChargeUp():void {
 	if (flags[kFLAGS.ELECTRA_FOLLOWER] < 2) outputText("You don't wait for her to tell you twice and run off back to camp.\n\n");
 	electraAffection(10);
 	if (player.lust100 < 90) player.lust = player.maxLust() * 0.9;
-	if (flags[kFLAGS.ELECTRA_FOLLOWER] < 2) doNext(camp.returnToCampUseOneHour);
-	else inventory.takeItem(useables.RPLASMA, camp.returnToCampUseOneHour);
+	if (flags[kFLAGS.ELECTRA_FOLLOWER] < 2) endEncounter();
+	else inventory.takeItem(useables.RPLASMA, explorer.done);
 }
 public function ElectraVoltTransfer():void {
 	clearOutput();
@@ -458,7 +458,7 @@ public function ElectraVoltTransfer():void {
 	outputText("You can see the pulse of your statics as a small glow in every thrust of her hips as she keeps fiercely masturbating in an attempt to expel the lust.\n\n");
 	outputText("You leave your lust receptacle there, it's unlikely Electra will stop masturbating anytime soon.");
 	player.sexReward("Default","Default",true,false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function ElectraSeXHeadpat():void {
 	outputText("For reasons unknown you feel like head patting ");

--- a/classes/classes/Scenes/NPCs/EtnaFollower.as
+++ b/classes/classes/Scenes/NPCs/EtnaFollower.as
@@ -910,7 +910,7 @@ public function etnaPussyOpera():void
 {
 	clearOutput();
 	etnaPussyOpera2();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function etnaPussyOpera2():void
 {
@@ -951,7 +951,7 @@ public function etnaShareDrink():void
 	outputText("Etna smirks and reciprocates passing her rough cat tongue on your tail pussy lips. Having a tail pussy is a one of a kind feeling as you both feed and feel indecent pleasure from it. It would be hard for you to give up on that body part. You resume drinking both ways, orgasming at the same time as your tail pussy bottoms up and goes empty. Etna thankfully, however, has extra barrels and gives you both a refill");
 	if (player.hasVagina()) outputText(" the [pussy] between your legs wets the ground as a new cargo of cum fills your tail cavity");
 	outputText(".\n\nAfter several minutes, both of you are done and there's no cum left. You lay down next to Etna for a moment, enjoying the afterglow of your shared dinner. That was quite a good meal and seeing as she has several barrels of this which she seems to replenish daily you like the idea of doing this again. You head back to your tent most satisfied.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 	player.sexReward("cum");
 }
 
@@ -1000,7 +1000,7 @@ private function tailExploration():void {
 		+ "\n"
 		+ "Pint by pint you flood her cunt until you are all in, the manticore begging for you to stop. Midway you hear something hit the ground next to you but heck you don’t care, this cunt is a treasure trove. Every single crevice of her tail wall is dripping with girl fluids and you can even taste the residual cum of her few past meals. Etna/The manticore’s tail is twitching as you violate her insides like no other cock could. Her screams are so loud you can hear her moans of ecstasy from inside. Deciding to go to the depth of the matter you finally reach the end of her tail at the base of her ass which might as well be connected to her stomach and unsurprisingly it is. Since you aren't interested into a digestive acid bath you lick clean the rest of her tail walls with your body, making sure to remove any remnant of cum, and begin to flood out. As you finish oozing on the ground you hear a confused moan and turn over. Etna is on the ground, eyes crossed from the mind-blowing sex you performed inside her tailcunt. Eh?! You hope you didn’t break her, this must be quite the experience, one you would sure love to do again.\n");
 	player.sexReward("vaginalFluids");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function etnaSleepToggle():void {
@@ -1046,7 +1046,7 @@ public function etnaInfidelityEncounter():void {
 		outputText("“<i>T...Thanks [name] I will try to make it up to you one way or another!</i>”[pg]");
 		outputText("That said you leave Etna to her lunch heading back to camp just in time to see the minotaur explode in her tail again.[pg]");
 		EtnaInfidelity = 1;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	function breakOffInfidelity():void {
 		clearOutput();
@@ -1058,7 +1058,7 @@ public function etnaInfidelityEncounter():void {
 		etnaAffection(-60);
 		if (flags[kFLAGS.SLEEP_WITH] == "Etna") flags[kFLAGS.SLEEP_WITH] = "";
 		if (flags[kFLAGS.ETNA_TALKED_ABOUT_HER] > 2) flags[kFLAGS.ETNA_TALKED_ABOUT_HER] = 2;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	function satisfyHerInfidelity():void {
 		clearOutput();
@@ -1068,7 +1068,7 @@ public function etnaInfidelityEncounter():void {
 		outputText("“<i>I will expect my daily share once you’re home.</i>”[pg]");
 		outputText("You really hope you didn't get in over your head.[pg]");
 		EtnaInfidelity = 3;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 public function etnaInfidelityEncounterRepeat():void {
@@ -1080,7 +1080,7 @@ public function etnaInfidelityEncounterRepeat():void {
 	outputText("“<i>Uh, hello… [name]. I was hungry and I… well you see all these walking reservoirs around here and...</i>”[pg]");
 
 	menu();
-	addButton(0, "Next", camp.returnToCampUseOneHour);
+	addButton(0, "Next", explorer.done);
 	addButtonIfTrue(1, "Satisfy her", satisfyHerInfidelity, "You dont have enough cum to satisfy her", player.cumQ() >= 2000);
 
 	function satisfyHerInfidelity():void {
@@ -1091,7 +1091,7 @@ public function etnaInfidelityEncounterRepeat():void {
 		outputText("“<i>I will expect my daily share once you’re home.</i>”[pg]");
 		outputText("You really hope you didn't get in over your head.[pg]");
 		EtnaInfidelity = 3;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 
@@ -1135,7 +1135,7 @@ private function etnaAfterInfidelity():void {
 	outputText("Well, that's a surprise, but then again she did say she would make it up to you. Well, if she’s ready to be a mother then you don’t mind. You tell her that whenever she will be pregnant you will be there for her, then head back to your things still considering the ramification of this decision.[pg]");
 	outputText("<b>Etna is off her contraceptive herbs</b>");
 	EtnaFertile = true;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function etnaKnockupAttempt():void {

--- a/classes/classes/Scenes/NPCs/HelScene.as
+++ b/classes/classes/Scenes/NPCs/HelScene.as
@@ -171,14 +171,14 @@ private function greetHelAsFuckbuddies():void {
 //PARTING FUCKBUDDIES (edited)
 private function postHelFuckBuddyFollowup():void {
 	if(followerHel() || flags[kFLAGS.HEL_FUCKBUDDY] == 0) {
-		camp.returnToCampUseOneHour();
+		explorer.done();
 		return;
 	}
 	clearOutput();
 	outputText("You wake up an hour or so later, still snuggled up to Hel, entwined in a post-coitus repose.  You spend a few moments basking in the warmth of her presence, but you know you have duties to attend to.  You give her a peck on the cheek, waking her, and she's quick to escalate your gesture into a long, tongue-entwining kiss.\n\n");
 
 	outputText("The two of you redress, teasing and flirting all the while – you give her ample ass a little smack, and she coyly brushes your thighs with her tail – but soon you must part.  Giving Hel another deep kiss, you make your way back to camp as she saunters off into the heart of the plains.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -379,7 +379,7 @@ if (CoC.instance.inCombat) outputText("\"<i>Aw, hell.  You're no fun,</i>\" she 
 	helFollower.helAffection(1);
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 private function afterSex():void {
@@ -896,7 +896,7 @@ private function leaveMinotaurHelThreesome():void {
 	outputText("You shake your head with a deprecating smile, and turn to leave her to her pleasures.");
 	if (!recalling) {
 		flags[kFLAGS.HEL_AFFECTION] = 0;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	} else doNext(recallWakeUp);
 }
 
@@ -977,7 +977,7 @@ private function bugOutAfterHelMinoThreesome():void {
 	outputText("On second thought, you'd rather keep it simple for now, even if it means battling back her future advances with force of arms instead of words.  You kiss her once more and give her breasts a squeeze for the road, then wordlessly get up and take your leave.\n\n");
 	//(reset Helgate to 0)
 	flags[kFLAGS.HEL_AFFECTION] = 0;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Berserker Mode]
@@ -1096,7 +1096,7 @@ private function leaveHelAfterMinoThreeSomeChat():void {
 
 	outputText("You tell her to count on it, and make your way back to camp.");
 	dynStats("lus", 2, "scale", false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //===================
 //THREESOMES AHOY!
@@ -1198,7 +1198,7 @@ private function salamanderXIsabellaDiplomacy2():void {
 	isabellaFollowerScene.isabellaAffection(5);
 	helFollower.helAffection(5);
 	flags[kFLAGS.HEL_ISABELLA_THREESOME_ENABLED] = 1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Watch (edited)
@@ -1223,7 +1223,7 @@ private function watchIsabellaAndHelFight():void {
 	outputText("\"<i>Count on it, naughty girl!</i>\" Isabella shouts before the two of them break apart and disappear into the brush to elude the hunting party.");
 
 	//(Return PC to camp, advance time 1 hour. 10% chance of Intro Scene playing whenever Isabella or Hel would normally be encountered until PC chooses Leave or Diplomacy in the future)
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Leave (edited)
@@ -1233,7 +1233,7 @@ private function skipTownOnIsabellaAndHelsFight():void {
 	outputText("Well, you're sure as hell not going to get involved in this – better to let them duke it out between themselves rather than risk your relationship with either girl.  You head on back to camp, not terribly surprised to hear sharp moos, grunts, and cries for some time in the distance.\n\n");
 	//(Return PC to camp, advance time 1 hour. Intro scene will not play again.)
 	flags[kFLAGS.HEL_ISABELLA_THREESOME_ENABLED] = -1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -1336,7 +1336,7 @@ private function leaveIsabellaSallyBehind():void {
 	clearOutput();
 	outputText("You decline the cow-girl's offer, but tell the redheads to have fun without you.  Though a bit disappointed, they both wave as you make your way back to camp.");
 	if(model.time.hours < 6) doNext(playerMenu);
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //[Drink]
@@ -1396,7 +1396,7 @@ private function noThreesomeSexWithSallyAndIssyLastMinute():void {
 	if(player.hasBalls()) outputText(" and balls bluer than the lake");
 	outputText(".");
 	if(model.time.hours < 6) doNext(playerMenu);
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //DICK (edited)
@@ -1526,6 +1526,7 @@ private function izzySallyThreeSomeFollowup():void {
 
 	outputText("\"<i>Yeah.  Resting is... resting is good,</i>\" Hel says, trying and failing to suppress a yawn of her own.  Smiling, you wrap your arms around your two beautiful, busty redheads and let sleep overcome you.");
 	//(Either return PC to camp or advance to the next day, if in plains or camp, respectively)
+	explorer.stopExploring();
 	if(model.time.hours < 6) doNext(playerMenu);
 	else doNext(camp.returnToCampUseFourHours);
 }
@@ -1571,6 +1572,7 @@ private function izzySallyThreeSomeVagoozlaz():void {
 	//Bump up follower tracking affection too
 	isabellaFollowerScene.isabellaAffection(4);
 	helFollower.helAffection(5);
+	explorer.stopExploring();
 	if(model.time.hours < 6) doNext(playerMenu);
 	else doNext(camp.returnToCampUseFourHours);
 }
@@ -1699,6 +1701,7 @@ private function foxyFluffOutro():void {
 	outputText("You awake to find yourself tucked into the bed, your clothes folded neatly next to you.  It looks like someone cleaned you up and tucked you in after your little orgy.  When you hear a loud snore beside you, you don't even need to guess who it was that took care of you.  You pull up the covers, and of course find Helia curled up beside you, her warm tail acting like a pillow for the two of you.  You smile, give her a long kiss, and collect your things.  You leave the salamander to sleep it off, and head back to camp.");
 	//Bump up follower tracking affection too
 	helFollower.helAffection(5);
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseFourHours);
 }
 
@@ -1797,7 +1800,7 @@ private function pussyOutOfHelSexAmbush():void {
 	outputText("\n\n\"<i>No sex for you,</i>\" you answer.");
 	outputText("\n\n\"<i>I.  But.  What.  You said.  We.  But.... WELL FUCK YOU ANYWAY.</i>\"");
 	outputText("\n\nYou shrug and head back to camp as Hel, half-mad with lust, starts masturbating, glaring at your back as you leave.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 	helFollower.helAffection(-20);
 }
 	}

--- a/classes/classes/Scenes/NPCs/JojoScene.as
+++ b/classes/classes/Scenes/NPCs/JojoScene.as
@@ -271,7 +271,7 @@ private function sendToFarm():void
 
 	flags[kFLAGS.FOLLOWER_AT_FARM_JOJO] = 1;
 
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function backToCamp():void
@@ -643,7 +643,7 @@ public function useTentacleJojo():void {
 	player.cuntChange(40, true);
 	player.sexReward("cum");
 	dynStats("cor", .5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Jojo milk payments
@@ -806,7 +806,7 @@ public function milkJojoFirst():void {
 		else outputText("A loud 'ding' chimes and a panel displays 0.864 Ls.  Ten gems roll out into a collection plate.  Whitney really put a lot of work into this!  You pocket the gems and g");
 
 		outputText("o on your way, dragging an exhausted mouse behind you as you head back towards camp.");
-		doNext(recalling ? recallWakeUp : camp.returnToCampUseOneHour);
+		doNext(recalling ? recallWakeUp : explorer.done);
 	}
 }
 
@@ -896,7 +896,7 @@ private function repeatMilkJojo(tentacle:Boolean = false):void {
 		outputText("o on your way, dragging an exhausted mouse behind you as you head back towards camp.");
 	}
 	player.orgasm();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Use Jojo to pay for Hair Care
 private function jojoPaysForPerms():void {
@@ -998,7 +998,7 @@ private function fillAmilysMouth():void {
 	outputText("\n\nThe sperm-filled girl burps and turns to kiss Jojo, the once-pure monk eagerly returning the embrace and getting a good taste for your seed as Amily fervently tongues it into his mouth.  She eventually pulls back to encourage him with an overwrought sigh. \"<i>Maybe if you service [master] better you'll be allowed to receive [his] seed next time.</i>\"  Jojo pants and licks at his lips, hands darting down to tend to his long-neglected phallus.");
 	outputText("\n\nYour personal whore laughs and hugs your leg, whispering, \"<i>Cum-slut thanks you, [master].</i>\"  You pull her up and smile at her, glad she's working to make your budding harem as sexually adept as possible.  She beams and grabs Jojo with her tail, no doubt eager to drag him off for more training.");
 	player.sexReward("saliva");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Fill Amily's Twat (requires not short-ass, weak-ass nigga) (Z)
 private function stuffAmilysMouthWithPostBJCUM():void {
@@ -1014,7 +1014,7 @@ private function stuffAmilysMouthWithPostBJCUM():void {
 	dynStats("sen", -1);
 	//{DONT FORGET PREGNANCY CHECK}
 	amilyScene.amilyPreggoChance();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Fill Jojo's Mouth (Z)
 private function fillJojosMouthWithHotStickyCum():void {
@@ -1025,7 +1025,7 @@ private function fillJojosMouthWithHotStickyCum():void {
 	outputText("\n\nWhile one of your mouse-toys is polishing your rod, the other is masturbating and panting.  \"<i>Please, [master], may I... may I have some cum?  Can I... I lick him clean?  He's so...</i>\"  She inhales and luridly moans, \"<i>...messy.</i>\"  You give her your assent as you withdraw your spit-shined pecker from Jojo's maw, not caring how the two of them get their rocks off so long as your harem is kept well-trained and willing.");
 	player.sexReward("saliva");
 	dynStats("lib", -1, "cor", 1);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Scene 2: Amily And Jojo Fuck (w/o Tentacles) (Z)
@@ -1048,7 +1048,7 @@ private function amilyAndJojoFuck():void {
 	player.orgasm();
 	//{DONT FORGET PREGNANCY CHECK}
 	//amilyPreggoChance();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function jojoFollowerMeditate(doClear:Boolean = true):void {
@@ -1079,7 +1079,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 		flags[kFLAGS.JOJO_LAST_MEDITATION] = model.time.days;
 		player.addStatusValue(StatusEffects.JojoMeditationCount, 1, 1);
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 		public function jojoDefenseToggle():void {
@@ -1661,7 +1661,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 			outputText("You sneer at him and shake your head, hissing out, \"<i>It would be so much better for you if you didn't try to resist, my slut.</i>\"  ");
 			player.sexReward("saliva", "Dick");
 			dynStats("cor", 0.5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function corruptJojoBJGentle():void {
@@ -1682,7 +1682,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 			else outputText("You give him one last fond caress, running your fingers through his fur in an almost patronizing petting motion, then turn without another word and leave him to retreat back into the jungle.  ");
 			player.sexReward("saliva", "Dick");
 			dynStats("cor", 0.5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function corruptJojoGiveBJ():void {
@@ -1703,7 +1703,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 			outputText("Once the vulgar kiss is finished, you stand and smile, dismissing him with a casual wave of your hand.  ");
 			player.sexReward("cum", "Lips");
 			dynStats("cor", 0.5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function corruptJojoVaginalGentle():void {
@@ -1732,7 +1732,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 			else player.knockUp(PregnancyStore.PREGNANCY_JOJO, PregnancyStore.INCUBATION_MOUSE + 82); //Jojo's kids take longer for some reason
 			player.sexReward("cum","Vaginal");
 			dynStats("cor", 0.5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function corruptJojoVaginalSmother():void {
@@ -1749,7 +1749,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 			outputText("He gasps for breath and coughs a few times, and once you are sure that he is safe, you laugh softly and walk back to your camp.  ");
 			player.sexReward("saliva","Vaginal");
 			dynStats("cor", 0.5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function corruptJojoAnalCruel():void {
@@ -1767,7 +1767,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 			outputText("You pull out of Jojo's ass once your orgasm has subsided and wipe your " + player.cockDescript(x) + " off on the fur of his back, then walk away to leave him to his own devices.  ");
 			player.sexReward("no", "Dick");
 			dynStats("cor", 0.5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function corruptJojoAnalGentle():void {
@@ -1786,7 +1786,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 			outputText("You can't help but laugh at the scene, and draw out of his ass with a groan of pleasure. You watch as he crawls back into the jungle in shame, leaving a trail of your cum the whole way.  ");
 			player.sexReward("Default","Dick");
 			dynStats("cor", 0.5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function corruptJojoAnalSmother():void {
@@ -1808,7 +1808,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 			outputText("He gasps for breath and coughs a few times, and once you are sure that he is safe, you laugh softly and walk back to your camp.");
 			player.sexReward("saliva","Anal");
 			dynStats("cor", 0.5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function corruptJojoBreasts():void { //Should only be available to players with biggestBreastSize > 2
@@ -1833,7 +1833,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 			outputText("He slinks back into the woods, chased by your amused laughter.");
 			player.sexReward("cum");
 			dynStats("cor", 0.5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//Extra Scenes
@@ -1885,6 +1885,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 				outputText("As you move away from the mouse, you step into a huge puddle of Jojo's creamy rodent cum and look back. You see that his dick, still trapped under his body and pointing behind the two of you, blasted long ropes of thick mouse spunk far into the depths of the forest.  Feeling beyond satisfied, you give your mouse slut a quick scratch behind the ear as he passes out – cum splattered and smiling.");
 			}
 			player.sexReward("no", "Dick");
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 		}
 
@@ -2031,7 +2032,7 @@ public function lowCorruptionIntro():void
 	//Choices time!
 	menu();
 	addButton(0, "Meditate", meditateInForest); // OH GOD NO SEND HELP
-	addButton(1, "Leave", camp.returnToCampUseOneHour);
+	addButton(1, "Leave", explorer.done);
 }
 
 public function highCorruptionJojoEncounter():void {
@@ -2044,7 +2045,7 @@ public function highCorruptionJojoEncounter():void {
 	//Choices time!
 	menu();
     addButton(0, "Accept", SceneLib.jojoScene.meditateInForest);
-    addButton(1, "Decline", camp.returnToCampUseOneHour);
+    addButton(1, "Decline", explorer.done);
 	rapeButton(2, false);
 }
 
@@ -2060,14 +2061,14 @@ public function repeatJojoEncounter():void {
         addButton(0, "Meditate", SceneLib.jojoScene.meditateInForest);
         addButton(1, "Purge", SceneLib.jojoScene.wormRemoval).hint("Request him to purge the worms from your body.");
 		rapeButton(2, false);
-        addButton(4, "Leave", camp.returnToCampUseOneHour);
+        addButton(4, "Leave", explorer.done);
 		return;
 	}
 	SceneLib.jojoScene.jojoSprite();
 	outputText("Jojo the monk appears before you, robes and soft white fur fluttering in the breeze.  He asks, \"<i>Are you ready for a meditation session?</i>\"");
 	//Choices time!
 	menu();
-    doYesNo(SceneLib.jojoScene.meditateInForest, camp.returnToCampUseOneHour);
+    doYesNo(SceneLib.jojoScene.meditateInForest, explorer.done);
 	rapeButton(2, false);
 }
 
@@ -2110,6 +2111,7 @@ public function meditateInForest():void {
 				//get a small talisman if not have one
 				player.createKeyItem("Jojo's Talisman", 0, 0, 0, 0);
 			}
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 			return;
 		}
@@ -2119,12 +2121,14 @@ public function meditateInForest():void {
 	if (player.statusEffectv1(StatusEffects.JojoMeditationCount) % 5 == 0)
 	{
 		outputText("\n\nYou ponder and get an idea - the mouse could stay at your camp.  There's safety in numbers, and it would be easier for the two of you to get together for meditation sessions.  Do you want Jojo's company at camp?");
+		explorer.stopExploring();
 		doYesNo(jojoScene.acceptJojoIntoYourCamp, camp.returnToCampUseTwoHours);
 		return;
-	}
-	else
+	} else {
 		outputText("\n\nHe bows his head sadly and dismisses you.");
-	doNext(camp.returnToCampUseTwoHours);
+		explorer.stopExploring();
+		doNext(camp.returnToCampUseTwoHours);
+	}
 }
 
 
@@ -2138,7 +2142,7 @@ public function acceptJojoIntoYourCamp():void {
 		outputText("You offer Jojo the chance to stay at your camp.  He cocks his head to the side and thinks, stroking his mousey whiskers.\n\n\"<i>Yes, it would be wise.   We would be safer together, and if you like I could keep watch at night to keep some of the creatures away.  I'll gather my things and be right there!</i>\"\n\nJojo scurries into the bushes, disappearing in a flash.  Knowing him, he'll be at camp before you!");
 		player.createStatusEffect(StatusEffects.PureCampJojo, 0, 0, 0, 0);
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Jojo In Camp
@@ -2451,7 +2455,7 @@ public function jojoTalkYourOrigin():void // Prob tack on some interaction count
 		outputText("You tell Jojo about how you spent a lot of your time... making money.  When the naive little monk asks how, you just smile as you fondly remember the older whore, Poison, showing you the ropes and teaching the tricks of the trade.  Regardless of how it made people think of you, it was certainly good money.  In an attempt to hide some of the messier details of your past from the monk, you explain how you accepted... odd jobs for people, important work that not many others in the village would be willing to accept.  He seems confused but shrugs it off.\n\n");
 	}
 	else if (player.hasPerk(PerkLib.HistoryFeral)) {
-		outputText("You tell Jojo about how you spent a lot of your time in the wild. You tell him that before arriving in Mareth, you were living your life among a pack of wild wolves.  \n\n");  // I am not a writer, feel free to amend. 
+		outputText("You tell Jojo about how you spent a lot of your time in the wild. You tell him that before arriving in Mareth, you were living your life among a pack of wild wolves.  \n\n");  // I am not a writer, feel free to amend.
 	}
 	else {
 		outputText("You're not sure where to start. You have been doing countless activities before arriving in Mareth that it'd be virtually impossible to list all of them. It's almost impossible to choose where to start or what to even begin talking about. It comes to the point where you're not sure if there's anything you HAVEN'T done.\n\n");
@@ -2724,7 +2728,7 @@ public function apparantlyJojoDOESlift():void
 		dynStats("wis", 1); //Wisdom boost to 100
 		player.trainStat("wis", .5, player.trainStatCap("wis",100));
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function wormRemoval():void {
@@ -2744,7 +2748,7 @@ public function wormRemoval():void {
 	player.buff("Infested").remove();
 	dynStats("lus", -99, "cor", -15);
 	player.orgasm();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function jojoFreaksOutSoulless():void {
@@ -2761,7 +2765,7 @@ public function jojoFreaksOutSoulless():void {
 		outputText("[pg]On this note, Jojo takes a safe distance from you. He doesn't trust you fully… not anymore but still he's willing to give you a chance.");
 		outputText("[pg]\"<i>Once you have the item, meet me in the forest. For my own safety I'm leaving your camp until you do.</i>\"");
 		SceneLib.alvinaFollower.JojoDevilPurification = 1;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 
@@ -2780,7 +2784,7 @@ public function jojoForestPurifyMeFromDevilry():void {
 		outputText(item.longName +"\n");
 		addButton(button++, item.shortName, jojoDevilPurificationScene, item);
 	}
-	addButton(14, "Never mind", camp.returnToCampUseOneHour);
+	addButton(14, "Never mind", explorer.done);
 
 	function jojoDevilPurificationScene(item:ItemType):void {
 		outputText("[pg]Jojo begins to draw circles into the ground.[pg]");
@@ -2793,6 +2797,7 @@ public function jojoForestPurifyMeFromDevilry():void {
 		player.cor -= 50;
 		SceneLib.alvinaFollower.JojoDevilPurification = 2;
 		player.consumeItem(item);
+		explorer.stopExploring();
 		doNext(camp.returnToCampUseFourHours);
 	}
 }
@@ -2953,7 +2958,7 @@ private function anallyFuckTheMouseButtSlut():void {
 	flags[kFLAGS.JOJO_ANAL_XP]++;
 	flags[kFLAGS.JOJO_SEX_COUNTER]++;
 	player.sexReward("default","default",true,false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function getAnallyFuckedByMouseYouSlut():void {
@@ -2979,7 +2984,7 @@ private function getAnallyFuckedByMouseYouSlut():void {
 	flags[kFLAGS.JOJO_ANAL_CATCH_COUNTER]++;
 	flags[kFLAGS.JOJO_SEX_COUNTER]++;
 	player.sexReward("cum","Anal");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function getVagFuckedByMouse():void {
@@ -3014,7 +3019,7 @@ private function getVagFuckedByMouse():void {
 	if (player.hasUniquePregnancy()) player.impregnationRacialCheck();
 	else player.knockUp(PregnancyStore.PREGNANCY_JOJO, PregnancyStore.INCUBATION_MOUSE + 82, (jojoCumQ() < 2000 ? 100 - (jojoCumQ() / 50) : 60));
 	player.sexReward("cum","Vaginal");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function giveBirthToPureJojoBabies():void {
@@ -3053,7 +3058,7 @@ private function suckJojosCock():void {
 	flags[kFLAGS.JOJO_SEX_COUNTER]++;
 	dynStats("lus", 20, "cor", -1);
 	player.sexReward("cum","Lips");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function mishapsLunaJojo():void {

--- a/classes/classes/Scenes/NPCs/PatchouliScene.as
+++ b/classes/classes/Scenes/NPCs/PatchouliScene.as
@@ -77,7 +77,7 @@ public class PatchouliScene extends NPCAwareContent {
 			flags[kFLAGS.PATCHOULI_FOLLOWER] = MET;
 			menu();
 			addButton(0, "Accept", patchouliExploreLuckyWheel).hint("Let him lead you to new places.");
-			addButton(1, "Decline", camp.returnToCampUseOneHour);
+			addButton(1, "Decline", explorer.done);
 		}
 		else if (follower == MET || follower == FORGIVEN) {
 			outputText("As you explore the forest you come over Patchouli the cat again. He's lazily resting on a nearby tree branch. The moment he notices you, he gives you his most unsettling smile before engaging the conversation.\n\n");
@@ -87,7 +87,7 @@ public class PatchouliScene extends NPCAwareContent {
 			}
 			menu();
 			addButton(0, "Yes", patchouliExploreLuckyWheel).hint("Let him lead you to new places.");
-			addButton(1, "No", camp.returnToCampUseOneHour);
+			addButton(1, "No", explorer.done);
 		}
 		else {
 			outputText("You spot Patchouli resting lazily on a nearby branch. He notices you, opens his eyes and starts to use his usual line just as you grab him and shove him on the ground, holding him by the neck.\n\n");
@@ -108,7 +108,7 @@ public class PatchouliScene extends NPCAwareContent {
 			outputText("\"<i>Thank you! Thank you! Don’t worry, I will never trick anyone again!</i>\"\n\n");
 			outputText("He vanishes into thin air and with his characteristic smirk and you simply head back to camp.");
 			flags[kFLAGS.PATCHOULI_FOLLOWER] = FORGIVEN;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		function patchouliKillHim(silly:Boolean = false):void {
@@ -122,7 +122,7 @@ public class PatchouliScene extends NPCAwareContent {
 				outputText("You head back to camp, most disturbed by this.");
 			}
 			flags[kFLAGS.PATCHOULI_FOLLOWER] = BADENDED;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 	}
 
@@ -147,7 +147,7 @@ public class PatchouliScene extends NPCAwareContent {
 			outputText(".\n\n");
 			if (!recalling) {
 				player.sexReward("cum", "Vaginal");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			} else doNext(recallWakeUp);
 		}
 
@@ -171,7 +171,7 @@ public class PatchouliScene extends NPCAwareContent {
 			outputText(".\n\n");
 			if (!recalling) {
 				player.sexReward("Default", "Dick", true, false);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			} else doNext(recallWakeUp);
 		}
 	}
@@ -188,7 +188,7 @@ public class PatchouliScene extends NPCAwareContent {
 				outputText("you end up in an exceedingly colorful version of the forest. Things here look weirder than usual, but not in a sexual way, rather it’s like the painting of a mad artist.\n\n");
 				outputText("\"<i>Well wow, out of all locations I didn’t expect us to end up in here... just... just pick up a fruit or two and I will escort you out.</i>\"\n\n");
 				outputText("The cat seems uneasy, but you don’t care. You spot a weird set of whisker fruits in a nearby tree and proceed to pack them up before leaving this strange place. You had the weird feeling something was watching you while you were leaving, but this must be your imagination.\n\n");
-				inventory.takeItem(consumables.WOFRUIT, camp.returnToCampUseOneHour);
+				inventory.takeItem(consumables.WOFRUIT, explorer.done);
 				if (flags[kFLAGS.PATCHOULI_AND_WONDERLAND] < 1) flags[kFLAGS.PATCHOULI_AND_WONDERLAND] = 1;
 			}
 			else {
@@ -200,7 +200,7 @@ public class PatchouliScene extends NPCAwareContent {
 			}
 			function patchouliExploreWonderlandLeave():void {
 				outputText("You decide it's best to return to camp.\n\n");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			function patchouliExploreWonderlandStay():void {
 				outputText("You decide to stay regardless of the cat’s thoughts on the matter and hear a roar somewhere in the forest. Patchouli whimpers in terror and tries to hide.\n\n");
@@ -472,7 +472,7 @@ public class PatchouliScene extends NPCAwareContent {
 			flags[kFLAGS.PATCHOULI_FOLLOWER] = MATE;
 		}
 		player.sexReward("vaginalFluids","Dick");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function patchouleVaginal():void {
@@ -511,7 +511,7 @@ public class PatchouliScene extends NPCAwareContent {
 			flags[kFLAGS.PATCHOULI_FOLLOWER] = MATE;
 		}
 		player.sexReward("vaginalFluids","Dick");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function patchouleTakeVaginal():void {
@@ -534,7 +534,7 @@ public class PatchouliScene extends NPCAwareContent {
 		outputText("She's obviously liking it, which only bolsters your lust. Soon, you find yourself on the verge of orgasm. Patchoulie finally loses control of her cock as it twitches, filling you with kitty jizz and causing your own orgasm shortly after.\n\n");
 		outputText("Unsated, you keep milking the prankster for a few hours until you both pass out.\n\n");
 		player.sexReward("cum","Vaginal");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function patchouleAnal():void {
@@ -562,7 +562,7 @@ public class PatchouliScene extends NPCAwareContent {
 		outputText(". However I don’t mind it, It's exactly how I want my mate to be, completely perverted.</i>\"\n\n");
 		outputText("Well considering the cum still dripping from her cunt you guess the word mate applies as no matter how you sex her, she manages to get your dick in the right spot anyway.\n\n");
 		player.sexReward("no", "Dick");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function patchouleGiveItem():void {
@@ -655,7 +655,7 @@ public class PatchouliScene extends NPCAwareContent {
 					           Appearance.breastCup(flags[kFLAGS.PATCHOULI_CUP_SIZE]) +
 					           " size, spewing a fountain of milk in the process.\n\n");
 				}
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -681,7 +681,7 @@ public class PatchouliScene extends NPCAwareContent {
 				flags[kFLAGS.PATCHOULI_HAIR_COLOR] = colour;
 				outputText("You ask Patchoulie to coat her hair with the bottle and she complies. Her hair turning to " +
 				           colour + ".\n\n");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 	}

--- a/classes/classes/Scenes/NPCs/TyrantiaFollower.as
+++ b/classes/classes/Scenes/NPCs/TyrantiaFollower.as
@@ -134,7 +134,7 @@ public function firstEncounterYesHideSurrender():void {
 	outputText("She looks at the golem leg in her hands, looks at you, looks back at the leg...then shrugs. \"<i>Okay, fair enough. Stupid thing wanted to hit you too.</i>\" A demon incubus claws his way out of the ruins, but the spider-giant turns, whipping the golem’s arm at the creature. It crushes the luckless demon’s skull, and she turns back to you, completely unphased.\n\n");
 	outputText("\"<i>So...who are you?</i>\" You tell her your name, that you’re a champion from Ingnam, and that you’re no fan of demons either. \"<i>No Kiddin’? Well shit. Name’s Tyrantia. Sorry. I’m a bit busy right now, so why don’t you come back another time, and we’ll get a fresh start, okay?</i>\"\n\n");
 	tyraniaAffection(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function firstEncounterYesNoHiding():void {
 	clearOutput();
@@ -149,7 +149,7 @@ public function firstEncounterYesNoHidingDunno():void {
 	outputText("You shrug, not really knowing why you’d do that. She looks at you, dumbfounded, for a second, before bursting into uproarious laughter. A bit of black energy pulses around her, making your cheeks flush, but the laughter dies down quickly. \"<i>Y’know, for a little "+player.mf("guy","gal")+", you have some balls.</i>\" ");
 	outputText("You tell her that you’re [name], a Champion from Ignam, but she wheels about. A single demon crawls out from underneath a pillar and she turns, running after him. \"<i>Hey, I’ll talk to you another time!</i>\"\n\n");
 	tyraniaAffection(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function firstEncounterYesNoHidingTPolice():void {
 	clearOutput();
@@ -160,7 +160,7 @@ public function firstEncounterYesNoHidingTPolice():void {
 	outputText("You tell her that you’re [name], a champion from Ignam, and her five functioning eyes light up. \"<i>Oh?</i>\" She gives you a slap on the back. \"<i>Well, you’ve gotta show me what you can do sometime.</i>\" She sobers up a bit. ");
 	outputText("\"<i>But not today. I need to find me another demon to fight, and you, "+player.mf("mister","miss")+" ‘titty police’ should find someone else to arrest</i>\" She picks up her spear, giving you a sarcastic salute before striding away.\n\n");
 	tyraniaAffection(10);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function firstEncounterYesNoHidingFight():void {
 	clearOutput();
@@ -172,7 +172,7 @@ public function firstEncounterYesNoHidingFight():void {
 public function firstEncounterNo():void {
 	clearOutput();
 	outputText("You decide that anyone having fun in this kind of horrid landscape might not be someone you want to meet. Camp is sounding very good right now, and you sneak away while the sounds of grinding stone echo behind you. ");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function postFightOptions(hpVictory:Boolean):void {
@@ -225,7 +225,7 @@ public function postFightOptionsKiss():void {
 		outputText("\"<i>[name]...I…</i>\" Her voice is surprisingly soft, almost affectionate. \"<i>Why do you do this?</i>\" She clenches her fists. \"<i>I can’t do this. I just can’t.</i>\" She forces herself to her feet. ");
 		outputText("\"<i>[name]...You’re great and all...But I can’t be what you want me to be...Not without hurting you.</i>\" She stands, groaning from her injured legs. \"<i>Just...Stop torturing me with what can’t be.</i>\" You call out to your spider-lady, but she flees,faster than you’ve ever seen her move before. You pick yourself up, try to run after her, but Tyrantia’s gone.\n\n");
 		TyrantiaFollowerStage = 1.5;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else if (TyrantiaAffectionMeter > 20) {
 		outputText("\"<i>Look...This is cute and all, but I’ve got...things to do.</i>\" She doesn’t push you away, though, and you hold on, slipping your finger underneath her metal plates. A clasp gives way, and she blushes bright red, too weak to pull away, but clearly uncomfortable.\n\n");
@@ -280,7 +280,7 @@ public function repeatEncounterBattlefield():void {
 	if (TyraniaPostFinalKissScene && TyrantiaFollowerStage < 4) addButton(9, "LiveWithMe", TyrantiaLiveWithMe).hint("Take the Spooder home. Do it NOW ^^");
 	else if (isLover()) addButtonDisabled(9, "LiveWithMe","She's already in your camp!");
 	else addButtonDisabled(9, "???", "Req. special scene after reaching 40%+ affection.");
-	addButton(14, "Leave", camp.returnToCampUseOneHour);
+	addButton(14, "Leave", explorer.done);
 }
 public function repeatEncounterBattlefieldRe():void {
 	clearOutput();
@@ -301,7 +301,7 @@ public function repeatEncounterBattlefieldRe():void {
 	if (TyrantiaFollowerStage < 4) addButton(9, "LiveWithMe", TyrantiaLiveWithMe)
 		.hint("Take the Spooder home. Do it NOW ^^")
 		.disableIf(!TyraniaPostFinalKissScene, "Req. special scene after reaching 40%+ affection.");
-	addButton(14, "Leave", camp.returnToCampUseOneHour);
+	addButton(14, "Leave", explorer.done);
 }
 public function repeatEncounterBattlefieldTalk():void {
 	clearOutput();
@@ -329,7 +329,7 @@ public function repeatEncounterBattlefieldTalkSelf():void {
 	clearOutput();
 	outputText("You ask the Drider-Giant what she thinks of you. She tilts her head, folding her legs underneath her. \"<i>Well...You’re fairly small, but strong. I like that. You’re unafraid to fight for what you believe in, and you have no fear of demons or corruption.</i>\" She looks down and away. \"<i>You’re a stand-up person, [name], and don’t forget it.</i>\"\n\n");
 	outputText("You thank Tyrantia for her kind words, and take your leave.\n\n");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function repeatEncounterBattlefieldTalkFightingStyle():void {
 	clearOutput();
@@ -343,7 +343,7 @@ public function repeatEncounterBattlefieldTalkFightingStyle():void {
 		outputText("\"<i>Maybe. Might not be as effective for you as me, but hey, why not?</i>\" She shrugs her shoulders. \"<i>Alright...The first thing you need to do is think dirty...and think</i> really <i>dirty. You need to be able to sustain that for a while...and during fights as well.</i>\" Tyrantia runs you through a series of mental exercises more akin to mental porn than meditation, but taken with the same meticulous, organized manner.\n\n");
 		outputText("You thank Tyrantia for her time, and excuse yourself, heading back to camp.\n\n");
 		TyrantiaTrainingSessions = 0.5;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else {
 		outputText("\"<i>No offense [name], but I don’t really want to talk about it. My fighting style is...Odd. Can we talk about something else?</i>\"\n\n");
@@ -354,13 +354,13 @@ public function repeatEncounterBattlefieldTalkKiha():void {
 	clearOutput();
 	outputText("<i>“Oh, you wanted to know about her?”</i> Tyrantia shrugs. <i>“We interacted a few times while we were both labrats. Some of the sickos working there had a perversion revolving around their ‘pets’ getting along. So...Yeah, we’ve done some things to each other. None of it was voluntary, but…”</i> She winces. <i>“Honestly, a part of me was genuinely happy when she made her escape...But she also didn’t come back. Can’t really blame her though.”</i> Tyrantia rolls her shoulders. <i>“She’s one hell of a fighter, too. That axe of hers may make it easy to counterattack if she misses, but if her strike lands...say goodbye to whatever limb got hit.”</i>\"\n\n");
 	//affection gains (0)
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function repeatEncounterBattlefieldTalkDiva():void {
 	clearOutput();
 	outputText("\"<i>“I’d heard about the “Drama Queen” prototype for the Demon’s airforce. Never really thought she’d be so…prissy.”</i> Tyrantia shrugs. <i>“I mean, me and the other prototype…We’re fighters, so you’d expect us to kick some ass and escape…but she acts like an actor in a really bad traveling play.”</i> She chuckles. <i>“Other than that, she’s alright, but the blood-drinking kinda weirds me out.”</i>\"\n\n");
 	//affection gains (0)
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function repeatEncounterBattlefieldTalkHer():void {
 	clearOutput();
@@ -455,7 +455,7 @@ public function repeatEncounterBattlefieldTalkHerLifeBeforeDemonsYeah():void {
 	outputText("\"<i>I knew you’d get it,</i>\" she says, relieved. \"<i>I’m sorry. Here I am, blathering on, when you’ve lost people too.</i>\"You shake your head, waving it off, and the two of you begin to exchange stories of your adventures. This cheers her up a little, but you can tell her mind is elsewhere. You turn to leave, and she stands as well, wrapping her warm, floofy arms around you.\n\n");
 	outputText("\"<i>[name]...Come back sometime, okay? Battlefield seems a bit more bearable when your tiny ass comes around.</i>\" Her eyes watch you leave. \"<i>I L-</i>\" She cuts herself off. \"<i>I left an imp skull back at the rock! Fuck!</i>\" She rushes off into the battlefield.\n\n");
 	tyraniaAffection(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function repeatEncounterBattlefieldTalkHerLifeBeforeDemonsNo():void {
 	outputText("\"<i>The fuck do you mean ‘no’?</i>\" Tyrantia seems taken aback. \"<i>You have people at home, back through the portal you guard. You should understand perfectly. What, were you one of those shut-ins who couldn’t stand others or something?!</i>\"\n\n");
@@ -475,7 +475,7 @@ public function repeatEncounterBattlefieldTalkHerLifeBeforeDemonsNo():void {
 	if (TyrantiaFollowerStage > 1) {
 		outputText("Tyrantia shakes herself, armor pieces clattering loudly. \"<i>But anyways, that’s in the past. Now I’m here…With you.</i>\" She gives you a grin.\n\n");
 		eachMinuteCount(15);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else {
 		outputText("She looks at you, tears in her eyes. \"<i>[name], they...did such terrible things.</i>\" She finally breaks down, and you comfort the desolate Drider any way you can. Ultimately, you can only wait out the tears. After it dies down, and Tyrantia sinks into a shallow, sad sleep, you untie yourself from her grip, intent on going home...until a whisper comes from the ground where you left her.\n\n");
@@ -488,7 +488,7 @@ public function repeatEncounterBattlefieldTalkHerLifeBeforeDemonsNo():void {
 public function repeatEncounterBattlefieldTalkHerLifeBeforeDemonsNoNo():void {
 	outputText("You gently explain that you have to go back to the portal. Tyrantia cries into her makeshift pillow, but ultimately lets you go. You hear her bitter tears as you head back to your camp.\n\n");
 	tyraniaAffection(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function repeatEncounterBattlefieldTalkHerLifeBeforeDemonsNoYes():void {
 	outputText("You lie down beside Tyrantia’s upper half, and she takes your hands in hers. \"<i>Thank you,</i>\"she whispers, kissing you on the lips. Her fangs are out of the way, and you kiss back, a gentle, slow thing. You tell her that you’d never leave her alone like this. This gets a smile from the spider-girl, and she hums a gentle tune as she drifts off to sleep.\n\n");
@@ -502,7 +502,7 @@ public function repeatEncounterBattlefieldTalkHerNoHerm():void {
 	outputText("You grin, cracking a joke about how she still waves her Dick around, and she gives you a laugh, her eyes glistening. \"<i>Okay, ya got me there.</i>\" She rubs the shaft with one finger, the hair on her arms standing up. \"<i>Demons and imps run more often if you run at them screaming ‘I’m gonna shove m’dick down your throat!’, then if you threaten to kill them. Fucking Crazy, the lot of them!</i>\"\n\n");
 	outputText("She laughs, but you notice that the laughter doesn’t quite reach her eyes. You idly chat with your Drider comrade for a while, and when you leave, she seems a bit happier than before.\n\n");
 	tyraniaAffection(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function repeatEncounterBattlefieldTalkHerLifeOnTheBattlefield():void {
 	clearOutput();
@@ -510,26 +510,26 @@ public function repeatEncounterBattlefieldTalkHerLifeOnTheBattlefield():void {
 	if (TyraniaPostFinalKissScene) outputText("\"<i>Things have slowed down a lot lately…Apparently keeping me busy was their goal.</i>\" She shudders at the thought. \"<i>Now they’re not constantly coming at me, I have…too much time to think.</i>\"\n\n");
 	else outputText("Tyrantia rolls her shoulders. \"<i>I don’t even know why the demons come here. There’s stuff to salvage, sure, but nothing worth sending people to die.</i>\" She taps her back legs against the ground. \"<i>At least it keeps me busy, eh?</i>\"\n\n");
 	//affection gains
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function repeatEncounterBattlefieldTalkHerDifferentParts():void {
 	clearOutput();
 	outputText("You ask about her non-spider parts, and Tyrantia sighs, her horse-ears folding. \"<i>Look, it’s not something I like to discuss. Suffice to say, Demons happened. I trust you not to fuck me when I’m not with it, but…</i>\" She looks down, glaring at the ground, and whispers, so low you can barely make it out. \"<i>I can’t…</i>\"\n\n");
 	outputText("You apologize to your Drider friend, patting her leg sympathetically. You tell her that if she isn’t comfortable with it, you won’t pry. You give her leg a hug before heading back to camp.\n\n");
 	tyraniaAffection(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function repeatEncounterBattlefieldTalkHerGoblin():void {
 	clearOutput();
 	outputText("<i>“Oh, Flitzy? She’s one of the Salon Bitch’s many daughters. Found her wandering around the mountains. ‘Taur tried to rape her, she didn’t want it, and I...Well, you know what I do.”</i> Tyrantia looks mildly embarrassed. <i>“Saved her ass, and we’ve kinda become friends. Gobbos don’t usually care about...Anything besides getting knocked up, but whatever, y’know?”</i> You get the feeling she was going to say something else, but you decide to leave it alone. You thank her for the time, and head back to camp.\n\n");
 	tyraniaAffection(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function repeatEncounterBattlefieldTalkHerIzumi():void {
 	clearOutput();
 	outputText("<i> “Oh, her? Yeah, she’s a blast! Go up to the mountains sometimes to get eggs if I feel in the mood, and ran into her beating the shit out of a Taur. We hit it off, and she’s the best kind of mate to party with.”</i> She shrugs her massive shoulders. <i>“Sometimes you need a friend to beat the crap out of you, or to lean on, y’know? And there aren’t many people I can lean on.”</i> She smiles. <i>“Some more than others.”</i> She brings a single finger down, touching the tip of your nose. <i>“Boop.”</i>\n\n");
 	tyraniaAffection(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function talkHerKids():void {
 	clearOutput();
@@ -579,7 +579,7 @@ public function TyraniaAndFlitzyScene():void {
 		else addButtonDisabled(2, "Sex", "Not for genderless ones.");
 		if (TyrantiaAffectionMeter >= 40) addButton(3, "Flirt", TyraniaAndFlitzySceneFlirt);
 		else addButtonDisabled(3, "Flirt", "Req. 40%+ affection.");
-		addButton(4, "Leave", camp.returnToCampUseOneHour);
+		addButton(4, "Leave", explorer.done);
 	}
 	else {
 		TyraniaSeenFlitzy = true;
@@ -599,13 +599,13 @@ public function TyraniaAndFlitzyScene():void {
 		else addButtonDisabled(2, "Sex", "Not for genderless ones.");
 		if (TyrantiaAffectionMeter >= 40) addButton(3, "Flirt", TyraniaAndFlitzySceneFlirt);
 		else addButtonDisabled(3, "Flirt", "Req. 40%+ affection.");
-		addButton(4, "Leave", camp.returnToCampUseOneHour);
+		addButton(4, "Leave", explorer.done);
 	}
 }
 public function TyraniaAndFlitzySceneApologize():void {
 	outputText("You keep your hands up, telling her that you didn’t mean to intrude, and that you were here patrolling, since your camp isn’t far from here. Your explanation seems to pacify the big woman, and she looks you up and down. \"<i>Y’know...Not sure I believe you.</i>\" She shrugs, not caring so much. \"<i>Look...I don’t mind so much if you wanna look. I know I’m sexy.</i>\" She laughs a little, her breasts shaking and sending droplets every which way. \"<i>But Flitzi doesn’t really want to be disturbed while she’s bathing. So thanks for waiting until she’s gone.</i>\"\n\n");
 	outputText("You nod, and she flicks her hand. \"<i>Alright, ya lil’ perv. I need to finish up here, and you probably have shit y’need to do. So leave me, please.</i>\" You decide that annoying the giant bathing drider probably isn’t in your best interest, and you excuse yourself, heading back to camp.\n\n");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function TyraniaAndFlitzySceneFlirt():void {
 	outputText("You tell your Drider-friend that she looks much better without the armor. Her tan face flushes red, and she seems happy with the complement. \"<i>Uh...thanks, [name]. I…</i>\"\n\n");
@@ -623,7 +623,7 @@ public function TyraniaAndFlitzySceneFlirtFuzzy():void {
 	addButton(1, "Hug", TyraniaAndFlitzySceneHug);
 	if (player.gender > 0) addButton(2, "Sex", TyrantiaSexMenu);
 	else addButtonDisabled(2, "Sex", "Not for genderless ones.");
-	addButton(4, "Leave", camp.returnToCampUseOneHour);
+	addButton(4, "Leave", explorer.done);
 }
 public function TyraniaAndFlitzySceneFlirtSmooth():void {
 	outputText("You say that you like your lovers like you like your pick-up lines. Smooth, silky, and ready to have fun. Tyrantia nods once, and resumes her shaving. For a while, you relax until she’s finished. When she calls, you walk back over, and you run your hands up her silky-smooth legs, getting a shudder every time you touch. ");
@@ -632,19 +632,19 @@ public function TyraniaAndFlitzySceneFlirtSmooth():void {
 	addButton(1, "Hug", TyraniaAndFlitzySceneHug);
 	if (player.gender > 0) addButton(2, "Sex", TyrantiaSexMenu);
 	else addButtonDisabled(2, "Sex", "Not for genderless ones.");
-	addButton(4, "Leave", camp.returnToCampUseOneHour);
+	addButton(4, "Leave", explorer.done);
 }
 public function TyraniaAndFlitzySceneFlirtYouChoose():void {
 	outputText("You gently push her leg aside, standing on a rock so that you’re face to face with her. \"<i>[name], what are you doing?</i>\" You lean in, putting your forehead against hers, looking into her eyes. You tell her that the choice is hers. That you shouldn’t have a say. Her body is her own. She almost laughs at that. \"<i>Sometimes...I almost believe that.</i>\" You ask her what she means by that, but the Giantess puts a finger on your lips. ");
 	outputText("\"<i>[name], you’re so sweet. Thank you. Just...Let me hold you for a bit, okay? No talking.</i>\" You fall silent, and for a time, the only sounds you hear are the gentle burbling of flowing water, the rustle of the leaves...and her heartbeat. After an hour, you pull yourself out of her arms. You tell your spider-lover that you need to get back to the portal. She nods, watching your [ass] as you leave.\n\n");
 	tyraniaAffection(10);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function TyraniaAndFlitzySceneHug():void {
 	outputText("You reach up, wrapping your arms around your Drider giantess.\n\n");
 	outputText("\"<i>...[name]?</i>\" Tyrantia’s cheeks are bright red, and she blinks twice before wrapping her furry arms around you. Her muscles are hardened, but the soft fur makes it a surprisingly cozy embrace. Tyrantia holds you tight, slowly edging towards the waterfall. You lean in, bringing your lips to hers as she backs into the flowing water, soaking you both. She sighs, looking into your eyes as she brings you in behind the flowing water. There’s a small cave behind the waterfall, and despite the water dripping from your [skin], it’s warm, almost hot. Your Drider lover is barely able to stand in this place, but she pulls you in, sighing happily.\n\n");
 	outputText("\"<i>You know…I honestly didn’t think I’d find someone to bring here.</i>\" She says simply. \"<i>But…I trust you.</i>\" She tightens her grip, sighing heavily as she buries her face in your neck. \"<i></i>\"\n\n");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function TyraniaAndIzumiScene():void {
 	outputText("You peek inside Izumi’s lair, expecting a fight. You clench your fists, parting the Curtain...and blink your [eyes] in surprise. Sitting there in front of you is Izumi and Tyrantia, the big Oni sitting at her table, the massive spider-lady standing beside the table. The two are sipping a fragrant tea, but at the table is a half-empty bottle of Oni's sake, and some other concoctions. Izumi pours herself more of the tea, mixing a half-cup of rice-wine in with it.\n\n");
@@ -666,11 +666,11 @@ public function TyraniaAndIzumiSceneYes():void {
 	outputText("\"<i>Me too,</i>\" Tyrantia adds. \"<i>All this talk of battle has made my blood boil. Thank you for the time, Izumi. Always nice to chat.</i>\"\n\n");
 	outputText("You head back to camp, a small smile on your face.\n\n");
 	tyraniaAffection(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function TyraniaAndIzumiSceneNo():void {
 	outputText("You are content knowing that the giantess has friends to enjoy more than just sexy times with, a valuable and rare thing in Mareth these days. You head back down the mountain and to camp.\n\n");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function TyrantiaSleepToggle():void {
 	clearOutput();
@@ -739,7 +739,7 @@ public function TyrantiaReactions2():void {
 	if (player.hasKeyItem("Radiant shard") >= 0) player.addKeyValue("Radiant shard",1,+1);
 	else player.createKeyItem("Radiant shard", 1,0,0,0);
 	outputText("\n\n<b>Before fully settling in your camp as if remembering something Tyrantia pulls a shining shard from her inventory and hand it over to you as a gift. You acquired a Radiant shard!</b>");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function AmilyReaction():void {
 	clearOutput();
@@ -781,7 +781,7 @@ public function MakeTheSpoodLeaveYouMotherFucker():void {
 	outputText("You nod, telling Amily that if she bothers her that much, she has to go. You tell Amily that she matters to you a lot. Amily hugs you happily.\n\nYou go over to Tyrantia’s hutch, a frown on your face. She sees this, and closes her eyes. \"<i>You want me gone...don’t you?</i>\" You protest, but her corruption Aura flares. ");
 	outputText("\"<i>Don’t LIE to me!</i>\" You take a step back, instinctive fear, and this, more than anything else, seems to break the giantess. \"<i>so...All that time...All the help you gave me...You didn’t really want me. Not as someone you could stay with, or trust, or…</i>\" Tyrantia packs up her saddlebags, leaving her spear in the hutch. \"<i>Don’t say anything, [name]. You won’t be bothered by my face again.</i>\" She walks out into the wilderness, heading right back towards the battlefield...Without her weapon. You realize that you can see her carapace, she’s not wearing her armor, either. She runs into Mareth, leaving you behind. You know you’ll never see her again.\n\n");
 	TyraniaIsRemovedFromThewGame = true;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function TyrantiaSpar():void {
@@ -907,7 +907,7 @@ public function TyrantiaTraining2():void {
 	player.dynStats("sen", -1);
 	player.dynStats("cor", 1);
 	statScreenRefresh();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function encounterBattlefieldAfter40Affection():void {
@@ -936,7 +936,7 @@ public function TyrantiaLetDieYouMonster():void {
 	clearOutput();
 	outputText("You watch as the fiery light that was always in your Drider companion’s eyes leave them for good. The commander demon’s dick expands, moving like a third arm as it flicks aside the hatch covering her spider-pussy. He begins pistoning in and out, and as Tyrantia silently orgasms, her legs folding, a blackened piece of lethicite, nearly as large as one of her boobs, comes out with it. The commander demon sighs happily, taking it and swallowing the crystal. The demons walk away, leaving Tyrantia’s body lying there on the battleground. As you watch, her body turns jet-black, then begins to dissolve, fading into powder, blowing away in the breeze.\n\n");
 	TyraniaIsRemovedFromThewGame = true;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function TyrantiaSaveFight():void {
@@ -1021,7 +1021,7 @@ public function TyrantiaLovinCave():void {
 public function TyrantiaButYTho():void {
 	clearOutput();
 	outputText("You aren’t really in the mood for sex, and you give her a chaste kiss on the forehead before pulling yourself from the giantess’s grasp. She lets you go, but there’s sadness in her eyes as you head back to camp. As you leave, she grabs her spear, up against the wall, and sighs, turning the shaft of the phallus-tip and hiding the blade inside. <i>“Well...Just me and my Dick again.”</i>\n\n");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function TyrantiaCantmakeitRN():void {
@@ -1339,7 +1339,7 @@ public function itemImproveMenuCorrupt():void {
 		else player.addKeyValue("Radiant shard",1,-3);
 		player.gems -= 20000;
 		player.destroyItems(from, 1);
-		inventory.takeItem(item, camp.returnToCampUseOneHour);
+		inventory.takeItem(item, explorer.done);
 	}
 }
 /*

--- a/classes/classes/Scenes/Places/WoodElves.as
+++ b/classes/classes/Scenes/Places/WoodElves.as
@@ -1,20 +1,19 @@
 package classes.Scenes.Places{
-	import classes.*;
-	import classes.BodyParts.Antennae;
-	import classes.BodyParts.Horns;
-	import classes.BodyParts.RearBody;
-	import classes.BodyParts.Skin;
-	import classes.BodyParts.Tail;
-	import classes.BodyParts.Wings;
-	import classes.GlobalFlags.kFLAGS;
+import classes.*;
+import classes.BodyParts.Antennae;
+import classes.BodyParts.Horns;
+import classes.BodyParts.RearBody;
+import classes.BodyParts.Skin;
+import classes.BodyParts.Tail;
+import classes.BodyParts.Wings;
+import classes.GlobalFlags.kFLAGS;
 import classes.IMutations.IMutationsLib;
+import classes.Scenes.Areas.Forest.WoodElvesHuntingParty;
 import classes.Scenes.Crafting;
-	import classes.Scenes.Areas.Forest.WoodElvesHuntingParty;
-    import classes.display.SpriteDb;
-	import classes.internals.SaveableState;
-	import classes.CoC;
+import classes.display.SpriteDb;
+import classes.internals.SaveableState;
 
-	public class WoodElves extends BaseContent implements SaveableState {
+public class WoodElves extends BaseContent implements SaveableState {
 
 		public static var WoodElvesQuest:int;
 		public static const QUEST_STAGE_METELFSANDEVENBEATSTHEM:int = -1;
@@ -508,7 +507,7 @@ import classes.Scenes.Crafting;
 					"\n\nMerisiel sighs. \"<i>I figured you would when I realized your memories were returning. Don’t worry, we won’t try to stop you.</i>\"\n\n" +
 					"Elenwen tells you where your old equipment is being stored. \"<i>We didn’t get rid of it… we were planning on giving it back to you after your naming ceremony tomorrow anyway. I suppose you’ll be wanting it.</i>\"\n\n" +
 					"Alyssa has tears in her eyes as she pleads with you but your mind's made up and you decide to leave, heading back to your camp.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function KeepName():void {
@@ -524,7 +523,7 @@ import classes.Scenes.Crafting;
 					" you certainly wouldn’t mind coming back now and again to spend more time with the lovely elves," +
 					" now that you’ve sorted out their rather forceful welcome. The thought manages to bring a stirring heat deep within you.");
 			WoodElvesQuest = QUEST_STAGE_PCNOTELF;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function Ceremony1():void {
@@ -651,6 +650,7 @@ import classes.Scenes.Crafting;
 				flags[kFLAGS.APEX_SELECTED_RACE] = Races.WOODELF;
 			IMutationsLib.ElvishPeripheralNervSysIM.trueMutation = true;
 			player.removeAllRacialMutation();
+			explorer.stopExploring();
 			doNext(camp.returnToCamp, 16);
 		}
 
@@ -710,7 +710,7 @@ import classes.Scenes.Crafting;
 			addButton(5, "Lutien", Lutien);
 			addButton(6, "Chelsea", Chelsea)
 					.disableIf(hasTrainedToday, "You need a break from your recent training before you can train again.");
-			addButton(14, "Leave", camp.returnToCampUseOneHour);
+			addButton(14, "Leave", explorer.done);
 		}
 
 		public function River():void {
@@ -773,7 +773,7 @@ import classes.Scenes.Crafting;
 						" resist the urge to join them, for now; you can always find another release later, when you’re a little less busy.")
 				player.dynStats("lus",+30);
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function Tent():void {
@@ -838,7 +838,7 @@ import classes.Scenes.Crafting;
 			player.sexReward("vaginalFluids", "Vaginal");
 			player.trainStat("lib", +1, player.trainStatCap("lib",80));
 			CoC.instance.timeQ = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function Fletching():void {
@@ -886,6 +886,7 @@ import classes.Scenes.Crafting;
 					player.addPerkValue(PerkLib.CraftedArrows, 4, 100);
 					break;
 			}
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 
@@ -921,6 +922,7 @@ import classes.Scenes.Crafting;
 			outputText("You work for 8 hours adjusting your new " + itype.shortName + " string to your bow. This will serve you well in your adventures.");
 			player.addStatusValue(StatusEffects.FletchingTable, 2, 1);
 			player.destroyItems(itype, 1);
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 
@@ -983,6 +985,7 @@ import classes.Scenes.Crafting;
 					else player.destroyItems(itype, 1);
 					break;
 			}
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 
@@ -1098,7 +1101,7 @@ import classes.Scenes.Crafting;
 				else bowSkill1(5);
 			}
 			CoC.instance.timeQ = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function Alyssa():void {
@@ -1176,7 +1179,7 @@ import classes.Scenes.Crafting;
 			else{
 				hasTrainedToday = true;
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function LutienMF(boy:String,girl:String):String {
@@ -1225,7 +1228,7 @@ import classes.Scenes.Crafting;
 					" \"<i>Now, if you would excuse me, I would like to continue my reading in peace.</i>\"\n\n");
 			outputText("You leave Lutien to "+LutienMF("his","her")+" work, not wanting to disturb their efforts, and not especially appreciating "+LutienMF("his","her")+" company.");
 			if (WoodElfMagicTraining == QUEST_STAGE_MAGICTRAINING0) WoodElfMagicTraining = QUEST_STAGE_MAGICTRAINING1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function Lutien3():void {
 			clearOutput();
@@ -1238,7 +1241,7 @@ import classes.Scenes.Crafting;
 			outputText("Well, she doesn’t have the best personality, but the prospect of learning new ways to deal with your opponents is too good to pass up. Lutien pats the bench next to her, and you sit beside her to begin your lesson.\n\n");
 			outputText("<b>Found Lutien in the Elven village!</b>");
 			WoodElfMagicTraining = QUEST_STAGE_MAGICTRAINING2;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function LutienMain():void {
 			clearOutput();
@@ -1338,6 +1341,7 @@ import classes.Scenes.Crafting;
 			}
 			player.trainStat("int", 2 + rand(4), player.trainStatCap("int",100));
 			CoC.instance.timeQ = 3;
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 		}
 		public function LutienMainSex():void {
@@ -1402,7 +1406,7 @@ import classes.Scenes.Crafting;
 			outputText("You can't say it was an unpleasurable experience.[pg]");
 			outputText("He smiles warmly, \"<i>Good, I hope we can try this again later... I'll be seeing you around, then.</i>\"[pg]");
 			player.sexReward();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function LutienFuckBussy():void {
 			clearOutput();
@@ -1421,7 +1425,7 @@ import classes.Scenes.Crafting;
 			outputText("Lutien breathes softly, exhausted as you pull out your deflating erection. \"<i>Hah... that was... definitely an experience like no other... I wouldn't argue about looking into it again if you were ever to ask... </i>\"[pg]");
 			outputText("He brushes himself off, cum still leaking out of his bussy. \"<i>I'll get us cleaned up, then you can return to other matters.</i>\"[pg]");
 			player.sexReward();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function Chelsea():void {
@@ -1463,7 +1467,7 @@ import classes.Scenes.Crafting;
 			player.SexXP((5+player.level) * 10);
 			player.trainStat("lib", 4, player.trainStatCap("lib",100));
 			WoodElfSeductionTraining = QUEST_STAGE_SEDUCTIONTRAINING2;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function ChelseaTraining1No():void {
 			clearOutput();
@@ -1471,7 +1475,7 @@ import classes.Scenes.Crafting;
 			outputText("You decline Chelsea offer fully confident in your own skills.[pg]");
 			outputText("\"<i>Well if you ever need your big sister assistance just come to me and ill teach ya everything there is to sex and controlling your desires.</i>\"[pg]");
 			WoodElfSeductionTraining = QUEST_STAGE_SEDUCTIONTRAINING1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function ChelseaMain():void {
 			clearOutput();
@@ -1491,7 +1495,7 @@ import classes.Scenes.Crafting;
 			spriteSelect(SpriteDb.s_WoodElves);
 			outputText("You tell her you just wanted to say hello really. You two talk of everything and nothing before you say your goodbye and head back to the elven commons. Chelsea waves you goodbye before you go.[pg]");
 			outputText("\"<i>Come back anytime, I will be right here.</i>\"[pg]");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function ChelseaTrainingRandom():void {
 			clearOutput();
@@ -1513,7 +1517,7 @@ import classes.Scenes.Crafting;
 			hasTrainedToday = true;
 			player.SexXP((5+player.level) * 10);
 			player.trainStat("lib", 4, player.trainStatCap("lib",100));
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function ChelseaRandomTrain1():void {
 			outputText("Chelsea disrobe and encourage you to do the same as she heads toward her tent letting you in.[pg]");
@@ -1553,7 +1557,7 @@ import classes.Scenes.Crafting;
 			//Effect: Slutty Seduction 10, Wizard Endurance 60. Increase tease total damage by x 2 when worn by a wood elf. Inflicting Tease damage reduces the wielder's own lust by a small amount.
 			//The wearer of this dress desire and pleasure is no longer vexed by the limitations of mortal flesh allowing one to keep control over their lust long enough to claim victory by diluting their own lust within the ambiant natural world for a time. So long as a Green Magic spell was cast within the 5 previous rounds the user of this dress effectively is able to maintain their focus and mind entirely to the task at hand at the cost of potentialy turning into a lecherous sex maniac due to all the dilluted lust merging back with the user at the end of combat. There is a small chance for this to backfire instead causing the ambiant flora to turn on and rape the wearer of the dress.
 
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function CaptureGoblin():void {


### PR DESCRIPTION
Replaced exploration function with new system.

Replaced in Forest(I) and Deepwoods encounters return-to-camp with endEncounter/explorer.done/explorer.stopExploring.