### PR TITLE
Update

### DIFF
--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -10,6 +10,7 @@ import classes.Scenes.Dungeons.DungeonAbstractContent;
 import classes.Scenes.Holidays;
 import classes.Scenes.Inventory;
 import classes.Scenes.Places.Ingnam;
+import classes.Scenes.QuestLib;
 import classes.Scenes.SceneLib;
 import classes.Transformations.TransformationLib;
 import classes.internals.Utils;
@@ -698,6 +699,10 @@ import coc.xxc.StoryContext;
 		protected function get vehicles():VehiclesLib{
 			return CoC.instance.vehicles;
 		}
+		
+		protected static function get questLib():QuestLib {
+			return CoC.instance.questLib;
+		}
 		protected function get inventory():Inventory{
 			return SceneLib.inventory;
 		}
@@ -818,6 +823,7 @@ import coc.xxc.StoryContext;
 			doNext(explorer.done);
 		}
 
+		public static var submenuPage:int = 0;
 		/**
 		 * Print a submenu from the provided buttons
 		 * @param buttons List of buttons for the menu
@@ -840,6 +846,9 @@ import coc.xxc.StoryContext;
 			if (total + totalConst > 15) //can't fit on 1 page!
 				totalConst += 2; // prev/nex
 			var buttonsPerPage:int = 15 - totalConst; // including back, prev/next, other shit
+			var pageCount:int = Math.ceil(total / buttonsPerPage);
+			page = boundInt(0, page, pageCount);
+			submenuPage = page;
 			menu();
 			// menu buttons
 			var n:int = Math.min(total,(page+1)*buttonsPerPage); // max index for this page
@@ -854,8 +863,8 @@ import coc.xxc.StoryContext;
 					button(bi).show(constButtons[cbi][0], constButtons[cbi][1])
 						.hint(constButtons[cbi].length > 2 ? constButtons[cbi][2] : "");
 			if (page!=0 || total>buttonsPerPage) {
-				button(bi++).show("Prev Page", curry(submenu, buttons, back, page - 1, IsSorted, constButtons)).disableIf(page == 0);
-				button(bi++).show("Next Page", curry(submenu, buttons, back, page + 1, IsSorted, constButtons)).disableIf(n >= total);
+				button(bi++).show("Prev Page", curry(submenu, buttons, back, page - 1, IsSorted, constButtons)).disableIf(page == 0).icon("Left");
+				button(bi++).show("Next Page", curry(submenu, buttons, back, page + 1, IsSorted, constButtons)).disableIf(n >= total).icon("Right");
 			}
 			if (back != null) button(bi++).show("Back",back);
 		}

--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -15,6 +15,7 @@ import classes.Items.*;
 import classes.Scenes.API.Encounter;
 import classes.Scenes.API.Encounters;
 import classes.Scenes.API.SimpleEncounter;
+import classes.Scenes.QuestLib;
 import classes.Transformations.TransformationLib;
 import classes.display.DebugInfo;
 import classes.display.PerkMenu;
@@ -94,7 +95,7 @@ public class CoC extends MovieClip
     // Items/
     public var itemTemplates:ItemTemplateLib       = new ItemTemplateLib();
     public var consumables:ConsumableLib           = new ConsumableLib();
-    public var useables:UseableLib;
+    public var useables:UseableLib                 = new UseableLib();
     public var weapons:WeaponLib                   = new WeaponLib();
     public var weaponsrange:WeaponRangeLib         = new WeaponRangeLib();
     public var weaponsflyingswords:FlyingSwordsLib = new FlyingSwordsLib();
@@ -106,6 +107,8 @@ public class CoC extends MovieClip
     public var jewelries:JewelryLib                = new JewelryLib();
     public var shields:ShieldLib                   = new ShieldLib();
     public var vehicles:VehiclesLib                = new VehiclesLib();
+    
+    public var questLib:QuestLib;
 
 
     // Force updates in Pepper Flash ahuehue
@@ -219,7 +222,7 @@ public class CoC extends MovieClip
         _instance = this;
         context = new StoryContext(this);
 
-        useables = new UseableLib();
+        questLib = new QuestLib();
 
         this.kFLAGS_REF = kFLAGS;
         this.kACHIEVEMENTS_REF = kACHIEVEMENTS;

--- a/classes/classes/ItemSlotClass.as
+++ b/classes/classes/ItemSlotClass.as
@@ -1,6 +1,8 @@
 ﻿package classes
 {
-	public class ItemSlotClass extends Object
+import classes.internals.Utils;
+
+public class ItemSlotClass extends Object
 	{
 		// storage types (for determining stack size)
 		public static const STORAGE_NORMAL:int = 0;
@@ -58,6 +60,17 @@
 
 			if (this._quantity == 0)
 				this._itype = ItemType.NOTHING;
+		}
+		/**
+		 * Remove at most `count` items.
+		 * @param count
+		 * @return number of actual items removed
+		 */
+		public function removeMany(count:int):int {
+			count = Utils.boundInt(0, count, _quantity);
+			_quantity -= count;
+			if (_quantity == 0) _itype = ItemType.NOTHING;
+			return count;
 		}
 
 		public function get quantity():Number

--- a/classes/classes/Items/DynamicItems.as
+++ b/classes/classes/Items/DynamicItems.as
@@ -306,7 +306,7 @@ public class DynamicItems extends ItemConstants {
 		// If quality > 0, add 20%*quality
 		// If quality < 0, subtract 10%*quality but no less than 50%
 		var valueMul:Number = 1.0;
-		value *= Rarities[rarity].value;
+		value *= Rarities[rarity].valueMul;
 		if (quality > 0) valueMul *= quality * 0.2;
 		if (quality < 0) valueMul *= Math.max(0.5, quality * 0.1);
 		

--- a/classes/classes/Items/ItemConstants.as
+++ b/classes/classes/Items/ItemConstants.as
@@ -337,7 +337,7 @@ public class ItemConstants extends Utils {
 	 *
 	 * - name: display name ("magical")
 	 * - buttonColor: button label color
-	 * - value: Base value multiplier
+	 * - valueMul: Base value multiplier
 	 */
 	public static const Rarities:/*EnumValue*/Array = [];
 	
@@ -349,27 +349,27 @@ public class ItemConstants extends Utils {
 	EnumValue.add(Rarities, RARITY_COMMON, "COMMON", {
 		name: "common",
 		buttonColor: "#000000",
-		value: 1
+		valueMul: 1
 	});
 	EnumValue.add(Rarities, RARITY_MAGICAL, "MAGICAL", {
 		name: "magical",
 		buttonColor: "#0000C0",
-		value: 1
+		valueMul: 1
 	});
 	EnumValue.add(Rarities, RARITY_RARE, "RARE", {
 		name: "rare",
 		buttonColor: "#006000",
-		value: 2
+		valueMul: 2
 	});
 	EnumValue.add(Rarities, RARITY_LEGENDARY, "LEGENDARY", {
 		name: "legendary",
 		buttonColor: "#FFFF40",
-		value: 3
+		valueMul: 3
 	});
 	EnumValue.add(Rarities, RARITY_DIVINE, "DIVINE", {
 		name: "divine",
 		buttonColor: "#80EEEE",
-		value: 4
+		valueMul: 4
 	});
 	
 	public static const BTNCOLOR_CURSED:String = "#800000";

--- a/classes/classes/Items/UseableLib.as
+++ b/classes/classes/Items/UseableLib.as
@@ -144,7 +144,10 @@ use namespace CoC;
 			"You look at the goblin ear.  You admire the overall curve of the ear yet you find no obvious uses for it.");
 		public const GLDSTAT:SimpleUseable = new SimpleUseable("GldStat", "GldStat", "a golden statue", 2000,
 			"An intricate golden idol of an androgynous humanoid figure with nine long tails.  It probably had some spiritual significance to its owner.",
-			"", SceneLib.forest.kitsuneScene.kitsuneStatue);
+			"", function():void {
+					// SceneLib is not available during class initialization
+					SceneLib.forest.kitsuneScene.kitsuneStatue();
+				});
 		public const IMPSKLL:SimpleUseable = new SimpleUseable("ImpSkll", "ImpSkull", "an imp skull", 25,
 			"A skull taken from a slain imp.",
 			"You look at the imp skull.  A pair of horns protrude from the skull. You admire the overall frame of the skull, yet you find no obvious uses for it.");

--- a/classes/classes/PlayerInfo.as
+++ b/classes/classes/PlayerInfo.as
@@ -1807,9 +1807,14 @@ public class PlayerInfo extends BaseContent {
 
 	private static var filterChoices:Array = [0,1,1,1,1,1,1,1,1,1];	//1 - is active?, 2-10 - is shown?
 	public function perkBuyMenu():void {
-		CoC.instance.perkMenu.newPerkMenu();
+		if (CoC.instance.perkMenu.preferOld) {
+			perkBuyMenuOld();
+		} else {
+			CoC.instance.perkMenu.newPerkMenu();
+		}
 	}
 	public function perkBuyMenuOld():void {
+		CoC.instance.perkMenu.preferOld = true;
 		clearOutput();
 		var perks:/*PerkType*/Array    = PerkTree.availablePerks(player, false);
 		hideMenus();
@@ -1819,7 +1824,8 @@ public class PlayerInfo extends BaseContent {
 			outputText("<b>You do not qualify for any perks at present.  </b>In case you qualify for any in the future, you will keep your " + num2Text(player.perkPoints) + " perk point");
 			if (player.perkPoints > 1) outputText("s");
 			outputText(".");
-			doNext(playerMenu);
+			button(0).show("Next",playerMenu);
+			button(1).show("New Menu",CoC.instance.perkMenu.newPerkMenu);
 			return;
 		}
         if (CoC.instance.testingBlockExiting) {
@@ -1842,6 +1848,7 @@ public class PlayerInfo extends BaseContent {
 			mainView.hideMenuButton(MainView.MENU_NEW_MAIN);
 			menu();
 			addButton(1, "Skip", perkSkip);
+			addButton(3, "New Menu",CoC.instance.perkMenu.newPerkMenu);
 			addButton(4,"Filter",changeFilter, 0).hint("Filter perks by reqired stats")
 			if (filterChoices[0]==1)
 			{

--- a/classes/classes/SaveUpdater.as
+++ b/classes/classes/SaveUpdater.as
@@ -1264,17 +1264,17 @@ public class SaveUpdater extends NPCAwareContent {
 			clearOutput();
 			outputText("Jiangshi getting Tag'd and your backpack feel somehow cheaper (no worry will get back some gems for it if needed).");
 			if (player.hasKeyItem("Backpack") >= 0) player.gems += (150 * player.keyItemvX("Backpack", 1));
-			if (player.hasKeyItem("Adventurer Guild: Copper plate") >= 0 && AdventurerGuild.Slot01Cap < 1) {
+			if (player.hasKeyItem("Adventurer Guild: Copper plate") >= 0 && AdventurerGuild.lootBag.SlotCaps[0] < 1) {
 				outputText(" Very small present from Adventure Guild for having easier to manage all the loot ;)");
-				AdventurerGuild.Slot01Cap = 10;
-				AdventurerGuild.Slot02Cap = 10;
+				AdventurerGuild.lootBag.SlotCaps[0] = 10;
+				AdventurerGuild.lootBag.SlotCaps[1] = 10;
 			}
-			if (player.hasKeyItem("Adventurer Guild: Iron plate") >= 0 && AdventurerGuild.Slot03Cap < 1) {
+			if (player.hasKeyItem("Adventurer Guild: Iron plate") >= 0 && AdventurerGuild.lootBag.SlotCaps[2] < 1) {
 				outputText(" Small present from Adventure Guild for having easier to manage all the loot ;)");
-				AdventurerGuild.Slot01Cap = 10;
-				AdventurerGuild.Slot02Cap = 10;
-				AdventurerGuild.Slot03Cap = 10;
-				AdventurerGuild.Slot04Cap = 10;
+				AdventurerGuild.lootBag.SlotCaps[0] = 10;
+				AdventurerGuild.lootBag.SlotCaps[1] = 10;
+				AdventurerGuild.lootBag.SlotCaps[2] = 10;
+				AdventurerGuild.lootBag.SlotCaps[3] = 10;
 			}
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] < 2 && player.hasPerk(PerkLib.NinetailsKitsuneOfBalance) && player.perkv4(PerkLib.NinetailsKitsuneOfBalance) > 0) {
 				outputText(" Oops seems your PC get Nine-tails Kitsune of Balance ahead of time... no worry you will get points back and perk permanency will be nullified.");
@@ -1514,7 +1514,7 @@ public class SaveUpdater extends NPCAwareContent {
 				flags[kFLAGS.MOD_SAVE_VERSION] = 35.021;
 			}
 			if (flags[kFLAGS.MOD_SAVE_VERSION] < 35.022) {
-				if (AdventurerGuild.Slot04Cap >= 5) AdventurerGuild.Slot05Cap = 10;
+				if (AdventurerGuild.lootBag.SlotCaps[3] >= 5) AdventurerGuild.lootBag.SlotCaps[4] = 10;
 				flags[kFLAGS.MOD_SAVE_VERSION] = 35.022;
 			}
 			flags[kFLAGS.MOD_SAVE_VERSION] = 36.0;

--- a/classes/classes/Scenes/API/AbstractQuest.as
+++ b/classes/classes/Scenes/API/AbstractQuest.as
@@ -1,0 +1,161 @@
+package classes.Scenes.API {
+import classes.BaseContent;
+import classes.internals.EnumValue;
+
+import flash.utils.Dictionary;
+
+public class AbstractQuest extends BaseContent {
+	public static const ALL_QUESTS_MAP:Dictionary = new Dictionary();
+	public static const ALL_QUESTS_LIST:/*AbstractQuest*/Array = [];
+	
+	/**
+	 * EnumValue properties:
+	 * - id: var name ("COMPLETED")
+	 * - value: code (3)
+	 * - name: display name ("Completed")
+	 * - color: text color, optional
+	 */
+	public static const AllStatuses:/*EnumValue*/Array = [];
+	/**
+	 * Player does not know about this quest
+	 */
+	public static const STATUS_UNKNOWN:int     = 0;
+	EnumValue.add(AllStatuses, STATUS_UNKNOWN, "UNKNOWN", {
+		name: "Unknown"
+	});
+	/**
+	 * Player knows about this quest, but haven't started it
+	 */
+	public static const STATUS_NOT_STARTED:int = 1;
+	EnumValue.add(AllStatuses, STATUS_NOT_STARTED, "NOT_STARTED", {
+		name: "Not started"
+	});
+	/**
+	 * Player started the quest, but not completed it yet.
+	 * It can also mean that player completed the quest but didn't take the rewards yet.
+	 */
+	public static const STATUS_IN_PROGRESS:int = 2;
+	EnumValue.add(AllStatuses, STATUS_IN_PROGRESS, "IN_PROGRESS", {
+		name: "In progress",
+		color: "#0080ff"
+	});
+	/**
+	 * Player successfully completed the quests and took the rewards.
+	 */
+	public static const STATUS_COMPLETED:int = 3;
+	EnumValue.add(AllStatuses, STATUS_COMPLETED, "COMPLETED", {
+		name: "Completed",
+		color: "#00a000"
+	});
+	/**
+	 * Player failed the quest.
+	 */
+	public static const STATUS_FAILED:int  = 4;
+	EnumValue.add(AllStatuses, STATUS_FAILED, "FAILED", {
+		name: "Failed",
+		color: "#a00000"
+	});
+	/**
+	 * Return value to indicate invalid quest id
+	 */
+	public static const STATUS_INVALID:int = -1;
+	EnumValue.add(AllStatuses, STATUS_INVALID, "INVALID", {
+		name: "Invalid",
+		color: "#ff0000"
+	});
+	
+	private var _id:String;
+	private var _group:String;
+	private var _title:String;
+	
+	public function AbstractQuest(
+			id:String,
+			group:String,
+			title:String
+	) {
+		this._id    = id;
+		this._group = group;
+		this._title = title;
+		ALL_QUESTS_MAP[_id] = this;
+		ALL_QUESTS_LIST.push(this);
+	}
+	
+	public function get id():String { return _id }
+	public function get title():String { return _title }
+	public function get group():String { return _group }
+	
+	public function get description():String {
+		// Implement in subclass (optional)
+		return "";
+	}
+	/**
+	 * Quest objectives, as viewed by player.
+	 * Array of parts [status, test]
+	 */
+	public function objectives():Array {
+		// Implement in subclass
+		return [
+				[STATUS_UNKNOWN, "ERROR: Quest '"+id+"' is missing objectives"]
+		];
+	}
+	public function formattedObjectives(colored:Boolean):/*String*/Array {
+		var result:/*String*/Array = [];
+		for each (var obj:Array in objectives()) {
+			var ev:EnumValue = AllStatuses[obj[0]];
+			var s:String;
+			if (obj[0] == STATUS_UNKNOWN) {
+				s = "???";
+			} else {
+				s = obj[1];
+			}
+			if (colored && ev.color) s = '<font color="' + ev.color + '">' + s + '</font>';
+			result.push(s);
+		}
+		return result;
+	}
+	
+	/**
+	 * STATUS_XXXX
+	 */
+	public function get status():int {
+		// Implement in subclass
+		return STATUS_UNKNOWN;
+	}
+	public function statusName(colored:Boolean):String {
+		var obj:EnumValue = AllStatuses[status];
+		var s:String = obj.name;
+		if (colored && obj.color) s = '<font color="'+obj.color+'">'+s+'</font>';
+		return s;
+	}
+	/**
+	 * Player knows about the quest
+	 */
+	public function get isKnown():Boolean {
+		return status > STATUS_UNKNOWN;
+	}
+	/**
+	 * If quest is unknown, hint to reveal it. Can be empty
+	 */
+	public function get hintToUnlock():String {
+		return "";
+	}
+	/**
+	 * Quest was started but not completed
+	 */
+	public function get isStarted():Boolean {
+		return status == STATUS_IN_PROGRESS;
+	}
+	/**
+	 * Quest was finished (successfully or not)
+	 */
+	public function get isEnded():Boolean {
+		return status == STATUS_COMPLETED || status == STATUS_FAILED;
+	}
+	public function get isCompleted():Boolean {
+		return status == STATUS_COMPLETED;
+	}
+	public function get isFailed():Boolean {
+		return status == STATUS_FAILED;
+	}
+}
+}

--- a/classes/classes/Scenes/API/FnHelpers.as
+++ b/classes/classes/Scenes/API/FnHelpers.as
@@ -3,8 +3,8 @@
  */
 package classes.Scenes.API {
 import classes.BaseContent;
-import classes.GlobalFlags.kFLAGS;
 import classes.CoC;
+import classes.GlobalFlags.kFLAGS;
 
 public class FnHelpers extends BaseContent {
 	public static const FN:FnHelpers = new FnHelpers();
@@ -89,7 +89,7 @@ public class FnHelpers extends BaseContent {
 	 * @return Function returning `true` if player is at least `minLevel` or at least `daysPerLevel`*`minLevel` days have passed
 	 */
 	public static function isLevelMin(minLevel:int, daysPerLevel:int = 6):Boolean {
-		return (CoC.instance.player.level>=minLevel || CoC.instance.time.days>=minLevel*daysPerLevel);
+		return (CoC.instance.player.level>=minLevel || daysPerLevel > 0 && CoC.instance.time.days>=minLevel*daysPerLevel);
 	}
 	/**
 	 * @return Function returning Number, linearly dependent on player level:

--- a/classes/classes/Scenes/API/GroupEncounter.as
+++ b/classes/classes/Scenes/API/GroupEncounter.as
@@ -5,7 +5,7 @@ package classes.Scenes.API {
 import classes.internals.Utils;
 
 public class GroupEncounter implements Encounter {
-	protected var components:Array;// of Encounter
+	public var components:/*Encounter*/Array;
 	protected var name:String;
 	public function GroupEncounter(name:String, components:Array) {
 		this.name = name;

--- a/classes/classes/Scenes/API/MerchantMenu.as
+++ b/classes/classes/Scenes/API/MerchantMenu.as
@@ -263,7 +263,7 @@ public class MerchantMenu extends BaseContent {
 		if (storageMode == STORAGE_MODE_INVENTORY) {
 			playerStorage = player.itemSlots.slice(0, player.itemSlotCount());
 		} else if (storageMode == STORAGE_MODE_PEARL) {
-			playerStorage = inventory.pearlStorageDirectGet().slice(0, inventory.pearlStorageSize());
+			playerStorage = inventory.pearlStorageSlice();
 		}
 		grid = new Block({
 			layoutConfig: {

--- a/classes/classes/Scenes/API/SimpleEncounter.as
+++ b/classes/classes/Scenes/API/SimpleEncounter.as
@@ -78,7 +78,7 @@ public dynamic class SimpleEncounter implements Encounter {
 		var kind:* = null;
 		if ('kind' in this) kind = this['kind'];
 		if (kind is Function) kind = kind();
-		return String(kind).toLowerCase();
+		return kind ? String(kind).toLowerCase() : "";
 	}
 	public function getLabel():String {
 		var label:* = getTooltipHeader();

--- a/classes/classes/Scenes/Areas/Battlefield/DilapidatedShrine.as
+++ b/classes/classes/Scenes/Areas/Battlefield/DilapidatedShrine.as
@@ -57,7 +57,7 @@ public class DilapidatedShrine extends BaseContent
 			//addButtonDisabled(8, "East", "???");//life god subshrine
 			//addButtonDisabled(10, "Crypt", "???");//heavenly kings resting place
 			addButton(12, "South", southSection);
-			addButton(14, "Leave", camp.returnToCampUseOneHour);
+			addButton(14, "Leave", explorer.done);
 		}
 		
 		private function shinshoku():Boolean {

--- a/classes/classes/Scenes/Areas/BattlefieldBoundary.as
+++ b/classes/classes/Scenes/Areas/BattlefieldBoundary.as
@@ -8,6 +8,8 @@ package classes.Scenes.Areas
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.API.Encounters;
+import classes.Scenes.API.ExplorationEntry;
+import classes.Scenes.API.FnHelpers;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Battlefield.*;
 import classes.Scenes.NPCs.EtnaFollower;
@@ -24,16 +26,61 @@ use namespace CoC;
 		}
 
 		private var _battlefieldBoundaryEncounter:GroupEncounter = null;
+		private var _battlefieldLoot:GroupEncounter = null;
 		public function get battlefieldBoundaryEncounter():GroupEncounter {
 			return _battlefieldBoundaryEncounter;
 		}
+		public function get battlefieldLoot():GroupEncounter {
+			return _battlefieldLoot;
+		}
 
 		private function init():void {
+			const fn:FnHelpers = Encounters.fn;
+			_battlefieldLoot = Encounters.group("battlefieldLoot", {
+				name: "MG_SFRP",
+				label: "MGSFRPill",
+				kind  : 'item',
+				chance: 0.08,
+				when: fn.ifLevelMin(24,0),
+				call: curry(findItem, consumables.MG_SFRP)
+			}, {
+				name: "D_ARCON",
+				label: "Dil.ARC",
+				kind  : 'item',
+				chance: 0.08,
+				when: fn.ifLevelMin(24,0),
+				call: curry(findItem, consumables.D_ARCON)
+			}, {
+				name: "SPIL_SH",
+				label: "SpikeLShield",
+				kind  : 'item',
+				chance: 0.10,
+				when: fn.ifLevelMin(16,0),
+				call: curry(findItem, shields.SPIL_SH)
+			}, {
+				name: "LG_SFRP",
+				label: "LGSFRPill",
+				kind  : 'item',
+				chance: 0.17,
+				call: curry(findItem, consumables.LG_SFRP)
+			}, {
+				name: "VDARCON",
+				label: "V.D.ARC",
+				kind  : 'item',
+				chance: 0.17,
+				call: curry(findItem, consumables.VDARCON)
+			}, {
+				name: "metal",
+				label : "Scrap",
+				kind  : 'item',
+				chance: 0.4,
+				call: findMetalScrap
+			});
 			_battlefieldBoundaryEncounter = Encounters.group("batllefieldboundary", {
 				//Discover Outer Battlefield
 				name: "discoverOuter",
 				label : "New Area",
-				kind  : 'event',
+				kind  : 'place',
 				unique: true,
 				chance: 30,
 				when: function ():Boolean {
@@ -44,7 +91,7 @@ use namespace CoC;
 				//Find Tripxi gun parts
 				name: "gunPart",
 				label : "Gun Parts",
-				kind  : 'event',
+				kind  : 'item',
 				unique: true,
 				chance:30,
 				when: function ():Boolean {
@@ -56,21 +103,17 @@ use namespace CoC;
 				name: "dilapidatedShrine",
 				label : "Dilapidated Shrine",
 				shortLabel: "D.Shrine",
-				kind  : 'event',
+				kind  : 'place',
 				unique: true,
 				call: SceneLib.dilapidatedShrine.firstvisitshrineintro,
 				when: function ():Boolean {
 					return flags[kFLAGS.DILAPIDATED_SHRINE_UNLOCKED] == 1
 				},
 				chance: 0.2
-			}, {
-				name: "items",
-				label : "Items",
-				kind  : 'event',
-				call: findItems
-			}, {
+			}, battlefieldLoot, {
 				name: "nothing",
-				label : "walk",
+				label : "Walk",
+				kind  : "walk",
 				call: findNothing
 			}, {
 				//Helia monogamy fucks
@@ -149,11 +192,15 @@ use namespace CoC;
 		}
 
 		public function exploreBattlefieldBoundary():void {
-			clearOutput();
-			flags[kFLAGS.DISCOVERED_BATTLEFIELD_BOUNDARY]++;
-			doNext(camp.returnToCampUseOneHour);
-			battlefieldBoundaryEncounter.execEncounter();
-			flushOutputTextToGUI();
+			explorer.prepareArea(battlefieldBoundaryEncounter);
+			explorer.setTags("battlefield", "battlefieldBoundary");
+			explorer.prompt = "You explore the battlefield boundary.";
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				flags[kFLAGS.DISCOVERED_BATTLEFIELD_BOUNDARY]++;
+			}
+			explorer.leave.hint("Leave the battlefield boundary");
+			explorer.skillBasedReveal(16, flags[kFLAGS.DISCOVERED_BATTLEFIELD_BOUNDARY]);
+			explorer.doExplore();
 		}
 		
 		public function battlefieldBoundaryChance():Number {
@@ -162,38 +209,19 @@ use namespace CoC;
 			return temp;
 		}
 
-		private function findItems():void {
+		private function findItem(item:ItemType):void {
 			clearOutput();
-			if (rand(2) == 0) {
-				outputText("You spot something on the ground among various items remains. Taking a closer look, it's ");
-				if (rand(2) == 0) {
-					if (player.level >= 24 && rand(3) == 0) {
-						outputText("a mid-grade Soulforce Recovery Pill. ");
-						inventory.takeItem(consumables.MG_SFRP, camp.returnToCampUseOneHour);
-					} else {
-						outputText("a low-grade Soulforce Recovery Pill. ");
-						inventory.takeItem(consumables.LG_SFRP, camp.returnToCampUseOneHour);
-					}
-				} else {
-					if (player.level >= 24 && rand(3) == 0) {
-						outputText("a diluted Arcane Regen Concotion. ");
-						inventory.takeItem(consumables.D_ARCON, camp.returnToCampUseOneHour);
-					} else {
-						outputText("a very diluted Arcane Regen Concotion. ");
-						inventory.takeItem(consumables.VDARCON, camp.returnToCampUseOneHour);
-					}
-				}
-			} else {
-				if (player.level >= 16 && rand(5) == 0) {
-					outputText("You spot something on the ground among various items remains. Taking a closer look, it's a Light Spiked Shield. ");
-					inventory.takeItem(shields.SPIL_SH, camp.returnToCampUseOneHour);
-				} else {
-					outputText("While exploring the battlefield you find the remains of some metal scraps. At first you think you won't find anything useful there but a metal plate draws your attention, it could be useful later. You put the item in your backpack and head back to camp.\n\n");
-					outputText("<b>You found a metal plate.</b>");
-					flags[kFLAGS.CAMP_CABIN_METAL_PIECES_RESOURCES]++;
-					doNext(camp.returnToCampUseOneHour);
-				}
-			}
+			outputText("You spot something on the ground among various items remains. Taking a closer look, it's ");
+			outputText(item.longName);
+			outputText(". ");
+			inventory.takeItem(item, explorer.done);
+		}
+		private function findMetalScrap():void {
+			clearOutput();
+			outputText("While exploring the battlefield you find the remains of some metal scraps. At first you think you won't find anything useful there but a metal plate draws your attention, it could be useful later. You put the item in your backpack and head back to camp.\n\n");
+			outputText("<b>You found a metal plate.</b>");
+			flags[kFLAGS.CAMP_CABIN_METAL_PIECES_RESOURCES]++;
+			endEncounter();
 		}
 
 		private function findNothing():void {
@@ -206,7 +234,7 @@ use namespace CoC;
 				outputText("Some grey, maybe black colored shape seemly wiggling as it like moving in your direction." + (silly() ? " Oh are you approaching me?" : "") + " Bit tired and on the edge due to meeting potential enemies moments ago you decide to return this time. Maybe next time you will check out closer that 'fog' or whatever it's.");
 			} else outputText("You spend an hour exploring this deserted battlefield but you don't manage to find anything interesting, yet this trip had made you a little wiser.");
 			dynStats("wis", .5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function discoverOuter():void {
@@ -214,7 +242,8 @@ use namespace CoC;
 			player.explored++;
 			clearOutput();
 			outputText("As you explore the boundary of the endless field, you cautiously step over countless remains of fallen and golem husks littered across the ground. Treading further, you reach a part of the battlefield you haven't seen yet. The air is thick, and it constantly feels like you're being watched by something. Perhaps the war isn't quite finished yet...\n\n<b>You've discovered the (Outer) Battlefield!</b>");
-			doNext(camp.returnToCampUseOneHour);
+			explorer.stopExploring();
+			endEncounter();
 		}
 
 		public function partsofTwinGrakaturd():void {
@@ -223,7 +252,7 @@ use namespace CoC;
 			outputText("You carefully put the pieces of the Twin Grakaturd in your back and head back to your camp.\n\n");
 			player.addStatusValue(StatusEffects.TelAdreTripxi, 2, 1);
 			player.createKeyItem("Twin Grakaturd", 0, 0, 0, 0);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 	}
 }

--- a/classes/classes/Scenes/Areas/BattlefieldOuter.as
+++ b/classes/classes/Scenes/Areas/BattlefieldOuter.as
@@ -9,6 +9,7 @@ import classes.*;
 import classes.GlobalFlags.kFLAGS;
 import classes.Items.Vehicles;
 import classes.Scenes.API.Encounters;
+import classes.Scenes.API.ExplorationEntry;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Battlefield.*;
 import classes.Scenes.NPCs.EtnaFollower;
@@ -75,14 +76,10 @@ public class BattlefieldOuter extends BaseContent
 			},
 			chance: 0.1,
 			call: takeWrathMech
-		}, {
-			name: "items",
-			label : "Items",
-			kind  : 'event',
-			call: findItems
-		}, {
+		}, SceneLib.battlefiledboundary.battlefieldLoot, {
 			name: "nothing",
-			label : "walk",
+			label : "Walk",
+			kind  : "walk",
 			call: findNothing
 		}, {
 			//Helia monogamy fucks
@@ -169,51 +166,21 @@ public class BattlefieldOuter extends BaseContent
 
 
 	public function exploreOuterBattlefield():void {
-		clearOutput();
-		flags[kFLAGS.DISCOVERED_OUTER_BATTLEFIELD]++;
-		doNext(camp.returnToCampUseOneHour);
-		battlefieldOuterEncounter.execEncounter();
-		flushOutputTextToGUI();
+		explorer.prepareArea(battlefieldOuterEncounter);
+		explorer.setTags("battlefield", "battlefieldOuter");
+		explorer.prompt = "You explore the outer battlefield.";
+		explorer.onEncounter = function(e:ExplorationEntry):void {
+			flags[kFLAGS.DISCOVERED_OUTER_BATTLEFIELD]++;
+		}
+		explorer.leave.hint("Leave the outer battlefield");
+		explorer.skillBasedReveal(18, flags[kFLAGS.DISCOVERED_OUTER_BATTLEFIELD]);
+		explorer.doExplore();
 	}
 	
 	public function battlefieldOuterChance():Number {
 		var temp:Number = 0.5;
 		temp *= player.npcChanceToEncounter();
 		return temp;
-	}
-
-	private function findItems():void {
-		clearOutput();
-		if (rand(2) == 0) {
-			outputText("You spot something on the ground among various items remains. Taking a closer look, it's ");
-			if (rand(2) == 0) {
-				if (player.level >= 24 && rand(3) == 0) {
-					outputText("a mid-grade Soulforce Recovery Pill. ");
-					inventory.takeItem(consumables.MG_SFRP, camp.returnToCampUseOneHour);
-				} else {
-					outputText("a low-grade Soulforce Recovery Pill. ");
-					inventory.takeItem(consumables.LG_SFRP, camp.returnToCampUseOneHour);
-				}
-			} else {
-				if (player.level >= 24 && rand(3) == 0) {
-					outputText("a diluted Arcane Regen Concotion. ");
-					inventory.takeItem(consumables.D_ARCON, camp.returnToCampUseOneHour);
-				} else {
-					outputText("a very diluted Arcane Regen Concotion. ");
-					inventory.takeItem(consumables.VDARCON, camp.returnToCampUseOneHour);
-				}
-			}
-		} else {
-			if (player.level >= 24 && rand(5) == 0) {
-				outputText("You spot something on the ground among various items remains. Taking a closer look, it's a Heavy Spiked Shield. ");
-				inventory.takeItem(shields.SPIH_SH, camp.returnToCampUseOneHour);
-			} else {
-				outputText("While exploring the battlefield you find the remains of some metal scraps. At first you think you won't find anything useful there but a metal plate draws your attention, it could be useful later. You put the item in your backpack and head back to camp.\n\n");
-				outputText("<b>You found a metal plate.</b>");
-				flags[kFLAGS.CAMP_CABIN_METAL_PIECES_RESOURCES]++;
-				doNext(camp.returnToCampUseOneHour);
-			}
-		}
 	}
 
 	private function findNothing():void {
@@ -226,7 +193,7 @@ public class BattlefieldOuter extends BaseContent
 			outputText("Some grey, maybe black colored shape seemly wiggling as it like moving in your direction." + (silly() ? " Oh are you approaching me?" : "") + " Bit tired and on the edge due to meeting potential enemies moments ago you decide to return this time. Maybe next time you will check out closer that 'fog' or whatever it's.");
 		} else outputText("You spend an hour exploring this deserted battlefield but you don't manage to find anything interesting, yet this trip had made you a little wiser.");
 		dynStats("wis", .5);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function tyrantiaEncounterFn():void {
@@ -241,7 +208,8 @@ public class BattlefieldOuter extends BaseContent
 		player.explored++;
 		clearOutput();
 		outputText("As you explore the boundary of the endless field, you cautiously step over countless remains of fallen and golem husks littered across the ground. Treading further, you reach a part of the battlefield you haven't seen yet. The air is thick, and it constantly feels like you're being watched by something. Perhaps the war isn't quite finished yet...\n\n<b>You've discovered the (Outer) Battlefield!</b>");
-		doNext(camp.returnToCampUseOneHour);
+		explorer.stopExploring();
+		endEncounter();
 	}
 
 	public function takeWrathMech():void {
@@ -268,7 +236,7 @@ public class BattlefieldOuter extends BaseContent
 		outputText("You carefully put the pieces of the (new firearms) in your back and head back to your camp.\n\n");
 		player.addStatusValue(StatusEffects.TelAdreTripxi, 2, 1);
 		player.createKeyItem("Twin Grakaturd", 0, 0, 0, 0);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}*/
 }
 }

--- a/classes/classes/Scenes/Areas/Desert/AntsScene.as
+++ b/classes/classes/Scenes/Areas/Desert/AntsScene.as
@@ -55,7 +55,7 @@ public class AntsScene extends BaseContent
             //options
             function later():void {
                 outputText("The cart is standing in the middle of the desert, and still nobody has looted it? It's clearly a trap. And you're not ready to risk your life for any rubbish inside it right now. You return to your camp, hoping that the time you'll be strong enough.");
-                camp.returnToCampUseOneHour();
+                endEncounter();
             }
 
             function approach():void {
@@ -86,7 +86,7 @@ public class AntsScene extends BaseContent
 				outputText("After seeing the large pack of demons you decide it's best not to act.  You yourself are in no condition to help the poor creature, and knowing full well what comes after demons 'subdue' their prey, you don't want to stick around either.  You glance over and realize the skirmish has already started.  It's too late to really help her anyway, you argue to yourself, plus she's covered in muscle.");
 				outputText("\n\nAssuring yourself that she'll be fine, you take the opportunity to flee while the demons are distracted, heading back to camp.  Leaving the ant-girl to her fate.");
 				//[End of Event]
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
             else demonsFuckAntgirl();
         }
@@ -163,7 +163,7 @@ public class AntsScene extends BaseContent
                     player.sexReward("Default","Default",true,false);
                     dynStats("sen", -1,  "cor", 3);
                 }
-                doNext(recalling ? recallWakeUp : camp.returnToCampUseOneHour);
+                doNext(recalling ? recallWakeUp : explorer.done);
             }
 		}
 
@@ -230,7 +230,7 @@ public class AntsScene extends BaseContent
 			outputText("\n\nThe ant queen gives you a dismissive wave with one of her larger arms, giving you reason to think her good will is anything but.  As you turn to leave, your eye catches Phylla's and she shyly smiles at you.  Her mother sees this and delivers a final, cryptic warning.  \"<i>One last thing before you depart, 'Champion'.  Should you fail, the consequences, for you, will be... dire.</i>\"");
 			outputText("\n\nAs you mull over this ominous message, your guide reappears and leads you back through the maze of tunnels, to the exit of the colony.  You leave the anthill behind and head to camp, considering your best course of action.");
 			flags[kFLAGS.PC_READY_FOR_ANT_COLONY_CHALLENGE] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //The Challenges
@@ -274,7 +274,7 @@ public class AntsScene extends BaseContent
 		{
 			clearOutput();
 			outputText("Deciding to better prepare yourself first, you inform the thin fight manager that you will return later.  You leave the colony, heading back to camp.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function antColiseumFight():void
@@ -481,7 +481,7 @@ public class AntsScene extends BaseContent
 			outputText("\n\nYou reassuringly tell her and plant a kiss on her lips then get yourself redressed and make the departure back to your camp.");
 			if (!recalling) {
 				flags[kFLAGS.PHYLLA_GEMS_HUNTED_TODAY] = 1; //Dirty checking for disabling the ant temporarily for 1 day.
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else doNext(recallWakeUp);
 		}
@@ -494,7 +494,7 @@ public class AntsScene extends BaseContent
 			outputText("\n\nYou have a feeling that you won't see her again.");
 			if (!recalling) {
 				flags[kFLAGS.ANTS_PC_FAILED_PHYLLA] = 1;
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else doNext(recallWakeUp);
 		}
@@ -942,7 +942,7 @@ public class AntsScene extends BaseContent
 			else player.createKeyItem("Radiant shard", 1,0,0,0);
 			outputText("\n\n<b>Before fully settling in your camp as if remembering something Phylla pulls a shining shard from her inventory and hand it over to you as a gift. You acquired a Radiant shard!</b>");
 			flags[kFLAGS.ANT_WAIFU] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //►[Stay Here]
@@ -954,7 +954,7 @@ public class AntsScene extends BaseContent
 			outputText("\n\nAs you turn to leave she quickly says, \"<i>If you ever feel your camp is safe enough for me to join you, p-please come get me.  If you want.  I mean, I'm not going anywhere... not that I could with my mother watching anyway...</i>\"");
 			outputText("\n\nYou nod and without another word, head back to camp.");
 			flags[kFLAGS.PHYLLA_STAY_HOME] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //If PC returns to colony after telling her to stay with her mother:

--- a/classes/classes/Scenes/Areas/Desert/GorgonScene.as
+++ b/classes/classes/Scenes/Areas/Desert/GorgonScene.as
@@ -1,13 +1,12 @@
-package classes.Scenes.Areas.Desert 
+package classes.Scenes.Areas.Desert
 {
 import classes.*;
 import classes.BodyParts.Face;
-import classes.Scenes.Areas.Desert.Gorgon;
 
 public class GorgonScene extends BaseContent
 	{
 		
-		public function GorgonScene() 
+		public function GorgonScene()
 		{
 		}
 
@@ -67,7 +66,7 @@ public function gorgonEncounter():void {
 				if(player.cockTotal() >= 3) outputText("She takes one in each hand, stroking them slowly and making sure to pay attention to the tip. Every so often she switches to a different dick to make sure that each and every one of your throbbing cocks has some love given to them. ");
 				outputText("A hiss of pleasure escapes your lips as the gorgon strokes your [cocks], her talented fingers bringing you further into a state of arousal. She stops her caress and brings her hand to a scaly covering at her crotch, spreading it wide to reveal her soft pussy.\n\n");
 				
-				//[player has one dick] 
+				//[player has one dick]
 				if(player.cockTotal() == 1) outputText("She carefully lines it up with your member and starts to tease the tip before gently inserting the first few inches. ");
 				//[player has two dicks]
 				if(player.cockTotal() == 2) outputText("She carefully lines it up with both of your members and starts to tease their tips before gently inserting the first few inches. ");
@@ -77,7 +76,7 @@ public function gorgonEncounter():void {
 				outputText("Every thrust brings you deeper inside of her pussy, its soft walls massaging you. It seems like her pussy managed to swallow your entire cock in no time at all. The gorgon pauses for a moment, your hips pressed together, panting. You shift your arms up a little higher to rest at her waist and lower your head to nuzzle at her neck. The gorgon leans her head into yours and wraps one of her arms around your head. Once more she pulls back her hips before thrusting them back onto your cock. No longer is she slowly bringing you inside her, now she thrusts herself onto you, going faster and faster. Your tails tighten around each other as you reach climax. A sudden yell escapes your throat as you cum inside of her, your tail squeezing hard enough to crush a lesser being. The gorgon shudders in your grip as she reaches her own climax. ");
 				//[lots of jizz]
 				if(player.cumQ() > 250) outputText("You quickly fill her with your seed to the point where she overflows, leaving her pussy dripping with semen afterwards.");
-				//[JIZZ, JIZZ EVERYWHERE] 
+				//[JIZZ, JIZZ EVERYWHERE]
 				else if(player.cumQ() > 1000) outputText("Her stomach quickly swells from the sheer volume of seed pumped into her. The sperm that her womb is unable to hold starts to gush out from her stuffed cunt.");
 				
 				outputText("\n\nThe two of you lay there for a moment, basking in the warm glow of orgasm. Eventually the gorgon slowly unwraps her tail from your own and gives you a kiss on the forehead. \"<i>I look forward to our next encounter,</i>\" she whispers softly into your ear before slithering off into the desert.  You watch as she leaves and wave her a kiss goodbye before she disappears from your sight.\n\n");
@@ -106,6 +105,7 @@ public function gorgonEncounter():void {
 			player.cuntChange(30,true,false,true);
 			player.sexReward("Default","Default",true,false);
 			outputText("You think it would be a very good idea to come to the desert more often.");
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseFourHours);
 			return;
 		}
@@ -124,8 +124,8 @@ public function gorgonEncounter():void {
         	outputText("\"<i>We should do this more often,</i>\" she says before you head off.\n\n");
 		}
 		outputText("You think it would be a very good idea to come to the desert more often.");
-		doNext(camp.returnToCampUseOneHour);
 		dynStats("lus", player.lib/5, "scale", false);
+		endEncounter();
 		return;
 	}
 	//If player's last fight did not involve them being a naga
@@ -140,12 +140,12 @@ public function gorgonEncounter():void {
 		//No fight for this encounter, brings you back to the camp. Next time you see her, she will attack you unless you turn back into a naga in the meantime
 		player.changeStatusValue(StatusEffects.Naga,1,0);
 		outputText("You walk in the desert for what feels like an eternity, thinking of how much easier it was to move across the sand back when you had a tail, but then you're brought back to reality by a familiar hissing. The identity of your follower is no secret to you. As you open your mouth to greet your gorgon friend, you find yourself unable to pronounce any words. The girl comes towards you and slithers around in a confused way, trying to communicate. But the sounds that once formed words and phrases now seem to slip through you; all you can do is stand there, unable to grasp what she's trying to tell you. Realizing that you're not who you used to be anymore, she sadly looks down and turns around. The gorgon slithers away into the distance until she's nothing but a blink on the horizon.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		return;
 	}
 	startCombat(new Gorgon());
 }
 
-		
+	
 	}
 }

--- a/classes/classes/Scenes/Areas/Desert/NagaScene.as
+++ b/classes/classes/Scenes/Areas/Desert/NagaScene.as
@@ -49,7 +49,7 @@ public function nagaEncounter():void {
 		//No fight for this encounter, brings you back to the camp. Next time you see her, she will attack you unless you turn back into a naga in the meantime
 		player.changeStatusValue(StatusEffects.Naga,1,0);
 		outputText("You walk in the desert for what feels like an eternity, thinking of how much easier it was to move across the sand back when you had a tail, but then you're brought back to reality by a familiar hissing. The identity of your follower is no secret to you. As you open your mouth to greet your naga friend, you find yourself unable to pronounce any words. The girl comes towards you and slithers around in a confused way, trying to communicate. But the sounds that once formed words and phrases now seem to slip through you; all you can do is stand there, unable to grasp what she's trying to tell you. Realizing that you're not who you used to be anymore, she sadly looks down and turns around. The naga slithers away into the distance until she's nothing but a blink on the horizon.");
-		doNext(camp.returnToCampUseOneHour);
+		doNext(explorer.done);
 		return;
 	}
     camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_NAGAS);

--- a/classes/classes/Scenes/Areas/Desert/Oasis.as
+++ b/classes/classes/Scenes/Areas/Desert/Oasis.as
@@ -35,7 +35,7 @@ private function oasisRunAway():void {
 	//Run away successfully if fast enough.  80 speed = autosuccess.
 	if(player.spe > 15 && player.spe/2 > rand(40)) {
 		outputText("You bolt out from under your bush and scramble away over the sand. Before long the swishing sounds of pursuit fade away and looking back you see the few demons with the gusto to follow you tramping back to the oasis.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else {
 		outputText("You scramble away from the demons, but are too late. A swift demon with canine features tackles you to the ground.  Luckily he loses his grip as you tumble onto the sand and you slither free, stand up and wheel to face the host of leering demons which begin to advance with malicious intent.");
@@ -196,6 +196,7 @@ internal function oasisSexing():void {
 	outputText("You fuck for hours; 'feasting' with the demons. Pain, pleasure and exhaustion intermingle and no matter how hard you try to cling to consciousness you are in no state to concentrate. You dangle over the edge for what seems like eternity before another orgasm, stronger than any other, hits you like a solid wall and you black out. For a little while you drift in and out of conscious reality to find your body still the object of demonic attentions until eventually you wake to find that the seemingly endless string of orgasms has stopped. Looking around you see what demons remain awake engaged solely in fucking each other. Tender and sore from the abuse and still finding it hard to concentrate you gather your clothes and steal away, leaving them to the tail end of their orgy. In the aftermath you feel like you've just run an endurance race, but the rubbed raw sensitivity of your brutally fucked body tells another tale.");
 	player.sexReward("cum");
 	dynStats("tou", .5, "sen", .5, "cor", 4);
+	explorer.stopExploring();
     if (CoC.instance.inCombat) cleanupAfterCombat();
     else doNext(playerMenu);
 }

--- a/classes/classes/Scenes/Areas/Desert/SandTrapScene.as
+++ b/classes/classes/Scenes/Areas/Desert/SandTrapScene.as
@@ -14,7 +14,7 @@ public class SandTrapScene extends BaseContent{
 			return monster as SandTrap;
 		}
 
-				
+		
 		public function SandTrapScene()
 		{
 		}
@@ -35,7 +35,7 @@ public function encounterASandTarp():void {
 	}
 	flags[kFLAGS.TIMES_ENCOUNTERED_SAND_TRAPS]++;
 	if(flags[kFLAGS.TIMES_ENCOUNTERED_SAND_TRAPS] == 1) {
-		//femininity <= 65: 
+		//femininity <= 65:
 		if(player.femininity <= 65) {
 			outputText("You are exploring the endlessly undulating landscape of the desert when you hear an agonized cry for help over the nearest dune.  You quickly scramble up it and are confronted by the sight of a small, flat lake of exceptionally fine sand, overlooked on each side by tall dunes.  Trapped in the middle of it is a young woman with black hair, up to her armpits in the sand.  \"<i>Oh, thank the Gods!</i>\" she cries, spotting you.  \"<i>I'm sinking, please help me!</i>\"  The word 'quicksand' flashes through your mind like fire and you take a nervous step back, attempting to quickly evaluate the situation.");
 			if(player.inte > 65) outputText("  Something about this scene puts you on edge.  How come you've never encountered quicksand in this desert before, with no water and its steady, stubborn, but not violent winds?  There's something odd about the woman, too - although she can't be a sand witch with that hair, you can't quite make her features out clearly through the heat haze.");
@@ -49,15 +49,15 @@ public function encounterASandTarp():void {
 		simpleChoices("Save", saveTheSandTarps, "Don't Save", dontSaveTheTarps, "", null, "", null, "", null);
 	}
 	else {
-		//Standard encounter: 
+		//Standard encounter:
 		outputText("You are walking aimlessly through the desert when your [leg] sinks six inches into powdery sand.  The sound of hissing fills your ears as all around you sand cascades downwards into a conical depression.  A slender figure is emerging at the bottom... you desperately free your lower half and fight your way upwards, trying to stay ahead of the collapsing particulate.");
 		if(player.spe/10 + rand(20) >= 16) {
 			outputText("\n\nMoving as quickly and lightly as you can, you manage to hop clear of the sandtrap's pitfall and claw your way up a relatively stable dune.  You turn to take the androgynous creature in, half buried in its deep hollow.");
 			outputText("\n\n\"<i>You've got quick feet, little ant!</i>\" it giggles.  It lowers its brow and leers up at you with smouldering black eyes, its hands slowly and sensuously trailing patterns in the sand.  \"<i>I bet you're good at lots of other things, too.  Why doesn't the brave little ant come down here and show me?</i>\"  If you're going to fight this creature, you will have to step into its treacherous hollow to get in range, which is surely its intention - if you try launching things at it from where you are, it will probably just hide itself.  On the other hand, it would be easy to just ignore its taunts and walk away.");
 			//Fight]/[Leave]
-			simpleChoices("Fight", startSandTarpFight, "", null, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+			simpleChoices("Fight", startSandTarpFight, "", null, "", null, "", null, "Leave", explorer.done);
 		}
-		//Speed check fail: 
+		//Speed check fail:
 		else {
 			outputText("\n\nYou don't move quickly enough, however, and you may as well be running on the spot; the edge of the pit recedes as the fluid sand carries you downwards.  You struggle upright as best you can and ready yourself to fight the sandtrap, which is leering at you hungrily from the bottom of its vast pit.");
 			outputText("\n\n\"<i>Only a matter of time now, little ant,</i>\" it says huskily, in its fluttering, buzzing voice.  You will have to defeat it in order to escape, and before it pulls you to the bottom!");
@@ -74,14 +74,14 @@ public function encounterASandTarp():void {
 private function saveTheSandTarps():void {
 	clearOutput();
 	spriteSelect(SpriteDb.s_sandtrap);
-	//(femininity <= 65): 
+	//(femininity <= 65):
 	if(player.femininity <= 65) {
 		outputText("You carefully kneel at the edge of the quicksand and stretch your hand out towards the stricken woman, commanding her to grab hold.   With effort she pulls an arm clear of the treacherous powder and, straining, reaches out to grab the very tips of your fingers... before, with a triumphant sneer, pulling as hard as she can.  Thrown off-balance, you fall face-first into the quicksand.  Coughing, you right yourself and struggle desperately to get back up the side, but you have no leverage, and your thrashing causes you to sink waist deep into what feels like dry, impossibly heavy water.");
 		outputText("\n\n\"<i>Don't struggle,</i>\" says the woman, drifting further away from you as easily as if she were swimming.  You can see a second collarbone flexing beneath her first as her arms rest easily upon the surface, a whole second pair of limbs doing the delicate balancing work, and she speaks in a buzzing, fluttering voice, which is nothing like the one she enticed you into her trap with.  She smiles at you - or at least displays her teeth - and with a kind of horror you watch two sets of small, black eyes open on either side of her first pair to stare at you hungrily.  \"<i>Don't you know struggling just makes it worse?  Just relax.  Let me do all the work.</i>\"");
 		outputText("\n\nA rumbling, hissing sound fills your ears and the dunes surrounding you lift out of sight as all the sand in the hollow begins to run downwards, taking you with it.  You fight against it desperately, but you cannot swim up a landslide and within moments you find yourself buried up to your neck at the bottom of a huge, conical depression, eyes level with the naked abdomen of your captor.  You cough, spit and blink sand away and stare helplessly up at it.  The creature has a long, slim human upper half with four arms and a pair of flat breasts; its twenty slender fingers stroke your face, brush you off and massage your [chest] as it allows you to take it in.  With its glamour gone you can see clearly the six eyed creature is in fact male... or is it?  Its long face is soft around the edges with a cute, pointed chin, which is very pretty - or very handsome.  Every time the creature moves its face its gender seems to shift.  Unnerved, you look downwards, and wish you hadn't.  Although its lower half is obscured below the sand, you can see that below its waist the creature's body balloons outwards into what must be a massive, sand-colored insect thorax.  You feel something brush against you and you instinctively attempt to flinch, but you can't.  The sand feels packed against you, and straining every muscle you have to free your limbs gets you nowhere.  Gently, the creature slides its fingers behind your neck and makes you look into its black eyes.");
 		outputText("\n\n\"<i>You made it all too easy for me, little ant,</i>\" it says pityingly.  \"<i>Did no one warn you about sandtraps?</i>\"  Slowly it sinks downwards, and whilst it fondles your face you feel its other set of hands cup your [butt].  \"<i>Never mind,</i>\" the insect monster sighs into your forehead in its fluttery voice.  \"<i>I'll teach you everything there is to know.</i>\"");
 	}
-	//(else fem > 65): 
+	//(else fem > 65):
 	else {
 		outputText("You carefully kneel at the edge of the quicksand and stretch your hand out towards the stricken man, commanding him to grab hold.   With effort he pulls an arm clear of the treacherous powder and, straining, reaches out to grab the very tips of your fingers... before, with a triumphant sneer, pulling as hard as he can.  Thrown off-balance, you fall face-first into the quicksand.  Coughing, you right yourself and struggle desperately to get back up the side, but you have no leverage, and your thrashing causes you to sink waist deep into what feels like dry, impossibly heavy water.");
 		outputText("\n\n\"<i>Don't struggle,</i>\" says the man, drifting further away from you as easily as if he were swimming.  You can see a second collarbone flexing beneath his first as his arms rest easily upon the surface, a whole second pair of limbs doing the delicate balancing work, and he speaks in a buzzing, fluttering voice, which is nothing like the one he enticed you into his trap with.  He smiles at you - or at least displays his teeth - and with a kind of horror you watch two sets of small, black eyes open on either side of his first pair to stare at you hungrily.  \"<i>Don't you know struggling just makes it worse?  Just relax.  Let me do all the work.</i>\" ");
@@ -93,7 +93,7 @@ private function saveTheSandTarps():void {
 	doNext(playerMenu);
 }
 
-//[Don't Save]: 
+//[Don't Save]:
 private function dontSaveTheTarps():void {
 	clearOutput();
 	spriteSelect(SpriteDb.s_sandtrap);
@@ -105,7 +105,7 @@ private function dontSaveTheTarps():void {
 	else outputText("he");
 	outputText(" cries, neck sinking into the drift.  \"<i>Don't let me die like this... oh, very well.  Have it YOUR way!</i>\"  The ");
 	if(player.femininity <= 65) outputText("woman");
-	else outputText("man"); 
+	else outputText("man");
 	outputText(" suddenly thrusts upwards and plunges a fist into the fluid sand surrounding ");
 	if(player.femininity <= 65) outputText("her");
 	else outputText("him");
@@ -118,7 +118,7 @@ private function dontSaveTheTarps():void {
 	outputText(" midriff exposed and glamour gone, the creature looks quite different; six eyes as black as its hair look at you hungrily from its beautiful androgynous face, whilst four slender arms trail patterns in the sand around its willowy, flat-chested midsection.  It wriggles its body tauntingly at you, making the sand beneath it move ponderously.  You glimpse insect chitin beneath its flat humanoid belly; the buried half of this creature must be monstrous.");
 	outputText("\n\n\"<i>You aren't as slow as you look, little ant,</i>\" it calls up to you, grinning slyly.  It speaks in a buzzing, fluttering voice which is nothing like the one it attempted to entice you into its trap with.  \"<i>Why don't you come down here and dance for me some more?  I'm sure a quick, strong traveller like you could run rings around a simple little sandtrap like me.</i>\"  If you're going to fight this creature, you will have to step into its treacherous hollow to get in range, which is surely its intention - if you try launching things at it from where you are, it will probably just hide itself.  On the other hand, it would be easy to just ignore its taunts and walk away.");
 	//[Fight]/[Leave]
-	simpleChoices("Fight", startSandTarpFight, "", null, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+	simpleChoices("Fight", startSandTarpFight, "", null, "", null, "", null, "Leave", explorer.done);
 }
 
 
@@ -141,7 +141,7 @@ public function sandtrapmentLoss(clear:Boolean = false):void {
 	else outputText("\n\n");
 	spriteSelect(SpriteDb.s_sandtrap);
 	if(sandTrap.trapLevel() == 1) outputText("You are sunk to your belly in the depthless sand at the bottom of the pit, and are still falling fast.  The sun above you is blotted out by a shape which leans downwards towards you, smiling triumphantly.  Desperately, you try to keep your arms free so you can swing a blow at it, but with consummate ease, the sandtrap grabs your wrists with one set of hands while pushing you downwards with the others.  Within moments you are up to your armpits in the stuff, staring helplessly up at the strange androgynous creature who has you entirely at its mercy.");
-	//PC lust loss: 
+	//PC lust loss:
 	else outputText("You feel as radiant and molten as the sun above you... you just want to sink into the warm sand surrounding you forever.  Why are you struggling against it again?  You can't remember; with a sigh, you fall backwards onto the soft powder and allow yourself to be carried right down to the bottom.  The sandtrap chuckles softly as it envelops you in its waiting arms.  \"<i>Good " + player.mf("boy","girl") + "...</i>\"");
 
 	if (sceneHunter.uniHerms) {
@@ -160,15 +160,15 @@ internal function pcBeatsATrap():void {
 	clearOutput();
 	spriteSelect(SpriteDb.s_sandtrap);
 	flags[kFLAGS.SANDTRAP_LOSS_REPEATS] = 0;
-	//PC HP victory: 
+	//PC HP victory:
 	if(monster.HP <= monster.minHP()) outputText("The sandtrap groans and collapses forwards into the dirt.  With the creature no longer controlling it, the sand underneath you feels a great deal more stable... climbing out won't be too difficult.");
-	//PC lust victory: 
+	//PC lust victory:
 	else outputText("The sand around you stops sinking.  Overpowered with lust, the sandtrap moans and gives up control over itself and its pit to desperately run one set of hands over its flat chest whilst the other pushes into the sand to masturbate... whatever it has down there.  With your foe in this state, climbing out won't be so difficult now.");
-	//additional victory sentence if PC lust over 30: 
+	//additional victory sentence if PC lust over 30:
 	if (player.lust >= 33) {
 		outputText("\n\nBefore you go, you take in the helpless body of your would-be ambusher.  What do you do?");
 		menu();
-		if (player.isNaga() && player.hasStatusEffect(StatusEffects.Naga) && player.gender > 0 && player.faceType == Face.SNAKE_FANGS) 
+		if (player.isNaga() && player.hasStatusEffect(StatusEffects.Naga) && player.gender > 0 && player.faceType == Face.SNAKE_FANGS)
             addButton(0, "Naga3Some", nagaThreesomeWithSandTrap);
         else    addButtonDisabled(0, "???", "Requires naga lower body, naga fangs, and to have a certain Naga lover. (not genderless)")
 		addButtonIfTrue(1, "UseYourCock", stickWangInSandgina, "Req. to be strong enough (>60) and have a dick", player.hasCock() && player.str >= 60);
@@ -191,15 +191,15 @@ private function dickwieldersLoseToSandTarps():void {
 	outputText("\n\nThe cock prong slides into your mouth and past your teeth with ease, already dripping with its strange, clear lubicrant.  Sighing dreamily, the sandtrap slowly pushes half of its length into your mouth before pulling itself back out, then in again, picking up a gentle rhythm, each time pushing a bit more of itself into your mouth.  Soon it is stretching your lips wide as it takes you right to its thick base, its tip finding the back of your throat.  It groans and you feel your mouth fill with its oil; rather than ejaculate, the sandtrap's cock seems to perspire its odorless payload from all sides.  The stuff swabs and swathes your mouth in warmth; it makes your lips, the inside of your cheeks and your tongue feel relaxed, accepting and soft.  It feels like your mouth was made to take and enjoy this creature's cock... you begin to suckle the sandtrap eagerly, hoping for more.  Sighing at your greed, the creature pushes as much of itself as it can down your throat, leaking oil deliriously as it does.  Your lips stretched wide by the base of its prong, you can't help but dribble oil down your front even as you inadvertently swallow a great deal of its warm, coating ooze.");
 	
 	outputText("\n\nYou feel flutters spread throughout you, penetrating your core.  The rest of your body begins to feel just like your mouth; languid, sensual and submissive.  The sands encompassing you feel like the most comfortable straitjacket imaginable, and you close your eyes again as [eachCock] begins to harden.  It hazily occurs to you that the sensation of your cock hardening in the sand should irritate you, but in effect it doesn't; below you the substance feels more like packed mud, and the feeling of your length sliding through the yielding, enveloping dirt is incredibly pleasurable.  You actually smile dreamily around the prong stuffing your face when you feel something hot and wet press insistently against the tip of your [cock].   The sand massages every inch of your body as below the surface the sandtrap begins to sink its insect cunt down your sensitive shaft.");
-	//[Less than 6 inches:  
+	//[Less than 6 inches:
 	if(player.cocks[0].cockLength < 6) outputText("\n\nThe creature looks down in surprise at you when its dripping, grasping sex reaches the base of your cock so quickly.  You feel a familiar sense of shame creeping across your cheeks... but the sandtrap uses the two hands grasping your head to stroke your brow and face with odd tenderness.  \"<i>Yyou do not like being all man, do you?  Perhaps little ant likes fooling mates with its looks, too.  Perhaps little ant is more like sandtrap than I thought.</i>\"  You look up at it, its prong still buried in your face, to see an odd look of hunger in its six eyes.  \"<i>Do not worry,</i>\" it says, smiling widely.  \"<i>Hyou are perfect to me.</i>\"  It begins to slowly work your small shaft, its pulsing muscles squeezing you possessively up and down.");
-	//6 inches to 15: 
+	//6 inches to 15:
 	else if(player.cocks[0].cockLength < 15) outputText("\n\nThe creature owns an incredibly tight sex, which grasps you possessively once it is on you; it fits your cock like a glove.  The sandtrap sighs its fluttering sigh when it reaches your base and then slowly begins to work you, its punishing, pulsing muscles squeezing your cock up and down.");
-	//More than 15 inches: 
+	//More than 15 inches:
 	else outputText("\n\nThe creature owns an incredibly tight sex, which grasps you possessively once it is on you.  Sweat beads the sandtrap's elegant brow as it forces itself brutally down your huge shaft; when it finally stops with a sizable portion of your [cock] inside it and draws back slightly, it feels like it is going to suck the cum right out of you.  It slowly begins to work what it can of you, its punishing, pulsing muscles squeezing your cock up and down.");
 	
 	outputText("\n\nThe sandtrap caresses your face tenderly as you suck its pseudo-cock while below the sand it assiduously begins to milk you.  You are pushed further into the hopelessly relaxed sex daze the creature's warm oil has instilled in you; it feels like the sand itself is moving with the creature, massaging your body in waves at the same gentle rhythm as the creature fucks your face and cock.  You can't keep track of time; there is only the sensation inundating your mouth, your body and [cock], the sandtrap's gentle sighs, and the hiss and crunch of the sand itself.  Eventually the sandtrap begins to pick up the pace; it shoves your face into its groin as it begins to pant with need, stretching your mouth wide again as it begins to milk your cock as hard as it can.  Its vaginal muscles grip you tightly, rippling up and down your length; it feels like you are being fucked by a wet, grasping tube.  You can't possibly contain yourself against the creature who has sunk you into such glorious submission and, groaning around its prong, you spurt everything you can give into that clenching warmth.");
-	//[High cum: 
+	//[High cum:
 	if(player.cumQ() > 1000) outputText("  The sandtrap gasps and coos as you ejaculate over and over again, and beneath you feel your cum wet the sands as it beads around the clenching grip it has you in.");
 	if(player.hasVagina()) outputText("  Ignored entirely, your " + player.vaginaDescript(0) + " quivers and orgasms in tandem, flexing and wetting fruitlessly against the dry water pressing against it.");
 	
@@ -270,7 +270,7 @@ private function genderlessLoss():void {
 	outputText("\n\nThe sandtrap holds your hands whilst it pushes you further down with its other set of arms, until only your head is above the sand.  Below the surface you try to weakly move your limbs, try to work yourself out of this situation but it is impossible; the sand feels impossibly heavy and is packed against you.  The sandtrap seems to have no such difficulty.  It towers above you, moving with sinuous grace.  You feel something wet touch your thigh and you try to flinch, but aside from flexing your muscles you cannot move.");
     if (player.gender == 0) {
         outputText("\n\n\"<i>Hwhat a strange creature you arrrhe,</i>\" says the sandtrap, looking at you with vague bafflement as it gently strokes your face.  It seems the more excited it gets and the less it feels the need to pretend, the more fluttery and broken its voice becomes; it is like you are listening to a hive of bees that just happens to be forming words.  ");
-        //(Trap has fertilised eggs: 
+        //(Trap has fertilised eggs:
         if(monster.hasStatusEffect(StatusEffects.Fertilized)) outputText("\"<i>Not a worker OR a drone! Wwwell, that isz ok.  Even ants who hhhave nothing can be someone for somebody.  And hhyou can be mommy for my childrrhen!</i>\"");
         else outputText("\"<i>Not a worker OR a drone! Wwwell, that isz ok.  Hwwe can still have fun, can't we?</i>\"");
     }
@@ -309,19 +309,19 @@ private function sandTrapPregChance():void {
 public function birfSandTarps():void {
 	spriteSelect(SpriteDb.s_sandtrap);
 	outputText("\nYour eyes widen as a gout of oil suddenly gushes from your ass.  Before panic can set in, an incredible light-headedness overtakes you.  Dreamily, you discard your [armor] and squat.  More oil oozes out of you, and in your hazy euphoria, you scoop some of it up and rub it dreamily into your " + nippleDescript(0) + "s.  Part of you is disgusted at yourself, questioning what you are doing, but that is one voice in a million-strong chorus crooning you into total relaxation... the oil clings to your skin and seems to radiate warmth and softness.  Something round stretches your rectum wide, but in your state the sensation is practically orgasmic.");
-	//[Male: 
+	//[Male:
 	if(player.gender == 1) {
 		outputText("  You roll your eyes to the sky and moan, [eachCock] growing hard as you push out the egg.");
 		//[(mans and qualified horses only)]
 		if(!player.isTaur() || (player.tallness * (5/6) < player.cocks[player.longestCock()].cockLength)) outputText("  Your oily hands descend upon your cock, and you massage your shaft as you feel the pressure in your bowels intensify again.");
 	}
-	//Female: 
+	//Female:
 	else if(player.gender == 2) {
 		outputText("  You roll your eyes to the sky and moan, your " + vaginaDescript(0) + " moistening as you push out the egg.");
 		//[(no fukken horses from here)]
 		if(!player.isTaur()) outputText("  Your oily hands push softly into your cleft, fingering your needy " + player.clitDescript() + " as you feel the pressure in your bowels intensify again.");
 	}
-	//Herm: 
+	//Herm:
 	else if(player.gender == 3) {
 		outputText("  You roll your eyes to the sky and moan, [eachCock] growing hard and your [vagina] moistening as you push out the egg.");
 		//[(no horses)]
@@ -333,9 +333,9 @@ public function birfSandTarps():void {
 	
 	//Libido <30:
 	if(player.lib < 33) outputText("\n\nYou pick yourself up wearily, flap the flytraps you have birthed away and make your way back to camp.  This whole experience has been deeply unnerving, and you vow to make sure you don't have to repeat it.");
-	//Libido 30-65: 
+	//Libido 30-65:
 	else if(player.lib < 66) outputText("\n\nYou spend a moment enjoying your post-natal haze, then haul yourself out of it, flap the flytraps you have birthed away, and make your way back to camp.  Though this experience has been deeply unnerving, you can't help but acknowledge it has also been incredibly erotic.");
-	//Libido >65: 
+	//Libido >65:
 	else outputText("\n\nYou smile lazily, then lie back and glory in the sensual haze the oil has left you in.  After you have spent many minutes lying listening to the happy twittering of your flytrap children above you, you reluctantly get up.  You only hope that you get to experience the unearthly wonder of birthing these strange creatures again, and again, and again.");
 	player.buttChange(25,true,true,false);
 	outputText("\n");
@@ -365,24 +365,24 @@ private function useSandTarpsHands():void {
 
         sceneHunter.print("Details for different cock lengths and multicock up to 5");
         outputText("\n\nOne pair of the creature's hands slowly brush up your inner thighs whilst the other two feel around your [armor], clumsily loosening clasps and belts as it finds them.  One hand locates [oneCock] and, after pausing for a split second, slides its fingers around your shaft and begins to slowly rub up and down.  You sigh as you quickly harden in the creature's smooth, dry, enveloping grasp.  You look into the sandtrap's face as it works; blushing, it looks down from your gaze and concentrates upon what it is doing.  It begins to pump you faster and you hiss slightly at the abrasion this causes.  The sandtrap makes a throaty sound.  Curiously you look down in time to see it bring its other pair of hands up to its mouth and deposit a great dollop of clear ooze into its cupped palms.  Your disgust turns to delight as it swaps its hands and begins to massage its oil into your length, the warm lubricant allowing the creatures' fingers to glide around your shaft and head like they were made of silk.  Tentatively the creature uses its other hands to cup your [butt] and really gets to work on you.");
-		//Cock less than 6 inches: 
+		//Cock less than 6 inches:
 		if(player.longestCockLength() < 6) {
 			// balls:
 			if(player.balls == 0) outputText("\n\nThe sandtrap only needs one hand to pump your diminutive cock; it barely moves its wrist as it jerks you, occasionally wriggling its oily fingers along the bottom of your [cock "+x1[0]+"] to stimulate you even further.");
 			else outputText("\n\nThe sandtrap only needs one hand to pump your diminutive cock; it barely moves its wrist as it jerks you, occasionally wriggling its oily fingers along the bottom of your [cock "+x1[0]+"] to incite you even further, whilst it uses its free hand to gently cup your [balls].");
 			outputText("  Your small size doesn't seem to bother it; if anything, judging from the red rising in its thin cheeks and its shortening breath, the girliness of your cock actually seems to excite it.  It pauses and, whilst you are both panting lightly, it slowly and gently circles your head with its index finger whilst it still holds the entirety of your cock with the rest of its hand.");
 		}
-		//Cock 6-16 inches: 
+		//Cock 6-16 inches:
 		else if(player.longestCockLength() < 16) {
 			//[no balls:
 			if(player.balls == 0) outputText("\n\nThe sandtrap glides its hand up and down your [cock "+x1[0]+"], picking up a warm smooth rhythm.");
 			//Balls:
 			else outputText("\n\nThe sandtrap glides its hand up and down your [cock "+x1[0]+"], picking up a warm smooth rhythm as it gently cups your [balls] with its free hand. It slows down intermittently to move its palm around your length, letting every inch of your dick feel the tips of its delicate fingers.");
 		}
-		//Cock more than 16 inches: 
+		//Cock more than 16 inches:
 		else outputText("\n\nThe sandtrap quickly comes to the realisation it needs both hands for this.  Still cupping your behind, it moves one oily hand up the top end of your massive shaft, while the other works the other half.  You sigh with deep satisfaction, enjoying the all-too-rare sensation of having every inch of your [cock "+x1[0]+"] immersed in pleasure.  The creature screws its face up and looks away in distaste at the size of your straining dick, which is in danger of poking it in the nose.  As you enjoy the warm, slippery sensation inundating you, you find you couldn't care less what it thinks.");
 		//number of cock fork
-		//One cock: 
+		//One cock:
         switch(player.cockTotal()) {
         case 1:
             outputText("  The sandtrap pumps you faster and faster until its slippery hands are a blur of motion.  It clutches onto your butt cheeks so tightly you hazily realize the indents of its slender digits will be with you for hours afterwards.");
@@ -425,14 +425,14 @@ private function useSandTarpsHands():void {
             x1[i] = player.findCock(i+1, -1, -1, "length") + 1;
         sceneHunter.print("Details for different cock lengths and multicock up to 4");
         outputText("\n\nOne pair of the creature's hands slowly brush up your inner thighs whilst the other two feel around your \"<i>armor</i>\", clumsily loosening clasps and belts as it finds them.  One hand finds your [cock "+x1[0]+"] and, after pausing for a split second, slides its fingers around your shaft and begins to slowly rub up and down.  You sigh as you quickly harden in the creature's smooth, dry, enveloping grasp.  You look into the sandtrap's face as it works; blushing, it looks down from your gaze and concentrates upon what it is doing.  It begins to pump you faster and you hiss slightly at the abrasion this causes.  At this the sandtrap makes a throaty sound.  Curiously you look down in time to see it bring its other pair of hands up to its mouth and deposit a great dollop of clear ooze into its cupped palms.  Your disgust turns to delight as it swaps its hands and begins to massage its oil into your length, the warm lubricant allowing the creatures' fingers to glide around your shaft and head like they were made of silk.  As it moves its first hand up and down, it tentatively moves its second further between your legs.  It finds your [vagina] and, after pausing for a split second, slides its slender fingers into your moistness.  Although it is clumsy at first, the oil which coats its digits make them glide over your shaft and labia as if they were entirely frictionless.  It quickly gains confidence and begins to gently frig you as it slides its warm, slippery grasp up and down your [cock "+x1[0]+"], circling your [clit] whilst occasionally dipping into your dripping hole.  You sigh and begin to lose yourself in the wet, silky sensation.");
-		//Cock less than 6 inches:  
+		//Cock less than 6 inches:
 		if(player.longestCockLength() < 6) {
-			//[no balls: 
+			//[no balls:
 			if(player.balls == 0) outputText("\n\nThe sandtrap only needs one hand to pump your diminutive cock; it barely moves its wrist as it jerks you, occasionally wriggling its oily fingers along the bottom of your [cock "+x1[0]+"] to stimulate you even further.");
 			else outputText("\n\nThe sandtrap only needs one hand to pump your diminutive cock; it barely moves its wrist as it jerks you, occasionally wriggling its oily fingers along the bottom of your [cock "+x1[0]+"] to incite you even further, whilst it uses its free hand to gently cup your [balls].");
 			outputText("  Your small size doesn't seem to bother it; if anything, judging from the red rising in its thin cheeks and its shortening breath, the girliness of your cock actually seems to excite it.  It pauses and, while you are both panting lightly, it slowly and gently circles your head with its index finger, still holding the entirety of your cock with the rest of its hand.");
 		}
-		//Cock 6-16 inches: 
+		//Cock 6-16 inches:
 		else if (player.longestCockLength() < 16) {
 			if(player.balls == 0) outputText("\n\nThe sandtrap glides its hand up and down your [cock "+x1[0]+"], picking up a warm smooth rhythm.");
 			else outputText("\n\nThe sandtrap glides its hand up and down your [cock "+x1[0]+"], picking up a warm smooth rhythm as it gently cups your [balls] with its free hand.]  It slows down intermittently to move its fingers around your length, letting every inch of your dick feel the tips of its delicate fingers.");
@@ -465,7 +465,7 @@ private function useSandTarpsHands():void {
         sharedEnd();
     }
     function sharedEnd():void {
-        //All sexes go to: 
+        //All sexes go to:
         outputText("\n\nYou sigh with immense satisfaction and step back from the sandtrap.  Taking into account what an excellent job it did you opt not to rub its face in what you have made it do, particularly as you have managed to get quite a bit of your fluids on it anyway.  It watches you, still flushed and mouth slightly ajar, as you leisurely pull your [armor] back on.");
         outputText("\n\n\"<i>Please, lion,</i>\" it manages eventually.  You look at the strange, half-buried creature and notice that spots of fluid are darkening the sand around it; it is evidently perversely turned on by your domineering actions, and you have left it in no way satiated.  You curl your lip into an evil smirk.");
         outputText("\n\n\"<i>Not today, I think,</i>\" you say over your shoulder, as you clamber out of its pit.  \"<i>I think you'll have to try a bit harder if you want to get what you want from this lion.</i>\"  Your smile broadens as a deeply frustrated moan reaches your ears from behind you...");
@@ -487,9 +487,9 @@ private function rideDatSandTarpLikeIts1999():void {
 	outputText("\n\n\"<i>Pleasze...</i>\" the sandtrap manages in a tiny voice.  Its slender cheeks are red and it stares hopelessly into your eyes.  You twist your thighs and very gently tease its tip with your wet opening, before once again coming to an agonising halt.  The trap almost sobs.");
 	outputText("\n\n\"<i>Beg for it!</i>\"");
 	outputText("\n\n\"<i>Pleasze lion!  I hwill do anything for you!  I hhwill do anything to serve your body!  I am hyour slave! Just... pleasze pleasze fuck me!</i>\" it cries out, its fluttering voice in danger of breaking up completely.  You suppose that will do.  Holding the sandtrap down, you sink your wetness down onto its long, thin length with a pleasurable sigh.");
-	//Tight: 
+	//Tight:
 	if(player.vaginalCapacity() < 30) outputText("  Its thin length is a perfect fit for your tight pussy - the slick prong slides against your inner walls like a hand into a silk glove.  After slowly working your [hips] back and forth for a while you quickly pick up a rhythm, until you are ruthlessly bucking its pseudo-penis back towards its face, giggling as you ride the creature for all it is worth.  Its willowy upper body is your plaything and you tweak its pale nipples, stroke its sensitive armpits, anything that will make it flinch and force another cute, fluttering moan out of it.");
-	//Loose: 
+	//Loose:
 	else outputText("  Its thin length is lost in your vast pussy, and you find you have to work your [hips] hard, ruthlessly bucking its pseudo-penis back towards its face, to get what you can from it.  You spare no expense telling it how unsatisfied it leaves you, what a pathetically-sized penis it owns, more like a sissy clit really, and as you do so you tweak its pale nipples, stroke its sensitive armpits, saying or doing anything that will make it flinch and force another cute, fluttering moan out of it.");
 	player.cuntChange(14,true,true,false);
 	outputText("\n\nIt can't last long against your domineering fuck and you are only minutes in when, with a trembling gasp, it thrusts itself upwards and orgasms.  Rather than ejaculate, the sandtrap's cock seems to perspire its odorless payload from all sides; oil drools out of your [vagina].  You swoon at the sensation; the stuff makes you feel like butter in the desert sun, imbuing you with a lazy, radiant sensitivity.  You grip your hips around the trap, plugging as much of the wonderful substance in on its thick base, savoring the softness it brings.  It dreamily occurs to you that whilst the creature is capable of ejaculating, it apparently can't lose its erection; the thing in your cunt is more like a stinger than anything.  This strikes you as a feature to take full advantage of.  You lean downwards and blissfully inform the sandtrap that it came instantly like the sissy it is, and the only way it can make it up to you is giving you everything it's got over the course of the next few merciless hours.  The creature is incapable of responding.  Its thin chest heaves for air as its six eyes roll to the heavens as you begin to slowly buck against it once more.");
@@ -517,16 +517,16 @@ private function stickWangInSandgina():void {
         
         outputText("\n\nWith an air of purposefulness, you step forward and clinch the sandtrap around its abdomen.  It makes a startled, fluttering noise and grabs you instinctively with its four arms as you set your shoulder into it and heave, as if you were preparing to give it a fireman's lift.  With a rumbling, hissing sound, its bulging insect abdomen begins to emerge from the sand.  The sandtrap goes into full panic mode as you progressively winch it clear of its nest, beating its arms weakly against your back as it babbles.");
         outputText("\n\n\"<i>No!  Pleasze don't do that!  Pleasze I, I don't hhwant to be naked!  I'll leave you alone from nowhh on, I'll- I'll make sandcastles for you, juszt sztop...</i>\"  You ignore it, concentrating on the task in hand, and with one final heave pull it completely clear of its hole, spilling it onto the sand.  You catch your breath as you take it in.   Its fawn-coloured teardrop-shaped abdomen must be twice the mass of its human half, every bit as ponderous, leathery and alien as the rest of the creature is graceful, smooth and trim.  And at the very tip of it... a wave of heavy female sex pheromones assaults you as you observe, far more powerful this time, drawing blood from your head inexorably to your genitals.  Its lips and labia are strikingly human looking, bizarre against the leathery exoskeleton from which they protrude, but the vagina itself looks different: less like an opening and more like one end of a tight, fleshy tube.  Despite the creature's continuing babble of protests, it is dripping and ready, miraculously clean of sand.  You brace yourself against the beached trap's warm hide and try to clear your head, which is buzzing with the anticipation of sex.  Are you really going to do this?  <i>Yes.</i>  It's your dick again.  <i>Yes you are.</i>  You close your eyes and, thinking only of the heat in your veins and the pheromones in your nostrils, you grip the sandtrap's abdomen and push your " + player.cockDescript(x) + " into its wet sex.");
-        //8 inches or less: 
+        //8 inches or less:
         if(player.cocks[x].cockLength < 8) {
             outputText("\n\nThe creature's moist cunt is tight and is a perfect fit for your modest cock.  Working yourself slowly backwards and forwards, you sigh as you soon hilt yourself in the warm wet, nowhere near its full depth.");
         }
-        //8 inches to 35: 
+        //8 inches to 35:
         else if(player.cocks[x].cockLength < 35) outputText("\n\nThe creature's moist sex is tight and you have to work your way in carefully, letting it get used to your girth, slowly working it loose enough to take your big cock.  The creature moans as you patiently squeeze more and more of yourself into its warm wet, eventually hilting yourself deep in its depths as it dribbles fluids on the sand at your feet.");
-        //Megacock: 
+        //Megacock:
         else {
             outputText("\n\nThe creature's moist sex is tight and you honestly doubt it can even take your obscenely massive tool.  Never say never, though.  You work your way in carefully, letting it get used to your girth, slowly working it loose enough to take your " + player.cockDescript(x) + ".  The creature gasps and then moans as you patiently squeeze more and more of yourself into its warm wet; its sex may be narrow but it is incredibly long, running perhaps the entire length of its abdomen.  Your cock is more than a match for it however and your breath quickens as you continue thrusting more of yourself in, until it feels like the end of your cock is trapped inside a hot, soft, grasping drainpipe.  \"<i>Hhhhwhat even is that?</i>\" squeaks the panting, peering sandtrap, in a tone somewhere between terror and awe.  \"<i>Yyour leg?  Hwhat kind of monszter even are you?</i>\"  You're not taking that from an androgynous insect chimera.  You respond by giving it one last savage, triumphant push, bottoming out in the sandtrap's egg sac.");
-            //[Balls and cocklength >= 40:  
+            //[Balls and cocklength >= 40:
             if(player.hasBalls()) outputText("  Your [balls] slap against the creature's wet opening.  ");
             outputText("  Any coherence flies straight out of the sandtrap's head and it can do nothing but whine, buzz and moan as you begin to thrust in and out of it, penetrating it to its very core, the [cockHead] bumping against strange bulbous objects which give and push back against your sensitive end delightfully.");
         }
@@ -553,13 +553,13 @@ private function nagaThreesomeWithSandTrap():void {
 	spriteSelect(SpriteDb.s_sandtrap);
 	//Requirements: Player is naga with tail and fangs, has met desert naga as naga at least once
 	outputText("You slowly slither down to the bottom of the pit, your long patterned tail undulating in the sand, until you are by the sandtrap's side.  There is a mixture of fear and lust in its eyes as it regards your sinuous form; you slowly prise yourself out of your [armor].  You're not quite sure what you want to do with your lean, tender prize yet, so you follow what your snake instincts, speaking to you in the warm hush of your scales brushing through the sand, tell you to do.  The sandtrap murmurs in disquiet as you pass yourself around its willowy upper body, your tail looping first its abdomen and then its flat breasts, strong, muscular coils easily overcoming the struggles of its four thin arms.  Soon its upper frame is swaddled in your lower body.  It scowls at you and you beam back, displaying your fangs, enjoying the sight and feeling of this former aggressor entirely at your mercy.");
-	//First encounter: 
+	//First encounter:
 	if(flags[kFLAGS.SANDTRAP_NAGA_3SOME] == 0) {
 		outputText("\n\nA small cough from above you makes you start.  Looking up you are startled to see the desert naga peering down at the two of you.  Anxiety vies with amusement on her face.");
 		outputText("\n\n\"<i>I heard fighting and I heard you,</i>\" she says, in your lonely, shared tongue.  \"<i>I thought you might need help.</i>\"  She gestures with disdain at the creature held in your coils, the six eyes of whom are bulging with fright at the sight of the pair of you.  \"<i>I have encountered these creatures before.  They do... bad things if you let them surprise you.</i>\"  She twists her mouth, and you do the math yourself.");
 		outputText("\n\nAs you languidly corkscrewing your coils around your prize, you ask the Naga if she's in the mood for revenge against all the bad things he's done.  She blinks, and then smiles warmly.  \"<i>We </i>are<i> of one blood, you and I,</i>\" she says fondly, as she slowly slides down to join you.");
 	}
-	//Repeat encounter: 
+	//Repeat encounter:
 	else {
 		outputText("\n\nYou look up and are somehow unsurprised to see that whilst you were twining yourself around the sandtrap, you gained a spectator.  You look into the eyes of the desert naga seated above you and the two of you smile; there's no need for words.  She sinuously descends into the pit, the sandtrap moaning in its fluttery voice at the sight of her.");
 	}
@@ -573,15 +573,15 @@ private function nagaThreesomeWithSandTrap():void {
 
     //PARTS
     //==================================================================================================
-	//Male/Herm: 
+	//Male/Herm:
 	function dickF():void {
 		outputText("\n\nYou press your hardening [cock] against the creature's lips.  Its eyes still far away, the sandtrap opens its mouth and begins to lavish attention upon your head with its tongue, circling it with gentle pressure whilst giving your urethra the occasional faintest of flicks.  Sighing, you push yourself forward into the creature's soft mouth, its teeth parting to quiescently accept your dick.  At the edge of your concentration you hear a quiet gasp as your snake partner lowers herself slowly down the sandtrap's prong.  The creature's mind may be elsewhere, but its body evidently still understands pleasure; it gives out a muffled moan around your cock, sending pleasurable vibrations down your shaft, before beginning to suckle you in earnest.  The sensation is devilishly strange; you're feeding yourself into the sandtrap's mouth upside down, its tongue lavishing attention upon the upside of your dick.  It moves its tongue around and briefly you press against the incredibly wet and pliable tissue at the bottom of its mouth.  You light-headedly wonder if this isn't just the much better way of doing things.");
-		//[<14 inches: 
+		//[<14 inches:
 		if(player.cocks[0].cockLength < 14) {
 			outputText("\n\nYour [cock] is a good fit for the sandtrap's mouth and soon the creature is taking your whole length, lavishing its oil and saliva into your straining cock, lying its head back and opening its mouth wide so you can begin to piston into its submissive opening with fervor, ");
 			if(player.hasBalls()) outputText("slapping your [balls] into its nose, forcing your cock all the way to the top of its tight throat.");
 		}
-		//14 inches or more: 
+		//14 inches or more:
 		else {
 			outputText("\n\nYour [cock] is bigger than what the sandtrap's mouth can accommodate, and it isn't long before you are beginning to push into the creature's tight throat.  It lavishes its oil and saliva onto your straining cock, lying its head back and opening its mouth as wide as it can to aid you in your task, and soon you are ");
 			if(player.skinType == Skin.PLAIN) outputText("beading sweat, ");
@@ -598,10 +598,10 @@ private function nagaThreesomeWithSandTrap():void {
 	    player.sexReward("saliva","Dick");
         sharedEnd();
 	}
-	//Female: 
+	//Female:
 	function vagF():void {
 		outputText("\n\nYou press your moistening " + player.vaginaDescript(0) + " against the creature's lips.  Its eyes still far away, the sandtrap opens its mouth and pushes its soft tongue into your cleft.  It explores your labia and hole before turning its attention to your " + player.clitDescript() + ", circling it with gentle pressure whilst giving it the occasional faintest of flicks.");
-		//[Squirtr, jotun of flooding: 
+		//[Squirtr, jotun of flooding:
 		if(player.wetness() < 4) outputText("  Its gentle worship of your " + player.vaginaDescript(0) + " soon has you streaming rivulets of girlcum from your oversexed hole, dribbling down the sandtrap's face as you eagerly press yourself down for more.");
 		outputText("  You close your eyes and lose yourself to the delightful sensation, contracting and relaxing the coils wrapped around your prey in time with throbs of pleasure.  At the edge of your concentration you hear a quiet gasp as your snake partner lowers herself slowly down the sandtrap's prong.  The creature's mind may be elsewhere, but its body evidently still understands pleasure; it gives out a muffled moan in your cunt, sending pleasurable vibrations deep into you, before sinking its tongue deep into you, slathering your sex with saliva and oil as it pushes its mouth fully onto you.  You buck against it excitedly, forcing more and more of its tender muscle into you, squealing as you reach an exuberant high, your vagina flexing around the sandtrap's tongue as you reward its attentions with a small waterfall of girlcum.");
 		outputText("\n\nSimmering with pleasure, you lazily work your thighs backwards and forwards, allowing the creature to lick your lips clean whilst still keeping you oiled and purring.  In front of you the naga moans, clear glaze dribbling out of her snatch as she moves sensuously atop the sandtrap's prong; she looks at you with heavy, pheromone-induced lust, her forked tongue flicking out of her mouth.  Your coils rub together over your shared meal's slim body, and you find yourself flicking your own tongue out in tandem with your lover, smiling as you touch one another for the briefest of moments, breathing in the scent of each other's flesh.  Mindlessly, the sandtrap's four arms clutch and stroke the warm scales that swaddle its upper body as the two of you continue to fuck it.");
@@ -632,7 +632,7 @@ private function sandTrapBadEnd():void {
 	outputText("\n\n\"<i>My people have stories about wanderers like you,</i>\" the androgyne says softly, its multiple black eyes looking into your own black orbs.  \"<i>It has been so long since we had such a one as you, and we were so winnowed by the soulless lions of the mountains, that your kind have passed into legend.  Surface scratchers who not only bear our children, but choose to do so willingly; who drink the fluids we gift them to become of our flesh; who come back to our lands time and again, answering a call only they can hear.</i>\"  The creature opens all four of its arms to you, beaming triumphantly.  \"<i>You need only to take the final step, Flytrap.  Come to me, and embrace your desztiny.</i>\"");
 	outputText("\n\nYou stand at the lip of the Sandtrap's hollow, shaking your head, trying to make sense of what it is saying.  It's talking nonsense...isn't it?  Again you feel light-headed, your thoughts a lonely cloud of bees without a hive.  They have no purpose, and the Sandtrap is offering you one... but don't you already have a purpose?  Not as good a purpose as this one.  Not as right a purpose, one that perfectly suits what your body has become...  ");
 	if(player.hasCock()) outputText("[EachCock] hardens and your thin frame feels aflame, barely understood impulses deep within you begging you to walk down and submit to the Sandtrap's will.  ");
-	//Female: 
+	//Female:
 	else if(player.hasVagina()) outputText("Your [vagina] moistens and your thin frame feels aflame, barely understood impulses deep within you begging you to walk down and submit to the Sandtrap's will.  ");
 	outputText("You inhale hard and try to clear your head, forcing yourself not to sleepwalk downwards into the Sandtrap's waiting embrace.  The creature doesn't seem to mind your hesitation; it smiles softly and confidently, waiting for you with the infinite patience of its kind.  You need to make a choice here fast, before your burning body makes it for you.");
 	//Fight/Desztiny/Leave
@@ -643,7 +643,7 @@ private function sandTrapBadEnd():void {
 	
 }
 
-//Fight: 
+//Fight:
 private function sandTrapBadEndFight():void {
 	clearOutput();
 	spriteSelect(SpriteDb.s_sandtrap);
@@ -658,7 +658,7 @@ private function leaveSandTrapBadEnd():void {
 	spriteSelect(SpriteDb.s_sandtrap);
 	outputText("With some effort you break your stare with the Sandtrap, turn away and step back towards camp, resolving to leave this disturbing scenario with its disturbing thoughts behind.");
 	outputText("\n\n\"<i>I understand, Flytrap,</i>\" a calm voice reaches you from behind.  \"<i>You need time to think things over and truly recognise what you are.  I know you will come back.  You always do.</i>\"");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Desztiny:
@@ -666,7 +666,7 @@ private function desztiny():void {
 	clearOutput();
 	spriteSelect(SpriteDb.s_sandtrap);
 	outputText("The Sandtrap is right.  What your body and subconscious are telling you is so right.  At your acceptance of what the creature is saying warmth floods through your body; your mind bubbles as blood rushes towards your skin, making you feel incredibly sensitive, incredibly sexual.  ");
-	//Male: 
+	//Male:
 	if(player.hasCock()) outputText("Your cock strains upwards and you moan; feeling as sensitive as you do, you are both desperate to be touched and desperate not to be.  ");
 	//Female:
 	else if(player.hasVagina()) outputText("You feel but barely hear the drip of moisture on the sand, both your [asshole] and [vagina] beading with oily need.  ");
@@ -683,7 +683,7 @@ private function loseLastFightWithSandTrap():void {
 	sandTrapBadEndFinale();
 }
 
-//Both go to: 
+//Both go to:
 private function sandTrapBadEndFinale():void {
 	spriteSelect(SpriteDb.s_sandtrap);
 	outputText("\n\nIts lips move a slippery friction against yours as it twines its tongue around yours and begins to work glands deep in its gourd, trickling oil into your mouth.  It holds the back of your head kindly yet firmly as it does this, as if it were feeding you, but there is no need for it to apply any pressure at all.  You are nothing but a vessel for it, accepting what it is doing to you without question; you know nothing but the texture of oil and the creature's tongue pushing into you.  Your willingness is rewarded by making the Sandtrap's fluids flow swifter; it smiles against your face before gushing oil into your mouth in a torrent.  At the very edge of your awareness, you feel the sand parting around your feet, of the Sandtrap pushing you slowly downwards, of the delicious feeling of an infinity of warm particles against your \"thighs\"; but this is as nothing to the warm ooze sliding down your throat, intensifying your sensitivity, making you gasp and pull away and gush fluids of your own against the Sandtrap, before being pushed back into its dripping mouth with that insistent, loving pressure.  You drink, and drink, and drink, transfixed by a kiss which is more like suckling at a teat...");

--- a/classes/classes/Scenes/Areas/Desert/SandWitchScene.as
+++ b/classes/classes/Scenes/Areas/Desert/SandWitchScene.as
@@ -109,7 +109,7 @@ public class SandWitchScene extends BaseContent implements TimeAwareInterface {
 				outputText("She smiles wickedly and intones, \"<i>nuf erutuf rof riah ydnas, nus tresed eht sa ydnas.</i>\"\n\nYou feel a tingling in your scalp, and realize your hair has become a sandy blonde!");
 				player.hairColor = "sandy blonde";
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		private function refuseSandWitchMagic():void {
@@ -192,14 +192,14 @@ internal function sandwitchRape():void {
 		cleanupAfterCombat();
 	}
 	//HP DEFEAT
-	else { 
+	else {
 		if(player.biggestTitSize() >= 9 && player.biggestLactation() >= 3) {
 			clearOutput();
 			outputText("You stagger and fall to one knee, too overcome by pain to keep fighting.\n\nAs your vision wavers with exhaustion, the witch strides towards you, seeming to glide across the sand. Your consciousness starts to fade, and you see the exotic woman lick her lips and smile cruelly, staring at your generous breasts.\n\nThe last thing you hear before passing out is a mysterious spell, murmured right into your ear in a low, throaty whisper: \"<i>Evals klim ym emoceb llahs uoy.</i>\"\n\nYou dream of walking proudly through the desert, enormous rack jiggling shamelessly with every step, and of tempting nubile young champions to wrap their lips around your nipples and drink. Your sleep becomes fevered as your dreams grow more and more corrupt - you dream of using dark magic to lactate succubus milk, and of your former friends from Ingnam greedily drinking your enhanced milk until their bellies strain to contain it all, then going wide-eyed as pound after pound of breast-flesh suddenly swells upon their chests...");
 			//BAD END.
 			doNext(sandWitchBadEnd);
 			return;
-		}				
+		}
 		outputText("\n<b>You fall, defeated by the Sand Witch!</b>\n\n");
 		cleanupAfterCombat();
 	}
@@ -355,7 +355,7 @@ private function centaurRide():void {
     //[has breasts]
     if(player.biggestTitSize() > 0) outputText("fondle your [allbreasts] and ");
     outputText("tease your " + nippleDescript(0) + "s, and you can feel her grinding herself against your strong shoulders. ");
-    //[orb penetrated player during combat] 
+    //[orb penetrated player during combat]
     outputText("With a start you realize that the witch's orb is still inside you as it suddenly begins to pulse within your " + player.assholeOrPussy() + ", causing you to cry out and hasten your pace across the dunes. ");
     outputText("You lose track of time and location as you ride, feeling her orgasm over and over against you, her milk pouring down your back and spilling onto the sands. ");
     //[has breasts]
@@ -365,7 +365,7 @@ private function centaurRide():void {
             outputText("Your own " + nippleDescript(0) + "s  are leaking as well, ");
             //[light-med lactation]
             if(player.biggestLactation() < 3) outputText("small streams running out ");
-            //[heavy lactation] 
+            //[heavy lactation]
             else outputText("torrents gushing out ");
             outputText("under her expert hands. ");
         }
@@ -455,7 +455,7 @@ private function centaurDick():void {
     else outputText("Lining up two of your cocks to her twin cunts and another to her anus, you thrust into her without pre-amble.  Her anal muscles try to keep you out, but they are no match for the strength of your legs.  You tear into her, ");
     //part 2
     outputText("eliciting a scream as your hind quarters push her forcefully over the sand. ");
-    //[largest cock is wide] 
+    //[largest cock is wide]
     if(player.cocks[x].cockThickness >= 3)
         outputText("It is hard to believe just how tight she is, though if her cries serve as any indication, she will not be after you are through with her.  Turned on even more, you thrust in with increasing vigor and try to widen her as much as possible. ");
     //[2+ cocks]
@@ -478,9 +478,9 @@ private function centaurDick():void {
     //[largest cock is not wide and/or long]
     else outputText(", and her cries have long since turned into groans of pleasure. ");
     outputText("You cannot hold off your orgasm any longer. Your [cocks] explode" + (cocks == 1 ? "" : "s") + ", ");
-    //[large cum production] 
+    //[large cum production]
     if(player.cumQ() >= 250) outputText("gushing massive amounts of your cum ");
-    //[regular cum production] 
+    //[regular cum production]
     else outputText("pushing your sperm ");
     outputText("deep into her ");
     //[1 cock, tentacle]
@@ -497,7 +497,7 @@ private function centaurDick():void {
 
 private function centaurVA_start():void {
     outputText("Finished with your games ");
-    //[has cunt] 
+    //[has cunt]
     if(player.hasVagina()) outputText("and your " + vaginaDescript(0) + " dripping with desire");
     outputText(", you push the witch unceremoniously to the ground and deliver a slap to her breasts.  She cries out in pain as milk splashes out onto the sand.  A cruel smile is brought to your face and you start slapping them even harder, alternatively smacking her pair of cunts for good measure.  Surprisingly, her cries of pain begin to turn into moans of pleasure with every slap.  She might even be pushing into the blows slightly, though it is difficult to tell.  After a sizable pool of milk and her juices has drained into the sands beneath her, you reach down and start to drive your fingers hard into one of the sand witch's cunts.  The first few thrusts are enough to violently bring her to orgasm.  You trot forward slowly until you are over her and the witch suddenly hops up. Driving her face into your ");
 }
@@ -509,7 +509,7 @@ private function centaurVag():void {
     if(player.vaginalCapacity() < 10) outputText("one of her fingers ");
     //[cunt size is normal]
     else if(player.vaginalCapacity() < 20) outputText("several of her fingers ");
-    //[cunt size is large] 
+    //[cunt size is large]
     else outputText("a fist ");
     outputText("pushing deep into your " + vaginaDescript(0) + ", and you're surprised as ");
     //[anus size is small]
@@ -596,7 +596,7 @@ public function sexMenu():void {
     outputText("\n\n<b>SceneHunter: Taur scenes reworked too - more options with UniHerms!</b>");
     //menu
     //because corrupt scenes are REALLY rough here. 2/3 is fair IMO
-    var lowCor:Boolean = player.cor < 66 + player.corruptionTolerance; 
+    var lowCor:Boolean = player.cor < 66 + player.corruptionTolerance;
     var hiCor:Boolean = player.cor >= 66 - player.corruptionTolerance;
     //pure options
     addButtonIfTrue(0, "Sex", sandwitchSex, "Req. cock and low corruption", lowCor && player.hasCock());
@@ -740,13 +740,13 @@ private function missingoSex6():void {
 
 	outputText("It is like fucking christmas up in here.");
 	//{Player gains about as many gems experience points as they would from a Sand Witch encounter, and the Champion is returned to camp.}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
 //Either type on Sandwich: Finished (Radar)(edited)
 //Display standard victory dialogue, yadda yadda, etc
-//[Sex]----> [sex options here]   [Oviposition] 
+//[Sex]----> [sex options here]   [Oviposition]
 private function ovipositSandWitches():void {
 	clearOutput();
 	outputText("As you glance down at the ");
@@ -756,7 +756,7 @@ private function ovipositSandWitches():void {
 	if(monster.HP <= monster.minHP()) outputText("fright as she clamors to get away.");
 	else outputText("an uneasy curiosity to see what exactly you have planned.");
 	
-	//PC won through HP victory: 
+	//PC won through HP victory:
 	if(monster.HP <= monster.minHP()) outputText("\n\nRolling your eyes, you offer a sympathetic hand to the defeated witch, showing her that you don't mean to hurt her any further, that you have something more... pleasurable in mind.  ");
 	outputText("The sand witch slows to a dead stop as she assesses your intentions, which are made all the more clear as you disrobe and toss your [armor] aside, exposing your ");
 	if(player.hasCock()) outputText("hardened  " + multiCockDescriptLight());
@@ -804,7 +804,7 @@ private function eggwitchForeplay():void {
 //[Get Fucking]
 private function getToFuckingWithZeEggsInWitch():void {
 	clearOutput();
-	//[PC corruption is less than 60: 
+	//[PC corruption is less than 60:
 	if(player.cor < 66) {
 		outputText("While you understand her reservation about being abruptly turned into a host for your young, you know that the experience can be mutually euphoric.  You descend upon the prone sand witch, taking her into a gentle embrace to soothe her uneasiness, and whisper to her that you understand her concern, but ask her to give this a chance.  Her apprehension evaporates slightly at your soft words, but quickly flares up again when she spots the wavering ovipositor that dangles hungrily behind you.  Hastily, you assure her that she'll enjoy the experience, before planting a passionate kiss on the sand witch's soft lips.");
 	
@@ -938,8 +938,8 @@ private function helpZeWithBirfBabies():void {
 	
 	//Body check
 	//no, not like in hockey
-	//PC has a centaur body, or other body capable of carrying the sand witch:  
-	//"W-what the hell did you do to yourself over the last few days?" the sand witch blurts, noticing the 
+	//PC has a centaur body, or other body capable of carrying the sand witch:
+	//"W-what the hell did you do to yourself over the last few days?" the sand witch blurts, noticing the
 	//difference in your appearance since the union with wide eyes.  The words are cut off, however, as she doubles over in pain. (transitions to PC is a drider/centaur/whatever scene)
 	if(!player.isDrider()) outputText("\n\n\"<i>W-what the hell did you do to yourself over the last few days?</i>\" the sand witch blurts, noticing the difference in your appearance since your union.  The words that come out of her mouth next are cut off however, as she doubles over in pain.");
 	
@@ -952,7 +952,7 @@ private function helpZeWithBirfBabies():void {
 		else outputText("gallop");
 		outputText(" across the dry desert sea...");
 	}
-	//PC is everything else: 
+	//PC is everything else:
 	else outputText("\n\nEasing a hand under her armpit, you give her the support she needs to hobble along the hot desert sand.  Which direction to hobble in gives you cause for concern though; you don't really know where you are at this point.  Making the only choice you can, you concentrate on the camp.  With the rough picture in mind you tell the sand witch to hold on, before the two of you slowly make your way across the dry desert sea...");
 	doNext(sandwitchBirthsYourMonstrosities, false);
 }
@@ -962,10 +962,10 @@ private function reluctantlyHelpZeWitch():void {
 	outputText("\n\nGreat.  Of all the things you could be doing, you get stuck helping this twit out.  Why she couldn't have just stayed home or gone to the swamp is beyond you at this point - you grumble at your misfortune, helping the bearer of your young to rise to her feet.");
 	
 	//body fork
-	//PC has a centaur body, or other body capable of carrying the sand witch: 
+	//PC has a centaur body, or other body capable of carrying the sand witch:
 	if(!player.isDrider()) outputText("\n\n\"<i>W-what the hell did you do to yourself over the last few days?</i>\" the sand witch blurts, noticing the difference in your appearance since your union.  The words that come out of her mouth next are cut off however, as she doubles over in pain.  Well, not like you needed any guff from a woman with four tits and multiple cunts.");
 
-	//PC is a drider/centaur/whatever:  
+	//PC is a drider/centaur/whatever:
 	if(player.isDrider() || player.isTaur()) {
 		outputText("\n\n\"<i>I-I can't get up, it hurts too much!</i>\" she cries out, despairing of making it somewhere safe it in time, and that your children will be born and die out here, all in the same day.  Annoyed at her lack of common sense, you tell her to get on your back, sinking to the ground to allow her to hobble up.");
 		outputText("\n\n\"<i>Please, not too fast!</i>\" she calls out, clearly trying her best to not have the labors of your lust right here and now.  You'll be goddamned furious if she ends up having the kids right here and now; it's a bear to clean parts of you when your arms can't reach them!  Rising to your feet, you attempt to recall which direction to go, only to realize that you're lost.  Even better- well, actually, it doesn't matter.  Concentrating on the camp, you yell at the sand witch to hold on, then ");
@@ -973,8 +973,9 @@ private function reluctantlyHelpZeWitch():void {
 		else outputText("gallop");
 		outputText(" across the dry desert sea...");
 	}
-	//PC is everything else:  
+	//PC is everything else:
 	else outputText("\n\nEasing a hand under her armpit, you give her the support she needs to hobble along the hot desert sand.  Which direction to hobble in gives you cause for concern though; you don't really know where you are at this point.  Making the only choice you can, you concentrate on the camp.  With the rough picture in mind you tell the sand witch to hold on, before the two of you slowly make your way across the dry desert sea...");
+	explorer.stopExploring();
 	doNext(sandwitchBirthsYourMonstrosities, true);
 }
 
@@ -1010,7 +1011,7 @@ public function witchBirfsSomeBees():void {
 	
 	outputText("\n\nContent with how things turned out, you head back to camp and decide on the next course of action for today.");
 	pregnancy.knockUpForce(); //Clear Pregnancy
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function sandwitchSpanking():void {

--- a/classes/classes/Scenes/Areas/Desert/Wanderer.as
+++ b/classes/classes/Scenes/Areas/Desert/Wanderer.as
@@ -1,8 +1,8 @@
 ﻿package classes.Scenes.Areas.Desert {
-	import classes.*;
-    import classes.display.SpriteDb;
+import classes.*;
+import classes.display.SpriteDb;
 
-	public class Wanderer extends BaseContent{
+public class Wanderer extends BaseContent{
 
 		public function Wanderer()
 		{
@@ -47,7 +47,7 @@ private function wandererLeave():void {
 	spriteSelect(SpriteDb.s_markus_and_lucia);
 	clearOutput();
 	outputText("Marcus looks disappointed and sighs, hefting his wheelbarrow and waddling away.  Lucia bounces after him, looking like the cat that got the cream.  You wonder what all that was about.   What a strange land.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Repeated encounter if he left
 private function wandererRepeatMeeting():void {
@@ -76,7 +76,7 @@ private function wandererStayHuman():void {
 	outputText("Marcus sighs, though you think you spy the hint of a smile on his lips, \"<i>As you wish... thanks for your guidance traveler, and may you find what you seek in this strange land.</i>\"\n\nAs they turn to leave, Lucia scowls at you over her shoulder...");
 	dynStats("lus", 1, "cor", -5);
 	player.createStatusEffect(StatusEffects.WandererHuman,0,0,0,0);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Ask marcus to go demon
 private function wandererGoDemon():void {
@@ -86,7 +86,7 @@ private function wandererGoDemon():void {
 	outputText("Marcus raises an eyebrow at the exchange, but smiles as his demonic lover returns to his side.  Lucia winks again, and huge wings explode from her back.  She grabs Marcus, who bleats in surprise, and lifts off, flying away with her prize to her lair.");
 	dynStats("lus", 5, "cor", 1);
 	player.createStatusEffect(StatusEffects.WandererDemon,0,0,0,0);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Demonic epilogue v1
@@ -101,7 +101,7 @@ private function wandererDemonEpilogue():void {
 			outputText("Lucia places a small bottle in your hand.  \"<i>So thank you, and have this present.  Perhaps you can create some lethicite for us later... oh, and before I forget, Marcus is loving his new existence.</i>\"\n\n");
 			outputText("She steps away and blows a kiss as her wings unfurl.  With a powerful downstroke she scatters sand everywhere, forcing you to throw an arm in front of your eyes.  When the debris settles, she's gone.\n\n");
 			dynStats("lus", 5, "scale", false);
-			inventory.takeItem(consumables.SDELITE, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.SDELITE, explorer.done);
 			player.statusEffectByType(StatusEffects.WandererDemon).value1 = 1;
 		}
 		//Second Encounter
@@ -110,12 +110,12 @@ private function wandererDemonEpilogue():void {
 			//Catch it
 			if(50 < (player.spe + rand(60))) {
 				outputText("You handily catch a small potion vial.  When you look up, she's gone.\n\n");
-				inventory.takeItem(consumables.SDELITE, camp.returnToCampUseOneHour);
+				inventory.takeItem(consumables.SDELITE, explorer.done);
 			}
 			//Drop it
 			else {
 				outputText("You dive for the falling bottle, but miss, and it shatters into the sands, the fluids wicking away nearly instantaneously.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 	}
@@ -134,12 +134,12 @@ private function wandererEpilogueHuman():void {
 			dynStats("lus", 10, "scale", false);
 			//Value 1 is used to track the status of the end state.
 			player.statusEffectByType(StatusEffects.WandererHuman).value1 = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		//Human Epilogue 2
 		else if(player.statusEffectv1(StatusEffects.WandererHuman) == 1) {
 			outputText("While exploring the desert, you find a strange bottle half-buried in the sand.  A small note is tied to it:\n\n\"<i>I just knew you'd find this.  Try this a few times and I think you might change your mind about Marcus' situation.\n  -Lovely Lucia</i>\"\n\n");
-			inventory.takeItem(consumables.SDELITE, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.SDELITE, explorer.done);
 		}
 	}
 }

--- a/classes/classes/Scenes/Areas/Forest.as
+++ b/classes/classes/Scenes/Areas/Forest.as
@@ -249,7 +249,6 @@ use namespace CoC;
 						},
 						call: SceneLib.exploration.demonLabProjectEncounters
 					}*/);
-			// TODO @aimozg 'plants' tag
 			_forestEncounter = Encounters.group("forest",
 					SceneLib.exploration.commonEncounters.withChanceFactor(0.1),
 					{
@@ -357,10 +356,7 @@ use namespace CoC;
 						kind  : 'event',
 						unique: true,
 						night : false,
-						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							SceneLib.woodElves.findElves();
-						},
+						call  : SceneLib.woodElves.findElves,
 						chance: 0.5,
 						when  : function ():Boolean {
 							return WoodElves.WoodElvesQuest == WoodElves.QUEST_STAGE_NOT_STARTED && player.level >= 10 && !player.blockingBodyTransformations()
@@ -371,10 +367,7 @@ use namespace CoC;
 						kind  : 'event',
 						unique: true,
 						night : false,
-						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							SceneLib.woodElves.findElvesRematch();
-						},
+						call  : SceneLib.woodElves.findElvesRematch,
 						chance: 0.75,
 						when  : function ():Boolean {
 							return WoodElves.WoodElvesQuest == WoodElves.QUEST_STAGE_METELFSANDEVENBEATSTHEM && player.level >= 10 && !player.blockingBodyTransformations()
@@ -425,10 +418,7 @@ use namespace CoC;
 							return flags[kFLAGS.DIANA_FOLLOWER] < 6 && !(flags[kFLAGS.DIANA_FOLLOWER] != 3 && flags[kFLAGS.DIANA_LVL_UP] >= 8) && player.statusEffectv4(StatusEffects.CampSparingNpcsTimers2) < 1 && !player.hasStatusEffect(StatusEffects.DianaOff);
 						},
 						chance: forestChance,
-						call: function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							SceneLib.dianaScene.repeatEnc();
-						}
+						call: SceneLib.dianaScene.repeatEnc
 					}, {
 						name: "dianaName",
 						label : "Diana",
@@ -439,10 +429,7 @@ use namespace CoC;
 							return ((flags[kFLAGS.DIANA_FOLLOWER] < 3 || flags[kFLAGS.DIANA_FOLLOWER] == 5) && flags[kFLAGS.DIANA_LVL_UP] >= 8) && !player.hasStatusEffect(StatusEffects.DianaOff) && player.statusEffectv4(StatusEffects.CampSparingNpcsTimers2) < 1;
 						},
 						chance: forestChance,
-						call: function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							SceneLib.dianaScene.postNameEnc();
-						}
+						call: SceneLib.dianaScene.postNameEnc
 					}, {
 						name: "walk",
 						call: forestWalkFn,
@@ -505,10 +492,8 @@ use namespace CoC;
 						label : "Mimic",
 						kind : 'monster',
 						when: fn.ifLevelMin(3),
-						call: function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							SceneLib.mimicScene.mimicTentacleStart(3);
-						},
+						// TODO @aimozg use area tags instead
+						call: curry(SceneLib.mimicScene.mimicTentacleStart, 3),
 						chance: 0.25
 					}, {
 						name  : "succubus",
@@ -523,10 +508,7 @@ use namespace CoC;
 						kind : 'monster',
 						day : false,
 						when: fn.ifLevelMin(12),
-						call  : function ():void {
-							player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-							SceneLib.werewolfFemaleScene.introWerewolfFemale();
-						},
+						call  : SceneLib.werewolfFemaleScene.introWerewolfFemale,
 						chance: 0.50
 					}/*, {
 						name: "demonProjects",
@@ -562,10 +544,7 @@ use namespace CoC;
 				kind  : 'npc',
 				unique: true,
 				night : false,
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.helScene.helSexualAmbush();
-				},
+				call  : SceneLib.helScene.helSexualAmbush,
 				chance: forestChance2,
 				when  : SceneLib.helScene.helSexualAmbushCondition
 			}, {
@@ -579,10 +558,7 @@ use namespace CoC;
 						   && !player.hasStatusEffect(StatusEffects.EtnaOff)
 						   && (player.level >= 20);
 				},
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.etnaScene.repeatYandereEnc();
-				}
+				call  : SceneLib.etnaScene.repeatYandereEnc
 			}, {
 				name  : "electra",
 				label : "Electra",
@@ -597,7 +573,6 @@ use namespace CoC;
 				},
 				chance: forestChance,
 				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 					if (flags[kFLAGS.ELECTRA_AFFECTION] == 100) {
 						if (flags[kFLAGS.ELECTRA_FOLLOWER] == 1) SceneLib.electraScene.ElectraRecruitingAgain();
 						else SceneLib.electraScene.ElectraRecruiting();
@@ -611,36 +586,25 @@ use namespace CoC;
 				when: function():Boolean {
 					return flags[kFLAGS.SOUL_SENSE_KITSUNE_MANSION] < 3;
 				},
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					kitsuneScene.enterTheTrickster();
-				}
+				call: kitsuneScene.enterTheTrickster
 			}, {
 				name: "celess-nightmare",
 				label : "Nightmare",
 				kind  : 'monster',
 				unique: true,
 				night : false,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					nightmareScene.nightmareIntro();
-				},
+				call: nightmareScene.nightmareIntro,
 				chance: forestChance,
 				when: function():Boolean {
 					return player.hasStatusEffect(StatusEffects.CanMeetNightmare) && player.statusEffectv1(StatusEffects.CanMeetNightmare) < 1 && !player.isPregnant();
 				}
-			},/*{ // [INTERMOD:8chan]
-			 name: "dullahan",
-			 call: dullahanScene
-			 }, */{
+			}, {
 				name: "akbal",
 				label : "Akbal",
 				kind  : 'monster',
+				unique: true,
 				night : false,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					akbalScene.supahAkabalEdition();
-				}
+				call: akbalScene.supahAkabalEdition
 			}, {
 				name  : "Tamani",
 				kind  : 'npc',
@@ -648,7 +612,6 @@ use namespace CoC;
 				night : false,
 				chance: 0.6,
 				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 					if (flags[kFLAGS.TAMANI_DAUGHTER_PREGGO_COUNTDOWN] == 0
 						&& flags[kFLAGS.TAMANI_NUMBER_OF_DAUGHTERS] >= 16 && flags[kFLAGS.SOUL_SENSE_TAMANI_DAUGHTERS] < 3 && rand(5) == 0) {
 						tamaniDaughtersScene.encounterTamanisDaughters();
@@ -668,10 +631,7 @@ use namespace CoC;
 				kind  : 'npc',
 				unique: true,
 				night : false,
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					encounterTamanisDaughtersFn();
-				},
+				call  : encounterTamanisDaughtersFn,
 				when  : function ():Boolean {
 					return player.gender > 0
 						   && player.hasCock()
@@ -715,10 +675,7 @@ use namespace CoC;
 				when: function():Boolean {
 					return flags[kFLAGS.ERLKING_DISABLED] == 0;
 				},
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					erlkingScene.encounterWildHunt();
-				}
+				call: erlkingScene.encounterWildHunt
 			}, {
 				name: "fera_1",
 				label : "Fera",
@@ -751,19 +708,15 @@ use namespace CoC;
 				chance: 4
 			}, corruptedGlade.encounter, {
 				name: "tentabeast",
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					tentacleBeastDeepwoodsEncounterFn();
-				}
+				label: "Tentacle Beast",
+				kind: "monster",
+				call: tentacleBeastDeepwoodsEncounterFn
 			}, {
 				name: "alraune",
 				label : "Alraune",
 				kind  : 'monster',
 				night : false,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					alrauneEncounterFn();
-				}
+				call: alrauneEncounterFn
 			}, {
 				name: "lilirauneIngrediant",
 				label : "Strange Flower",
@@ -777,20 +730,14 @@ use namespace CoC;
 				name  : "light_elf_scout",
 				label : "Light Elf Scout",
 				kind  : 'monster',
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					lightelfScene.introLightELfScout();
-				},
+				call  : lightelfScene.introLightELfScout,
 				chance: 0.8
 			}, {
 				name: "aiko",
 				label : "Aiko",
 				kind  : 'npc',
 				unique: true,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					aikoScene.encounterAiko();
-				},
+				call: aikoScene.encounterAiko,
 				when: function ():Boolean {
 					return (player.level > 35
 						&& flags[kFLAGS.AIKO_TIMES_MET] < 4
@@ -801,10 +748,7 @@ use namespace CoC;
 				label : "Dragon-Boy",
 				kind  : 'npc',
 				unique: true,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.tedScene.introPostHiddenCave();
-				},
+				call: SceneLib.tedScene.introPostHiddenCave,
 				when: SceneLib.tedScene.canEncounterTed
 			},{
 				name: "dungeon",
@@ -823,10 +767,7 @@ use namespace CoC;
 				label : "Werewolf (F)",
 				kind : 'monster',
 				day : false,
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.werewolfFemaleScene.introWerewolfFemale();
-				},
+				call  : SceneLib.werewolfFemaleScene.introWerewolfFemale,
 				chance: 0.50
 			}, {
 				name  : "truffle",

--- a/classes/classes/Scenes/Areas/Forest/AlrauneScene.as
+++ b/classes/classes/Scenes/Areas/Forest/AlrauneScene.as
@@ -2,7 +2,7 @@
  * ...
  * @author Liadri
  */
-package classes.Scenes.Areas.Forest 
+package classes.Scenes.Areas.Forest
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
@@ -70,7 +70,6 @@ public class AlrauneScene extends BaseContent
 				outputText("\"<i>Mmmmmm such a nice catch... Come closer into my pitcher.</i>\"\n\n");
 				outputText("There's no way you will let this thing pull you in!\n\n");
 			}
-			player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 			camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_ALRAUNE);
 			startCombat(new Alraune());
 		}

--- a/classes/classes/Scenes/Areas/Lake.as
+++ b/classes/classes/Scenes/Areas/Lake.as
@@ -6,6 +6,8 @@ package classes.Scenes.Areas
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.API.Encounters;
+import classes.Scenes.API.ExplorationEntry;
+import classes.Scenes.API.FnHelpers;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Lake.*;
 import classes.Scenes.Holidays;
@@ -36,10 +38,11 @@ use namespace CoC;
 		}
 
 		private function init():void {
+			const fn:FnHelpers = Encounters.fn;
 			_lakeEncounter = Encounters.group("lake", {
 				name: "villagepath",
 				label : "Village",
-				kind  : 'event',
+				kind  : 'place',
 				unique: true,
 				when: function ():Boolean {
 					return flags[kFLAGS.AMILY_VILLAGE_ACCESSIBLE] == 0
@@ -49,7 +52,7 @@ use namespace CoC;
 			}, {
 				name: "boat",
 				label : "Boat",
-				kind  : 'event',
+				kind  : 'place',
 				unique: true,
 				when: function ():Boolean {
 					return !player.hasStatusEffect(StatusEffects.BoatDiscovery)
@@ -58,7 +61,7 @@ use namespace CoC;
 			}, {
 				name: "farm",
 				label : "Farm",
-				kind  : 'event',
+				kind  : 'place',
 				unique: true,
 				when: function ():Boolean {
 					return !player.hasStatusEffect(StatusEffects.MetWhitney)  || player.statusEffectv1(StatusEffects.MetWhitney) <= 1
@@ -67,7 +70,7 @@ use namespace CoC;
 			}, {
 				name: "eggchoose",
 				label : "Eggs",
-				kind  : 'event',
+				kind  : 'item',
 				when: function ():Boolean {
 					return player.isPregnant() && (player.pregnancyType == PregnancyStore.PREGNANCY_OVIELIXIR_EGGS || player.pregnancy2Type == PregnancyStore.PREGNANCY_OVIELIXIR_EGGS)
 				},
@@ -86,24 +89,31 @@ use namespace CoC;
 				}
 			}, {
 				name: "walk",
+				kind: "walk",
 				when: function ():Boolean {
 					return player.level < 3 || player.canTrain('spe',player.trainStatCap("spe",50))
 				},
 				call: walkAroundLake
 			}, {
-				name: "finditems",
-				label : "Items",
-				kind  : 'event',
-				call: findLakeLoot
+				name: "EQUINUM",
+				label : "Equinum",
+				kind  : 'item',
+				call: findEquinum
+			}, {
+				name: "W_FRUIT",
+				label : "W.Fruit",
+				kind  : 'item',
+				call: findWFruit
 			}, {
 				name: "nothing",
 				label : "walk",
+				kind: "walk",
 				chance: 0.4,
 				call: findNothing
 			}, {
 				name: "holystuff",
 				label : "Holy Weapon",
-				kind  : 'event',
+				kind  : 'item',
 				when: function ():Boolean {
 					return !player.hasStatusEffect(StatusEffects.BlessedItemAtTheLake) && (
 							!player.hasStatusEffect(StatusEffects.TookBlessedSword) && !player.hasStatusEffect(StatusEffects.BSwordBroken) ||
@@ -188,13 +198,35 @@ use namespace CoC;
 				night: false,
 				call: SceneLib.rathazul.encounterRathazul
 			}, {
-				name: "slimeooze",
+				name: "slime",
 				label : "Green Slime",
 				kind : 'monster',
+				chance: function():Number {
+					return 1 - gooGirlChance()
+				},
+				mods: [fn.ifLevelMin(3)],
+				call: greenSlime
+			}, {
+				name: "googirl",
+				label : "Goo-Girl",
+				kind : 'monster',
+				chance: gooGirlChance,
+				mods: [fn.ifLevelMin(3)],
+				call: gooGirlScene.encounterGooGirl
+			}, {
+				name: "slimeoozesex",
+				label : "Goo x Ooze",
+				kind : 'event',
+				chance: function():Number {
+					//Chance of seeing ooze convert goo!
+					//More common if factory blew up
+					//Else pretty rare.
+					return flags[kFLAGS.FACTORY_SHUTDOWN] == 2 ? 0.1 : 0.04
+				},
 				when: function ():Boolean {
 					return player.level >= 3
 				},
-				call: slimeOozeEncounterFn
+				call: gooGirlScene.spyOnGooAndOozeSex
 			}, SceneLib.exploration.commonEncounters.wrap(function ():Boolean {
 				return player.level >= 3 && flags[kFLAGS.NEW_GAME_PLUS_LEVEL] > 0
 			}, [0.1]), {
@@ -262,12 +294,15 @@ use namespace CoC;
 		//Explore Lake
 		public function exploreLake():void
 		{
-			clearOutput();
-			player.exploredLake++;
-			player.createStatusEffect(StatusEffects.NearWater,0,0,0,0);
-			doNext(camp.returnToCampUseOneHour);
-			lakeEncounter.execEncounter();
-			flushOutputTextToGUI();
+			explorer.prepareArea(lakeEncounter);
+			explorer.setTags("lake", "lakeBeach", "water");
+			explorer.prompt = "You explore the lake beach.";
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				player.exploredLake++;
+			}
+			explorer.leave.hint("Leave the lake");
+			explorer.skillBasedReveal(1, player.exploredLake);
+			explorer.doExplore();
 		}
 
 		public function lakeChance():Number {
@@ -276,71 +311,48 @@ use namespace CoC;
 			return temp;
 		}
 
-		private function slimeOozeEncounterFn():void {
-			//Chance of seeing ooze convert goo!
-			//More common if factory blew up
-			if (flags[kFLAGS.FACTORY_SHUTDOWN] == 2 && rand(10) == 0) {
-				gooGirlScene.spyOnGooAndOozeSex();
-				return;
-			}
-			//Else pretty rare.
-			else if (rand(25) == 0) {
-				gooGirlScene.spyOnGooAndOozeSex();
-				return;
-			}
-			var girlOdds:Number = 50;
-			//50% odds of slime-girl, 75% if shutdown factory
-			if (flags[kFLAGS.FACTORY_SHUTDOWN] == 1)
-				girlOdds += 25;
-			if (flags[kFLAGS.FACTORY_SHUTDOWN] == 2)
-				girlOdds -= 25;
-			//Slimegirl!
-			if (rand(100) <= girlOdds) {
-				player.createStatusEffect(StatusEffects.NearWater, 0, 0, 0, 0);
-				gooGirlScene.encounterGooGirl();
-			}
-			//OOZE!
-			else {
-				flags[kFLAGS.TIMES_MET_OOZE]++;
-				spriteSelect(SpriteDb.s_green_slime);
-				//High int starts on even footing.
-				if (player.inte >= 25) {
-					clearOutput();
-					outputText("A soft shuffling sound catches your attention and you turn around, spotting an amorphous green mass sliding towards you!  Realizing it's been spotted, the ooze's mass surges upwards into a humanoid form with thick arms and wide shoulders.  The beast surges forward to attack!");
-					player.createStatusEffect(StatusEffects.NearWater, 0, 0, 0, 0);
-					startCombat(new GreenSlime());
-					if (flags[kFLAGS.FACTORY_SHUTDOWN] == 1) outputText("\n\n<b>You are amazed to encounter a slime creature with the factory shut down - most of them have disappeared.</b>");
-					return;
-				}
-				//High speed starts on even footing.
-				if (player.spe >= 30) {
-					clearOutput();
-					outputText("You feel something moist brush the back of your ankle and instinctively jump forward and roll, coming up to face whatever it is behind you.  The nearly silent, amorphous green slime that was at your feet surges vertically, its upper body taking the form of a humanoid with thick arms and wide shoulders, which attacks!");
-					player.createStatusEffect(StatusEffects.NearWater, 0, 0, 0, 0);
-					startCombat(new GreenSlime());
-					if (flags[kFLAGS.FACTORY_SHUTDOWN] == 1) outputText("\n\n<b>You are amazed to encounter a slime creature with the factory shut down - most of them have disappeared.</b>");
-					return;
-				}
-				//High strength gets stunned first round.
-				if (player.str >= 40) {
-					clearOutput();
-					outputText("Without warning, you feel something moist and spongy wrap around your ankle, nearly pulling you off balance.  With a ferocious tug, you pull yourself free and turn to face your assailant.  It is a large green ooze that surges upwards to take the form of humanoid with wide shoulders and massive arms.  It shudders for a moment, and its featureless face shifts into a green version of your own! The sight gives you pause for a moment, and the creature strikes!");
-					if (flags[kFLAGS.FACTORY_SHUTDOWN] == 1) outputText("\n\n<b>You are amazed to encounter a slime creature with the factory shut down - most of them have disappeared.</b>");
-					player.createStatusEffect(StatusEffects.NearWater, 0, 0, 0, 0);
-					startCombat(new GreenSlime());
-					outputText("\n\n");
-					monster.eAttack();
-					return;
-				}
-				//Player's stats suck and you should feel bad.
-				clearOutput();
-				outputText("Without warning, you feel something moist and spongy wrap around your ankle, pulling you off balance!  You turn and try to pull your leg away, struggling against a large green ooze for a moment before your foot comes away with a *schlorp* and a thin coating of green fluid.  The rest of the ooze rises to tower over you, forming a massive green humanoid torso with hugely muscled arms and wide shoulders.  Adrenaline rushes into your body as you prepare for combat, and you feel your heart skip a beat as your libido begins to kick up as well!");
-				if (flags[kFLAGS.FACTORY_SHUTDOWN] == 1) outputText("\n\n<b>You are amazed to encounter a slime creature with the factory shut down - most of them have disappeared.</b>");
-				dynStats("lib", 1, "lus", 10);
-				startCombat(new GreenSlime());
-			}
+		private function gooGirlChance():Number {
+			if (flags[kFLAGS.FACTORY_SHUTDOWN] == 1) return 0.75
+			if (flags[kFLAGS.FACTORY_SHUTDOWN] == 2) return 0.25;
+			return 0.5;
 		}
-
+		
+		private function greenSlime():void {
+			flags[kFLAGS.TIMES_MET_OOZE]++;
+			spriteSelect(SpriteDb.s_green_slime);
+			//High int starts on even footing.
+			if (player.inte >= 25) {
+				clearOutput();
+				outputText("A soft shuffling sound catches your attention and you turn around, spotting an amorphous green mass sliding towards you!  Realizing it's been spotted, the ooze's mass surges upwards into a humanoid form with thick arms and wide shoulders.  The beast surges forward to attack!");
+				startCombat(new GreenSlime());
+				if (flags[kFLAGS.FACTORY_SHUTDOWN] == 1) outputText("\n\n<b>You are amazed to encounter a slime creature with the factory shut down - most of them have disappeared.</b>");
+				return;
+			}
+			//High speed starts on even footing.
+			if (player.spe >= 30) {
+				clearOutput();
+				outputText("You feel something moist brush the back of your ankle and instinctively jump forward and roll, coming up to face whatever it is behind you.  The nearly silent, amorphous green slime that was at your feet surges vertically, its upper body taking the form of a humanoid with thick arms and wide shoulders, which attacks!");
+				startCombat(new GreenSlime());
+				if (flags[kFLAGS.FACTORY_SHUTDOWN] == 1) outputText("\n\n<b>You are amazed to encounter a slime creature with the factory shut down - most of them have disappeared.</b>");
+				return;
+			}
+			//High strength gets stunned first round.
+			if (player.str >= 40) {
+				clearOutput();
+				outputText("Without warning, you feel something moist and spongy wrap around your ankle, nearly pulling you off balance.  With a ferocious tug, you pull yourself free and turn to face your assailant.  It is a large green ooze that surges upwards to take the form of humanoid with wide shoulders and massive arms.  It shudders for a moment, and its featureless face shifts into a green version of your own! The sight gives you pause for a moment, and the creature strikes!");
+				if (flags[kFLAGS.FACTORY_SHUTDOWN] == 1) outputText("\n\n<b>You are amazed to encounter a slime creature with the factory shut down - most of them have disappeared.</b>");
+				startCombat(new GreenSlime());
+				outputText("\n\n");
+				monster.eAttack();
+				return;
+			}
+			//Player's stats suck and you should feel bad.
+			clearOutput();
+			outputText("Without warning, you feel something moist and spongy wrap around your ankle, pulling you off balance!  You turn and try to pull your leg away, struggling against a large green ooze for a moment before your foot comes away with a *schlorp* and a thin coating of green fluid.  The rest of the ooze rises to tower over you, forming a massive green humanoid torso with hugely muscled arms and wide shoulders.  Adrenaline rushes into your body as you prepare for combat, and you feel your heart skip a beat as your libido begins to kick up as well!");
+			if (flags[kFLAGS.FACTORY_SHUTDOWN] == 1) outputText("\n\n<b>You are amazed to encounter a slime creature with the factory shut down - most of them have disappeared.</b>");
+			dynStats("lib", 1, "lus", 10);
+			startCombat(new GreenSlime());
+		}
 		private function fetishCultist():void {
 			if (!player.hasStatusEffect(StatusEffects.FetishOn)) {
 				player.createStatusEffect(StatusEffects.FetishOn, 0, 0, 0, 0);
@@ -349,7 +361,7 @@ use namespace CoC;
 				outputText("After a moment, a number of the figures disembark down the gangplank and immediately go off in different directions.  You count half a dozen of them, and guess that they are female when one of them passes by close to you and you see the hole in her outfit over her naughty bits.  You look back at the boat to see it close the gangplank, and move back onto the lake, with only one of the figures still on board.  Surprised to hear a sudden yell, you look to the side and see the clothing of the one who passed you earlier shift and twist before becoming some pink outfit that clings to her backside.  You are stunned for a moment as she disappears from sight before you shake your head and move on.  It seems there are new residents to the lake.\n\n<b>(Fetish Cultists can now be encountered!)</b>");
 				//(increase player lust from the sights they saw)
 				dynStats("lus", 5, "scale", false);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			fetishCultistScene.fetishCultistEncounter();
@@ -387,19 +399,16 @@ use namespace CoC;
 				player.trainStat("spe", +1, player.trainStatCap("spe",50));
 			}
 			dynStats("spe", .75);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
-		private function findLakeLoot():void {
-			clearOutput();
-			if (rand(2) == 0) {
-				outputText("You find a long and oddly flared vial half-buried in the sand.  Written across the middle band of the vial is a single word: 'Equinum'.\n");
-				inventory.takeItem(consumables.EQUINUM, camp.returnToCampUseOneHour);
-			}
-			else {
-				outputText("You find an odd, fruit-bearing tree growing near the lake shore.  One of the fruits has fallen on the ground in front of you.  You pick it up.\n");
-				inventory.takeItem(consumables.W_FRUIT, camp.returnToCampUseOneHour);
-			}
+		private function findEquinum():void {
+			outputText("You find a long and oddly flared vial half-buried in the sand.  Written across the middle band of the vial is a single word: 'Equinum'.\n");
+			inventory.takeItem(consumables.EQUINUM, explorer.done);
+		}
+		private function findWFruit():void {
+			outputText("You find an odd, fruit-bearing tree growing near the lake shore.  One of the fruits has fallen on the ground in front of you.  You pick it up.\n");
+			inventory.takeItem(consumables.W_FRUIT, explorer.done);
 		}
 
 		private function findNothing():void {
@@ -417,7 +426,7 @@ use namespace CoC;
 				}
 			}
 			else dynStats("int", 1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function eggChooseFn():void {
@@ -446,13 +455,13 @@ use namespace CoC;
 			}
 			outputText(" light.  Immediately it flows into your skin, glowing through your arm as if it were translucent.  It rushes through your shoulder and torso, down into your pregnant womb.  The other lights vanish.");
 			player.statusEffectByType(StatusEffects.Eggs).value1 = eggType; //Value 1 is the egg type. If pregnant with OviElixir then StatusEffects.Eggs must exist
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		private function eggChooseEscape():void {
 			clearOutput();
 			outputText("You throw yourself into a roll and take off, leaving the ring of lights hovering in the distance behind you.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 	}

--- a/classes/classes/Scenes/Areas/Lake/CalluScene.as
+++ b/classes/classes/Scenes/Areas/Lake/CalluScene.as
@@ -1,18 +1,18 @@
-package classes.Scenes.Areas.Lake 
+package classes.Scenes.Areas.Lake
 {
-	import classes.*;
-	import classes.GlobalFlags.*;
-	
-	/**
+import classes.*;
+import classes.GlobalFlags.*;
+
+/**
 	 * ...
 	 * @author ...
 	 */
 	public class CalluScene extends AbstractLakeContent
 	{
 		
-		public function CalluScene() 
+		public function CalluScene()
 		{
-			
+		
 		}
 		
 		//Just want to do a quick Ottergirl event submission after you mentioned it!
@@ -182,7 +182,7 @@ package classes.Scenes.Areas.Lake
 			outputText("\n\nYou take a minute to recover before doing the same.  ");
 			player.sexReward("vaginalFluids","Dick");
 			dynStats("sen", -1);
-			inventory.takeItem(consumables.FISHFIL, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.FISHFIL, explorer.done);
 		}
 
 		//For Chicks
@@ -241,7 +241,7 @@ package classes.Scenes.Areas.Lake
 
 			player.sexReward("vaginalFluids");
 			dynStats("sen", -1);
-			inventory.takeItem(consumables.FISHFIL, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.FISHFIL, explorer.done);
 		}
 
 		//For Pansies
@@ -251,7 +251,7 @@ package classes.Scenes.Areas.Lake
 			outputText("You shake your head and explain you can't.  She simply shrugs, \"<i>Ain't no skin off my back.</i>\"");
 
 			outputText("\n\nThe two of you sit in silence for a little while.  It doesn't feel like an awkward silence, just a serene, relaxing void of noise.  The gentle lapping of the water almost puts you to sleep.  Eventually, you stand, say your goodbyes and leave.  As you're leaving, Callu shouts, \"<i>Come round any time, ya hear?</i>\"  You nod absently, then make your way back to camp.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//For Fatties
@@ -265,7 +265,7 @@ package classes.Scenes.Areas.Lake
 			outputText("\n\nYou thank Callu for the food and take your leave.  ");
 
 			//(You have gained Fish Fillet!)
-			inventory.takeItem(consumables.FISHFIL, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.FISHFIL, explorer.done);
 		}
 		
 		//Fishing Rod
@@ -286,14 +286,14 @@ package classes.Scenes.Areas.Lake
 			outputText("<b>You now have a fishing pole. Every now and then while on a body of water you will be able to retrieve fishes.</b>");
 			player.gems -= 50;
 			player.createKeyItem("Fishing Pole", 0, 0, 0, 0);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function noINotWannaFishing():void
 		{
 			clearOutput();
 			outputText("You will pass on this for now.\n\n");
 			outputText("\"<i>Well all okay. Just ask again if you ever change your mind.</i>\"");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 	}

--- a/classes/classes/Scenes/Areas/Lake/GooGirlScene.as
+++ b/classes/classes/Scenes/Areas/Lake/GooGirlScene.as
@@ -539,7 +539,7 @@ public class GooGirlScene extends AbstractLakeContent
 			outputText("The small, crimson heart-shaped core in the girl's body swims within her form uncertainly. The expanding " + gooColor8() + " lengths gradually approach the jewel-like nucleus at the girl's center, their corrupt fluids swirling within the trembling shafts, moments from release. In panic, the girl's heart leaps up into her head, and her eyes clench as her gaping mouth crinkles around the edges, and she lurches forward in a tremendous sneeze. The slime core launches from her lips and arcs through the air before splashing safely away from the orgy. Without an intellect, the girl's now doll-like body coos wordlessly when the ooze men climax, unleashing a torrent of seething viridian into her. The murky cum floods the goo's vibration-sexualized form, filling her belly, limbs, and head with a creeping green tint. The hollow slime blissfully strokes her distorted form as the corrupt slime within her begins to work its masculine influence on her shape. Her overfull curves bubble and collapse as the last of her " + gooColor() + " goo is smothered by the corrupt slime semen.  When it's all over, the hyper-feminine slime's body has been sculpted to a slightly effete male. A bulge rises from between her legs, dripping into a fresh, gooey cock.\n\n");
 			outputText("You hurry away before the five oozes take an interest in you next.");
 			dynStats("lus", (4 + player.cor / 10), "scale", false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function layBeeEggsInGoo():void

--- a/classes/classes/Scenes/Areas/Plains.as
+++ b/classes/classes/Scenes/Areas/Plains.as
@@ -6,6 +6,7 @@ package classes.Scenes.Areas
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.API.Encounters;
+import classes.Scenes.API.ExplorationEntry;
 import classes.Scenes.API.FnHelpers;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Plains.*;
@@ -29,6 +30,7 @@ use namespace CoC;
 			flags[kFLAGS.TIMES_EXPLORED_PLAINS] = 1;
 			outputText(images.showImage("area-plain"));
 			outputText("You find yourself standing in knee-high grass, surrounded by flat plains on all sides.  Though the mountain, forest, and lake are all visible from here, they seem quite distant.\n\n<b>You've discovered the plains!</b>");
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseOneHour);
 		}
 
@@ -36,7 +38,6 @@ use namespace CoC;
 
 		private function init():void {
 			const fn:FnHelpers = Encounters.fn;
-			// TODO @aimozg 'plants' tag
 			explorationEncounter = Encounters.group(/*SceneLib.commonEncounters,*/
 					SceneLib.exploration.commonEncounters.withChanceFactor(0.1),
 					SceneLib.exploration.angelEncounters.withChanceFactor(0.05),
@@ -47,10 +48,7 @@ use namespace CoC;
 				kind  : 'npc',
 				unique: true,
 				night : false,
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.helScene.helSexualAmbush();
-				},
+				call  : SceneLib.helScene.helSexualAmbush,
 				chance: plainsChance,
 				when  : SceneLib.helScene.helSexualAmbushCondition
 			}, {
@@ -65,10 +63,7 @@ use namespace CoC;
 						   && (player.level >= 20);
 				},
 				chance: plainsChance,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.etnaScene.repeatYandereEnc();
-				}
+				call: SceneLib.etnaScene.repeatYandereEnc
 			}, {
 				name: "electra",
 				label : "Electra",
@@ -80,7 +75,6 @@ use namespace CoC;
 				},
 				chance: plainsChance,
 				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 					if (flags[kFLAGS.ELECTRA_AFFECTION] == 100) {
 						if (flags[kFLAGS.ELECTRA_FOLLOWER] == 1) SceneLib.electraScene.ElectraRecruitingAgain();
 						else SceneLib.electraScene.ElectraRecruiting();
@@ -92,10 +86,7 @@ use namespace CoC;
 				label : "Werewolf (F)",
 				kind : 'monster',
 				day : false,
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.werewolfFemaleScene.introWerewolfFemale();
-				},
+				call  : SceneLib.werewolfFemaleScene.introWerewolfFemale,
 				chance: 0.50
 			}, {
 				name: "sidonie",
@@ -108,10 +99,7 @@ use namespace CoC;
 						   && flags[kFLAGS.SIDONIE_RECOLLECTION] < 1;
 				},
 				chance: plainsChance,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.sidonieFollower.meetingSidonieAtPlains();
-				}
+				call: SceneLib.sidonieFollower.meetingSidonieAtPlains
 			}, {
 				name: "diana",
 				label : "Diana",
@@ -122,10 +110,7 @@ use namespace CoC;
 					return flags[kFLAGS.DIANA_FOLLOWER] < 6 && !(flags[kFLAGS.DIANA_FOLLOWER] != 3 && flags[kFLAGS.DIANA_LVL_UP] >= 8) && player.statusEffectv4(StatusEffects.CampSparingNpcsTimers2) < 1 && !player.hasStatusEffect(StatusEffects.DianaOff);
 				},
 				chance: plainsChance,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.dianaScene.repeatEnc();
-				}
+				call: SceneLib.dianaScene.repeatEnc
 			}, {
 				name: "dianaName",
 				label : "Diana",
@@ -136,10 +121,7 @@ use namespace CoC;
 					return ((flags[kFLAGS.DIANA_FOLLOWER] < 3 || flags[kFLAGS.DIANA_FOLLOWER] == 5) && flags[kFLAGS.DIANA_LVL_UP] >= 8) && !player.hasStatusEffect(StatusEffects.DianaOff) && player.statusEffectv4(StatusEffects.CampSparingNpcsTimers2) < 1;
 				},
 				chance: plainsChance,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.dianaScene.postNameEnc();
-				}
+				call: SceneLib.dianaScene.postNameEnc
 			}, {
 				//Dem Kangasluts!  Force Sheila relationship phase!
 				name  : "sheila_xp3",
@@ -154,10 +136,7 @@ use namespace CoC;
 						   && model.time.hours == 20
 						   && flags[kFLAGS.SHEILA_CLOCK] >= 0;
 				},
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.sheilaScene.sheilaXPThreeSexyTime();
-				}
+				call  : SceneLib.sheilaScene.sheilaXPThreeSexyTime
 			}, {
 				//Add some holiday cheer
 				name: "candy_cane",
@@ -167,10 +146,7 @@ use namespace CoC;
 				when: function ():Boolean {
 					return isChristmas() && date.fullYear > flags[kFLAGS.CANDY_CANE_YEAR_MET];
 				},
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.holidays.candyCaneTrapDiscovery();
-				}
+				call: SceneLib.holidays.candyCaneTrapDiscovery
 			}, {
 				name: "polar_pete",
 				label : "Polar Pete",
@@ -179,10 +155,7 @@ use namespace CoC;
 				when: function ():Boolean {
 					return isChristmas() && date.fullYear > flags[kFLAGS.POLAR_PETE_YEAR_MET];
 				},
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.holidays.polarPete();
-				}
+				call: SceneLib.holidays.polarPete
 			}, {
 				//Find Niamh
 				name: "niamh",
@@ -197,7 +170,7 @@ use namespace CoC;
 			}, {
 				name  : "owca",
 				label : "Owca",
-				kind  : 'event',
+				kind  : 'place',
 				unique: true,
 				night : false,
 				chance: 0.3,
@@ -205,10 +178,7 @@ use namespace CoC;
 					return flags[kFLAGS.OWCA_UNLOCKED] == 0;
 				},
 				mods  : [fn.ifLevelMin(24)],
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.owca.gangbangVillageStuff();
-				}
+				call  : SceneLib.owca.gangbangVillageStuff
 			}, {
 				name  : "helXizzy",
 				label : "Hel x Izzy",
@@ -228,13 +198,13 @@ use namespace CoC;
 			}, {
 				name  : "ovielix",
 				label : "Items",
-				kind  : 'event',
+				kind  : 'item',
 				call  : findOviElix,
 				chance: 0.5
 			}, {
 				name  : "kangaft",
 				label : "Items",
-				kind  : 'event',
+				kind  : 'item',
 				call  : findKangaFruit,
 				chance: 0.5
 			}, {
@@ -243,20 +213,14 @@ use namespace CoC;
 				kind : 'monster',
 				night : false,
 				chance: 0.7,
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					gnollSpearThrowerScene.gnoll2Encounter();
-				}
+				call  : gnollSpearThrowerScene.gnoll2Encounter
 			}, {
 				name  : "gnoll2",
 				label : "Gnoll",
 				kind : 'monster',
 				night : false,
 				chance: 0.7,
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					gnollScene.gnollEncounter();
-				}
+				call  : gnollScene.gnollEncounter
 			}, {
 				name: "bunny",
 				label : "Bunny",
@@ -283,10 +247,7 @@ use namespace CoC;
 					return flags[kFLAGS.ISABELLA_PLAINS_DISABLED] == 0
 				},
 				chance: plainsChance,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.isabellaScene.isabellaGreeting();
-				}
+				call: SceneLib.isabellaScene.isabellaGreeting
 			}, {
 				name  : "helia",
 				label : "Helia",
@@ -299,10 +260,7 @@ use namespace CoC;
 				when  : function ():Boolean {
 					return !SceneLib.helScene.followerHel() && !player.hasStatusEffect(StatusEffects.HeliaOff);
 				},
-				call  : function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.helScene.encounterAJerkInThePlains();
-				}
+				call  : SceneLib.helScene.encounterAJerkInThePlains
 			}, {
 				name: "ted",
 				label : "Dragon-Boy",
@@ -315,7 +273,7 @@ use namespace CoC;
 			}, {
 				name: "snippler",
 				label : "Gun Parts",
-				kind  : 'event',
+				kind  : 'item',
 				unique: true,
 				when: function ():Boolean {
 					return player.hasStatusEffect(StatusEffects.TelAdreTripxiGuns4) && player.statusEffectv1(StatusEffects.TelAdreTripxiGuns4) == 0 && player.hasKeyItem("Snippler") < 0;
@@ -328,24 +286,18 @@ use namespace CoC;
 				kind : 'event',
 				night : false,
 				chance: 0.7,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					satyrScene.satyrEncounter();
-				}
+				call: satyrScene.satyrEncounter
 			}, {
 				name: "sheila",
 				label : "Sheila",
-				kind  : 'event',
+				kind  : 'npc',
 				unique: true,
 				night : false,
 				when: function ():Boolean {
 					return flags[kFLAGS.SHEILA_DISABLED] == 0 && flags[kFLAGS.SHEILA_CLOCK] >= 0
 				},
 				chance: 0.5,
-				call: function ():void {
-					player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-					SceneLib.sheilaScene.sheilaEncounterRouter();
-				}
+				call: SceneLib.sheilaScene.sheilaEncounterRouter
 			}/*, {
 				name: "demonProjects",
 				chance: 0.2,
@@ -356,11 +308,15 @@ use namespace CoC;
 			}*/);
 		}
 		public function explorePlains():void {
-			clearOutput();
-			flags[kFLAGS.TIMES_EXPLORED_PLAINS]++;
-			doNext(camp.returnToCampUseOneHour);
-			explorationEncounter.execEncounter();
-			flushOutputTextToGUI();
+			explorer.prepareArea(explorationEncounter);
+			explorer.setTags("plains", "plants");
+			explorer.prompt = "You explore the plains.";
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				flags[kFLAGS.TIMES_EXPLORED_PLAINS]++;
+			}
+			explorer.leave.hint("Leave the plains");
+			explorer.skillBasedReveal(9, flags[kFLAGS.TIMES_EXPLORED_PLAINS]);
+			explorer.doExplore();
 		}
 		public function plainsChance():Number {
 			var temp:Number = 0.5;
@@ -373,17 +329,17 @@ use namespace CoC;
 			outputText("You carefully put the pieces of the Snippler in your back and head back to your camp.\n\n");
 			player.addStatusValue(StatusEffects.TelAdreTripxi, 2, 1);
 			player.createKeyItem("Snippler", 0, 0, 0, 0);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function findKangaFruit():void {
 			outputText(images.showImage("item-kFruit"));
 			outputText("While exploring the plains you come across a strange-looking plant.  As you peer at it, you realize it has some fruit you can get at.  ");
-			inventory.takeItem(consumables.KANGAFT, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.KANGAFT, explorer.done);
 		}
 		private function findOviElix():void {
 			outputText(images.showImage("item-oElixir"));
 			outputText("While exploring the plains you nearly trip over a discarded, hexagonal bottle.  ");
-			inventory.takeItem(consumables.OVIELIX, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.OVIELIX, explorer.done);
 		}
 	}
 }

--- a/classes/classes/Scenes/Areas/Plains/BunnyGirl.as
+++ b/classes/classes/Scenes/Areas/Plains/BunnyGirl.as
@@ -29,7 +29,7 @@ public function bunnbunbunMeet():void {
 
 		outputText("Even though nearly a minute has passed, the bunny-lass is STILL frozen and staring.  She hasn't done anything since realizing that you're looking at her.  Well, it looks like the ball's in your court.  What do you do?");
 		//[Talk] [Rape Her]
-		simpleChoices("Talk", talkToBunnyBunBun, "Rape Her", rapeBunBun, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+		simpleChoices("Talk", talkToBunnyBunBun, "Rape Her", rapeBunBun, "", null, "", null, "Leave", explorer.done);
 	}
 	//Met her
 	else {
@@ -65,7 +65,7 @@ private function sexMenu():void {
 	addButton(3, "Your Ass", bunbunFucksPCInAss);
 	addButtonIfTrue(5, "LayYourEggs", ovipositBunnyEaster, "Req. any ovipositor.", player.canOviposit());
 	addButtonIfTrue(6, "Eggs & Honey", layEggsInBunbuns, "Req. bee ovipositor.", player.canOviposit());
-	addButton(14, "Leave", camp.returnToCampUseOneHour);
+	addButton(14, "Leave", explorer.done);
 }
 
 //[Talk]
@@ -92,7 +92,7 @@ private function rapeBunBun():void {
 	if(player.spe < 60) {
 		outputText("You lunge forward off your [feet], trying to tackle and pin the poor girl, but at the first sign of movement from you, she bounds off in the other direction!  She's hopping so fast there's no way you could possibly catch her, and in a matter of seconds you're left totally alone.  Well, perhaps not TOTALLY alone – there's one small egg nestled in the grass.  It fell from the bunny's basket in her haste to flee!");
 		//(pick and loot random egg)
-		inventory.takeItem(consumables.NPNKEGG, camp.returnToCampUseOneHour);
+		inventory.takeItem(consumables.NPNKEGG, explorer.done);
 	}
 	//[Rape Her Faster]
 	else {
@@ -192,6 +192,7 @@ private function bunbunFucksYourVag():void {
 	}
 	player.sexReward("cum","Vaginal");
 	dynStats("lib", 1, "sen", -3);
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseEightHours);
 }
 
@@ -281,6 +282,7 @@ private function bunbunFucksPCInAss():void {
 	player.buttKnockUp(PregnancyStore.PREGNANCY_BUNNY, PregnancyStore.INCUBATION_BUNNY_EGGS, 1, 1);
 	player.sexReward("cum","Anal");
 	dynStats("lib", 1, "sen", 1);
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseEightHours);
 }
 
@@ -364,7 +366,7 @@ private function bunbunGetsFucked():void {
 	player.sexReward("vaginalFluids","Dick");
 
 	dynStats("lib", 1, "sen", 1);
-	inventory.takeItem(consumables.NPNKEGG, camp.returnToCampUseOneHour);
+	inventory.takeItem(consumables.NPNKEGG, explorer.done);
 }
 
 private function bunbun69():void {
@@ -386,7 +388,7 @@ private function bunbun69():void {
 			//- Intelligence
 			//+ Lust
 			player.addCurse("int", 2, 2);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		else {
 			outputText("Without thinking it over too hard beyond 'that sounds hot', you declare your intention to 69 the bunny girl.  She bursts into laughter.  You're a little perturbed by this and make it clear you're quite serious by restating your goal.\n\n");
@@ -404,7 +406,7 @@ private function bunbun69():void {
 			player.addCurse("int", 2, 2);
 			//+ Lust
 			//+ Pink Egg
-			inventory.takeItem(consumables.NPNKEGG, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.NPNKEGG, explorer.done);
 		}
 		return;
 	}
@@ -462,7 +464,7 @@ private function bunbun69():void {
 				player.tailType = Tail.RABBIT;
 				player.ears.type = Ears.BUNNY;
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			player.sexReward("cum","Lips");
 			player.sexReward("vaginalFluids","Lips");
 			player.sexReward("saliva","Dick");
@@ -522,7 +524,7 @@ private function bunbun69():void {
 				player.tailType = Tail.RABBIT;
 				player.ears.type = Ears.BUNNY;
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			player.sexReward("cum","Lips");
 			player.sexReward("vaginalFluids","Lips");
 			player.sexReward("saliva","Dick");
@@ -566,7 +568,7 @@ private function bunbun69():void {
 			player.tailType = Tail.RABBIT;
 			player.ears.type = Ears.BUNNY;
 		}
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		player.sexReward("cum","Lips");
 		player.sexReward("vaginalFluids","Lips");
 		player.sexReward("saliva","Vaginal");
@@ -621,7 +623,7 @@ public function layEggsInBunbuns():void {
 	outputText("\n\nFinally you find you no longer have any to give to the egg-obsessed rabbit girl, and the ovipositor retracts into its slit.  Tired but blissful, she curls up to slumber, and you leave her to deal with having a stomach chock-full of eggs 'n honey, returning to camp until you once again need a warm body to play host.");
 	player.dumpEggs();
 	player.sexReward("Default","Default",true,false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -676,7 +678,7 @@ public function ovipositBunnyEaster():void {
 	player.dumpEggs();
 	player.orgasm();
 	dynStats("sen", -2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Bunny Girl Eggsplosion
@@ -719,7 +721,7 @@ private function adjathaEggsplosions():void {
 		if(player.cockThatFits(40) >= 0) addButton(2,"Fuck Her",fuckTheEggBoundBun);
 		else outputText("  <b>You're too big to fuck her!</b>");
 	}
-	addButton(14,"Leave",camp.returnToCampUseOneHour);
+	addButton(14,"Leave",explorer.done);
 }
 
 //[Free Her] (Any gender)
@@ -762,7 +764,7 @@ private function freeHerOhGodWhyDidYouDoThis():void {
 	outputText("\n\nThe frantic pace of her initial discharge ebbs as her hulking testes visibly shrink.  She leans up against the wobbling factories, resting atop them like they were hefty, liquid pillows.  It'll take her a while to finish emptying herself completely, but for the time being, she seems content.  You give her fluffy tail a playful poof and head back to camp, stooping to retrieve one of the girl's eggs from the ground as you go.\n\n");
 	//[End Encounter, gain neon pink egg]
 	dynStats("lus", 25, "scale", false);
-	inventory.takeItem(consumables.NPNKEGG, camp.returnToCampUseOneHour);
+	inventory.takeItem(consumables.NPNKEGG, explorer.done);
 }
 
 //[Fuck Her] (Male/Futa Only)
@@ -817,7 +819,7 @@ private function fuckTheEggBoundBun():void {
 	//[End Encounter, corruption up]
 	player.sexReward("no", "Dick");
 	dynStats("cor", 2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Get Egged] (Female/Futa only)
@@ -931,6 +933,7 @@ private function getEggflated():void {
 	outputText(player.modTone(0,3));
 	player.sexReward("cum","Vaginal");
 	dynStats("lib", 1, "sen", -3);
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseEightHours);
 }
 	}

--- a/classes/classes/Scenes/Areas/Plains/SatyrScene.as
+++ b/classes/classes/Scenes/Areas/Plains/SatyrScene.as
@@ -7,7 +7,7 @@ import classes.display.SpriteDb;
 
 public class SatyrScene extends BaseContent{
 
-		
+	
 	public function SatyrScene()
 	{
 	}
@@ -44,8 +44,8 @@ public function satyrEncounter(location:int = 0):void {
 		else outputText("sodden expanse of the swamp");
 		outputText(" when you hear strange music emanating not far from where you are.  Do you investigate?");
 		//[Yes][No]
-		if(location == 0) doYesNo(createCallBackFunction(consensualSatyrFuck,0), camp.returnToCampUseOneHour);
-		else doYesNo(createCallBackFunction(consensualSatyrFuck,0), camp.returnToCampUseOneHour);
+		if(location == 0) doYesNo(createCallBackFunction(consensualSatyrFuck,0), explorer.done);
+		else doYesNo(createCallBackFunction(consensualSatyrFuck,0), explorer.done);
 	}
 }
 
@@ -109,6 +109,7 @@ private function keepDrinking():void {
 	outputText(".  This must be the work of that satyr!  Mentally, you remind yourself to watch out for him next time.  You clean yourself up as best as you can and redress, then wobble your way towards your camp, trying to stifle the pain, in your head and elsewhere, along the way.");
 	//(8 hours lost) (PC is pregnant (either vagina or ass) with a satyr, slimefeed)
 	satyrPreggo();
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseFourHours);
 }
 
@@ -146,7 +147,7 @@ private function trickZeSatyr():void {
 	
 	player.gems += 10+rand(10);
 	statScreenRefresh();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[=Skip Foreplay=]
 private function skipForeplay():void {
@@ -292,7 +293,7 @@ private function femaleTakesAdvantageOfSatyr():void {
 	player.sexReward("saliva","Vaginal");
 	cleanupAfterCombat();
 }
-	
+
 //Male (Z)
 private function malesTakeAdvantageOfSatyrs():void {
 	clearOutput();
@@ -404,7 +405,7 @@ private function willinglyBoneSatyr():void {
 	//slimefeed, reduce lust, impregnational geographic
 	player.sexReward("cum","Vaginal");
 	satyrPreggo();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -2150,7 +2150,7 @@ public class Camp extends NPCAwareContent{
 		else addButtonDisabled(6, "Garden", "Req. to have Herb bag of any sort.");
 		addButton(7, "Herbalism", SceneLib.garden.herbalismMenu).hint("Use ingrediants to craft poultrice and battle medicines.").disableIf(isNightTime,"It's too dark to do any gardening!").disableIf(!player.hasStatusEffect(StatusEffects.CampRathazul),"Would you kindly find Rathazul first?");
 		addButton(8, "Materials", SceneLib.crafting.accessCraftingMaterialsBag).hint("Manage your bag with crafting materials.").disableIf(Crafting.BagSlot01Cap <= 0, "You'll need a bag to do that.");
-		addButton(9, "Quest Loot", SceneLib.adventureGuild.questItemsBag).hint("Manage your bag with quest items.").disableIf(AdventurerGuild.Slot01Cap <= 0, "Join the Adventure Guild for a quest bag!");
+		addButton(9, "Quest Loot", SceneLib.adventureGuild.questItemsBag).hint("Manage your bag with quest items.").disableIf(!AdventurerGuild.playerInGuild, "Join the Adventure Guild for a quest bag!");
 		addButton(10, "Questlog", questlog.accessQuestlogMainMenu).hint("Check your questlog.");
 		addButton(11, "Recall", sceneHunter.recallScenes).hint("Recall some of the unique events happened during your adventure.");
 		if (player.explored >= 1) addButton(12, "Dummy", DummyTraining).hint("Train your mastery level on this dummy.").disableIf(isNightTime,"It's too dark for that!");

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -10936,7 +10936,7 @@ public class Combat extends BaseContent {
 			healingPercent = 0;
             healingPercent += PercentBasedRegeneration();
             if (player.armor == armors.GOOARMR) healingPercent += (SceneLib.valeria.valeriaFluidsEnabled() ? (flags[kFLAGS.VALERIA_FLUIDS] < 50 ? flags[kFLAGS.VALERIA_FLUIDS] / 25 : 2) : 2);
-            if ((player.hasStatusEffect(StatusEffects.UnderwaterCombatBoost) || player.hasStatusEffect(StatusEffects.NearWater)) && (player.hasPerk(PerkLib.AquaticAffinity) || player.hasPerk(PerkLib.AffinityUndine)) && player.necklaceName == "Magic coral and pearl necklace") healingPercent += 1;
+            if (isNearWater() && (player.hasPerk(PerkLib.AquaticAffinity) || player.hasPerk(PerkLib.AffinityUndine)) && player.necklaceName == "Magic coral and pearl necklace") healingPercent += 1;
             if (player.statStore.hasBuff("CrinosShape") && player.hasPerk(PerkLib.ImprovingNaturesBlueprintsApexPredator)) healingPercent += 2;
             if (player.hasPerk(PerkLib.Sanctuary)) healingPercent += 1;
             if (player.shield == shields.SANCTYL) healingPercent += ((player.corruptionTolerance - player.cor) / (100 + player.corruptionTolerance)) * 4;
@@ -11050,7 +11050,7 @@ public class Combat extends BaseContent {
 		if (player.perkv1(IMutationsLib.HumanThyroidGlandIM) >= 2 && player.racialScore(Races.HUMAN) > 17) maxRegen += 1;
 		if (player.perkv1(IMutationsLib.HumanThyroidGlandIM) >= 3 && player.racialScore(Races.HUMAN) > 17) maxRegen += 1;
         if (player.hasPerk(PerkLib.HydraRegeneration) && !player.hasStatusEffect(StatusEffects.HydraRegenerationDisabled)) maxRegen += 1 * player.statusEffectv1(StatusEffects.HydraTailsPlayer);
-        if ((player.hasStatusEffect(StatusEffects.UnderwaterCombatBoost) || player.hasStatusEffect(StatusEffects.NearWater)) && (player.hasPerk(PerkLib.AquaticAffinity) || player.hasPerk(PerkLib.AffinityUndine)) && player.necklaceName == "Magic coral and pearl necklace") maxRegen += 1;
+        if (isNearWater() && (player.hasPerk(PerkLib.AquaticAffinity) || player.hasPerk(PerkLib.AffinityUndine)) && player.necklaceName == "Magic coral and pearl necklace") maxRegen += 1;
         //if (player.hasStatusEffect(StatusEffects.GnomeHomeBuff) && player.statusEffectv1(StatusEffects.GnomeHomeBuff) == 1) maxRegen += 15;
 		if (player.statStore.hasBuff("CrinosShape") && player.hasPerk(PerkLib.ImprovingNaturesBlueprintsApexPredator)) maxRegen += 2;
         if (player.hasStatusEffect(StatusEffects.SecondWindRegen)) maxRegen += 5;
@@ -16563,6 +16563,13 @@ private function touSpeStrScale(stat:int):Number {
         if (damage > maxPercentDamage) damage = maxPercentDamage; //no more than 1 billion!
         if (player.level < monster.level) damage *= doDamageReduction(); //punish more for high-levels
         return damage;
+    }
+    
+    public function isNearPlants():Boolean {
+        return player.hasStatusEffect(StatusEffects.NearbyPlants) || explorer.areaTags.plants;
+    }
+    public function isNearWater():Boolean {
+        return player.hasStatusEffect(StatusEffects.UnderwaterCombatBoost) || player.hasStatusEffect(StatusEffects.NearWater) || explorer.areaTags.water;
     }
 }
 }

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -789,7 +789,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.GreenCovenant)) {
 				bd.disable("You already connected with nearby plants!");
 			}
-			else if(!player.hasStatusEffect(StatusEffects.NearbyPlants) && !explorer.areaTags.plants) {
+			else if(!combat.isNearPlants()) {
 				bd.disable("Green Covenant requires having plants nearby.");
 			}
 			else if(player.hasStatusEffect(StatusEffects.CooldownGreenCovenant)) {

--- a/classes/classes/Scenes/Combat/SpellsGreen/DeathBlossomSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/DeathBlossomSpell.as
@@ -32,7 +32,7 @@ public class DeathBlossomSpell extends AbstractGreenSpell {
 		var uc:String = super.usabilityCheck();
 		if (uc) return uc;
 		
-		if (!player.hasStatusEffect(StatusEffects.NearbyPlants) && !explorer.areaTags.plants) {
+		if (!combat.isNearPlants()) {
 			return "Death Blossom require to have plants nearby.";
 		}
 		

--- a/classes/classes/Scenes/Combat/SpellsGreen/EntangleSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/EntangleSpell.as
@@ -38,7 +38,7 @@ public class EntangleSpell extends AbstractGreenSpell {
 		var uc:String = super.usabilityCheck();
 		if (uc) return uc;
 		
-		if (!player.hasStatusEffect(StatusEffects.NearbyPlants) && !explorer.areaTags.plants) {
+		if (!combat.isNearPlants()) {
 			return "Entangle require to have plants nearby.";
 		}
 		

--- a/classes/classes/Scenes/Combat/SpellsGreen/PlantGrowthSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/PlantGrowthSpell.as
@@ -53,7 +53,7 @@ public class PlantGrowthSpell extends AbstractGreenSpell {
 	
 	override protected function doSpellEffect(display:Boolean = true):void {
 		if (display) {
-			if (player.hasStatusEffect(StatusEffects.NearbyPlants) || explorer.areaTags.plants) {
+			if (combat.isNearPlants()) {
 				outputText("You focus your intent on the flora around you, infusing them with the power of your emotions. The onslaught of lust causes flowers to bloom into a pollen cloud as vine surges from the canopy and darts to your opponent.");
 				if (monster.lustVuln == 0) {
 					if (display) {

--- a/classes/classes/Scenes/Dungeons/DesertCave.as
+++ b/classes/classes/Scenes/Dungeons/DesertCave.as
@@ -1,5 +1,5 @@
 //Side Dungeon: Desert Cave (Refactored, may have bugs)
-package classes.Scenes.Dungeons 
+package classes.Scenes.Dungeons
 {
 import classes.*;
 import classes.BodyParts.Tongue;
@@ -50,7 +50,7 @@ public class DesertCave extends DungeonAbstractContent
 		public function openZeDoorToParadize():void {
 			clearOutput();
 			outputText(images.showImage("dungeon-entrance-desertcave"));
-			//Touch Sphere to Open: 
+			//Touch Sphere to Open:
 			if(flags[kFLAGS.ENTERED_SANDWITCH_DUNGEON] == 0) {
 				outputText("You hesitantly touch the dark sphere, admiring its smooth, glossy finish.  Almost as soon as you come in contact with it, it recedes into the wall.  The doorway rumbles, a giant slab vanishing into the sandy depths, opening a portal to the inside.  Meticulous carvings inlaid with pearl depict large breasted witches in great quantity, and though the specific means of the glyphs are foreign to you, it's clear this place is some kind of sanctuary for sand witches.");
 				flags[kFLAGS.ENTERED_SANDWITCH_DUNGEON] = 1;
@@ -70,7 +70,7 @@ public class DesertCave extends DungeonAbstractContent
 			inDungeon = false;
 			clearOutput();
 			outputText("You leave the door behind and take off through the desert back towards camp.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		private function checkPharmacyDoorUnlocked():Boolean {
@@ -404,7 +404,7 @@ public class DesertCave extends DungeonAbstractContent
 			player.sexReward("vaginalFluids", "Dick");
 			//[Next]
 			menu();
-			addButton(0,"Next",memeberedFolksFindTrueWuv3);	
+			addButton(0,"Next",memeberedFolksFindTrueWuv3);
 		}
 
 		public function memeberedFolksFindTrueWuv3():void {
@@ -538,7 +538,7 @@ public class DesertCave extends DungeonAbstractContent
 				else doNext(recallWakeUp);
 			}
 		}
-			
+		
 		//*Sapphic Win Sex
 		//Forced cunnlingus, rimjob, and clit-and-nipple sucking.
 		public function forceCunnilingusRimjobClitAndNipple():void {
@@ -1240,7 +1240,7 @@ public class DesertCave extends DungeonAbstractContent
                 else if (inDungeon)
                     doNext(playerMenu);
                 else
-                    doNext(camp.returnToCampUseOneHour);
+                    endEncounter();
             }
 		}
 
@@ -1283,7 +1283,7 @@ public class DesertCave extends DungeonAbstractContent
             else if (inDungeon)
                 doNext(playerMenu);
 			else
-                doNext(camp.returnToCampUseOneHour);
+                endEncounter();
 		}
 
 		//Female Victory Sex
@@ -1319,9 +1319,9 @@ public class DesertCave extends DungeonAbstractContent
             else if (inDungeon)
                 doNext(playerMenu);
 			else
-                doNext(camp.returnToCampUseOneHour);
+                endEncounter();
 		}
-			
+		
 		//Tentacle Victory Gangbang
 		//3+ Tentas
 		public function tentacleVictoryGangbangCumWitch():void {
@@ -1358,7 +1358,7 @@ public class DesertCave extends DungeonAbstractContent
             else if (inDungeon)
                 doNext(playerMenu);
 			else
-                doNext(camp.returnToCampUseOneHour);
+                endEncounter();
 		}
 
 		//Repeat Desert Loss Female & Herm
@@ -1366,7 +1366,7 @@ public class DesertCave extends DungeonAbstractContent
 			clearOutput();
 			//(HP)
 			if(player.HP < 1) outputText("Unable to further withstand the witch's magical assault, you topple over into the soft, warm sands. Before you can recover, the witch is on top of you, her powerful legs straddling your [hips]. Her long, dainty fingers lock through your [armor], pulling your face out of the sand and rolling you over to look up at her.");
-			//(Lust) 
+			//(Lust)
 			else outputText("Uncontrollable lust surges through you, your heart pounding beneath your [chest] as your [legs] collapse out from under you.  Your hands desperately claw at your [armor], trying to touch your needy cunt, the fire in your genitals burning like whitefire through your veins.  You moan with helpless lust as the witch looms over you, grabbing your hands away from your crotch and pushing you onto your back.  A moment later, she's on you, straddling your [hips] between her lush thighs.");
 			outputText("\n\nPinned beneath the witch, you struggle weakly in her grasp as she slowly strips off your [armor], bearing your [chest] to her surprisingly soft, gentle caresses.  ");
 			//if Multiboob:
@@ -1448,7 +1448,7 @@ public class DesertCave extends DungeonAbstractContent
 			cleanupAfterCombat();
 		}
 
-			
+		
 		public function lionpaws(skipped:Boolean = false):void {
 			clearOutput();
 			//[skip riddles, just request from menu (requires some event occurrence > 1)]
@@ -1471,7 +1471,7 @@ public class DesertCave extends DungeonAbstractContent
 				if(player.biggestCockArea() > 100) outputText("  It's not as if there's all that much else I can do for that monster of yours anyways.");
 				outputText("</i>\" She raises a paw and examines it, as though trying to figure out just what it is about them that you enjoy so much.  You cough as a means of drawing her attention once you've stripped off the last bit of your armor, shaking her from her reverie.");
 			}
-				
+			
 			outputText("\n\nSanura asks that you kneel, and you eagerly comply.  ");
 			//[if dick isn't already hard and PC knows what's coming]
 			if(player.lust < 50 && flags[kFLAGS.PAWJOBS] == 0) {
@@ -1543,7 +1543,7 @@ public class DesertCave extends DungeonAbstractContent
 			menu();
 			if(skipped) {
 				inDungeon = false;
-				addButton(0,"Next",camp.returnToCampUseOneHour);
+				addButton(0,"Next",explorer.done);
 			}
 			else {
 				menu();
@@ -1820,7 +1820,7 @@ public class DesertCave extends DungeonAbstractContent
 			menu();
 			if(submit) {
 				inDungeon = false;
-				addButton(0,"Next",camp.returnToCampUseOneHour);
+				addButton(0,"Next",explorer.done);
 			}
 			else {
 				addButton(0,"Enter",openZeDoorToParadize);
@@ -1929,7 +1929,7 @@ public class DesertCave extends DungeonAbstractContent
 			clearOutput();
 			outputText("You disrobe, tossing your [armor] aside into a small pile.  You stretch your muscles in the dry desert air and exult in the warm rays beating down on your " + player.skinFurScales() + " and [cocks].  Sanura pads around you, taking in your appearance with her chestnut-colored eyes before clicking her tongue approvingly.  Her leonine tail swishes across the top of your [cock biggest], stroking it with the silky soft tuft of fur at its tip.  You shiver at the contact, unsure of what to think.  Your penis, on the other hand, has no such conflictions, and immediately begins to rise.");
 			
-			//(Small dicks) 
+			//(Small dicks)
 			if(player.biggestCockArea() < 6) outputText("\n\n\"<i>Aw, it's so cute and compact.  I didn't know these things came in women's sizes,</i>\" she giggles, flicking the [cockHead biggest] of your cock with her tail.  You blush brightly.  Even by Ingnam standards you're a little below average, and in Mareth, well, you're just plain tiny.  \"<i>Don't worry, love, it will suffice for what I have in mind.</i>\"");
 			
 			//(Normal-sized dicks)
@@ -1942,7 +1942,7 @@ public class DesertCave extends DungeonAbstractContent
 				else if(player.hasVagina()) outputText("cunt");
 				else outputText("asshole");
 				outputText(" with the little tuft of fur.  \"<i>That bad boy will be just perfect.</i>\"");
-			}	
+			}
 			else outputText("\n\nSanura's eyes go wide upon seeing your monstrous cock.  She opens her mouth, attempting to speak, but no words come out.  Her tail reaches out, coiling around your dick in futility.  \"<i>By Marae's pillowy tits that thing is huge,</i>\" she says finally, regaining her voice.  \"<i>I don't know if I can take something that big... but goddamnit, I'm going to try.</i>\"");
 			
 			outputText("\n\nYour manhood spikes upwards at the attention, becoming painfully hard as the sphinx continues to survey your body.  Her tail flicks over your " + player.skinFurScales() + " gently, stopping briefly to tantalize ");
@@ -2051,7 +2051,7 @@ public class DesertCave extends DungeonAbstractContent
 			//Lowish Capacity
 			else {
 				outputText("\n\nYou will yourself to relax, but you just aren't big enough back there to make much of a difference.  Just having such an immense dong pressing at your backdoor is enough to push you to your limits, but your sphincter hasn't even dilated enough to take a fraction of her girth.  Sanura growls in frustration and begins to hump at it, smacking the blunted tip into it again and again. The shocking sensation makes your anal muscles twitch, spasm, and relax as she works to plow her way through your more than token resistance.");
-				//VIRGIN ALT: 
+				//VIRGIN ALT:
 				if(player.ass.analLooseness == 0) {
 					outputText("\n\nShe grunts, \"<i>Don't tell me you're a virgin?</i>\"  You nod and bite your lip as you try to endure.  Sanura stops immediately at that news, mulling it over with a detached expression, a smile slowly spreading across her features.  \"<i>Really?</i>\" she asks as her hips begin to slowly work at your ass once more, slowly picking back up to their old tempo.  \"<i>Then it's a good thing you're getting to ride my magic cock and not some brute's.  It might hurt a little, but I promise this will be buttsex worth remembering....</i>\"");
 				}
@@ -2461,11 +2461,11 @@ public class DesertCave extends DungeonAbstractContent
 			}
 			else sceneHunter.print("Check failed: 10 cocks!")
 			outputText("\n\nNow fully enveloped, you lean over your happily gurgling prey, admiring her swollen, milk-engorged bust as you take her in every way imaginable.  You wordlessly command your multitude of dongs to fuck faster, then, lean down for a sip of sweet breast milk.  Drinking happily, you allow your body to whip into a sexual frenzy, pumping and pounding, sliding and squeezing, fucking with the relentless power of a champion-turned-tentacle-beast.  Every ounce of exposed skin and every orifice is liberally slicked with your pre-cum, and as your one-man orgy winds to a fever pitch, you let the milky tit pop free and bellow out in bliss, cumming hard.");
-				
+			
 			outputText("\n\nA bevy of bulges work their way up your shafts as you orgasm, dozens of them quickly traveling from base to tip, stretching cunnies and gaping anuses as they go.  When they reach your large, throbbing tips, your cum slits stretch wide and unleash matching waves of white.  Both cunts are creamed from womb to lips.  Your new favorite slut's anus is given an alabaster enema.  All four tits get a frothing jizz-bath.");
 			if(tentaCnt >= 6) outputText("  Bubbling seed soaks her frantically jerking hands.");
 			outputText("  That was just the first explosions of relief.  You orgasm drags on as you squirt like a firehose, drenching the poor witch with white from head to toe.  Her belly rounds obscenely, stuffed from her throat, ass, and wombs, filled to absolute capacity until all four of the aforementioned holes are squirting torrents of sticky white man-milk into thick puddles.");
-				
+			
 			outputText("\n\nYou pull out as your pleasure dies down, aiming all " + num2Text(tentaCnt) + " of your cum-nozzles above her like an obscene shower, and drench her from head to toe again, a salty white wreck of a cumslut.  With her throat free for the first time in a long time, she swallows and whimpers, \"<i>Oooooh... gods.</i>\"  The cum-drunk fuck-slut begins to clean herself the only way she can right now - with her mouth.  She's so fucked out that she couldn't channel her magic if she tried.  You get dressed with a satisfied swagger.");
 			if(flags[kFLAGS.SAND_WITCHES_COWED] == 0) {
 				outputText("\n\nThe witches are suitably cowed, but you've ruined any chance at a friendly peace with them.");
@@ -2608,7 +2608,7 @@ public class DesertCave extends DungeonAbstractContent
             if (!CoC.instance.inCombat) doNext(playerMenu);
             else cleanupAfterCombat();
 		}
-			
+		
 		//*Lose Male Loss
 		//>Get turned into breeder or sumthin.
 		public function loseToSandMotherBadEnd():void {
@@ -2705,7 +2705,7 @@ public class DesertCave extends DungeonAbstractContent
 			EventParser.gameOver();
 			removeButton(1);
 		}
-			
+		
 		//*Lose Female Loss
 		//>Get turned into sand witch.
 		//Additional Sand Witch Entry (BY XODIN)
@@ -2885,7 +2885,7 @@ public class DesertCave extends DungeonAbstractContent
 			if(y >= 0) outputText("both your cocks");
 			else outputText("your " + cockDescript(x));
 			outputText(".");
-					   
+			
 			//HOARSES:
 			if(player.isTaur()) {
 				outputText("\n\nWhinnying in delight, you rest your forelegs on ");
@@ -3046,7 +3046,7 @@ public class DesertCave extends DungeonAbstractContent
 			player.sexReward("milk", "Vaginal");
 			doNext(playerMenu);
 		}
-			
+		
 		//*History
 		//>Learn about the origin of the sand witches.
 		public function sandWitchHistory():void {
@@ -3166,7 +3166,7 @@ public class DesertCave extends DungeonAbstractContent
 			flags[kFLAGS.MORE_CUM_WITCHES] = 1;
 			sandWitchMotherFriendlyMenu();
 		}
-			
+		
 		//*Pick Mothers
 		//>Ask about how Sand Mothers are chosen.
 		public function askHowSandMothersAreChosen():void {
@@ -3243,7 +3243,7 @@ public class DesertCave extends DungeonAbstractContent
 			flags[kFLAGS.SAND_WITCH_LOOT_TAKEN]++;
 			inventory.takeItem(consumables.LABOVA_, roomSandMotherThrone);
 		}
-			
+		
 		//TURN EM OFF!
 		public function unfriendlyWitchToggle():void {
 			clearOutput();
@@ -3392,7 +3392,7 @@ public class DesertCave extends DungeonAbstractContent
 		//*Take Barren Pills✓Kirbu
 		public function takeBarrenPills():void {
 			clearOutput();
-			//{Already contraceptive'ed} 
+			//{Already contraceptive'ed}
 			if(player.hasStatusEffect(StatusEffects.Contraceptives)) outputText("You're already under the effects of contraceptives.  Taking one of the brown pills wouldn't do anything.");
 			//{TAKE DAT SHIT YO}
 			else {
@@ -3541,7 +3541,7 @@ public class DesertCave extends DungeonAbstractContent
 				if (y >= 0) sceneType = 4;
 			}
 			else sceneHunter.print("Check failed: two or three 20-inch long tentacocks.");
-			//{if player does not have a tentacle cock} 
+			//{if player does not have a tentacle cock}
 			if(sceneType == 0) outputText("You grab the tanned shoulders of the closest pregnant witch and flip her over on to her back, trapping her beneath the weight of her belly and breasts while you grab both of her ankles.  Her dirty blonde, sweat-soaked hair lies in waves around her head on the floor as she pants heavily in sexual desperation.");
 			//{else if player has a tentacle cock}
 			else outputText("Your tentacle cock lashes outwards, extending as it goes, and wraps around the ankle of the closest girl. It flips her over on to her back, trapping her own torso beneath the weight of her heavy pregnancy and her own four massive leaking breasts.");
@@ -3562,13 +3562,13 @@ public class DesertCave extends DungeonAbstractContent
 			else outputText("\n\nYour hands slide along the witch's legs and up her thighs until they grasp her hips. You allow the shaft of your " + cockDescript(x) + " to slide up and down the folds of her dripping labia until your cockhead slips in between and presses against her entrance.  \"<i>P-please!  Q-quickly!  I n-n-neeeed it!</i>\"  You're all too eager to service her as you thrust forwards.");
 			outputText("  The witch's moans and grunts of pleasure arouse the other witches in the room as they watch with the utmost jealously.  Some grab their nipples while others try to finger their pussies; whining and getting off on their envious voyeurism as they watch you fuck their sister.");
 			
-			//{all} 
+			//{all}
 			outputText("\n\nYour thrusts become forceful enough to rock the impaled witch's torso up and down along the floor. Her upper breasts repeatedly smack her own face while her lower slap against the swollen sides of her pregnant belly. All four of her heavily milk engorged tits spray streams of her cream into the air. Whimpering moans of orgasmic ecstasy constantly stream from her perfectly plump lips. Her body shakes and trembles with the convulsions of constant climaxes. The sensation of your bare cock flesh sliding against the naked walls of her inner depths with every thrust quickly shuts down the girl's higher brain functions. She becomes a senseless pregnant she-beast lost in the throes of pleasure that your shaft");
 			if(sceneType >= 3) outputText("s constantly pound");
 			else outputText(" constantly pounds");
 			outputText(" into her nethers. Drool escapes her lips and drips down her cheek even as her eyes roll back in her head. Talk about an easy lay.");
 
-			//{if player has large but not extremely massive breasts} 
+			//{if player has large but not extremely massive breasts}
 			if(player.biggestTitSize() >= 4 && player.biggestTitSize() < 15) {
 				outputText("\n\nYour breasts bounce up and down as you get in to the groove of fucking your pregnant playtoy.");
 				//{if player is largely pregnant and has large breasts.}
@@ -3579,7 +3579,7 @@ public class DesertCave extends DungeonAbstractContent
 			//else if player has extremely huge breasts
 			else if(player.biggestTitSize() >= 15) {
 				outputText("\n\nYour [chest] are massive enough that they jiggle instead of bounce with each thrust.");
-				//if player has only one set of massive breasts 
+				//if player has only one set of massive breasts
 				if(player.bRows() == 1) outputText("  Your two heavy milk sacs sway and at times you must rest them on top of the poor witch's belly to keep from prematurely exhausting yourself.");
 				else if(player.bRows() >= 2) outputText("  Resting on top of each other and on top of the witch's legs, your giant globes of tit flesh quake each time you hips move.");
 				outputText("  The witches around the room can't help but gawk at how much more endowed your mammaries are than even their own, and how the wrong forwards or backwards movement could result in either you or the witch you're fucking to be suddenly smothered under the weight of your ridiculously engorged tits.");
@@ -3589,7 +3589,7 @@ public class DesertCave extends DungeonAbstractContent
 			outputText(" forces you to reach your own orgasm.");
 			if(player.hasBalls()) outputText("  Your [balls] tense with the anticipation of releasing the fruit of your loins into her waiting womb.");
 			outputText("  With both hands you reach up and grab the fat nipples of the witch's lower breasts, tugging on them like reins as you try to thrust deeper.  \"<i>Ung! Ah!</i>\" The witch bites her lower lip in pleasure and pain as you roughly handle her leaking teats.");
-			//{if player has huge or massive breasts} 
+			//{if player has huge or massive breasts}
 			if(player.biggestTitSize() >= 15) outputText("  The weight of your own tits bears heavily against your arms as you try to keep the motion of your hips constant while pulling on your lover's milk knobs.");
 			//{if player's tits can lactate}
 			else outputText("  Each of your [nipples] begin spraying milk over the witch as your body begins its crescendo.");
@@ -3649,7 +3649,7 @@ public class DesertCave extends DungeonAbstractContent
 				y = player.cockThatFits2(50);
 			}
 			outputText("These hormonally overwrought witches are each little more than five huge fleshy orbs of tits and bellies, desperately crawling towards you on hands and knees as their stares fixate on your " + cockDescript(y) + ".  ");
-			//{if player has two long tentacle cocks} 
+			//{if player has two long tentacle cocks}
 			if(player.countCocksWithType(CockTypesEnum.TENTACLE, 20) >= 2) outputText("Almost of their own accord your tentacle cocks lash out, wrapping around the arms of the two closest girls, lifting them to their knees only to roll them backwards and on to their sides with their backs to each other.  ");
 			else outputText("It takes little effort to grab the closest two witches and pull them up only to push them down again and on to their sides with their backs pressed against each other.  ");
 			outputText("The two witches lay before you with their heaving breasts and bellies jutting out to either side while their asses are mashed against each other.  You grab an ankle from each of them and raise their legs up to expose the dual pairs of pussies that they possess.");
@@ -3664,14 +3664,14 @@ public class DesertCave extends DungeonAbstractContent
 			outputText(".");
 			if(player.hasVisiblePregnancy()) outputText("  Each of these raised legs carefully bend at the knee to accomodate your own pregnant belly that looms over their prone figures.");
 			outputText("  As each witch lies on her side, both of them begin feeling your stiff cocks slap against their multiple pussies.  They moan as their four pairs of labia bloom in anticipation of the fucking to come.  Each set of nether lips are dark and dripping with gobs of desperation, but on each girl there's one set that looks particularly gaping as if the pressure inside was forcing it open.  It isn't difficult to figure out that those are the ones that lead to their already occupied wombs, while the other sets are the ones eagerly awaiting a fresh deposit of baby batter.");
-				
+			
 			outputText("\n\nYou feel supremely ready to fulfill those cum craving needs and you carefully align your cocks for the purpose.");
 			//{if has two horse cocks}
 			sceneHunter.print("Dick type fork: horse, dog, tentacle, demon.");
 			if(player.cocks[x].cockType == CockTypesEnum.HORSE && player.cocks[y].cockType == CockTypesEnum.HORSE) outputText("  The wide flaring tips of your equine pricks press flatly against the pair of sweltering nether lips, but they easily part with only a little pressing.  The hot swollen folds eagerly slurp around the wide ridged crowns of your cock heads as you press against their vaginal entrances.  They're looser than most normal pussies, yet around such thick cock heads they nonetheless feel enjoyably tight.  With a slightly harsher shove forwards you easily impale both whorish witches.  Pleasured cries of shock escapes their lips as your horse-dongs bore through their depths.");
-			//{else if two dog cocks} 
+			//{else if two dog cocks}
 			else if(player.cocks[x].cockType == CockTypesEnum.DOG && player.cocks[y].cockType == CockTypesEnum.DOG) outputText("  Your canine pricks easily part the obscenely wet folds of the girls' labia.  Each woman's juices drip down your smooth shafts as you begin pressing their pointed heads into their tight entrances, eliciting pleasured and desperate pleas for more from each of them.  A gentle thrust of your pelvis and both pussies become simultaneously impaled upon your doggy dicks, giving you complete control over the hormonal witches.");
-			//{else if two tentacle cocks} 
+			//{else if two tentacle cocks}
 			else if(player.cocks[x].cockType == CockTypesEnum.TENTACLE && player.cocks[y].cockType == CockTypesEnum.TENTACLE) outputText("  Your green tentacle formed cocks stiffen yet weave their ways around the various pussies in front of you.  Their dark fuchsia heads almost seem to have a mind of their own as they trace the outlines of each pussy, teasing the poor hormonal witches into even higher states of sexual desperation. Pussy juice squirts from the anxious cunts with each teasing slide along their labia.  Satisfied with the pleasured taunting your prehensile cocks get down to business, darting into each slutty snatch like snakes striking at prey.  You feel each girl's entrance brutally stretch to accommodate your shafts as they deeply worm a path into each girl's vaginal orifice, causing both to scream in frantic bliss.");
 			//{else if two demon dicks}
 			else if(player.cocks[x].cockType == CockTypesEnum.DEMON && player.cocks[y].cockType == CockTypesEnum.DEMON) outputText("\n\nThe big bumps and nodules that line the rims of each of your demonic cockheads feel particularly wonderful as they force their way between the dark, swollen folds of each witch's as yet unseeded pussy.  Both girls whimper and yelp in pleasure as the demonic ridges and soft protrusions along your shafts tease and taunt the erogenous zones of the inner walls of their cunts.  Your blighted cocks seem to swell even larger specifically to ensure the tightest fit possible within these two girls and it isn't long before each girl is leaking copious amounts of pussy juice around each cock as the highly textured shafts double time the twin twats.");
@@ -3687,13 +3687,13 @@ public class DesertCave extends DungeonAbstractContent
 				sceneHunter.print("Check failed: used cocks at least 20-inch long (hard to fit, better tenta).");
 				outputText("\n\nFinally, you penetrate them far enough to feel the thresholds of their wombs pressing back against your throbbing cock heads.  Each girl cries out in exquisite pain as you pound against their cervixes, yet both protest if you pull back.  Giving in to their needs you fuck and thrust away as hard as you can, and it isn't long until your shafts are tingling with the sensations of imminent release.");
 			}
-			//{if cocks >= 20} 
+			//{if cocks >= 20}
 			else outputText("\n\nWith one thrust at a time you slowly delve inch by strangled inch deeper into the tight tunnels of each girl's womanhood.  You eventually manage to brush up against the deep and tight entrances to each one's womb, and both cry out in pleasured pain as you pound against their inner thresholds.  With plenty of length to spare, your cocks fill each cunt's passage completely, and the witches' begging pleas for more despite the momentary jolts of pain leaves you no choice but to try to ram yourself into their actual wombs.  Leaning forward with their upright legs pressed tightly against your torso, you place more of your body weight behind each cock.  The girls cry out in joyous agony as they each feel their cervixes stretch and both wombs become impaled.  Their bodies suck in more cock than any normal woman ever could, allowing you to use their abdomens as living cock sleeves to fuck.  With such an opportunity you eagerly begin doing just that, thrusting repeatedly into their wombs.  Their cervixes feel like a second pussy within their first, and it isn't long before [eachCock] feels on the verge of climax.");
 			
 			outputText("\n\nThe eight milk-filled breasts of the two preggo sluts wobble lewdly as each witch's body shakes from your thrusting.  Milk spurting nipples plaster the floor with their cream.");
 			//{if player lactates}
 			if(player.lactationQ() >= 200) outputText("  Your own breasts begin spraying down the two pregnant sluts with your own dairy fluids.");
-			//{if player has large but not huge breasts} 
+			//{if player has large but not huge breasts}
 			if(player.biggestTitSize() >= 5 && player.biggestTitSize() < 20) outputText("  Each thrust in to the eager cunts causes your breasts to bounce up and down.");
 			else if(player.biggestTitSize() >= 20) outputText("  Each thrust in to the eager cunts causes your massive breasts to sway back and forth, slapping against your own sides.");
 			//{if player has six huge breasts}
@@ -3703,11 +3703,11 @@ public class DesertCave extends DungeonAbstractContent
 			if(player.hasBalls()) outputText("  The closer your shafts come to their climax the more tense your balls become, preparing to pump their loads through your cocks.");
 			
 			outputText("\n\nEvery other witch in the room is fingering herself off as they watch you recklessly pound their sisters.  Finally ready, you decide to let them see what they're missing as you plunge your cocks as deep as they'll go, and finally cum your brains out.  Your shafts swell as your seed surges upwards from their bases towards the tips that you've buried so expertly inside the milky whores.");
-			//{if cumNormal or Medium} 
+			//{if cumNormal or Medium}
 			if(player.cumQ() < 500) outputText("  The pair of girls yelp as they feel the hot seed splash forth inside them.  Millions of sperm swim in to their fertile wombs, seeking to turn them into doubly pregnant sluts.");
 			//{else if cumHigh}
 			else if(player.cumQ() < 1000) outputText("  The slutty pair of milk bags cry out in sensual surprise as they feel extraordinary amounts of cum pumping directly into their baby makers, knocking them up with the double pregnancy they've desperately wanted. Their bellies bulge with all of the cum you've deposited within them.");
-			//{else if cumVeryHigh} 
+			//{else if cumVeryHigh}
 			else if(player.cumQ() < 3000) outputText("  The two piles of tits and bellies scream in pleasured insanity as their empty wombs are assaulted with a surging torrent of jizz.  You can feel the heavy blasts of cum surging within your shafts as they flood forth in to slutty orifices that have swallowed your manhoods.  Your brain burns with ecstasy as your genitals pump each womb over and over again, forcing them to swell far beyond what they're intended to take from cum alone.  By the time your cocks feel satisfied each witch looks as if she's already full term with a second child, the cum filled womb creating a distinct second orb next to the first pregnancy.");
 			//{else if cumExtreme}
 			else outputText("  The eyes of every witch in the room open wide in shock as they watch their sister's bellies swell obscenely.  Your cocks feel as if they're trying to wrest control of your body from you as liters of hot sperm pump forcefully directly in to the extra fertile wombs of each slutty witch.  The two quad-breasted whores convulse in brain damaging pleasure, causing their huge milk filled tits to quake and bounce everywhere. A white flood of ejaculate erupts from their pussies around your cocks as their overfilled wombs fail to contain your bounty of baby batter.");
@@ -3742,14 +3742,14 @@ public class DesertCave extends DungeonAbstractContent
 			if (tentaCnt > fitCnt)
 				fitCnt = tentaCnt;
 			
-			//{if player has a single cock} 
+			//{if player has a single cock}
 			if(fitCnt == 1) {
 				outputText("\n\nWasting no time you move forwards to slide the shaft of your [cock] up and down the folds of the nearest witch's labia to lube it up.  She moans in frustrated pleasure, anxious to feel the length of your manhood pushing directly into those folds.  As you feel the crown of your cock head sliding along the lips of her cunt you decide not to tease her for the sake of your own pleasure.  With fingers from each hand you pull her nethers aside and press your cock directly into her entrance, feeling the tight orifice stretch around your man-flesh and swallow your cock as deeply as it can.");
 			}
 			//{else if player has two long cocks}
 			else if (fitCnt == 2)
 				outputText("\n\nAs you walk forwards you push two of the witches together, side by side, with their asses up in the air and their pairs of pussies facing you as your cocks press up against the nethers leading to their empty wombs.  Their dark cunts part and swallow up your shafts as you press forward, eliciting cries of pleasure from the whorish witches and forcing gobs of girl cum to drip down your cocks from their sexually charged holes.");
-			//{else if player has three long cocks} 
+			//{else if player has three long cocks}
 			else
 				outputText("\n\nYou gather three of the bent over witches together with their asses pressed tightly side by side, close enough for their sopping wet cunts to be in reach for three long cocks to fuck at once.  With your stiffening shafts growing harder with each passing moment you begin grabbing your pricks and angling them into the flush dark cunts.  As soon as you feel the entrances of each witch's pussy pressing against your cock heads you begin pressing forwards.  All three of them cry out as your shafts spear their cunts and fill their depths at the same time.  Their inner muscles contract and grip your cocks, almost as if they were trying to suck your bundle of shafts even deeper in to their whorish pregnant bodies.");
 			outputText("\n\nWith your shaft");
@@ -3784,13 +3784,13 @@ public class DesertCave extends DungeonAbstractContent
 			if(player.biggestTitSize() > 3 && player.biggestTitSize() < 10) outputText("  Your tits bounce as you enthusiastically grind away.");
 			//{else if player has huge tits}
 			else if(player.biggestTitSize() >= 10 && player.biggestTitSize() < 20) outputText("  The heavy weight of your huge tits causes them to sway with every thrust of your hips.");
-			//{if player has really huge tits} 
+			//{if player has really huge tits}
 			else if(player.biggestTitSize() >= 20) outputText("  The immense swells of your mammaries press down upon the ass of the girl in front of you.");
-			//{if player has four non-huge tits} 
+			//{if player has four non-huge tits}
 			if(player.bRows() >= 2) {
 				if(player.breastRows[1].breastRating >= 3) outputText("  Your second row of breasts slap against the ass cheeks of the girl in front of you.");
 			}
-			//{if player has six huge but not really huge tits} 
+			//{if player has six huge but not really huge tits}
 			if(player.bRows() >= 3) {
 				if(player.breastRows[2].breastRating >= 3 && player.breastRows[2].breastRating < 20) {
 					outputText("  Your lowermost row of breasts become squashed against the witch");
@@ -3885,7 +3885,7 @@ public class DesertCave extends DungeonAbstractContent
 			else outputText("\n\nThey fall");
 			outputText(" over.  Quickly, the rest of the witches in the room are eagerly raising their cunts in the air, begging for their turn at being impregnated.  Happily you oblige, shoving as much cock as you can into each wet hole that the hormonally overwrought sluts offer to you.  One pussy after another finds itself impaled on you, with you thrusting repeatedly until the massaging muscles within their cunts pull forth the rivers of baby gravy that their empty wombs are starving for.  One by one the witches find themselves filled and fall to the floor still reeling from the sensations, only for another new witch to take their place with a sopping cunt even more cum thirsty than the last.");
 			
-			//{if player has two or more cocks} 
+			//{if player has two or more cocks}
 			if(fitCnt > 1) outputText("\n\nFor the final witch you choose to shove two cocks inside her empty pussy.  Your double dicked thrusts force a joyous yelp from her with every thrust.  \"<i>Ah! T-t-too much!</i>\" she screams but her vaginal canal refuses to let you go regardless.  When you finally finish the torrent of sperm makes her feel as if she's on the verge of bursting.  The swelling of her womb causes her belly to bloat up enough to push her quad breasts upwards and siginificantly shift her center of gravity.  The orgasm that accompanies the feeling of your sperm flooding forcefully into her uterus and tubes is too much for her to bear and she slides off of your cocks like a well-used cock sleeve, oozing gobs of cum from between her dark nether lips.");
 			
 			outputText("\n\nFinally finished, you stand in a pool of your own jizz and stare down at the piles of tits and bellies that allegedly are women but for all intent and purpose have become nothing more than sacks of flesh filled with milk, babies, and cum.  Each of them is covered in a layer of sweat and splooge, and small mewing cries of satisfied delight emanate from somewhere underneath those heavy orbs.  You can't help but wonder how long it'll take for them to give birth so that you can once again knock them up with the broods of children that their bodies are so obviously intended to produce.");
@@ -3951,7 +3951,7 @@ public class DesertCave extends DungeonAbstractContent
 			else outputText("and grinning with lusty fervor, you push harder, slipping your fingers into her with ease, her milk providing the perfect lubricant to penetrate her.  The slave girl trembles at your sexual advance, but either does not want to stop you out of well-trained fear, or just doesn't want you to stop");
 			outputText(".  Before you can get too far, though, the slave girl turns on a heel, her huge rack pushing you back through the milky pool and then against the rim.  You're dazed for only a brief second before her breasts press firmly into your back, pressed so hard that a new streak of milk pours from her teats, wetting your back much as you did hers.  You relax against the rim as the slave cups up handfuls of milk, rubbing it into your own hair and shoulders, deft fingers massaging every muscle in your back with the skill of the greatest masseuses, and you can feel the tension bleeding from your muscles. You yawn powerfully, resting your chin on your arms and letting the milky girl massage you, coating your " + player.skinFurScales() + " in her rich, delicious milk.");
 			
-			//{If PC has a dick: 
+			//{If PC has a dick:
 			if(player.hasCock()) {
 				outputText("\n\nOne of the milk girl's hands brushes against your thigh, slipping around your [leg]; slender fingers wrap around your [cock], milky lubricant making her soft strokes all the more pleasurable.  You groan in lusty delight as her fingers slide up and down your quickly-hardening length");
 				if(player.hasBalls()) outputText(", her other hand cupping your [balls], rolling the " + num2Text(player.balls) + " orbs in her palm with surprising dexterity");
@@ -4031,7 +4031,7 @@ public class DesertCave extends DungeonAbstractContent
 			fatigue(-15);
 			doNext(playerMenu);
 		}
-			
+		
 		//[Drink & Masturbate]
 		public function drinkNFap():void {
 			clearOutput();
@@ -4047,7 +4047,7 @@ public class DesertCave extends DungeonAbstractContent
 			
 			outputText("\n\nAn excited moan worms out of the inky slave-girl's puffy lips, a testament to the raw sensitivity of her milk-bloated jugs.  As your tongue swirls over the leaky nozzle's pebbly skin, she releases another breathy pant of delight.  The vocal tremors seem to coo all the way down to your loins, joining with your fingers' caresses to stir you to aching, trembling arousal.");
 			//{Fork, no new PG}
-			//(DA HERMS) 
+			//(DA HERMS)
 			if(player.gender == 3) {
 				outputText("  Your [cock] throbs painfully in your hand, so hot and hard that you're sure you must have begun to leak precum, but any fluid is swiftly washed away by the ever-present milk.");
 				if(player.cockTotal() > 1) outputText("  You make sure to fondle each of your members equally, caressing, squeezing, and stroking to the tempo of your swelling passion.");
@@ -4088,7 +4088,7 @@ public class DesertCave extends DungeonAbstractContent
 		72 == painfully distended
 		48 == bulges with unclean spawn..blahblahblah*/
 		public function sandPregUpdate(womb:Object):Boolean {
-			//1: 
+			//1:
 			if(womb["incubation"] == 336) {
 				outputText("\nYour breasts have felt unusually heavy recently, and a strange pulsing sensation occasionally emanates from them.  Your appetite is a little off; you could really go for some milk...\n");
 				return true;
@@ -4313,7 +4313,7 @@ public class DesertCave extends DungeonAbstractContent
 			clearOutput();
 			outputText("<b><u>Eastern Warrens Main Hall (Western Portion)</u></b>\n");
 			outputText("This smooth, sandstone tunnel proceeds in a perfectly straight line from east to west, as if aligned to some titanic, invisible compass buried below the floor.  Flickering white plumes of illumination undulate through the air along the arched ceiling, trailing streamers of pearl incandescence that light the entire chamber with ghostly brightness.  You are at the entrance to the eastern warrens - the commons are still clearly visible to the west, and the pathway to the east goes on a-ways.  Hand woven tapestries adorn the walls, telling the history of this enclave in pictographic form, from its inception to present day.  Further east, you can see a few empty places, ready to be covered with more cloth, once the next chapter of history is ready to be told.  To the north, there is a small opening in the wall, blocked off by plain white curtains.");
-			dungeons.setDungeonButtons(roomSleepingChamber, null, roomCaveCommons, roomEastHall2); 
+			dungeons.setDungeonButtons(roomSleepingChamber, null, roomCaveCommons, roomEastHall2);
 		}
 		public function roomSleepingChamber():void {
 			dungeonLoc = DUNGEON_WITCH_SLEEPING_CHAMBER;
@@ -4347,7 +4347,7 @@ public class DesertCave extends DungeonAbstractContent
 			clearOutput();
 			outputText("<b><u>Eastern Warrens, East Portion, South Side (Cum Witch's Bedroom)</u></b>\n");
 			outputText("As soon as you brush back the curtain, you're assaulted by a pungent, salty smell.  It almost reminds you of tepid ocean water... or cum.  Regardless, you force your way in and take a look around.  This area has all the furnishings of a small domicile and comes complete with a solid oak bed and mattress.  The mattress and sheets seem to be cared for with immaculate precision, perhaps magically aided.  There is a simple dresser here, and though it looks to have been fashioned by crude tools, the wood looks sturdy and serviceable.  All of the drawers are closed, of course.  A few books sit on a nearby table, but it's obvious they're written in a language beyond your comprehension.  Whoever wrote them either did so in a different tongue or a magical language that would take years to decipher.  A thick curtain walls this chamber off from the eastern warrens' main hall, to the north.  To the west, there is a thinner, gauzy sheet hanging from an opening in the rock - likely leading to a similar room.");
-			dungeons.setDungeonButtons(roomEastHall2, null, roomCumWitchOffice, null); 
+			dungeons.setDungeonButtons(roomEastHall2, null, roomCumWitchOffice, null);
 		}
 		public function roomCumWitchOffice():void {
 			dungeonLoc = DUNGEON_WITCH_CUM_WITCH_OFFICE;

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -21,6 +21,7 @@ import classes.Scenes.Camp.Garden;
 import classes.Scenes.Camp.UniqueCampScenes;
 import classes.Scenes.NPCs.HolliPureScene;
 import classes.Scenes.NPCs.MagnoliaFollower;
+import classes.Scenes.Places.HeXinDao.AdventurerGuild;
 
 import coc.view.ButtonDataList;
 import coc.view.charview.DragButton;
@@ -82,6 +83,10 @@ use namespace CoC;
 
 		public function pearlStorageDirectGet():Array { return pearlStorage; }
 
+		public function pearlStorageSlice():/*ItemSlotClass*/Array {
+			return pearlStorage.slice(0, pearlStorageSize());
+		}
+		
 		public function gearStorageDirectGet():Array { return gearStorage; }
 
 //		public function currentCallNext():Function { return callNext; }
@@ -806,7 +811,10 @@ use namespace CoC;
 			return i;
 		}
 		
-		public function takeItem(itype:ItemType, nextAction:Function, overrideAbandon:Function = null, source:ItemSlotClass = null):void {
+		public function takeItem(itype:ItemType,
+								 nextAction:Function,
+								 overrideAbandon:Function = null,
+								 source:ItemSlotClass = null):void {
 			if (itype == null) {
 				CoC_Settings.error("takeItem(null)");
 				return;
@@ -839,11 +847,9 @@ use namespace CoC;
 				}
 			}
 			//Check for room in Guild quest bag and return the itemcount for it.
-			if (InCollection(itype, useables.IMPSKLL, useables.FIMPSKL, useables.MINOHOR, useables.DEMSKLL, useables.SEVTENT) && nextAction != SceneLib.adventureGuild.questItemsBag) {
-				temp = SceneLib.adventureGuild.roomInExistingStack(itype);
-				if (temp >= 0) {
-					SceneLib.adventureGuild.placeItemInStack(itype);
-					outputText("You place " + itype.longName + " in your quest materials pouch, giving you "+ (temp+1) +" of them.");
+			if (nextAction != SceneLib.adventureGuild.questItemsBag) {
+				if (AdventurerGuild.lootBag.addItem(itype, 1) == 1) {
+					outputText("You place " + itype.longName + " in your quest materials pouch, giving you " + AdventurerGuild.lootBag.itemCount(itype) + " of them.");
 					itemGoNext();
 					return;
 				}

--- a/classes/classes/Scenes/ItemBag.as
+++ b/classes/classes/Scenes/ItemBag.as
@@ -1,0 +1,113 @@
+package classes.Scenes {
+import classes.BaseContent;
+import classes.ItemType;
+
+public class ItemBag extends BaseContent {
+	public var Slots:/*int*/Array = [];
+	public var SlotCaps:/*int*/Array = [];
+	public var SlotCount:int;
+	public var itemTypes:/*ItemType*/Array;
+	private static var itemIdToSlotIndex:Object = {};
+	
+	/**
+	 * @param itemTypes Slot item types. Must be unique (except null/nothing)
+	 * @param slotCount Number of slots, 0 = same as items in slotDefs
+	 */
+	public function ItemBag(itemTypes:/*ItemType*/Array, slotCount:int=0) {
+		this.itemTypes = itemTypes;
+		this.SlotCount = Math.max(slotCount, itemTypes.length);
+		for (var i:int = 0; i < itemTypes.length; i++) {
+			var itype:ItemType = itemTypes[i];
+			if (itype && !itype.isNothing) itemIdToSlotIndex[itype.id] = i;
+		}
+		for (i = itemTypes.length; i < SlotCount; i++) itemTypes[i] = ItemType.NOTHING;
+		resetState();
+	}
+	
+	public function resetState():void {
+		for (var i:int = 0; i < SlotCount; i++) {
+			Slots[i] = 0;
+			SlotCaps[i] = 0;
+		}
+	}
+	
+	
+	/** item type stored in slot */
+	public function slotType(slot:int):ItemType {
+		if (slot < 0 || slot > itemTypes.length) return ItemType.NOTHING;
+		return itemTypes[slot];
+	}
+	/** slot for item type, -1 if no item */
+	public function slotForItem(itype:ItemType):int {
+		if (itype.id in itemIdToSlotIndex) return itemIdToSlotIndex[itype.id];
+		return -1;
+	}
+	/** current number of items of that type stored in loot bag */
+	public function itemCount(itype:ItemType):int {
+		var slot:int = slotForItem(itype);
+		if (slot < 0) return 0;
+		return Slots[slot];
+	}
+	/** current slot cap for item type, 0 if no such item */
+	public function itemCap(itype:ItemType):int {
+		var slot:int = slotForItem(itype);
+		if (slot < 0) return 0;
+		return SlotCaps[slot];
+	}
+	public function setItemCap(itype:ItemType, cap:int):Boolean {
+		var slot:int = slotForItem(itype);
+		if (slot < 0) return false;
+		SlotCaps[slot] = cap;
+		return true;
+	}
+	/** try to remove items from loot bag, return number of remvoed items (0 if no such item) */
+	public function removeItem(itype:ItemType, n:int):int {
+		if (n <= 0) return 0;
+		var slot:int = slotForItem(itype);
+		if (slot < 0) return 0;
+		n = Math.min(Slots[slot], n);
+		Slots[slot] -= n;
+		return n;
+	}
+	/** try to add items to loot bag, return number of items added (0 if no such item or no place) */
+	public function addItem(itype:ItemType, n:int):int {
+		if (n <= 0) return 0;
+		var slot:int = slotForItem(itype);
+		if (slot < 0) return 0;
+		n = boundInt(0, n, SlotCaps[slot] - Slots[slot]);
+		Slots[slot] += n;
+		return n;
+	}
+	
+	public function saveToObject():Object {
+		return {
+			Slots: Slots.slice(),
+			SlotCaps: SlotCaps.slice()
+		}
+	}
+	
+	public function loadFromObject(o:Object, ignoreErrors:Boolean):void {
+		if (o) {
+			if ("Slots" in o) {
+				// new version
+				Slots = o["Slots"].slice();
+				SlotCaps = o["SlotCaps"].slice();
+				while (Slots.length < SlotCount) Slots.push(0);
+				while (SlotCaps.length < SlotCount) SlotCaps.push(0);
+			} else if ("Slot01" in o) {
+				// old version: "Slot01".."Slot30", "Slot01Cap".."Slot30Cap"
+				for (var i:int = 0; i < SlotCount; i++) {
+					var s:String = padStart(String(i + 1), 2, "0");
+					Slots[i]     = numberOr(o["Slot" + s], 0);
+					SlotCaps[i]  = numberOr(o["Slot" + s + "Cap"], 0);
+				}
+			} else {
+				resetState();
+			}
+		} else {
+			// loading from old save
+			resetState();
+		}
+	}
+}
+}

--- a/classes/classes/Scenes/Monsters/IvorySuccubusScene.as
+++ b/classes/classes/Scenes/Monsters/IvorySuccubusScene.as
@@ -7,7 +7,6 @@
 package classes.Scenes.Monsters
 {
 import classes.BaseContent;
-import classes.StatusEffects;
 import classes.display.SpriteDb;
 
 public class IvorySuccubusScene extends BaseContent
@@ -29,13 +28,11 @@ public class IvorySuccubusScene extends BaseContent
         }
         else {
             outputText("She starts to close the distance by charging at you! It's a fight!");
-            player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 			startCombat(new IvorySuccubus());
         }
     }
 
     public function fightAgainstSuccubus():void {
-        player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 		startCombatImmediate(new IvorySuccubus());
     }
 

--- a/classes/classes/Scenes/NPCs/AmilyScene.as
+++ b/classes/classes/Scenes/NPCs/AmilyScene.as
@@ -162,7 +162,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 		private function dontExploreAmilyVillage():void {
 			clearOutput();
 			outputText("Standing up, you turn and walk away. You presume from the state of the pathway that the village at the other end must either be in dire straits, abandoned, or overwhelmed by demons. In other words, it's no safe place for a traveler like you.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//[Yes]
@@ -172,7 +172,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("(<b>\"TownRuins\" added to Places menu.</b>)");
 			//set village unlock flag
 			flags[kFLAGS.AMILY_VILLAGE_ACCESSIBLE] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function nailsEncounter():void {
@@ -184,7 +184,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("\n\nNails: ");
 			if (flags[kFLAGS.CAMP_CABIN_NAILS_RESOURCES] > SceneLib.campUpgrades.checkMaterialsCapNails()) flags[kFLAGS.CAMP_CABIN_NAILS_RESOURCES] = SceneLib.campUpgrades.checkMaterialsCapNails();
 			outputText(flags[kFLAGS.CAMP_CABIN_NAILS_RESOURCES]+"/" + SceneLib.campUpgrades.checkMaterialsCapNails() + "");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//[Exploring the Ruined Village]
@@ -246,7 +246,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 					default:
 						outputText("  <b>Please let Ormael/Aimozg know about this bug.</b>");
 				}
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			//20% of finding nails
@@ -263,14 +263,14 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 					return;
 				}
 				outputText("You enter the ruined village cautiously. There are burnt-down houses, smashed-in doorways, ripped-off roofs... everything is covered with dust and grime. You explore for an hour, but you cannot find any sign of another living being, or anything of value. The occasional footprint from an imp or a goblin turns up in the dirt, but you don't see any of the creatures themselves. It looks like time and passing demons have stripped the place bare since it was originally abandoned. Finally, you give up and leave. You feel much easier when you're outside the village.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			//Schrödinger Amily corrupted that damn place!
 			else if (flags[kFLAGS.AMILY_FOLLOWER] == 2) {
 				amilySprite();
 				outputText("You enter the ruined village, still laughing at your past nefarious deeds. Maybe it's just your imagination, but you feel like this entire place reeks of corruption now... You explore for an hour, then go back to your camp, knowing your tainted slave will be more than happy to satisfy your urges.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			//Remove worm block if player got rid of worms.
@@ -301,7 +301,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			//Amily Un-encounterable (worms):
 			if (flags[kFLAGS.AMILY_GROSSED_OUT_BY_WORMS] == 1 || player.cor > 25 + player.corruptionTolerance || flags[kFLAGS.AMILY_CORRUPT_FLIPOUT] > 0) {
 				outputText("You enter the ruined village cautiously. There are burnt-down houses, smashed-in doorways, ripped-off roofs... everything is covered with dust and grime. For hours you explore, but you cannot find any sign of another living being, or anything of value. The occasional footprint from an imp or a goblin turns up in the dirt, but you don't see any of the creatures themselves. It looks like time and passing demons have stripped the place bare since it was originally abandoned. Finally, you give up and leave. You feel much easier when you're outside of the village – you had the strangest sensation of being watched while you were in there.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			amilySprite();
@@ -442,7 +442,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 						outputText("\"<i>Hey, us girls gotta stick together, right?</i>\" She winks at you then wanders off behind a partially collapsed wall, disappearing into the rubble.");
 						//Set flag for 'last gender met as'
 						flags[kFLAGS.AMILY_PC_GENDER] = player.gender;
-						doNext(camp.returnToCampUseOneHour);
+						endEncounter();
 						return;
 					}
 					//Lesbo lovin confession!
@@ -501,7 +501,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 						outputText("She turns and walks away, vanishing into the dust and the rubble like magic.");
 						//Set flag for 'last gender met as'
 						flags[kFLAGS.AMILY_PC_GENDER] = player.gender;
-						doNext(camp.returnToCampUseOneHour);
+						endEncounter();
 						return;
 					}
 					//Medium affection 33% chance, guaranteed by 20.
@@ -579,7 +579,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 						}
 						//Set flag for 'last gender met as'
 						flags[kFLAGS.AMILY_PC_GENDER] = player.gender;
-						doNext(camp.returnToCampUseOneHour);
+						endEncounter();
 						return;
 					}
 				}
@@ -689,7 +689,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			if (flags[kFLAGS.AMILY_WANG_LENGTH] == 0 && flags[kFLAGS.AMILY_HERM_QUEST] == 2 && flags[kFLAGS.AMILY_AFFECTION] >= 40 && player.gender == 3)
 				addButton(3, "Efficiency", makeAmilyAHerm).hint("You could probably bring up the efficiency of having two hermaphrodite mothers, particularly since you have this purified incubi draft handy.")
 						.disableIf(!player.hasItem(consumables.P_DRAFT), "You could probably bring up the efficiency of having two hermaphrodite mothers, should you find a bottle of purified incubi draft.");
-			addButton(14, "Leave", camp.returnToCampUseOneHour);
+			addButton(14, "Leave", explorer.done);
 		}
 
 		private function determineAmilySexEvent(forced:Boolean = false):Function {
@@ -789,7 +789,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			//{+10 Affection}
 			flags[kFLAGS.AMILY_AFFECTION] += 10;
 			//{-5 Libido}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//[Announce yourself]
@@ -822,7 +822,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			amilySprite();
 			outputText("\"<i>So, have you changed your mind? Have you come to help me out?</i>\" Amily asks curiously.\n\n");
 			//Accept / Politely refuse / Here to talk / Get lost
-			simpleChoices("Accept",secondTimeAmilyOfferedAccepted,"RefusePolite",secondTimeAmilyRefuseAgain,"Just Talk",repeatAmilyTalk,"Get Lost",tellAmilyToGetLost,"Leave",camp.returnToCampUseOneHour);
+			simpleChoices("Accept",secondTimeAmilyOfferedAccepted,"RefusePolite",secondTimeAmilyRefuseAgain,"Just Talk",repeatAmilyTalk,"Get Lost",tellAmilyToGetLost,"Leave",explorer.done);
 		}
 
 		//[Accept]
@@ -846,7 +846,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("\"<i>All right; it is your choice. But my offer still stands, you know,</i>\" she tells you.\n\n");
 
 			outputText("You let her know you'll remember that, and then turn and leave.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//[Here to talk]
@@ -871,7 +871,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			flags[kFLAGS.AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 1;
 			//{Ruined Village removed from Places list}
 			//I think one variable can handle both these...
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 
@@ -893,7 +893,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 							outputText("Amily can still move quickly despite her pregnancy, and you are very promptly left all alone. Perhaps it would be better not to broach the subject that bluntly with her while she's in this state.\n\n");
 							//Reduce affection. DERP
 							flags[kFLAGS.AMILY_AFFECTION] -= 3;
-							doNext(camp.returnToCampUseOneHour);
+							endEncounter();
 						}
 						//[Medium Affection]
 						else if (flags[kFLAGS.AMILY_AFFECTION] < 40) {
@@ -918,7 +918,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 							outputText("Annoyed, she turns and waddles off. You do not give chase; you can tell that you've offended her.\n\n");
 							//Reduce affection
 							flags[kFLAGS.AMILY_AFFECTION] -= 3;
-							doNext(camp.returnToCampUseOneHour);
+							endEncounter();
 						}
 						//[Medium Affection]
 						else if (flags[kFLAGS.AMILY_AFFECTION] < 40) {
@@ -929,7 +929,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 							outputText("\"<i>It's not that I don't like you, [name], it's just... well, I don't feel comfortable doing that,</i>\" she explains apologetically.\n\n");
 							outputText("You apologize back for confronting her with something she's uncomfortable with, and leave for your own camp, lest you insult her seriously.");
 							flags[kFLAGS.AMILY_AFFECTION] -= 3;
-							doNext(camp.returnToCampUseOneHour);
+							endEncounter();
 						}
 						//[High Affection]
 						else {
@@ -1246,7 +1246,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("Feeling the weight of the empty village pressing in on you, you quickly retreat yourself. There's no point coming back here.\n\n");
 			//turn off village.
 			flags[kFLAGS.AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//[Turn her down bluntly]
@@ -1267,7 +1267,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			//{Amily can no longer be encountered}
 			flags[kFLAGS.AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 1;
 			//{Ruined Village removed from Places list}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//[Birth]
@@ -1292,7 +1292,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("The next morning, you find a note scratched onto a slab of bark beside your sleeping roll, reading, \"<i>The babies and I are both fine. No thanks to you!</i>\"\n\n");
 			//{Affection goes down}
 			flags[kFLAGS.AMILY_AFFECTION] -= 10;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 
@@ -1317,7 +1317,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("  Their color patterns vary considerably; white, black and brown are most common, and you even see one or two with your hair color. Amily flops back onto her rump and then topples over onto her back, clearly too tired to stand up. Her offspring crowd around, cuddling up to her, and she gives them a tired but happy smile.\n\n");
 
 			outputText("Making sure that there doesn't seem to be any danger, you quietly let yourself out. It seems that she's too concerned about the children to notice you leave.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//[Help]
@@ -1370,7 +1370,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("As the rambunctious little mouselets burn up their energy and curl up beside Amily to sleep, you gently excuse yourself and return to camp.");
 			//{Affection goes up}
 			flags[kFLAGS.AMILY_AFFECTION] += 5;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 
 		}
 
@@ -1395,7 +1395,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("Amily inclines her head towards you in a respectful nod, and then joins her vast brood as they begin to march away purposefully. You watch them go until they have vanished from sight, then shake your head with a sneer. Like you need her or her brats, anyway! Spinning on your heel, you stride purposefully out of this dump of a village; you don't intend to come back here again.\n\n");
 
 			outputText("Amily has left the region with her children to found a new colony elsewhere.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//{Amily can no longer be encountered}
 			//{Ruined Village removed from Places list}
 			flags[kFLAGS.AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 1;
@@ -1475,7 +1475,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			}
 			//Disable amily encounters in the village!
 			flags[kFLAGS.AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//Conversations - talk wif da bitch.
@@ -1504,7 +1504,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 					if(sexAfter) doNext(determineAmilySexEvent());
 					else {
 						outputText("Promising you'll keep that in mind, you take your leave of Amily.\n\n");
-						doNext(camp.returnToCampUseOneHour);
+						endEncounter();
 					}
 					return;
 				}
@@ -1924,7 +1924,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			if(sexAfter) {
 				doNext(determineAmilySexEvent(true));
 			}
-			else doNext(camp.returnToCampUseOneHour);
+			else endEncounter();
 		}
 
 		//First Time Sekksin:
@@ -1994,7 +1994,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			//Affection downer
 			flags[kFLAGS.AMILY_AFFECTION] -= 5;
 			amilyPreggoChance();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		//[=Wait for Her=]
 		private function beSomeKindofNervousDoucheAndWaitForAmily():void {
@@ -2015,7 +2015,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			flags[kFLAGS.AMILY_AFFECTION] -= 2;
 			amilyPreggoChance();
 			player.sexReward("vaginalFluids","Dick");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		//[=Kiss Her=]
 		private function kissAmilyInDaMoufFirstTimeIsSomehowBetterThatWay():void {
@@ -2045,7 +2045,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			//Affection boost?
 			flags[kFLAGS.AMILY_AFFECTION] += 3;
 			player.sexReward("vaginalFluids","Dick");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			amilyPreggoChance();
 		}
 
@@ -2057,7 +2057,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			if(x == -1 && player.hasCock()) {
 				outputText("Amily looks between your legs and doubles over laughing, \"<i>There is no way that thing is fitting inside of me!  You need to find a way to shrink that thing down before we get in bed!</i>\"");
 				flags[kFLAGS.AMILY_AFFECTION]--;
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			if(flags[kFLAGS.AMILY_FUCK_COUNTER] == 0) {
@@ -2122,7 +2122,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			//worm infested reaction
 			if(player.hasStatusEffect(StatusEffects.Infested)) {
 				outputText("\"<i>EWWWW!  You're infested!</i>\" she shrieks, \"<i>Get out!  Don't come back 'til you get rid of the worms!</i>\"\n\nYou high tail it out of there.  It looks like Amily doesn't want much to do with you until you're cured.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				flags[kFLAGS.AMILY_AFFECTION] -= 3;
 				flags[kFLAGS.AMILY_GROSSED_OUT_BY_WORMS] = 1;
 				return;
@@ -2198,7 +2198,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			flags[kFLAGS.AMILY_AFFECTION] += 1 + rand(2);
 			player.sexReward("vaginalFluids");
 			dynStats("sen", -1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 
@@ -2288,7 +2288,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			amilySprite();
 			clearOutput();
 			outputText("You smile at her and give her a kiss before saying goodbye and returning to your camp.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//[Stay A While]
@@ -2298,7 +2298,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("You decide you'd rather stay with her a little longer, so you get up, go to her and with a kiss and some caresses draw her down again. She doesn't really put up any resistance, so you both lie there kissing and caressing each other for some time before you finally say goodbye and return to your camp.");
 			//Bonus affection mayhapz?
 			flags[kFLAGS.AMILY_AFFECTION] += 3;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 
@@ -2356,7 +2356,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			flags[kFLAGS.AMILY_FUCK_COUNTER]++;
 			player.sexReward("vaginalFluids");
 			dynStats("sen", -1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//preggo chance
 			amilyPreggoChance();
 		}
@@ -2400,7 +2400,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			flags[kFLAGS.AMILY_FUCK_COUNTER]++;
 			player.sexReward("vaginalFluids","Dick");
 			dynStats("sen", -1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//preggo chance
 			amilyPreggoChance();
 		}
@@ -2464,7 +2464,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			if (pregnancy.isPregnant && pregnancy.incubation == 0 && flags[kFLAGS.AMILY_FOLLOWER] == 2) {
 				clearOutput();
 				amilyPopsOutKidsInCamp();
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			//Jojo + Amily Spar
@@ -2787,7 +2787,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			//(Random camp discussion takes place)
 			talkWithCuntIMeanAmily();
 			//AbandonedTownRebuilt.InTown = false;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function talkToAmilyWithSexAfter():void { talkWithCuntIMeanAmily(true); }
@@ -3059,7 +3059,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 
 			outputText("With a contented sigh and a broad, satisfied smile, Amily murmurs, \"<i>That felt great...</i>\" She switches her position again so that her head is again next to yours, puts her arms around you and nuzzles you a bit. You embrace her too, and enjoy the afterglow with her for some time, before you both go back to work.\n\n");
 			player.sexReward("vaginalFluids");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//Take Charge: Mount Amily
@@ -3109,7 +3109,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			}
 			player.sexReward("cum", "Vaginal");
 			dynStats("sen", -1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//[=Let Amily Lead=]
@@ -3140,7 +3140,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				outputText("You'd never have expected the little mousegirl to do something like this - and you certainly would never have thought it would feel so good. Sure enough, you soon feel yourself reaching the \"<i>point of no return</i>\", but any attempts to tell her that you won't be able to hold back much longer are made futile by her enduring kisses. You're quite sure she's smiling at your predicament - she probably planned for this to happen. Shrugging mentally, you decide to go with the flow and worry about it later. So you try to relax (as much as you can do that while Amily is giving you an incredible tailjob...) and simply enjoy the feeling. Sure enough, it doesn't take her much longer to finally make you cum. Breaking the kiss, she steps back and with a broad grin asks: \"<i>Did you enjoy that, you naughty " + player.mf("man","girl") + "?</i>\"\n\n");
 
 				outputText("Naturally, you tell her that you enjoyed it very much, and with a smile, Amily helps you clean up. \"<i>If you liked it that much...</i>\" she says over her shoulder and winks at you as she goes to take care of something else.\n\n");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				player.sexReward("no", "Dick");
 				dynStats("sen", -1);
 			}
@@ -3153,7 +3153,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				outputText("Looking at her hands and feet covered by your cum, Amily jokingly accuses you of forcing her to clean herself yet again, just because you have no control. Your eyes widen a bit in surprise when the mousegirl lightly licks one of her hands and comments \"<i>Mmhhmm... not bad, actually...</i>\" With a grin, she cleans up the results of her hand-and-foot-job before pulling you to your feet again. \"<i>Back to work, Champion!</i>\"\n\n");
 
 				outputText("With a satisfied smile, you turn to other things.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				player.sexReward("no", "Dick");
 				dynStats("sen", -1);
 			}
@@ -3181,7 +3181,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				if(flags[kFLAGS.AMILY_WANG_LENGTH] > 0) outputText("and limp cock ");
 				outputText("across your chest as she repositions herself so that she is looking you in the eyes, laying atop you. \"<i>You always know how to make a girl feel special, don't you?</i>\" she says, softly. Then she kisses you, probing her tongue deep into your mouth to get a good taste of her juices, before wriggling off of you, grabbing her pants and running merrily away. You watch her go, then clean yourself off.\n\n");
 				player.sexReward("vaginalFluids", "Lips", false);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				dynStats("int", .25, "lus", 10);
 			}
 			//B4: Get Ridden
@@ -3205,7 +3205,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				outputText("Exhausted, you feel a quick nap is in order yourself. When you wake up, you're alone in the nest but Amily is nearby; she hands you some food and then points you in the direction of the stream to wash up.\n\n");
 				amilyPreggoChance();
 				//if (AbandonedTownRebuilt.InTown = false) {
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				//if (AbandonedTownRebuilt.InTown = true) doNext(AbandonedTownRebuilt.EnterTown);
 				player.sexReward("vaginalFluids", "Dick");
 				dynStats("sen", -1);
@@ -3227,7 +3227,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				outputText("You shrug, uncertain. Slowly, Amily sits up and gets off of you. \"<i>I... um... thank you.</i>\" She says, then quickly steals a kiss from you before running off. She's in such a hurry that she's clear over on the other side of the camp before you can tell her that she left her pants behind.");
 				player.sexReward("cum","Lips", false);
 				//if (AbandonedTownRebuilt.InTown = false) {
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				//if (AbandonedTownRebuilt.InTown = true) doNext(AbandonedTownRebuilt.EnterTown);
 				dynStats("int", .25, "lus", 10);
 			}
@@ -4405,7 +4405,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			player.sexReward("saliva");
 			dynStats("sen", 1, "cor", 1);
 			//if (AbandonedTownRebuilt.InTown = false) {
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//if (AbandonedTownRebuilt.InTown = true) doNext(AbandonedTownRebuilt.EnterTown);
 		}
 		private function corruptAmilyLickPussiesLikeAPro():void {
@@ -4482,7 +4482,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			player.sexReward("saliva");
 			dynStats("sen", -1, "cor", 1);
 			//if (AbandonedTownRebuilt.InTown = false) {
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//if (AbandonedTownRebuilt.InTown = true) doNext(AbandonedTownRebuilt.EnterTown);
 		}
 
@@ -4562,7 +4562,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("Amily beams with happiness, \"<i>Yes mistress!</i>\" then proceeds to clean you up, licking every single drop she can out of your body.  To finish it all up, she licks your [feet] clean of whatever juices remained on them. Satisfied, you dismiss Amily with a wave, heading back to the camp, while Amily rubs the results of your coupling on her body.");
 			player.sexReward("vaginalFluids");
 			dynStats("sen", -1, "cor", 1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		//Fuck corrupt Amily's pussaaaaaayyyyy
 		private function corruptAmilysPussyGetsMotherfuckingFucked():void {
@@ -4657,7 +4657,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			amilyPreggoChance();
 			player.sexReward("vaginalFluids","Dick");
 			dynStats("sen", -2, "cor", 2);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//Let corrupt Amily bone you with her cock
@@ -4727,7 +4727,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			player.sexReward("cum","Vaginal");
 			dynStats("sen", -2, "cor", 2);
 
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 
@@ -4779,7 +4779,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("; stopping only when you're completely clean. You pat her head and praise her, \"<i>That's a good cumdumpster.</i>\" She responds by smiling tiredly, still panting a bit, and swaying her tail in happiness. You wipe the remaining saliva off your dick on her face and dress yourself. \"<i>Don't waste a single drop, cunt,</i>\" you tell her.  You leave the tired mouse alone to recompose herself.");
 			player.sexReward("no", "Dick");
 			dynStats("sen", -2, "cor", 1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 
@@ -4823,7 +4823,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("You watch her go, feeling a little guilty, but you just don't swing that way. You can only hope she'll be all right.\n\n");
 			//(Amily's affection drops back down to Low)
 			if(flags[kFLAGS.AMILY_AFFECTION] > 10) flags[kFLAGS.AMILY_AFFECTION] = 10;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//Amily's Surprise:
@@ -4863,7 +4863,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("Amily stops, her new cock wilting, her expression making it quite obvious that she's heartbroken. Her head falls, tears dripping from her eyes, and she turns and runs away. You glare after her as she vanishes, sobbing, into the ruins, hoping she never comes back.");
 			//no moar amily in village
 			flags[kFLAGS.AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//Yuri:
@@ -4903,7 +4903,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("Your own strength returning to you, you sit up and smile at your mousey lover before giving her a deep kiss, tasting your juices and letting her get a taste of her own. Then you redress yourself and return to your camp.");
 			player.sexReward("cum","Vaginal");
 			flags[kFLAGS.AMILY_TIMES_FUCKED_FEMPC]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//Herm Amily on Female:
@@ -4957,7 +4957,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			player.sexReward("cum","Vaginal");
 			flags[kFLAGS.AMILY_HERM_TIMES_FUCKED_BY_FEMPC]++;
 			flags[kFLAGS.AMILY_FUCK_COUNTER]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//Player gives Birth (quest version):
@@ -5350,7 +5350,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 					dynStats("lus", 25+player.sens/10, "scale", false);
 				}
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		//"Why Not Herms?" (Req medium 'like')
 		private function whyNotHerms():void {
@@ -5379,7 +5379,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("\"<i>But it's unnatural!</i>\" She barks... well, squeaks indignantly, anyway. \"<i>Women with cocks, men with cunts - before those fucking demons, you never saw creatures like that! They're not normal! I mean, you don't seem to be a bad person, but I could never have sex with someone like that!</i>\"\n\n");
 
 			outputText("At that, she turns and runs off, quickly vanishing into the rubble. You choose not to pursue; it seems she's clearly not in the mood to talk about it.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			flags[kFLAGS.AMILY_HERM_QUEST]++;
 		}
 
@@ -5420,7 +5420,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 
 			outputText("Looking deeply sad, she turns and walks away, vanishing into the urban wilderness in that way only she can. Instinctively, you realize that you will never see her again.");
 			flags[kFLAGS.AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//Conversation: Efficiency
@@ -5502,7 +5502,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				outputText("\"<i>I hope you don't mind, [name], but I contacted them to come and take their new siblings back with them shortly after we confirmed I was pregnant.</i>\" Amily says, sheepishly. \"<i>We just can't really care for them here, and they'll be safer and happier with all their siblings.</i>\"\n\n");
 
 				outputText("You nod your head and admit that you agree. Once you have regained your strength, you spend some time talking with your fully adult children and playing with your overdeveloped newborns. Then, with a final wave goodbye, the "+((flags[kFLAGS.AMILY_NOT_FURRY]==0)?"mouse-morphs":"family of mice")+" disappear into the wilderness once more.");
-				//if (AbandonedTownRebuilt.RebuildState == 3) AbandonedTownRebuilt.MousetownPopulation += 5;	
+				//if (AbandonedTownRebuilt.RebuildState == 3) AbandonedTownRebuilt.MousetownPopulation += 5;
 			}
 			//CORRUPT!
 			else {
@@ -5647,7 +5647,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				else outputText("You think about some of the more interesting potions you found while exploring; perhaps you could use some of them...");
 			}
 			dynStats("lus", 25, "scale", false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//FLAG THAT THIS SHIT WENT DOWN
 			flags[kFLAGS.AMILY_CORRUPT_FLIPOUT] = 1;
 		}
@@ -5668,13 +5668,13 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				//(if PC doesn't have the required items)
 				if(!(player.hasItem(consumables.L_DRAFT) || player.hasItem(consumables.F_DRAFT)) || !player.hasItem(consumables.GOB_ALE)) {
 					outputText("You think about going into the Ruined Village, but you don't have the ingredients to create more of Amily's medicine. You return to your camp.");
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 					return;
 				}
 				//(if PC is genderless and has the ingredients.)
 				else if(player.gender == 0) {
 					outputText("You think about going into the Ruined Village, but without a cock or a pussy you can't complete the mixture. You return to your camp.");
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 					return;
 				}
 				//(else)
@@ -5713,13 +5713,13 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				//(if PC doesn't have the required items and has >= 25 Corruption)
 				if(!(player.hasItem(consumables.L_DRAFT) || player.hasItem(consumables.F_DRAFT)) || !player.hasItem(consumables.GOB_ALE)) {
 					outputText("You think about going into the Ruined Village, but decide it's best to wait until you have a plan underway (maybe some lust draft and a goblin ale to get the ball rolling... you return to your camp.");
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 					return;
 				}
 				//(else if the PC is genderless)
 				else if(player.gender == 0) {
 					outputText("You think about going into the Ruined Village, but decide to turn back; right now, you just don't have the proper 'parts' to get the job done, and so you return to your camp.\n\n");
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 					return;
 				}
 				//(else)
@@ -5761,7 +5761,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				}
 			}
 			player.orgasm();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function sendCorruptCuntToFarm():void
@@ -5778,7 +5778,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("\n\nShe will make a hard worker for Whitney, you think, but you doubt she will be much use protection wise.");
 
 			flags[kFLAGS.FOLLOWER_AT_FARM_AMILY] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function backToCamp():void
@@ -5845,7 +5845,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				//(If player has no main item:)
 				if(player.itemSlot1.quantity == 0) {
 					outputText("You tell her that you'll call for her, if you ever need her knowledge.\n\n");
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 					return;
 				}
 				//(If player has an item:)
@@ -6149,7 +6149,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 
 				outputText("You chuckle a little and tell her you'll think about it.  As you leave, she begins to masturbate, no doubt fantasizing about being used by a tentacle beast.");
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 
@@ -6373,7 +6373,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			if (!recalling) {
 				flags[kFLAGS.AMILY_CORRUPTION]++;
 				dynStats("cor", 5);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			} else doNext(recallWakeUp);
 		}
 
@@ -6400,7 +6400,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				sceneHunter.print("NEED MORE CORRUPTION!!");
 				player.orgasm();
 				dynStats("cor", 2);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			//(else)
@@ -6458,7 +6458,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				sceneHunter.print("NEED MORE CORRUPTION!!");
 				player.orgasm();
 				dynStats("cor", 2);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			outputText("That was good, but now it's time to reward Amily for her efforts, besides you could really use a proper licking.\n\n");
@@ -6500,7 +6500,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			if (!recalling) {
 				flags[kFLAGS.AMILY_CORRUPTION]++;
 				dynStats("cor", 5);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			} else doNext(recallWakeUp);
 		}
 
@@ -6512,7 +6512,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			//(if PC is genderless)
 			if(player.gender == 0) {
 				outputText("You would love to play with your mouse bitch, but you don't have the parts for that; so you return to the camp.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			outputText("You enter the ruined village hoping to find your corrupted mouse cumbucket. It doesn't take long until you spot her; she's stroking her pussy and blowing a wood carved dildo, practicing like you told her to.\n\n");
@@ -6579,7 +6579,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				sceneHunter.print("Not corrupt enough...");
 				player.sexReward("saliva");
 				dynStats("cor", 3);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			outputText("You push her back and withdraw, not yet satisfied. <b>A familiar power gathers inside you, and you decide to tap into it.</b>\n\n");
@@ -6658,7 +6658,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 
 				outputText("You return to the camp.");
 				sceneHunter.print("Not corrupt enough...");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				player.orgasm();
 				dynStats("cor", 3);
 				return;
@@ -6735,7 +6735,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				} else flags[kFLAGS.MARBLE_OR_AMILY_FIRST_FOR_FREAKOUT] = 2;
 				//Disable amily encounters in the village!
 				flags[kFLAGS.AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 1;
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			} else doNext(recallWakeUp);
 		}
 
@@ -6787,6 +6787,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			}
 			else {
 				outputText("You search for Amily high and low, but can't find a single trace of her. Frustrated, you return to the camp.  Maybe if you were smarter or faster you could find her.");
+				explorer.stopExploring();
 				doNext(camp.returnToCampUseTwoHours);
 			}
 		}
@@ -6798,7 +6799,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			//(if PC is genderless)
 			if(player.gender == 0) {
 				outputText("You think about going into the ruined village, but playing with Amily is not going to be possible if you don't have the parts for it... You return to your camp.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			//(else)
 			else {
@@ -6826,7 +6827,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 					outputText("Amily shakes her head and yells, \"<i>No! I can't!</i>\" before darting off.\n\n");
 
 					outputText("You laugh and put the bottle away, then return to your camp.\n\n(Not corrupt enough...)");
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 					return;
 				}
 				outputText("You begin stripping off your [armor] and show her your ");
@@ -6862,7 +6863,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			//(if PC is genderless)
 			if(player.gender == 0 ) {
 				outputText("You think about going into the ruined village, but playing with Amily is not going to be possible if you don't have the parts for it... You return to your camp.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			amilySprite();
@@ -6904,7 +6905,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			amilySprite();
 			outputText("Amily approaches you, looking concerned.  \"<i>Darling... I don't know what's been going on, but you need to start taking better care of yourself.  I can smell the corruption taking root in you - if you don't stop, you'll soon start acting like any other demon.</i>\"\n\n");
 			flags[kFLAGS.AMILY_WARNING] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//Farewell Note:
@@ -6965,7 +6966,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("There's a long pause while Amily digests your implication.  \"<i>You want me to... change?</i>\" she asks quietly.  \"<i>Would that... make you want to mate with me?</i>\"  You can't make any promises, but it would definitely change your considerations, you explain.\n\n");
 			outputText("After another long silence, she sighs.  \"<i>I don't know.  What would my family say if I just... went and made myself a completely different person, all for the sake of a human?</i>\"  You slowly move to her and lay a hand on her shoulder, forcing her to look once more into your eyes.  It's not the fact that she won't be a mouse, you insist.  It's the fact that she's moving on for the sake of her race.  She manages a little smile at that, her expression brightening just a bit.  \"<i>I'll think about it,</i>\" she finally decides.  \"<i>If you can find some non-demonic reagents, perhaps we can give it a try.  If anything bad happens, though,</i>\" she warns, wagging a finger at you threateningly.  She backs off and stands awkwardly for a second.\n\n");
 			outputText("\"<i>Well, uh... bye,</i>\" Amily concludes, whirling around and walking away.  You can't be sure, but it seems like she's exaggerating the sway of her hips a bit.  You don't think much of it, heading back toward camp and beginning to formulate a concoction to de-mouse your potential breeding partner.  Perhaps... a <b>golden seed</b> for a human face, a <b>black egg</b> to get rid of the fur, and some <b>purified succubus milk</b> to round things off.  You make a mental note to remember those ingredients, for they won't show up again and you'd feel positively silly if you somehow completely forgot them.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		// Check if we have all the shit we need
 		private function amilyCanHaveTFNow():Boolean
@@ -7002,7 +7003,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("A cry brings your attention from the hair-pile back up to her face.  As if by magic, her rodent snout simply recedes back into her face, the nose reforming into a more human model.  She gently reaches up and brushes a fingertip across her new lips, eyes glazing over as tears begin to form.  \"<i>So... different,</i>\" she whispers as the transformation continues.  You move to her and wrap her in a warm, comforting hug, and after a moment's pause, she wraps her arms around you as well.\n\n");
 			outputText("Finally, the process comes to a close.  You break from each other and stand at arm's length, both of you studying the changes to her previously-animalistic self.  Her auburn-colored ears and bare tail remain unchanged, but other than that, Amily's completely human.  Though a bit conflicted, Amily seems happy enough with her decision.  \"<i>Well, I guess that's all there is to it,</i>\" she says, scratching her newly bare cheek idly.  \"<i>I'll let you think for a bit... see you later.</i>\"\n\n");
 			outputText("She stalks off into the ruins once more, humming a little tune as she goes.  You note a little more spring in her step, now that hope is restored in repopulating her race.\n\n");
-			doNext(camp.returnToCampUseOneHour); // To camp
+			endEncounter(); // To camp
 		}
 
 //Anyone, find a place to call it please
@@ -7202,6 +7203,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			outputText("You watch Urta take a nice long drink from the proffered bottle, but before she gets well and truly smashed, you politely excuse yourself and, helping an inebriated Amily to her feet, exit the Wet Bitch.  The two of you make your way back to camp and, putting the drunken mouse-girl to bed, you give her a kiss on the cheek and soon fall asleep.");
 			//Disable threesomes between them forever.
 			flags[kFLAGS.AMILY_VISITING_URTA] = 3;
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseFourHours);
 		}
 
@@ -7238,7 +7240,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			//(Display Appropriate Options: [Use Cock] [Use Vag])
 			if (player.hasCock()) addButton(0, "Use Cock", threesomeAmilUrtaCAWKS);
 			if (player.hasVagina()) addButton(1, "Use Vagina", urtaXAmilyCuntPussyVagSQUICK);
-			addButton(4, "Never mind", camp.returnToCampUseOneHour);
+			addButton(4, "Never mind", explorer.done);
 		}
 
 		//Amily/Urta -- Use Cock
@@ -7327,6 +7329,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				outputText("\n\n(<b>Urta unlocked in Amily's sex menu!</b>)");
 				flags[kFLAGS.AMILY_VISITING_URTA] = 4;
 			}
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseFourHours);
 		}
 		public function pureAmilyPutsItInYourRectumDamnNearKilledEm():void {
@@ -7411,7 +7414,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			player.sexReward("cum","Anal");
 			dynStats("sen", 1);
 			//if (AbandonedTownRebuilt.InTown = false) {
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//if (AbandonedTownRebuilt.InTown = true) doNext(AbandonedTownRebuilt.EnterTown);
 		}
 
@@ -7491,7 +7494,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			dynStats("sen", -2);
 			flags[kFLAGS.TIMES_FUCKED_AMILYBUTT]++;
 			//if (AbandonedTownRebuilt.InTown = false) {
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//if (AbandonedTownRebuilt.InTown = true) doNext(AbandonedTownRebuilt.EnterTown);
 		}
 		
@@ -7594,7 +7597,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			amilyPreggoChance();
 			player.sexReward("vaginalFluids","Dick");
 			dynStats("sen", -1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//First talk: Finished (Bagpuss)(Zedited, but no followups are ready yet)
@@ -7742,7 +7745,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			clearOutput();
 			outputText("You wake up almost an hour later, Amily still dozing on top of you.  Gently picking her up, you take her to her nest and lay the girl down in the soft bedding, smiling at the bulge in her stomach.  It takes you a little while to clean yourself off and redress, though you can't help but feel that getting a little bit of slime on your [armor] was a price worth paying.");
 			//if (AbandonedTownRebuilt.InTown = false) {
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//if (AbandonedTownRebuilt.InTown = true) doNext(AbandonedTownRebuilt.EnterTown);
 		}
 
@@ -7871,7 +7874,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			dynStats("sen", -1);
 			amilyPreggoChance();
 			//if (AbandonedTownRebuilt.InTown = false) {
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//if (AbandonedTownRebuilt.InTown = true) doNext(AbandonedTownRebuilt.EnterTown);
 		}
 
@@ -8155,6 +8158,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 				outputText(" definitely got pregnant.</b>)");
 			}
 			//if (AbandonedTownRebuilt.InTown = false) {
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseFourHours);
 			//if (AbandonedTownRebuilt.InTown = true) doNext(AbandonedTownRebuilt.EnterTown);
 		}
@@ -8299,7 +8303,7 @@ public class AmilyScene extends NPCAwareContent implements TimeAwareInterface
 			dynStats("sen", -2);
 			amilyPreggoChance();
 			//if (AbandonedTownRebuilt.InTown = false) {
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//if (AbandonedTownRebuilt.InTown = true) doNext(AbandonedTownRebuilt.EnterTown);
 		}
 

--- a/classes/classes/Scenes/NPCs/BelisaFollower.as
+++ b/classes/classes/Scenes/NPCs/BelisaFollower.as
@@ -6,7 +6,6 @@ package classes.Scenes.NPCs
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
-import classes.Items.UndergarmentLib;
 import classes.Scenes.Areas.Swamp.CorruptedDrider;
 import classes.Scenes.SceneLib;
 import classes.internals.SaveableState;
@@ -231,7 +230,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 	
 	public function secondEncounterLeaveAlone():void {
 		outputText("You apologize for startling her, and turn your boat around. You blink, realizing you didn’t even get her name. You turn back and ask loudly what the Drider’s name is. As you row away, you can see the white orb sinking beneath the water’s surface. <i>\"Belisa\",</i> you hear on the breeze. You see her eyes, and the ripple on the water as The Drider-No, <i>Belisa,</i> slips underneath the surface of the water, following her home down.\n\n");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	
 	public function secondEncounterNahFight():void {
@@ -250,14 +249,14 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 	public function secondEncounterNo():void {
 		clearOutput();
 		outputText("After a few sidelong glances, you row away from the odd object, shrugging to yourself. This boat trip wasn’t productive, but oddities aren’t entirely unwelcome.\n\n");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	
 	public function secondEncounterNever():void {
 		clearOutput();
 		outputText("You’ve experienced enough of Mareth to leave curious objects alone. You vow to give this object a wide berth in the future.\n\n");
 		BelisaInGame = false;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	
 	public function subsequentEncounters():void {
@@ -343,7 +342,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 				eachMinuteCount(15);
 				doNext(BelisaTalk);
 			}
-			else doNext(camp.returnToCampUseOneHour);
+			else endEncounter();
 		}
 	}
 	public function BelisaTalkAbsisters(): void {
@@ -352,13 +351,13 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		outputText("<i>\"...Thank you, [name]. If she’s as corrupt as you say...then perhaps it’s best I keep my distance for now...But knowing she’s alive brings joy to my heart. Thank you.\"</i> You excuse yourself, extracting yourself from Belisa’s embrace and heading back to camp. You can feel her eyes on your back as you walk away.\n\n");
 		BelisaToldTyrantia = true;
 		BelisaAffection(10);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	public function BelisaTalkYouEnd():void {
 		clearOutput();
 		outputText("You tell Belisa that you didn’t catch her name, and that her speed, strength and corruption makes her a dangerous foe, even for you. She nods in understanding, but there’s a clear look of disappointment on her face. <i>\"Thank you for sharing your experiences with me.\"</i> You politely excuse yourself, heading back to camp.\n\n");
 		BelisaAffection(5);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	
 	public function BelisaTalkHome():void {
@@ -370,7 +369,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 			eachMinuteCount(15);
 			doNext(BelisaTalk);
 		}
-		else doNext(camp.returnToCampUseOneHour);
+		else endEncounter();
 	}
 	
 	public function BelisaTalkHer():void {
@@ -447,7 +446,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		clearOutput();
 		if (BelisaAffectionMeter < 15) {
 			outputText("She pushes you back, now a bit more annoyed than before. <i>\"Look...I’m trying to be nice, but you brought up a touchy subject. So please, before I lose...My composure…\"</i> You turn and walk away, but you hear her crying as you leave, little <i>\"Tk-tk-tk\"</i> noises occasionally coming with the sobs.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		else {
 			outputText("You wrap your arms all the way around Belisa’s upper body, and she leans into you slightly. She returns the embrace for a second. <i>\"Sorry about that.\"</i> She wipes the tears from her face. <i>\"It’s been a while, but...Sometimes they still make me sad, just talking about those disgusting things that used to be my people.\"</i> She gently pulls back from your embrace. <i>\"Can we talk about something else?\"</i>\n\n");
@@ -457,7 +456,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 	public function BelisaTalkHerNohermLeave():void {
 		clearOutput();
 		outputText("You apologize to the Drider-girl, and she nods, acknowledging your apology. You turn and walk away, but you hear her crying as you leave, little <i>\"Tk-tk-tk\"</i> noises occasionally coming with the sobs.\n\n");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	public function BelisaTalkHerSkittish():void {
 		clearOutput();
@@ -467,7 +466,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		outputText("<i>“I mean…Really, [name]. My best defense is people like that not knowing where I am…so it’s kind of obvious…Right?”</i> You sigh, telling her that she’s made her point. <i>“Look…If I’ve learned anything on my own out here, it’s that I can’t really trust that the normal-looking person I see in the distance won’t try and turn me into some kind of fuck-toy…No matter how lonely that really is.”</i>\n\n");
 		outputText("It seems you’ve touched a nerve. You apologize for your words, and Belisa smirks a little, putting a hand over your mouth. <i>“It’s okay, [name]. Honestly, it was a little funny.”</i>\n\n");
 		outputText("You head back to camp, a little embarrassed about that rather boneheaded question.\n\n");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	public function BelisaTalkInjuries():void {
 		clearOutput();
@@ -487,7 +486,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 			outputText("You tell Belisa that she doesn’t need to hide her pretty face anymore. This gets more of a blush, but she seems to take this to heart. You stay with her for a little while longer, but eventually excuse yourself. You tell Belisa that you need to head back to camp. She seems a little saddened, but she nods. \"<i>I will never forget what you’ve done for me today. Never.</i>\" Belisa waves as you leave. \"<i>Stay safe!</i>\"\n\n");
 			BelisaFollowerStage = 2;
 			BelisaQuestComp = true;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		else {
 			outputText("You ask her about her other fang, and why she hides it from you. Belisa instinctively turns away, but you continue talking. You tell her that  it doesn’t make her any less of a person. That you care about her, and want to see if you can help. Slowly, surely, Belisa turns around, facing towards you. She slowly pulls back her lip to reveal the right side of her mouth. Several teeth are broken, cracks along the enamel, but worst of all is the fang. She’s hidden it under a layer of silk bandages, but as she pulls it back, you can’t help but wince. ");
@@ -505,7 +504,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		outputText("You ask her what happened, how she’d managed to injure herself so badly. <i>\"Demons\"</i>, she spits. <i>\"Demons thought it would be funny to make the little Drider bite metal, then stomp on her jaw.\"</i> She closes her eyes. <i>\"And now...I can’t even bite my food properly.\"</i>\n\n");
 		outputText("You put a hand on her shoulder and pull her into you. You tell Belisa that even though she has trouble with food, she should never worry about finding the good, even now. You tell her about her accomplishments, and how tough she is, living on her own in these times. Your words put a small smile on the little Drider’s face, but she turns away. You excuse yourself and walk back to camp, but at the back of your mind, a question rises. Could you help her?\n\n");
 		BelisaAffection(5);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	public function BelisaTalkInjuriesHeal():void {
 		clearOutput();
@@ -518,13 +517,13 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		if (flags[kFLAGS.DIANA_FOLLOWER] >= 6 && !player.hasStatusEffect(StatusEffects.DianaOff)) outputText("Diana should be able to heal such a curse. You make a note to ask her.\n\n");
 		BelisaAffection(5);
 		BelisaQuestOn = true;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	public function BelisaTalkInjuriesEw():void {
 		clearOutput();
 		outputText("You say nothing, but turn away quickly. Belisa closes her mouth, nervous. <i>\"I-i’m sorry.\"</i> She sounds crestfallen at your reaction. You make small talk, then leave, but Belisa seems very saddened by your reaction.\n\n");
 		BelisaAffection(-20);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	
 	public function BelisaSleepToggle():void {
@@ -548,7 +547,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		if (BelisaAffectionMeter < 20) {
 			outputText("<i>\"You...\"</i> The Drider sinks back under the water, leaving nothing but her mouth, looking up at you, above the surface. <i>\"No. I don't think that's a good idea.\"</i> She points away, back where you came from. <i>\"Please leave me alone now\"</i>\n\n");
 			outputText("Not wanting to aggravate the odd, aquatic Drider any further, you take your leave, heading back towards camp.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		else {
 			outputText("<i>\"You just want to...hang out?\"</i> Belisa seems taken aback by this, but she smiles slightly. <i>\"I...wouldn't be opposed to spending some time with you. What are you thinking of doing?\"</i>\n\n");
@@ -566,7 +565,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		clearOutput();
 		if (BelisaAffectionMeter < 30) {
 			outputText ("<i>\"You want to fight...ME?!\"</i> she seems rather angry...and afraid. <i>\"Was this just your way of getting me to lower my guard? To be able to fight me, 'for fun' or 'for training', and weaken me so I can't run?\"</i> without listening to your denials, she immediately sinks to the bottom of the lake.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		else {
 			outputText("You ask Belisa if she feels ready to fight a demon. The little Drider looks at you, and shakes her head. <i>\"I don’t really like fighting, [name]. So…\"</i> You tell her that running and hiding won’t save her forever.\n\n");
@@ -622,7 +621,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		else outputText(" You dive down, deep into the lake with Belisa. Eventually, you begin to run low on air, and...she keeps going down! You turn back, but Belisa grabs your foot, pulling you down to her. The spider-girl produces an odd, silky bag, draping it over your head. You struggle at first, but you quickly realize that the bag’s...full of breathable air? She takes it off your head, and giggles, sending bubbles back up to the surface of the water.\n\n");
 		outputText("You spend an hour under the water with Belisa, and she swims with you. You catch a few fish, but you can’t hold a candle to the water-spider. Her eight lower limbs move precisely, and she swims circles around you. You miss your spear throw a few times, and when you do, she gives you a bright laugh, swimming over to your spear and bringing it back to you. It’s odd, but a lot of fun, just throwing spears and swimming deep under the lake. Eventually, you point back to the surface. Belisa’s bright smile shrinks a little, but she nods, guiding you back to her silky orb.\n\n");
 		outputText("<i>\"I forgot how nice it was to have a fishing partner\"</i>, she says simply, taking your hand as you leave the water together. <i>\"Come back soon, okay?\"</i> She looks into your eyes, then pulls her hand away. <i>\"It gets lonely out here.\"</i> You smile to yourself as Belisa dives back into the water, and head back to camp.\n\n");
-		inventory.takeItem(consumables.FREFISH, camp.returnToCampUseOneHour);
+		inventory.takeItem(consumables.FREFISH, explorer.done);
 	}
 	
 	public function BelisaHangMagic():void {
@@ -645,7 +644,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 			player.createStatusEffect(StatusEffects.KnowsBlind,0,0,0,0);
 			outputText("<b>New White Magic Spell Learned: Blind</b>");
 		}
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	public function BelisaHangWeave():void {
@@ -655,7 +654,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		outputText("<i>\"If you want to learn some basic threads, I can teach you.\"</i>\n\n");
 		outputText("You spend an hour with the Drider, learning the basics of weaving spider-silk into a rope. Your efforts are...well, crappy, but she seems to approve. <i>\"Well, you’re better than…\"</i> She looks down at her lap. <i>\"Never mind. You’re doing well, [name]. I think that’s enough for today, though. I need some time alone.\"</i>\n\n");
 		BelisaAffection(5);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	
 	public function BelisaHangHouse():void {
@@ -666,7 +665,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		outputText("<i>\"Cool, right?!\"</i> Belisa asks, a huge smile on the half of her face she’ll let you see. <i>\"My silk has an odd effect on the water. No matter how deep we go, we’ll have breathable air for a long time. I don’t know how it works, but…It lasts for over a day if I don’t do anything strenuous.\"</i> Now you understand how your Drider friend’s been able to remain hidden for so long.\n\n");
 		outputText("For a while, you sit in Belisa’s odd, but surprisingly cozy home, chatting with your Drider friend. Eventually, you tell her that you need to leave. Belisa nods, and brings the silk bubble back to the surface. As you step out onto the shore, you realize it’s been nearly an hour. You excuse yourself, and Belisa waves as you leave.\n\n");
 		BelisaAffection(5);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	
 	private function BelisaShop():void {
@@ -1112,7 +1111,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		outputText("\n\n<b>Before fully settling in your camp as if remembering something Belisa pulls a shining shard from her inventory and hand it over to you as a gift. You acquired a Radiant shard!</b>");
 		BelisaFollowerStage = 3;
 		BelisaInCamp = true;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		model.time.hours = 21;
 	}
 
@@ -1202,7 +1201,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 			else if (BelisaAffectionMeter < 80) outputText("Belisa blushes, turning her head away from you shyly. <i>\"...[name], I can’t right now, okay?\"</i> She heads back into her home, and you can hear some rustling inside. You can hear a small gasp, and a wet <i>schluck</i>. Is...Is Belisa...?\n\n");
 			else if (BelisaAffectionMeter >= 80) outputText("Your shy Drider looks you up and down, a small bit of drool dripping from the corner of her mouth. She snaps out of it, then immediately turns her head. <i>\"Nope! Nope nope nope nope! Nope!\"</i> She sprints as fast as she can, launching herself face-first into the water. Judging from her reaction…she wants to…? But…Something’s in the way? You’re not sure whether to be amused or insulted by her reaction.\n\n");
 			if (BelisaInCamp) doNext(BelisaMainCampMenu);
-			else doNext(camp.returnToCampUseOneHour);
+			else endEncounter();
 		}
 	}
 

--- a/classes/classes/Scenes/NPCs/Exgartuan.as
+++ b/classes/classes/Scenes/NPCs/Exgartuan.as
@@ -184,7 +184,7 @@ public function fountainEncounter():void {
 	outputText("You come closer and discover a placard.  It reads, \"Fountain of Endowment\".  Well, clearly it's supposed to enhance something, but at what cost?\n\n");
 	outputText("Do you drink from the fountain?");
 	//[Yes] [No]
-	doYesNo(drinkFountainEndowment,camp.returnToCampUseOneHour);
+	doYesNo(drinkFountainEndowment,explorer.done);
 }
 
 private function drinkFountainEndowment():void {
@@ -237,7 +237,7 @@ private function drinkFountainEndowment():void {
         changed = true;
 	}
     if (!changed) outputText("\n\nWeird. You thought it would make you feel different somehow.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 private function exgartuanInfestDick():void {
 	spriteSelect(SpriteDb.s_exgartuan);
@@ -259,7 +259,7 @@ private function exgartuanInfestDick():void {
     outputText("\n\n\"<i>Yes I am.  You should consider yourself lucky – you're now the host of the great demon Exgartuan, and you'd best please me every few hours, or I'll make sure your body finds someone to relieve my building pressure.  But I think you'll do fine.  Come now, I can see a wonderful camp in your mind that we can paint white,</i>\" it suggests.");
     outputText("\n\nWell now... this was certainly unexpected.  Perhaps there's a way to be rid of this thing?");
 	infestDick();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 private function exgartuanInfestTits():void {
 	outputText("\n\nYour [allbreasts] jiggle as they grow MUCH larger, turning into obscene mounds that shake with every motion of your body.  All your " + nippleDescript(0) + "s puff up with them, gaining volume to match their new, larger homes.  They feel hot and ache to be touched.");
@@ -275,7 +275,7 @@ private function exgartuanInfestTits():void {
 	outputText("\n\n\"<i>Yes I am,</i>\" mutters Xenora, spurting a trickle of milk from your " + nippleDescript(0) + "s for emphasis, \"<i>and you had better take me back to that lovely camp I can see in your memories and give me a nice long massage.</i>\"");
 	outputText("\n\nWell now... this was certainly unexpected.  Perhaps there's a way to be rid of this thing?");
 	infestBoobs();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 	public function exgartuanMasturbation_dick():void {

--- a/classes/classes/Scenes/NPCs/IsabellaScene.as
+++ b/classes/classes/Scenes/NPCs/IsabellaScene.as
@@ -113,7 +113,7 @@ public function isabellaGreeting():void {
 		outputText("While walking through the high grasses you hear a rich, high voice warbling out a melodious tune in a language you don't quite understand.  Do you approach or avoid it?");
 		//[Approach – to meeting] [Avoid – camp] – dont flag as met yet
 		//Approach - sets flags[kFLAGS.ISABELLA_CAMP_APPROACHED] to 1 and calls this function
-		simpleChoices("Approach", isabellaGreetingFirstTime, "", null, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+		simpleChoices("Approach", isabellaGreetingFirstTime, "", null, "", null, "", null, "Leave", explorer.done);
 		return;
 	}
 	//CAMP MEETING – UMAD BRAH!?
@@ -160,7 +160,7 @@ public function isabellaGreeting():void {
 				else outputText("  The cow's eyes close, disappointment visible on her face when she sees the sheer size of your bulge.");
 			}
 			//[Talk – real conversations] [Drink – leads to breastfeeding] [Get Licks – leads to oral for small fries] [Rape?]
-			simpleChoices("Talk", talkWithIsabella, "Drink", nomOnMommaIzzysTits, "Get Licked", suck, "Fight", fightIsabella, "Leave", camp.returnToCampUseOneHour);
+			simpleChoices("Talk", talkWithIsabella, "Drink", nomOnMommaIzzysTits, "Get Licked", suck, "Fight", fightIsabella, "Leave", explorer.done);
 		}
 		return;
 	}
@@ -237,7 +237,7 @@ public function isabellaGreeting():void {
 		}
 	}
 	choices("Talk", talkWithIsabella, "Drink", nomOnMommaIzzysTits, "Get Licked", suck, "Fight 4 Rape", fightIsabella, "Offer Oral", volunteerToSlurpCowCunt,
-		"", null, "", null, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+		"", null, "", null, "", null, "", null, "Leave", explorer.done);
 	//outputText("ISABELLA HAS BROKEN.  PLEASE TELL FENOXO.", true);
 }
 
@@ -251,7 +251,7 @@ public function leaveAngryIzzy():void {
 	spriteSelect(SpriteDb.s_isabella);
 	clearOutput();
 	outputText("You shrug and make it quite clear you're leaving.  Crazy cow.  She shouts, \"<i>And stay avay, demon!  Izabella has no need of your foul tricks!</i>\"");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[Fight]
 public function unwelcomeFightCowGal():void {
@@ -307,7 +307,7 @@ public function tryToTalkDownAngryCow():void {
 		outputText("You sit down in the dirt and impart your tale, explaining how you came here as a 'champion', chosen by your village.  You go on to speak of your encounters and how strange everything is here, and Isabella nods quite knowingly as you go on and on.  Now that you've begun to tell your tale, the words fall out of your mouth, one after another.  Like an unbroken chain, they spool out of your maw until nearly an hour later, you finally run out of things to say.  You rub your jaw, your throat a little sore from the diatribe, and look on to Isabella to see how she reacts.\n\n");
 		outputText("The busty cow-girl has moisture glimmering in the corners of her big brown eyes, and she nods emphatically to you as she vocalizes her feelings, \"<i>I, too, know how you feel, Champion [name].  Mein own story is similar, though mein fate vas not thrust upon me so.  Perhaps I vill tell you sometime, but for now, ve should part.  You are velcome to return in ze future.</i>\"\n\n");
 		outputText("You smile to yourself, glad to have made a friend.\n\n");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		isabellaFollowerScene.isabellaAffection(10); //yay
 		flags[kFLAGS.ISABELLA_OKAY_WITH_TALL_FOLKS]++;
 	}
@@ -464,7 +464,7 @@ public function nomOnMommaIzzysTits():void {
 	//(Chance of thickening body to 75, chance of softening body if PC has a vag)
 	if(rand(2) == 0) outputText(player.modThickness(75,4));
 	if(rand(2) == 0 && player.hasVagina()) outputText(player.modTone(0,4));
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[GET ORAL'ED AS A SMALL MALE]
@@ -606,7 +606,7 @@ public function izzyGivesSmallWangsFreeOral():void {
 		isabellaFollowerScene.isabellaAffection(7); //disappointed, but anyway..
 	}
 	player.sexReward("saliva", "Dick");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Give Isy Oral]
@@ -666,21 +666,21 @@ public function volunteerToSlurpCowCunt():void {
 			outputText("before offering something else.  \"<i>Perhaps you could undress?  I ");
 			if(isabellaAccent()) outputText("vould like to return ze favor.</i>\"");
 			else outputText("would like to return the favor.</i>\"");
-			doYesNo(izzyGivesSmallWangsFreeOral,camp.returnToCampUseOneHour);
+			doYesNo(izzyGivesSmallWangsFreeOral,explorer.done);
 			return;
 		}
 	}
 	isabellaFollowerScene.isabellaAffection(15); //thankful!
 	if(!isabellaFollower() || !player.hasVagina() || player.biggestTitSize() < 1) {
 		sceneHunter.print("Check failed: Isabella follower, vagina, tits.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else {
 		//(Change the ending of the \"Service Her\" option on an affectionate Isabella to the following; PC must NOT have a dick that suits her and MUST have a vagina)
 		if(!isabellaAccent()) outputText("Seeing the ardent desire your sexual service has so visibly inspired in your body - in your slick, ready cunt and erect nipples - the cow-girl smiles slightly, and asks, \"<i>Perhaps you would like me to return the favor?  It seems only fair...</i>\"");
 		else outputText("Seeing the ardent desire your sexual service has so visibly inspired in your body - in your slick, ready cunt and erect nipples - the cow-girl smiles slightly, and asks, \"<i>Perhaps you vould like me to return ze favor?  It seems only fair...</i>\"");
 		//[Leave] [Get Cowlicked]
-		simpleChoices("Get Licked", isabellaFollowerScene.receiveAllTheCowTOngues, "Leave", camp.returnToCampUseOneHour, "", null, "", null, "", null);
+		simpleChoices("Get Licked", isabellaFollowerScene.receiveAllTheCowTOngues, "Leave", explorer.done, "", null, "", null, "", null);
 	}
 }
 
@@ -1361,7 +1361,7 @@ public function victoryAgainstIzzzzzySixtyNine(x:int):void {
 	isabellaFollowerScene.isabellaAffection(15); //okay, redeemed)
 	flags[kFLAGS.ISABELLA_ANGRY_AT_PC_COUNTER] = 0;
     if (CoC.instance.inCombat) cleanupAfterCombat();
-    else doNext(camp.returnToCampUseOneHour);
+    else endEncounter();
 }
 
 //['Too Big' Victory Titfucking Funtimes With Milk]
@@ -1599,7 +1599,7 @@ public function talkWithIsabella():void {
         isabellaFollowerScene.isabellaAffection(5); //smaller later
     }
 	flags[kFLAGS.ISABELLA_TALKS]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 	}
 }

--- a/classes/classes/Scenes/NPCs/IzmaScene.as
+++ b/classes/classes/Scenes/NPCs/IzmaScene.as
@@ -125,7 +125,7 @@ public function meetIzmaAtLake():void {
 		outputText("You nod in agreement, earning a smile from Izma.  You chat for another short while before you part ways, heading back to your camp.");
 		//(Izmacounter +1)
 		flags[kFLAGS.IZMA_ENCOUNTER_COUNTER]++;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		return;
 	}
 	//[Next 2 encounters with Izma] (Izmacounter = 2 or 3)
@@ -256,7 +256,7 @@ private function readSharkCuntManual2():void {
 	else outputText("leave the shark-girl to her books.");
 	//(Izmacounter +1)
 	flags[kFLAGS.IZMA_ENCOUNTER_COUNTER]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function buyBookCombatManual():void {
@@ -314,7 +314,7 @@ private function readSharkEdgingGuideLOL():void {
 	else outputText("leave the shark-girl to her books.");
 	//(Izmacounter +1)
 	flags[kFLAGS.IZMA_ENCOUNTER_COUNTER]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function buyBookEtiquetteGuide():void {
@@ -382,7 +382,7 @@ private function readSharkgirlPornzYouFuckingPervertAsshole():void {
 	else outputText("  You nonchalantly glance at Izma, and mention that it doesn't really compare to your own fantasies and experiences.  With that, you hold the closed book out and tuck it neatly into the cleavage of her breasts!  Keeping your hand on it, you quirk an eyebrow at her; she shivers, colors deeply, and turns around, snatching the book from you.  \"<i>You... perv,</i>\" she teases back.  \"<i>Why don't you write a book yourself then?</i>\" As you go to leave, you notice her grass skirt has shifted to the front and lies taut against the contours of her butt.  Too tempting!  You plant an open-palmed smack on it and take off running as she shouts after you.");
 	//(Izmacounter +1)
 	flags[kFLAGS.IZMA_ENCOUNTER_COUNTER]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function buyBookPorn():void {
@@ -433,7 +433,7 @@ private function talkToASharkCoochie():void {
 	outputText("\n\nEventually the two of you decide to part ways, and you head back to camp.");
 	//(Izmacounter +1)
 	flags[kFLAGS.IZMA_ENCOUNTER_COUNTER]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[Leave]
 private function leaveSumSharkPussyOnTheBeach():void {
@@ -441,7 +441,7 @@ private function leaveSumSharkPussyOnTheBeach():void {
 	clearOutput();
 	outputText("Having no business with Izma for the time being, you head off back to your camp.");
 
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Fight]
@@ -454,7 +454,6 @@ private function fightSharkCunt():void {
 	else if(flags[kFLAGS.IZMA_TIMES_FOUGHT_AND_WON] > 2) outputText("Izma seems uncertain with herself as she prepares for battle. \"<i>Go a little easier on me this time... please?</i>\"");
 	else if(flags[kFLAGS.IZMA_TIMES_FOUGHT_AND_WON] < 0 && flags[kFLAGS.IZMA_TIMES_FOUGHT_AND_WON] >= -2) outputText("\"<i>Hm, really?  Well, maybe you'll get lucky this time,</i>\" she mocks, gesturing at you to strike first.");
 	else outputText("Izma laughs slightly and shakes her head.  \"<i>If you insist.  At least TRY this time, will ya?</i>\"");
-	player.createStatusEffect(StatusEffects.NearWater,0,0,0,0);
 	startCombat(new Izma());
 	spriteSelect(SpriteDb.s_izma);
 }
@@ -706,7 +705,7 @@ private function nonFightIzmaSmexPAINUS():void {
 	//(lust -100, gain 1 t-shark toof, Izmacounter+1)
 	flags[kFLAGS.IZMA_ENCOUNTER_COUNTER]++;
 	player.sexReward("cum","Lips");
-	inventory.takeItem(consumables.TSTOOTH, camp.returnToCampUseOneHour);
+	inventory.takeItem(consumables.TSTOOTH, explorer.done);
 }
 
 //[no-fight sex: get your ass in the car]
@@ -723,7 +722,7 @@ private function nonFightIzmaSmexASS():void {
 
 		outputText("Izma rolls her eyes.  \"<i>I've dominated with my holes before.  You ride 'em hard enough, they don't feel as much pleasure.  Now, fuck off.</i>\"\n\n");
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[no-fight sex: use vagino]
 private function nonFightIzmaSmexCUNTPUSSYSNATCHQUIM():void {
@@ -751,7 +750,7 @@ private function nonFightIzmaSmexCUNTPUSSYSNATCHQUIM():void {
 	//(lust minus 100, gain 1 t-shark tooth, Izmacounter +1)
 	flags[kFLAGS.IZMA_ENCOUNTER_COUNTER]++;
 	player.sexReward("cum","Lips");
-	inventory.takeItem(consumables.TSTOOTH, camp.returnToCampUseOneHour);
+	inventory.takeItem(consumables.TSTOOTH, explorer.done);
 }
 
 //Decline Izma moving in
@@ -764,7 +763,7 @@ private function IzmaStayAtTheLakeBitch():void {
 	outputText("You give her a small kiss on the lips and then leave for camp.");
 	//Set 'NO CAMP Izma' flag
 	flags[kFLAGS.IZMA_FOLLOWER_STATUS] = -1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Accept
 private function acceptIzmaAsYourBitch():void {
@@ -858,7 +857,7 @@ private function acceptIzmaAsYourBitch():void {
 	}
 	else player.createKeyItem("Radiant shard", 1,0,0,0);
 	outputText("\n\n<b>Before fully settling in your camp as if remembering something Izma pulls a shining shard from her inventory and hand it over to you as a gift. You acquired a Radiant shard!</b>");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Amily arrives: Izma is at camp first]
@@ -888,7 +887,7 @@ public function newAmilyMeetsIzma():void {
 	outputText("\"<i>You have a point there...</i>\" Amily mumbles, staring at Izma with obvious curiosity.  \"<i>Hmm... well, I should keep an eye on her, but I guess she's earned the right to the benefit of the doubt.  It might be nice to have somebody else to talk to here in the camp...</i>\"  She trails off, mumbling, as she goes off to unpack.\n\n");
 	//wrap up all conditionals
 	flags[kFLAGS.IZMA_AMILY_FREAKOUT_STATUS] = -1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Marble: Izma is at camp first]
@@ -922,7 +921,7 @@ public function newMarbleMeetsIzma():void {
 	outputText(".</i>\"  You give her a nervous chuckle and assure her that this isn't the case, but Izma doesn't want to listen.  \"<i>I'll keep quiet for now, but if that bovine steps out of line...</i>\" she trails off and her fangs pop free, before she goes to set up her bedroll and trunk near your own bed.  Seems she wants to keep close to your bed to protect you.  Or at least, that's your interpretation.  You give a sigh and shake your head.  It's doubtful these two will ever warm up to each other.");
 	//wrap up all conditionals
 	flags[kFLAGS.IZMA_MARBLE_FREAKOUT_STATUS] = -1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[=Sex=]
@@ -943,7 +942,7 @@ private function izmaLakeTurnedDownCampSex(fromCamp:Boolean = false):void {
 	addButton(0, "Equals", izmaLakeSexAsEquals);
 	addButton(1, "Dominate", izmaLakeDominate);
 	addButton(2, "Submit", submitToLakeIzma);
-	addButton(4, "Back", fromCamp ? camp.returnToCampUseOneHour : meetIzmaAtLake);
+	addButton(4, "Back", fromCamp ? explorer.done : meetIzmaAtLake);
 }
 
 //[Equals]
@@ -1020,7 +1019,7 @@ private function izmaLakeDominate():void {
 			outputText("\"<i>What about a goodbye kiss?</i>\" she asks, trying to sound plaintive, but really sounding eager.  Happily, you allow her to embrace you, but in the midst of your passionate kiss, she suddenly pokes something from her mouth into yours, using her tongue to shove it down your throat and make you swallow.  You break away from her, coughing, and ask what that was.\n\n");
 
 			outputText("\"<i>Birth control,</i>\" she explains. You give her a half-hearted slap across the face and tell her not to be so audacious, but you can see by her smiling expression that she's pleased to have stolen a march on you.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		} else {
 			outputText("Izma retrieves a crumpled leaf, then holds it out to you with a smile.  \"<i>Here, take this.  It's an anti-pregnancy herb.</i>\" Do you take it?");
 			doYesNo(eatIzmasLeafAfterRapinHer,dontEatIzamsLeafAfterRape); //careful - only NON-voluntary options here
@@ -1045,7 +1044,7 @@ private function izmaLakeDominate():void {
 		dynStats("sen", -1);
 		if (voluntary) {
 			outputText("The two of you get dress after a while, have some small talk, and then you make your way back to camp.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		} else izmaAfterDom();
 	}
 }
@@ -1093,7 +1092,7 @@ private function izmaLakeDominateContinueVanilla(vanilla:Boolean = true) :void
 	}
 	player.sexReward("vaginalFluids", "Dick");
 	dynStats("sen", -1);
-	if (voluntary) doNext(camp.returnToCampUseOneHour);
+	if (voluntary) endEncounter();
 	else izmaAfterDom();
 }
 
@@ -1329,7 +1328,7 @@ private function submitToLakeIzma():void {
 				outputText("\"<i>I'd be happy to make some babies with you... but <b>after</b> you accept me as a mate.\"</i>  She smirks, giving you a second, decidedly unchaste kiss before she helps you up.  You dress yourself and head back to camp feeling very sated.");
 			}
 			else outputText("She gives you a decidedly unchaste kiss before she helps you up.  You dress yourself and head back to camp feeling very sated.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		} else {
 			outputText("She releases your [feet], allowing your [butt] to hit the sand with a plop, and gets to work redressing while you lie still.");
 			if(!player.isPregnant() || player.hasNonVisiblePregnancy()) {
@@ -1615,7 +1614,7 @@ private function followerIzmaMountsPC(lastHalf:Boolean = false):void {
 	outputText("You're too busy gasping for breath to reply, at first.  But then, with a smile, you pick yourself up and give her a quick kiss on the cheek.  To your surprise, the ever-horny shark-girl actually blushes with delight at the gesture.  The two of you leisurely dress yourselves and then go your separate ways; you back to your camp, Izma back to the stream to soak and recover.");
 	player.sexReward("vaginalFluids","Dick");
 	dynStats("sen", -2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function izmaPreg():void {
@@ -1654,7 +1653,7 @@ private function RadarIzmaLeaveHerWangUnWingWanged():void {
 	outputText("You're too busy gasping for breath to reply, at first.  But then, with a smile, you pick yourself up and give her a quick kiss on the cheek.  To your surprise, the ever-horny shark-girl actually blushes with delight at the gesture.  The two of you leisurely dress yourselves and then go your separate ways; you back to your camp, Izma back to the stream to soak and recover.");
 	player.sexReward("vaginalFluids");
 	dynStats("sen", -2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -1793,7 +1792,7 @@ private function followerIzmaTakesItInPooper():void {
 	if(player.hasCock()) player.sexReward("no", "Dick");
 	player.sexReward("cum","Anal");
 	dynStats("sen", -1);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Vag fuck]
@@ -1858,7 +1857,7 @@ private function followerIzmaTakesItInVagoo():void {
 	izmaPreg();
 	player.sexReward("vaginalFluids","Dick");
 	dynStats("sen", -2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Deny her]
@@ -1913,7 +1912,7 @@ private function facialWhereItGoesRadarIzmaXpack():void {
 	izmaPreg();
 	player.sexReward("no", "Default");
 	dynStats("sen", -2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[Your chest]
 private function RadarIzmaCumInYourChest():void {
@@ -1944,7 +1943,7 @@ private function RadarIzmaCumInYourChest():void {
 	player.sexReward("cum");
 	player.sexReward("vaginalFluids","Dick");
 	dynStats("sen", -2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function IzmaSelfFacialWheeRadar():void {
@@ -1962,7 +1961,7 @@ private function IzmaSelfFacialWheeRadar():void {
 	izmaPreg();
 	player.sexReward("vaginalFluids","Dick");
 	dynStats("sen", -2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[69]
 private function followerIzmaTakesIt69():void {
@@ -2013,7 +2012,7 @@ private function followerIzmaTakesIt69():void {
 	if(player.hasCock())player.sexReward("no", "Dick");
 	player.sexReward("cum");
 	dynStats("sen", -2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Talk]
@@ -2030,7 +2029,7 @@ private function talkWivIzma():void {
 
 		outputText("She heaves a sigh, and you place a hand on her shoulder, bringing a small blush to her face.  \"<i>Thanks, but I don't mind. Really.</i>\"  She gives you a quick kiss. \"<i>Thanks for listening.</i>\"\n\n");
 		flags[kFLAGS.IZMA_TALK_LEVEL]++;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	//[Talk option 2]
 	else if(flags[kFLAGS.IZMA_TALK_LEVEL] == 1) {
@@ -2054,7 +2053,7 @@ private function talkWivIzma():void {
 		//(Slight lust gain)
 		dynStats("lus", 5, "scale", false);
 		flags[kFLAGS.IZMA_TALK_LEVEL]++;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	//[Talk option 3]
 	else if(flags[kFLAGS.IZMA_TALK_LEVEL] == 2) {
@@ -2072,7 +2071,7 @@ private function talkWivIzma():void {
 
 		outputText("\"<i>Well... minotaurs taste like beef, unsurprisingly, but imps taste like a mile of burnt ass.</i>\"  With a laugh, you ask if she's ever eaten a goblin - or if she prefers to fuck those and then throw them back?  She blushes.  \"<i>They are pretty cute... it's hard to eat anything cute.  I could eat them out, though...</i>\"  You smile at that and, after teasing her about letting you watch next time, you leave her be.\n\n");
 		flags[kFLAGS.IZMA_TALK_LEVEL]++;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	//[Talk topic 4.]
 	else if(flags[kFLAGS.IZMA_TALK_LEVEL] == 3) {
@@ -2109,7 +2108,7 @@ private function talkWivIzma():void {
 		if(flags[kFLAGS.IZMA_NO_COCK] == 0) outputText("..  and patiently ignoring the fact you can feel her cock starting to stiffen against your thigh.");
 		outputText("  You release her, trying to avoid turning her on too much.  Thanking her for the talk, you leave as she buries herself back into her books.");
 		flags[kFLAGS.IZMA_TALK_LEVEL]++;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	//[Talk Option 6]
 	else {
@@ -2137,7 +2136,7 @@ private function talkWivIzma():void {
 
 		outputText("You thank Izma for talking to you, insisting that you didn't mean to hurt her by probing such painful memories.  She smiles warmly at you and hugs you tight.  \"<i>It's okay. It... it feels nice to be able to share that information with someone,</i>\" she says, giving you a small kiss as she slips her glasses back on.");
 		flags[kFLAGS.IZMA_TALK_LEVEL] = 0;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 //[Leave]
@@ -2145,7 +2144,7 @@ private function chooseNotToFlirtWithIzma():void {
 	spriteSelect(SpriteDb.s_izma);
 	clearOutput();
 	outputText("You thank Izma for the interesting conversation, even if it did end up meandering a bit, and then walk away, leaving her to her private thoughts.\n\n");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Flirt]
 private function chooseToFlirtWithIzma():void {
@@ -2165,7 +2164,7 @@ private function chooseToFlirtWithIzma():void {
 		//[(If player is male/genderless)
 		if(player.gender <= 1) {
 			outputText("  \"<i>That's kinda weird, man... I'm not sure the god in charge of this world would allow something like that.  It seems too silly.</i>\"");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			return;
 		}
 		///(Female/herm)
@@ -2390,7 +2389,7 @@ public function izmaKidsPlaytime():void {
 		else outputText(num2Text(flags[kFLAGS.IZMA_CHILDREN_TIGERSHARKS]) + " tigersharks");
 	}
 	outputText(" living here; the fruits of your love with Izma.\n\n");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 
 	if (choice == 1) {
 		if (flags[kFLAGS.IZMA_CHILDREN_TIGERSHARKS] == 1) {
@@ -2440,7 +2439,7 @@ public function izmaKidsPlaytime():void {
 		//outputText("You see that two of your shark-girls are hugging each other in a way that, at first glance, seems familial.  As you get closer, though, you can see it's somewhat less than sisterly; each is hugging in such a way that it looks inappropriate.  Izma blushes and hastily explains that your children have strong libidos, so it's natural for them to experiment like this.  You blush and look away from the young shark-girls.");
 		outputText("You see that two of your shark-girls are hugging each other in a way that, at first glance, seems familial.  As you get closer, though, you can see it's somewhat less than sisterly; each is groping the other's breasts, experimentally playing with her sibling's boobs to see what makes her gasp and moan in pleasure.  Their faces are pressed together in a very unchaste kiss.  Izma blushes and hastily explains that your children have strong libidos, so it's natural for them to experiment like this.  She assures you that they won't do anything really sexual with each other - and, even if they did, it's not like anything can come of a little harmless girl-on-girl, right?");
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function inCampRideIzmasDickDongTheWitchIsDead():void {
@@ -2528,7 +2527,7 @@ private function inCampRideIzmasDickDongTheWitchIsDead():void {
 	}
 	if(player.hasCock())player.sexReward("no", "Dick");
 	player.sexReward("cum");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Using Izma's books in camp]
@@ -2571,7 +2570,7 @@ private function campCuntManual():void {
 		player.KnowledgeBonus("str",2);
 	}
 	outputText("\n\nAfter about an hour you yawn and stretch, telling Izma that you're going off to do other business.  She nods lazily at your words but doesn't look up from her old book. \"<i>Sure thing [name], I'm just gonna read this for a little while longer,</i>\" Izma says.  You nod at her, before moving off.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[E.Guide]
 private function entropyGuideByStephenHawking():void {
@@ -2583,7 +2582,7 @@ private function entropyGuideByStephenHawking():void {
 	dynStats("cor", -2);
 
 	outputText("As time passes you realize that you do have other things to do.  You thank Izma for her company and get up to leave.  \"<i>All right, thanks for sitting with me [name].  You go on ahead, I'm just going to read some more of this,</i>\" she replies, not even looking up from the pages of her book.\n\n");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[Porn]
 private function stephenHawkingPorn():void {
@@ -2598,7 +2597,7 @@ private function stephenHawkingPorn():void {
 	else outputText("but that's not exactly possible for someone who keeps squirming, creating lewd squishes from below the waist.  You laugh openly and give Izma's silver hair a soft tug, before getting up and telling her you have business elsewhere.  Izma simply nods in taciturn response but keeps her gaze fixed on the lewd images before her.  Another laugh escapes your lips as soon as you think you're out of earshot.");
 	dynStats("lus", 5, "scale", false);
 	player.KnowledgeBonus("lib",1);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //(Trying to use another book inside the span of 6 hours)
 private function tooSoonExecutus():void {
@@ -2629,7 +2628,7 @@ private function findLostIzmaKidsII():void {
 	outputText("This sparks off a happy chain of thoughts in your mind, and you inform your wayward daughter that Izma is now living with you (and there's room for another).  She squeaks happily at the news, and tells you that she'll meet you at camp.  She pecks you on the cheek, then runs into the shallows and disappears.  You walk away, beaming at the thought of seeing a new face in camp.");
 	//(+1 Izma children.)
 	flags[kFLAGS.IZMA_CHILDREN_SHARKGIRLS]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Ask Izma About Removing Her Dick
@@ -2704,7 +2703,7 @@ private function izmaDickToggle():void {
 		outputText("You flash Izma a smile and tell her she can regrow her penis.  She cheers so violently that her glasses nearly go flying, \"<i>Hell yes!</i>\"  The black-striped girl digs into her trunk and pulls out a strange tablet, popping it into her mouth before you can change your mind.  She chews vigorously, finishing it in seconds.  Izma cups her drooling snatch and moans, her palms slowly pushed away from her body by a red, masculine member.  It grows larger by the second, soon surpassing six inches, then eight, then ten, and not stopping until it's as big as it used to be.  A second later, a spherical protrusion falls down, filling out a new-grown flap of skin.  Plop!  Another joins it.  Finally, two more orbs fall from her body into her new ballsack.  <b>Izma is a herm again!</b>");
 		flags[kFLAGS.IZMA_NO_COCK] = 0;
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Fuck her pussy-Dominant]
@@ -2801,7 +2800,7 @@ private function radarIzmaGasm():void {
 	player.sexReward("cum");
 	dynStats("sen", -1);
 	izmaPreg();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Anal (dominant)]
@@ -2865,7 +2864,7 @@ private function radarIzmaAnalDominant():void {
 		outputText("\n\nContent, you slide to the ground to the right of the trunk you propped yourself up against, going prone as your tigershark lover lands softly on top of you.  Neither of you have the energy to get up, but you won't let some random passerby see this and think you are the bitch in this relationship.  With her still inside of you, you roll both yourself and Izma onto your sides, allowing her to stay inside of you as you drift off to sleep. Her arms trace over you and embrace you appreciatively as you surrender yourself to slumber.");
 
 		outputText("\n\nA half hour passes before you wake up; Izma peacefully snoozing away as she holds you in a lover's embrace.  Faintly, you pull yourself from her grasp and place your [armor] back on.  As you finish placing the last piece of your gear back on, Izma wakes and rises to her feet, planting a tender kiss on her Alpha's neck as she sees you off.  Before you go though, Izma quietly asks, \"<i>So... where's my gift?</i>\", smirking as you turn around to respond to her.  With a firm slap on your ass, you tell her that going all the way with her Alpha was the gift.  Sheepishly grinning, she sees you off as you head out to tend to other matters.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	if(player.hasCock())player.sexReward("no", "Dick");
 	player.sexReward("cum");
@@ -2888,13 +2887,13 @@ private function radarIzmaAnalDomResultTuckIn():void {
 		outputText("With a great show of force, you take Izma under the legs and back, lifting her off the ground and starting toward her bedroll. In little time flat, you reach her bedding and lie her down gently. As you turn, you remark to Izma that she better rest up; you'll likely have another \"itch\" that will need scratching.  Her raspy words ring out behind you as you begin to walk away; \"<i>Promise?</i>\"  Turning your head slightly to catch her in your left eye, you grin mischievously at the shark-morph and continue on your way.");
 		dynStats("cor", -2);
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[Leave her]
 private function radarIzmaLeaveHerInTheDirtAfterAnalDom():void {
 	clearOutput();
 	outputText("Laughing, you tell Izma that she needs to work on her stamina, and that she'll have to recuperate out here in the grass.  She weakly acknowledges your choice, telling you that it's the right thing to do with worn out betas.  You stop and forcefully tell her that she did well; just that she needs to work on her endurance.  With a shaky nod, she smiles and drifts off to sleep.  To ensure she remains safe, you keep watch nearby as she naps peacefully.  Thankfully, she wakes after a half hour and saunters seductively past you, thanking her Alpha for fucking her and watching over her as she heads off to the lake to clean up.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private var tdJerking:Boolean = false;
@@ -3059,17 +3058,17 @@ private function analFuckRadarEnding():void {
 		}
 	}
 	sceneHunter.print("Are you sure aren't missing out on anything? Maybe you could cum even more?");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function tdCumHelp():void {
 	outputText("Sighing, you reach down to the shark morph and help her to her feet, allowing her to rub the soles of her feet against your [armor] so that she can at least walk while you help her to the lake.  She slips a few times along the way, " + (player.tallness > 50 ? "almost sliding out of your grip as she does." : "damn near knocking you over as she tumbles to the ground. She promptly gets back with some assistance, and continues alongside you to the lake.  While you might argue being small has its advantages, it certainly isn't helping out here.") + " Finally, after some effort, you reach the lake and gently guide Izma's body into the river.  With your kind deed done, you inform your Beta that she better clean up fast; you'll likely take her body again sooner rather than later.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function tdCumLeave():void {
 	outputText("Chuckling to yourself, you pull your leg away and stare down at the shark morph; her expression turns from one of helplessness and need to cold realization that you aren't going to help her.  Calmly, you scold Izma for giving up so easily; that no Beta of yours would give up without a fight, and that you are wondering if she is still worthy of being your Beta.  Realizing her weakness, she resolves to crawl towards the river.  Praising your submissive lover, you tell her that you'll be waiting at camp for her return; that by the time she gets back, you'll be ready to dominate her once again.  The thought of being made into your bitch once more appears to resonate through Izma, driving her to quicken her pace along the ground.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function tdCumUltimatum():void {
@@ -3079,7 +3078,7 @@ private function tdCumUltimatum():void {
 		+ "With three minutes to go, you take hold of your [cocks], cradling " + (player.cockTotal() > 1 ? "them" : "it") + " in your hands as you whistle at Izma.  Raising your voice, you tell Izma that THIS is what she is fighting for; the privilege for her Alpha to bestow upon her the \"blessings\" she enjoys, and that no Beta of yours will fail to make the deadline. Growling with newfound drive, Izma feverishly claws along the ground, greatly picking up her pace as you praise her progress.\n"
 		+ "\n"
 		+ "With one minute to go, Izma reaches the river bank; running into the water, you taunt Izma by slapping your [cocks] against the water, commenting that she could taste you if she was in the water right now.  That seems to the final bit of encouragement she needs; with a great shove against the slope of the river bank, Izma begins her descent down into the water.  The sand doesn't even seem to slow her down as she becomes a humanoid missile, speeding down the bank and into the water with a loud, resounding splash.  Satisfied, you wade over to the tigershark that floats on her back, sporting a look of pure triumph as she slowly drifts down the stream.  As you grab her and drag her closer to shore, she mutters loudly, \"<i>The things I do for a good dicking...</i>\" Noting that her face is clear of cum, you dart in and kiss her fiercely, cradling the side and the back of her head as you reward your Beta for her efforts.  After a few moments, you break that kiss and tell the hermaphroditic shark-morph that she better clean up fast; that you will be taking her again soon, and that she better not keep her Alpha waiting.  Climbing out of the water, you leave your wildly thrashing Beta to quickly clean up in preparation for the next time you decide to fuck her.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Internal, Global option for non-TD and TD scenes]
@@ -3092,7 +3091,7 @@ private function internalIzmaAnalCumShot():void {
 		player.sexReward("vaginalFluids", "Dick");
 	}
 	outputText("\n\nContent with the results, you kiss your Beta one last time before leaving to clean yourself up.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[External, Non-TD scenes]
 private function backJizzShot():void {
@@ -3112,7 +3111,7 @@ private function backJizzShot():void {
 	}
 	outputText("\n\nContent with the results, you kiss your Beta one last time before leaving to clean yourself up.");
 	player.sexReward("vaginalFluids", "Dick");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Izma dominating Latexy
@@ -3187,7 +3186,7 @@ private function izmaDomsLatexyPartI():void {
 	flags[kFLAGS.TIMES_IZMA_DOMMED_LATEXY]++;
 	flags[kFLAGS.GOO_FLUID_AMOUNT] = 100;
 	dynStats("lus", 20+player.lib/10, "scale", false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function stopIzmaLatexy():void {
@@ -3196,7 +3195,7 @@ private function stopIzmaLatexy():void {
 	outputText("\n\nVisibly chastized, the tigershark-girl backs off with a meek, \"<i>Yes, Alpha.</i>\"  Just like that, she's running off, probably to jack that raging mega-boner she built up from playing with the goo.");
 	flags[kFLAGS.IZMA_X_LATEXY_DISABLED] = 1;
 	flags[kFLAGS.TIMES_IZMA_DOMMED_LATEXY]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Click Latexy Submenu In Izma's Menu

--- a/classes/classes/Scenes/NPCs/LatexGirl.as
+++ b/classes/classes/Scenes/NPCs/LatexGirl.as
@@ -1,7 +1,6 @@
 ﻿package classes.Scenes.NPCs{
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
-import classes.CoC;
 import classes.Scenes.SceneLib;
 import classes.display.SpriteDb;
 
@@ -156,7 +155,7 @@ public function meanGooGirlRecruitment():void {
 		outputText("\n\nYou heave her up over your shoulder, straining your capable muscles to hold up those giant mammaries and remain upright.  The task is arduous, but you're strong enough for anything!  ");
 		if(player.tou < 40) {
 			outputText("Halfway there, you get too tired to continue.  You may be strong, but you don't have the endurance to heft a burden like this long term.  You'll have to leave her for now and try to recapture her once she's conscious.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			fatigue(30);
 			return;
 		}
@@ -167,7 +166,7 @@ public function meanGooGirlRecruitment():void {
 	//Too weak and dumb:
 	else {
 		 outputText("\n\nYou try to lift her, but she's too heavy!  Drat!  There's no way you'll get her back to camp like this, and you can't leave the portal undefended long enough to wait for her to wake.  You'll have to leave her for now and try to recapture her once she's awake.");
-		 doNext(camp.returnToCampUseOneHour);
+		 endEncounter();
 		 return;
 	}
 	//[Next] (Go to aftermath)
@@ -272,7 +271,8 @@ private function nameZeLatexGoo():void
 	flags[kFLAGS.GOO_HAPPINESS] = 1;
 	flags[kFLAGS.GOO_OBEDIENCE] = 1;
 	flags[kFLAGS.GOO_FLUID_AMOUNT] = 100;
-	doNext(camp.returnToCampUseOneHour);
+	explorer.stopExploring();
+	endEncounter();
 }
 //PC Couldn't Bring Her Back
 public function encounterLeftBehindGooSlave():void {
@@ -350,7 +350,7 @@ public function pureGooRecruitmentStart():void {
 private function leaveTheLatexGooGirl():void {
 	clearOutput();
 	outputText("You don't have the time to deal with this... thing.  You put the girl down on the shore and head on back to camp.  Hopefully, whatever finds her won't be TOO horrible.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Take her Home(F)
 private function niceGuysTakeLatexHome():void {
@@ -367,7 +367,7 @@ private function niceGuysTakeLatexHome():void {
 		if(player.tou < 40) {
 			outputText("Halfway there, you get too tired to continue.  You may be strong, but you don't have the endurance to heft a burden like this long term.  You'll have to leave her for now and try to find her once she's conscious.");
 			fatigue(30);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			return;
 		}
 		outputText("You're out of breath when you get to camp, but you made it!  It'll take awhile for you to catch your wind after all that work...  Your arms and legs are still burning from the exertion!");
@@ -376,7 +376,7 @@ private function niceGuysTakeLatexHome():void {
 	//{Too weak and dumb:}
 	else {
 		outputText("You try to lift her, but she's too heavy!  Drat!  There's no way you'll get her back to camp like this, and you can't leave the portal undefended long enough to wait for her to wake.  You'll have to leave her for now and try finding her again once she's awake.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		return;
 	}
 	//[Next] (Go to PURE aftermath)
@@ -428,7 +428,8 @@ private function bootOutNiceGoo():void {
 	outputText("You did your civic duty bringing her back with you, but taking care of her in the long term... that's asking too much.  \"<i>I understand,</i>\" she says, bowing her head sadly as she struggles unsteadily to her feet.  \"<i>It's all right.  You've done more than enough, really.  I'll go.  Hopefully some of my sisters in the lake will be willing to help me, even if I'm so... so different... from them, now.  Goodbye, my friend.  Maybe we'll meet again sometime.</i>\"");
 	outputText("\n\nShe's gone a moment later, waving over her shoulder as she unsteadily walks back toward the lake.");
 	flags[kFLAGS.GOO_TOSSED_AFTER_NAMING] = 1;
-	doNext(camp.returnToCampUseOneHour);
+	explorer.stopExploring();
+	endEncounter();
 }
 
 //Keep Her(F):
@@ -444,7 +445,8 @@ private function niceGuysKeepTheirGooGals():void {
 	flags[kFLAGS.GOO_HAPPINESS] = 60;
 	flags[kFLAGS.GOO_OBEDIENCE] = 20;
 	flags[kFLAGS.GOO_FLUID_AMOUNT] = 100;
-	doNext(camp.returnToCampUseOneHour);
+	explorer.stopExploring();
+	endEncounter();
 }
 
 
@@ -567,8 +569,8 @@ private function sendToFarm():void
 	outputText("\n\n\"<i>As you wish [master],</i>\" she sighs, before slowly sliding off in the direction of the lake. She will be utterly useless as either a worker or a protector, you think; however, you suspect if Whitney keeps her well fed she will be able to harvest latex from her, which is surely worth something, and maybe some good old fashioned exertion will do the willful goo some good.");
 	
 	flags[kFLAGS.FOLLOWER_AT_FARM_LATEXY] = 1;
-	
-	doNext(camp.returnToCampUseOneHour);
+	explorer.stopExploring();
+	endEncounter();
 }
 
 private function backToCamp():void
@@ -818,7 +820,7 @@ private function changeLatexyTits(arg:int = 0):void {
 	}
 	flags[kFLAGS.GOO_PREFERRED_TIT_SIZE] = arg;
 	if(gooObedience() < 75) gooObedience(3);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Feeding Her(F)
@@ -900,7 +902,7 @@ private function feedLatexyCumIndirectly():void {
 	//{Boost her happiness a tiny amount.}
 	gooHappiness(4);
 	player.orgasm();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Feed Lady-Cum Indirectly(F)
 private function feedLatexyGirlCumIndirectly():void {
@@ -943,7 +945,7 @@ private function feedLatexyGirlCumIndirectly():void {
 	gooFluid(fluid);
 	//{Boost her happiness a tiny amount.}
 	gooHappiness(4);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Feed Her Minotaur Cum {Nice Vs Hard}:(F)
 private function minotaurCumFeedingGoo(nice:Boolean = false):void {
@@ -984,7 +986,7 @@ private function minotaurCumFeedingGoo(nice:Boolean = false):void {
 				outputText("\n\nStaggering onto her feet, " + flags[kFLAGS.GOO_NAME] + " growls, \"<i>Fuck it, I'm not that thirsty!</i>\"  She turns away from you, unwilling to even talk at this point.");
 				gooObedience(-5);
 				gooHappiness(-3);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			outputText("\n\nStaggering up on her feet, " + flags[kFLAGS.GOO_NAME] + " looks about ready to quit.  Then, she licks her lips and shudders, as if remembering her own hunger.  She slumps down onto her knees and tips her head back, shaking a few strands of latex out of her face as she opens her mouth.  Then, her onyx lips mouth, \"<i>Feed me, please.</i>\"");
@@ -1012,7 +1014,7 @@ private function minotaurCumFeedingGoo(nice:Boolean = false):void {
 	gooHappiness(15);
 	if(nice) gooObedience(-1);
 	else gooObedience(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Feed Cum Directly(F)
@@ -1081,7 +1083,7 @@ private function feedLatexyCumDirectly():void {
 		gooObedience(5);
 		player.orgasm();
 		dynStats("sen", -2);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	//{DISOBEDIENT:}
 	else {
@@ -1212,7 +1214,7 @@ private function feedLatexyGirlCumDirect():void {
 		gooObedience(4);
 		player.orgasm();
 		dynStats("sen", -2);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	//{DISOBEDIENT; chose not to/could not Assert Control}
 	else {
@@ -1283,7 +1285,7 @@ private function assertControlOverCuntDrainingLatexGoo():void {
 	//{Boost her happiness a tiny amount.}
 	gooHappiness(5);
 	gooObedience(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Savin Says: Disobedient Pets get Punished with Gentle Loving PC-Dom (MALE)
@@ -1321,7 +1323,7 @@ private function tryToAssertMaleDomWhileLatexGooDrains():void {
 	//{Boost her happiness a tiny amount.}
 	gooHappiness(5);
 	gooObedience(5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Dominant Fucking Her(F)
@@ -1348,7 +1350,7 @@ private function femalePCDomFucksLatexGoo():void {
 		else outputText(" has");
 		outputText(" you doubting that claim, but she seems resolute in her desire to avoid direct sex, for now.");
 		if(gooFluid() < 15) outputText("  Her hunger is palpable, perhaps it would be best if you simply 'fed' her soon?");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		gooObedience(-3);
 		return;
 	}
@@ -1403,7 +1405,7 @@ private function femalePCDomFucksLatexGoo():void {
 		gooFluid(5 + player.wetness() * 2);
 		gooObedience(5);
 		gooHappiness(2);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 //Female Dominant Fuck (Goo IS Futa)(F)
@@ -1423,7 +1425,7 @@ private function femalePCDomFucksLatexGooFuta():void {
 		outputText(", \"<i>No.  You can't make me.  I may be stuck in this camp and separated from my people, but I will not let myself be some sexual toy.</i>\"  A trickle of inky lubricant between her legs and the rigidity of her " + gooCock() + " have you doubting that claim, but she seems resolute in her desire to avoid direct sex, for now.");
 		if(gooFluid() < 10) outputText("  Her hunger is palpable, perhaps it would be best if you simply 'fed' her soon?");
 		gooObedience(-3);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		return;
 	}
 	//{OBEDIENT ENOUGH}
@@ -1504,7 +1506,7 @@ private function femalePCDomFucksLatexGooFuta():void {
 	gooFluid(5+player.wetness()*2);
 	gooObedience(4);
 	gooHappiness(2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Male Dominant Fuck(F)
@@ -1531,7 +1533,7 @@ private function malePCDomFucksLatexGoo():void {
 		outputText(" you doubting that claim, but she seems resolute in her desire to avoid direct sex, at least until you train her a bit better.");
 		if(gooFluid() < 10) outputText("  Her hunger is palpable, perhaps it would be best if you simply 'fed' her soon?");
 		gooObedience(-3);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		return;
 	}
 	//{OBEDIENT ENOUGH}
@@ -1609,7 +1611,7 @@ private function malePCDomFucksLatexGoo():void {
 	fatigue(10);
 	gooObedience(4);
 	gooHappiness(2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Savin Really Wants to Breastfeed Latexy Because He's a Weird Milk Fetishist Like That
@@ -1668,7 +1670,7 @@ private function feedLatexySomeMilk():void {
 	fatigue(5);
 	player.orgasm();
 	dynStats("sen", 2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 	
 }
 }

--- a/classes/classes/Scenes/NPCs/Rathazul.as
+++ b/classes/classes/Scenes/NPCs/Rathazul.as
@@ -75,7 +75,7 @@ public function encounterRathazul(meet:Boolean = true):void {
 	offered = rathazulWorkOffer();
 	if(!offered) {
 		outputText("He sighs dejectedly, \"<i>I am not sure what I can do for you, youngling.  This world is fraught with unimaginable dangers, and you're just scratching the surface of them.</i>\"\n\nYou nod and move on, leaving the depressed alchemist to his sadness.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 
@@ -83,13 +83,13 @@ private function rathazulMoveToCamp():void {
 	clearOutput();
 	outputText("Rathazul smiles happily back at you and begins packing up his equipment.  He mutters over his shoulder, \"<i>It will take me a while to get my equipment moved over, but you head on back and I'll see you within the hour.  Oh my, yes.</i>\"\n\nHe has the look of someone experiencing hope for the first time in a long time.");
 	player.createStatusEffect(StatusEffects.CampRathazul, 0, 0, 0, 0);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function rathazulMoveDecline():void {
 	clearOutput();
 	outputText("Rathazul wheezes out a sigh, and nods.\n\n\"<i>Perhaps I'll still be of some use out here after all,</i>\" he mutters as he packs up his camp and prepares to head to another spot along the lake.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function campRathazul():void {
@@ -273,12 +273,12 @@ private function rathazulWorkOffer():Boolean {
 			}
 			else if(!player.hasItem(consumables.SMART_T,5)) outputText("  You should probably find some if you want that...");
 			else outputText("  You need more gems to afford that, though.");
-			outputText("\n\n");			
+			outputText("\n\n");
 		}
 		//Purification potion for Minerva
 		if (flags[kFLAGS.MINERVA_PURIFICATION_RATHAZUL_TALKED] == 2 && flags[kFLAGS.MINERVA_PURIFICATION_PROGRESS] < 10 && player.hasKeyItem("Rathazul's Purity Potion") < 0) {
 			outputText("The rodent alchemist suddenly looks at you in a questioning manner. \"<i>Have you had any luck finding those items? I need pure honey and at least two samples of other purifiers; your friend’s spring may grow the items you need.</i>\"");
-			outputText("\n\n");	
+			outputText("\n\n");
 		}
 		if (player.hasItem(consumables.LACTAID, 5) && player.hasItem(consumables.P_LBOVA, 2)) {
 			outputText("The rodent sniffs your possessions. \"<i>You know, I could make something with five bottles of Lactaid and two bottles of purified LaBova. I'll also need 250 gems.</i>\"");
@@ -298,11 +298,11 @@ private function rathazulWorkOffer():Boolean {
 			}
 			else if(!player.hasItem(consumables.INCOINS,5)) outputText("  You should probably find some if you want that...");
 			else outputText("  You need more gems to afford that, though.");
-			outputText("\n\n");			
+			outputText("\n\n");
 		}
 	}
 	if(totalOffers == 0 && spoken) {
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		return true;
 	}
 	if(totalOffers > 0) {
@@ -330,7 +330,7 @@ private function rathazulWorkOffer():Boolean {
 		if (silly() && player.hasStatusEffect(StatusEffects.CampRathazul)) addButton(12, "Flirt", getThatRatAss).hint("Try to score with Rathazul.");
 		addButton(13, "Rare offers", oneTimeOptions).hint("All the one time options.");
 		if (player.hasStatusEffect(StatusEffects.CampRathazul)) addButton(14,"Leave", camp.campFollowers);
-		else addButton(14, "Leave", camp.returnToCampUseOneHour);
+		else addButton(14, "Leave", explorer.done);
 		return true;
 	}
 	return false;
@@ -415,12 +415,12 @@ private function rathazulPurifyIncubiDraft():void {
 
 //For Belisa's Tooth Quest
 public function BelisaRalthazulTalk():void {
-	outputText("Hoping your trusty alchemist friend can make Belisa's smile whole again, You ask Ralthazul about curing a cursed injury. \"<i>Oh? Cursed injury, you say?</i>\" He ponders for a second. \"<i>What sort of injury, and what kind of curse?</i>\"\n\n"); 
-	outputText("You explain Belisa’s plight, and he nods thoughtfully, hand on his chin. \"<i>Well…As a matter of fact, there might be a way I can help, young one.</i>\" He brings you over to his beakers excitedly. \"<i>You see, Succubus magic tends to draw upon corruption, and long-term curses…well, they’re niggly little bits of magic.</i>\" He shakes his head. \"<i>If the Succubus in question was a practiced hexmage, they’ll know how to get around this…But if they weren’t…</i>\" He gives you a wry little grin. \"<i>Standard curses of that nature draw upon corruption, if not from the individual, than from the environment around them.</i>\" He rummages around, producing a purity philter. \"<i>However, this little mixture here can cut the curse off from the environment, if you cover the wound in it, starving it out.</i>\"\n\n"); 
-	outputText("You begin to get excited. Belisa is pure. Perhaps too pure. You know her body won’t give this magic any fuel.\n\n"); 
-	outputText("\"<i>But…I’ll need other ingredients to cure the actual injury. Unless we also heal the injury, the curse will just return once it absorbs enough corrupted energy.</i>\" He nods. \"<i>I can do it. I’ll need a shark’s tooth from the lake, one of my purity philter and one vitality tincture.</i>\"\n\n"); 
+	outputText("Hoping your trusty alchemist friend can make Belisa's smile whole again, You ask Ralthazul about curing a cursed injury. \"<i>Oh? Cursed injury, you say?</i>\" He ponders for a second. \"<i>What sort of injury, and what kind of curse?</i>\"\n\n");
+	outputText("You explain Belisa’s plight, and he nods thoughtfully, hand on his chin. \"<i>Well…As a matter of fact, there might be a way I can help, young one.</i>\" He brings you over to his beakers excitedly. \"<i>You see, Succubus magic tends to draw upon corruption, and long-term curses…well, they’re niggly little bits of magic.</i>\" He shakes his head. \"<i>If the Succubus in question was a practiced hexmage, they’ll know how to get around this…But if they weren’t…</i>\" He gives you a wry little grin. \"<i>Standard curses of that nature draw upon corruption, if not from the individual, than from the environment around them.</i>\" He rummages around, producing a purity philter. \"<i>However, this little mixture here can cut the curse off from the environment, if you cover the wound in it, starving it out.</i>\"\n\n");
+	outputText("You begin to get excited. Belisa is pure. Perhaps too pure. You know her body won’t give this magic any fuel.\n\n");
+	outputText("\"<i>But…I’ll need other ingredients to cure the actual injury. Unless we also heal the injury, the curse will just return once it absorbs enough corrupted energy.</i>\" He nods. \"<i>I can do it. I’ll need a shark’s tooth from the lake, one of my purity philter and one vitality tincture.</i>\"\n\n");
 	BelisaFollower.BelisaRalthTalked = true;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function RathazulMakesToothCursePotion():void {
@@ -431,7 +431,7 @@ private function RathazulMakesToothCursePotion():void {
 	outputText("You run over to Ralthazul, showing him the ingredients you’ve obtained in your adventures. \"<i>Alright, that should do it. Give me just a moment please.\"</i> The wizened alchemist grinds up the teeth, and begins to mix the ingredients together. You take a small stroll around the camp to let him work, and within fifteen short minutes, Ralthazul comes to you, a smile on his old face. \n\n");
 	outputText("\"<i>Remember, you must completely submerge the injury in the mixture. And it needs some time to work.\"</i> He blinks, remembering something. \"<i>Oh, and this will hurt, in all probability. Most curses don’t go easily, and the mouth is rather sensitive.\"</i> He passes you a small vial of a silver-white liquid, with streaks of red running through it. \"<i>An hour, at least. Depending on the curse’s power.\"</i> \n\n");
 	BelisaFollower.BelisaFollowerStage = 1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //For Minerva purification.
@@ -441,7 +441,7 @@ public function purificationByRathazulBegin():void {
 	outputText("\n\n\"<i>I am afraid that I have never truly succeeded in my efforts to create a potion to purify the corrupted themselves.</i>\" The rat alchemist explains sadly. \"<i>The problem is there is very little, if anything, in this world that is capable of removing corruption from a consumer... But, I do have a theoretical recipe. If you can just find me some foodstuffs that would lower corruption and soothe the libido, and bring them to me, then I might be able to complete it. I can suggest pure giant bee honey as one, but I need at least two other items that can perform at least one of those effects. You said that the spring was able to keep your friend's corruption in check? Maybe some of the plants that grow there would be viable; bring me some samples, and a fresh dose of pure honey, and we’ll see what I can do.</i>\" He proclaims, managing to shake off his old depression and sound determined.");
 	outputText("\n\nWith that in mind, you walk away from him; gathering the items that could cure Minerva is your responsibility.");
 	flags[kFLAGS.MINERVA_PURIFICATION_RATHAZUL_TALKED] = 2;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function rathazulMakesPurifyPotion():void {
@@ -1176,7 +1176,7 @@ private function getThatRatAss3():void {
 	outputText("Sheesh, what a drama queen. A simple \"No thanks\" would've been fine. You toss the note aside with a huff and turn back to camp.\n\n");
 	outputText("Still though, thinking about that rat ass gets you turned on...");
 	dynStats("lus", 10, "scale", false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 }
 }

--- a/classes/classes/Scenes/NPCs/SheilaScene.as
+++ b/classes/classes/Scenes/NPCs/SheilaScene.as
@@ -167,7 +167,7 @@ public function sheilaEncounterRouter():void {
 		else if(flags[kFLAGS.SHEILA_XP] == 4) fuckBuddySheilaMeeting();
 		else {
 			outputText("A BUG HAPPENED.  YOUR SHEILA_XP: " + flags[kFLAGS.SHEILA_XP] + ". <b>Value should be between -3 to 4.</b>");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 	}
 	//DEMONS!
@@ -254,7 +254,7 @@ private function sheila1stEncStayHidden():void {
 	clearOutput();
 	outputText("You regulate your breathing and hold yourself still to avoid rustling anything softly, waiting for the creature to finish its business and leave.");
 	//no change in sheila xp
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP0 - Look Closer]
@@ -310,7 +310,7 @@ private function sheila1ndEncLookCloserPtIILeave():void {
 	outputText("\"<i>Good onya.  Maybe I'll see you around.</i>\"  With that, you take your leave of the strange woman.");
 	//set sheila xp = 1
 	flags[kFLAGS.SHEILA_XP] = 1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP0 - Look Closer - Talk]
@@ -333,7 +333,7 @@ private function sheila1ndEncLookCloserPtIITalkLeave():void {
 	clearOutput();
 	outputText("Wordlessly, you get up and back away from the woman... though not without a dirty glance.  She follows you with her eyes until you judge yourself far enough away to turn your back to her.");
 	//go to camp
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP0 - Look Closer - Talk - Fight]
@@ -374,7 +374,7 @@ private function apologyAvoidSheila():void {
 	outputText("\n\n\"<i>Well... I expect I could arrange that if you'll play along,</i>\" she says, ears twitching in irritation.  \"<i>Take care of yourself, mate.</i>\"  She resets the trap and lays down in her spot in the tall grass again, pointedly turning over on her side to show you her back.");
 	//set sheilapreg = -1
 	flags[kFLAGS.SHEILA_DISABLED] = 1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP-1 - Apologize]
@@ -390,7 +390,7 @@ private function apologySheilaApology():void {
 	
 	//set sheila xp = 1
 	flags[kFLAGS.SHEILA_XP] = 1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP-1 - Slap'n'sult]
@@ -422,7 +422,7 @@ private function apologySheilaSayNothing():void {
 	outputText("\n\nYou grunt and watch her resume her cover in the long grass, then turn about and head back to camp.");
 	
 	//no change in sheila xp
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //XP-2 Sheila's apology (sheila xp = -2 and demon sheila = 0):
@@ -451,7 +451,7 @@ private function sheilaIsSorryButLeaveMeAlone():void {
 	outputText("You shake your head and turn away, dismissing [sheilaname] with a pointed gesture.  \"<i>H-hey!</i>\" the girl calls angrily from behind you.  \"<i>Dammit, I said I was sorry, you bastard!  Screw you!  See if I talk to you again!</i>\"");
 	//set sheilapreg = -1
 	flags[kFLAGS.SHEILA_DISABLED] = 1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[XP-2 - Forgive]
 private function sheilaIsSorryAndYouForgive():void {
@@ -467,7 +467,7 @@ private function sheilaIsSorryAndYouForgive():void {
 	//set sheila xp to 4 if joeycount > 0, else set sheila xp to 1
 	if(flags[kFLAGS.SHEILA_JOEYS] > 0) flags[kFLAGS.SHEILA_XP] = 4;
 	else flags[kFLAGS.SHEILA_XP] = 1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP-2 - Fight]
@@ -527,7 +527,7 @@ private function castArouseAndLeaveSheila():void {
 	flags[kFLAGS.SHEILA_DEMON] = 1;
 	flags[kFLAGS.SHEILA_CITE] = -1;
 	dynStats("cor", 10);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP-2 - Cast Arouse - Let Her]
@@ -567,7 +567,7 @@ private function sheilaReallyMadLeave():void {
 	clearOutput();
 	outputText("Huffing, you throw the animals down and turn away.  What a display.");
 	//go to camp, reincarnate as something slightly better next life
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP-3 - Stand]
@@ -618,7 +618,7 @@ private function sheilaReconcileDunWanna():void {
 	
 	outputText("\n\n\"<i>Guess it's bodgy bikkie again today...</i>\"");
 	//no change in sheila xp
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP1 - Kay]
@@ -670,7 +670,7 @@ private function sheilaReconcileKay2():void {
 	outputText("\n\nA broad smile lets you know she's just joking as she scatters the cooling fire with her spit, stirring and dispersing the ashes.  \"<i>Thanks for the chatter.  Maybe I'll see you again.</i>\"  Picking up her catch, she turns and lopes off.");
 	//set sheila xp to 2
 	flags[kFLAGS.SHEILA_XP] = 2;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //XP2: Familiarizing (Sheila XP = 2; or Sheila XP = 3 AND time =/= 20:00 and demon sheila = 0):
@@ -693,7 +693,7 @@ private function sheilaGettingFamiliar():void {
 	addButton(2,"Curfew?",sheilaFriendlyCurfew);
 	addButton(3,"No Questions",sheilaFriendlyNoQuestions);
 	
-	addButton(14,"Leave",camp.returnToCampUseOneHour);
+	addButton(14,"Leave",explorer.done);
 }
 
 
@@ -710,7 +710,7 @@ private function sheilaFriendlyNoQuestions():void {
 	outputText("\n\n\"<i>Yeah.</i>\"  [sheilaname] turns and departs with her long-legged gait.");
 	//set sheila xp to 3
 	flags[kFLAGS.SHEILA_XP] = 3;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP2 - Come Here Often?]
@@ -728,7 +728,7 @@ private function sheilaFriendlyComeHereOften():void {
 	outputText("\n\nExplanation concluded, she folds her hands over her stomach and resumes staring at the clouds.  You join her for a while, then get up and depart.");
 	//set sheila xp to 3
 	flags[kFLAGS.SHEILA_XP] = 3;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP2 - Her People]
@@ -782,7 +782,7 @@ private function sheilaFriendlyHerPeoples():void {
 		//set sheila xp to 3
 	}
 	flags[kFLAGS.SHEILA_XP] = 3;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP2 - Curfew?]
@@ -802,7 +802,7 @@ private function sheilaFriendlyCurfew():void {
 	
 	//set sheila xp to 3
 	flags[kFLAGS.SHEILA_XP] = 3;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //XP3: Sexy Time (sheila xp = 3 AND time = 20:00 and demon sheila = 0):
@@ -846,7 +846,7 @@ private function sheilaXPThreeSexyTimeDitchHer():void {
 		flags[kFLAGS.SHEILA_CORRUPTION] = 100;
 		flags[kFLAGS.SHEILA_DEMON] = 1;
 		flags[kFLAGS.SHEILA_CITE] = -1;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	} else doNext(recallWakeUp);
 }
 
@@ -871,7 +871,7 @@ private function sheilaXPThreeSexyTimePostSexLetHerBe():void {
 	outputText("Pulling away from you, [sheilaname] gathers her clothing and departs, looking satisfied.  The glance she gives you over her shoulder is even a little warmer than before.");
 	if (!recalling) {
 		flags[kFLAGS.SHEILA_XP] = 4;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	} else doNext(recallWakeUp);
 }
 
@@ -1231,7 +1231,7 @@ private function sheilaXPThreeSexyTimeGuardDuty():void {
 		flags[kFLAGS.SHEILA_XP] = 4;
 		if (player.lib < 40) dynStats("lus", 5, "scale", false);
 		else dynStats("lus", 15, "scale", false);
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	} else doNext(recallWakeUp);
 }
 
@@ -1265,7 +1265,7 @@ private function fuckBuddySheilaMeetingMaybeLater():void {
 	
 	outputText("\n\n\"<i>Okay,</i>\" she agrees, subdued.  \"<i>Maybe later.</i>\"");
 	//wow, it's fucking nothing!
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP4 - Just Hang]
@@ -1289,7 +1289,7 @@ private function fuckBuddySheilaMeetingJustHangOut():void {
 	outputText("\n\n\"<i>Maybe I'll be up for some fun when you catch me next time,</i>\" she declares.  \"<i>Stay safe.</i>\"");
 	//minus small lust and corruption
 	dynStats("lus", -10, "cor", -1);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP4 - Chat]
@@ -1367,7 +1367,7 @@ private function fuckBuddySheilaMeetingChatFamilyAndFriends():void {
 		outputText("\n\n[sheilaname]'s skin blooms with red and her lips compress to a thin line; she about-faces and walks off without another word.");
 	}
 	//oh gosh someone dropped a dollar here how lucky
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP4 - Chat - Old Loves]
@@ -1426,7 +1426,7 @@ private function fuckBuddySheilaMeetingChatOldLoves():void {
 		outputText("\n\n[sheilaname] frowns unhappily and doesn't answer... but she does play with your hand, articulating the fingers and rubbing it against her warm cheek until it's time for her to go.");
 	}
 	//you no touch candle!
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP4 - Chat - Why Hide?]
@@ -1446,7 +1446,7 @@ private function fuckBuddySheilaMeetingChatWhyHide():void {
 	outputText("\n\n[sheilaname] shivers a bit and lifts your arm to place it around her shoulder, then looks gloomily out across the plains.  She doesn't seem to be in the mood to talk anymore.");
 	
 	//blood on the sand
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP4 - Chat - Live With Me]
@@ -1459,7 +1459,7 @@ private function fuckBuddySheilaMeetingChatLiveWithMe():void {
 	
 	outputText("\n\n[sheilaname] gets to her feet and balances her catch on her shoulders, looking wistful.  When you ask about it, however, she just shakes her head and tells you it's nothing, then walks off subdued.  Seems like she really wanted to say 'yes', instead.");
 	//ancient Chinese secret, eh?
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP4 - Chat - Kids] - requires joeycount >= 1
@@ -1597,7 +1597,7 @@ private function fuckBuddySheilaMeetingChatKids():void {
 			return;
 		}
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP4 - Chat - Kids - joeycount >= 10 - lib >= 50 - Rest For Now]
@@ -1613,7 +1613,7 @@ private function fuckBuddySheilaMeetingChatKidsRest4Now():void {
 	outputText("\n\nYou nod and she dozes off; her face looks much more placid in sleep.  After an hour you gently nudge her awake, and she picks herself up and leaves you with a hug.  \"<i>Love you, [name].</i>\"");
 	//corruption down
 	dynStats("cor", -1);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[XP4 - Sex]
@@ -1863,7 +1863,7 @@ private function consensualSheila69(x:int):void {
 			outputText("\"<i>Forget it.  With the way you worked me, I forgive you.  Just be careful, you wanker.</i>\"  [sheilaname] closes her eyes and pulls your arm around her shoulder");
 			if(fits) outputText(", smearing your dangling hand into the mess on her tits");
 			outputText(".  The two of you lie like that for a while, until she gets up.  \"<i>I should really go... need to cure my catch.  Not to mention I'll have to clean up before I can even put my damn clothes back on.</i>\"  [sheilaname] picks up her stuff.  \"<i>Hehe... see you soon.</i>\"");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 	}
 }
@@ -2049,7 +2049,7 @@ private function consentacleVagSexForKangarooSlutBitches():void {
 			if(player.cumQ() < 500) outputText("as she strokes the " + player.skinFurScales()  + " of your chest");
 			else outputText("as she wipes off as much jizz as she can");
 			outputText(", then get up and collect your gear.  \"<i>Um... see you later, ok?</i>\" she says.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		if (!recalling) {
 			sheilaPreg();
@@ -2085,7 +2085,7 @@ private function sheilaMutualMasturbation():void {
 	{
 		CoC_Settings.error("");
 		outputText("ERROR - SHEILA MASTURBATE BROKE, SON");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	target = choices[rand(choices.length)];
 	
@@ -2229,7 +2229,7 @@ private function sheilaMutualMasturbation():void {
 		}
 		else {
 			outputText("\n\nShe nuzzles you in the affection borne of climax, until she pulls away and gets up.  \"<i>I wish I could stay and talk, but my civic duty's making me walk,</i>\" [sheilaname] offers apologetically.  She gathers her scattered clothing and, with a little wave, leaves.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 	}
 }
@@ -2253,7 +2253,7 @@ private function sheilaCorruptionWarningsChooseFondle():void {
 	flags[kFLAGS.SHEILA_XP] = -3;
 	flags[kFLAGS.SHEILA_CORRUPTION] = 90;
 	dynStats("cor", -10);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Any Corruption Warning - Listen to Her]
@@ -2269,7 +2269,7 @@ private function sheilaCorruptionWarningListenToHer():void {
 	//no change in sheila corruption (remains at 80), PC corr -10, set sheila clock = -13
 	dynStats("lus", -10, "scale", false);
 	flags[kFLAGS.SHEILA_CLOCK] = -4;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -3061,7 +3061,7 @@ private function normalSheilaPregNotifNumberOneYepIssue():void {
 	//set sheilapreg = -1, and set joeycount + 1 if you plan to track that stat even after Sheila's disabled
 	flags[kFLAGS.SHEILA_DISABLED] = 2;
 	flags[kFLAGS.SHEILA_JOEYS]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Normal Preg Notif #1 - Nah]
@@ -3085,7 +3085,7 @@ private function normalSheilaPregNotifNumberOneCoolDeal():void {
 	}
 	if(flags[kFLAGS.SHEILA_XP] < 4) flags[kFLAGS.SHEILA_XP] = 4;
 	flags[kFLAGS.SHEILA_JOEYS]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 	//if sheila xp < 4, set sheila xp = 4; increment joeycount + 1
 }
 
@@ -3131,7 +3131,7 @@ private function normalSheilaPregNotifREPEATEDEDLetHerGo():void {
 	outputText("\n\nPicking it up and seating it on her head, she nods curtly and shuffles off again.");
 	
 	//wow, it's fucking nothing!
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Normal Preg Subsequent - Walk With Her]
@@ -3153,7 +3153,7 @@ private function normalSheilaPregNotifREPEATEDEDWalkWithHer():void {
 	outputText("\n\n\"<i>Have a squizz over there, mate,</i>\" she says, pointing at a patch of tall weeds.  \"<i>Good cover for me to catch a wink.  This should be okay.</i>\"  She pulls her hand from yours and finally sets her hat atop her head, then shrugs off her pack.  \"<i>I'm gonna get set up now.  Thanks again... see you soon.</i>\"");
 	//get slightly lowered corruption and a warm fuzzy
 	dynStats("cor", -1);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Normal Preg Subsequent - Help]
@@ -3261,8 +3261,10 @@ private function normalSheilaPregNotifREPEATEDEDHelpABitchOut():void {
 	}
 	//pass 4 hours and reduce corruption or something, give 3 hrs rest if naga, increase archery skill and increase fatigue by a lot (50-60+) if angel of death
 	dynStats("cor", -2);
-	if(model.time.hours + 4 < 21) doNext(camp.returnToCampUseFourHours);
-	else {
+	if(model.time.hours + 4 < 21) {
+		explorer.stopExploring();
+		doNext(camp.returnToCampUseFourHours);
+	} else {
 		//(if time after adding 4 hours >= 21:00 or = 0:00, additionally output)
 		outputText("\n\n<b>\"<i>Oh, god dammit.</i>\"</b>");
 		outputText("\n\n[sheilaname]'s voice startles you, and you look over at her.  The woman is slumped down on the ground, staring at the horizon, and as you look closer you can see her chest quaking as she chokes back a sob.  \"<i>What's wrong?</i>\" you ask.");
@@ -3292,7 +3294,7 @@ private function normalSheilaPregNotifREPEATEDEDHelpABitchOutANDWELP():void {
 	
 	outputText("\n\n\"<I>You're right,</i>\" [sheilaname] sniffles finally, wiping her red eyes.  \"<i>I just... let it get the better of me for a moment.  I'm okay now.  Thanks, mate.</i>\"  She hugs you weakly and picks up her catch.  \"<i>I'll see ya later...</i>\"");
 	//suck it up, marine
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -3401,6 +3403,7 @@ private function normalSheilaPregNotifREPEATEDEDHelpABitchOutANDSTAYDERE():void 
 		outputText("\n\nYou rub your smarting jaw, glaring back, and tell [sheilaname] that it's her turn to watch.  Well, the adrenaline will keep her up, at least.");
 	}
 	if(!player.isTaur()) outputText("  She grudgingly repositions, allowing you to rest against her.");
+	explorer.stopExploring();
 	model.time.days++;
 	model.time.hours = 2;
 	statScreenRefresh();
@@ -3435,7 +3438,7 @@ private function normalSheilaPregNotifREPEATEDEDHelpABitchOutANDSTAYDERE2():void
 		sheilaXP4Sex(false);
 		addButton(9,"LeaveHerBe",normalSheilaPregNotifREPEATEDEDHelpABitchOutANDSTAYDEREBUTLEAVEHERBE);
 	}
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //[Normal Preg Subsequent - Help - 21:00 hours - Stay Up With Her - Lust >= 30 - Leave Her Be]
@@ -3443,7 +3446,7 @@ private function normalSheilaPregNotifREPEATEDEDHelpABitchOutANDSTAYDEREBUTLEAVE
 	clearOutput();
 	outputText("You relent, allowing the woman to free herself with a peck on your cheek.  She loads up her catch, and then turns to you.  \"<i>Thanks, [name].  Owe you one.</i>\"");
 	//This is your Protoshield! I can't take this!
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Normal Preg Subsequent - Help - 21:00 hours - To Camp]
@@ -3496,6 +3499,7 @@ private function normalSheilaPregNotifREPEATEDEDHelpABitchOutTOCAMP():void {
 	//if nightwatch, normal night's sleep
 	//if no nightwatch, 4 hours sleep and suppress any imp rapes
 	//lparchive.org/Deadly-Premonition
+	explorer.stopExploring();
 	camp.sleepRecovery(false);
 	model.time.hours = 7;
 	model.time.days++;
@@ -3546,7 +3550,7 @@ private function sheilaGoesDemon():void {
 	flags[kFLAGS.SHEILA_DEMON] = 1;
 	//good place to cut off content if you don't have time to code it all in one go
     if (!CoC.instance.inCombat)
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
 	else cleanupAfterCombat();
 }
 
@@ -3563,7 +3567,7 @@ private function demonSheilaEncounter():void {
 	if(player.lust >= 33) addButton(1,"LetHerFuck",sheilaLetHerFuckYou);
 	addButton(2,"Resist",demonSheilaResist);
 	//run simply returns to camp and should be the default spacebar option
-	addButton(4,"Run",camp.returnToCampUseOneHour);
+	addButton(4,"Run",explorer.done);
 }
 
 //[Demon Sheila - Resist]
@@ -3617,7 +3621,7 @@ private function tellSheilaDemonToFuckOff():void {
 	}
 	else {
 		outputText("but she remasters herself with effort.  \"<i>No worries.  I'm sorry to hear you don't have any time for love, my special one.  I'll be here until you do, thinking about you and touching myself.</i>\"  She releases you and steps away, then crudely shoves her spade through her thighs, grabs it, and half-moans as she thrusts her pelvis back and forth, jerking the thick black flesh in her hand.  With a wink, she abruptly releases it, then turns her back and departs.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	//go to fight if bitch is crazy, else plus lust and return to camp
 	dynStats("lus", 10, "scale", false);
@@ -3825,7 +3829,7 @@ private function leavePregDemonSheila():void {
 	
 	//plus more lust if cock, go to camp
 	if(player.hasCock()) dynStats("lus", 10, "scale", false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Preg Demon Sheila - Other Sex]
@@ -3847,7 +3851,7 @@ private function pregDemonSheilaOtherSex():void {
 		dynStats("lus", 15, "scale", false);
 		beatUpDemonSheila(false);
 	} else {
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 
@@ -4024,7 +4028,7 @@ private function loseToNormalSheilaAndGetRidden():void {
 	sheilaCorruption(-10);
 	if (CoC.instance.inCombat)
 		cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //Loss - tail-spade sounding for fuckhueg cock (for cockarea > 56)
@@ -4067,7 +4071,7 @@ private function tailSpadeSoundingForFuckHugeDongsWithDemonSheila():void {
 	sheilaCorruption(-10);
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Loss - clit-swelling and clit-sounding or clit-anal
@@ -4219,7 +4223,7 @@ private function clitSwellingDemonSheilaClitSoundingAnal():void {
 	dynStats("sen", -2);
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 
@@ -4242,7 +4246,7 @@ private function aintGotNoGenderAndKangarooRaped():void {
 	dynStats("lus", 20+player.lib/4, "scale", false);
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //Win against demon Sheila
@@ -4343,7 +4347,7 @@ private function missionaryForThePurposesOfCreatingImpsWithSheila():void {
 		//if short scene, sheilapreg check, reduce PC lust and libido
         if (CoC.instance.inCombat)
             cleanupAfterCombat();
-		else doNext(camp.returnToCampUseOneHour);
+		else endEncounter();
 	}
 	//(else if RNG doesn't end scene)
 	else {
@@ -4397,7 +4401,7 @@ private function missionaryForThePurposesOfCreatingImpsWithSheila():void {
 		}
         if (CoC.instance.inCombat)
             cleanupAfterCombat();
-		else doNext(camp.returnToCampUseOneHour);
+		else endEncounter();
 	}
 }
 
@@ -4487,7 +4491,7 @@ private function sheilaAnalHateFuckAGoGoNO():void {
 	dynStats("cor", 2);
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //[Demon Victory Sex - Anal Hate-fuck - Tear Her Up - Worms Suit You]
@@ -4523,7 +4527,7 @@ private function sheilaAnalHateFuckAGoGoGETYOUSOMEWORMS():void {
 	flags[kFLAGS.SHEILA_DISABLED] = 3;
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //[Demon Victory Sex - Anal Hate-fuck - Call Jojo] - corrupted mouse version:
@@ -4586,7 +4590,7 @@ private function analHateFucksWithJojoNo(clear:Boolean):void {
 	dynStats("lus", player.lib/3, "cor", 2);
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //[Demon Victory Sex - Anal Hate-fuck - Call Jojo - Ruin Them]
@@ -4636,7 +4640,7 @@ private function jojoRuinsTheAnalHateFuck(clear:Boolean = true):void {
 	flags[kFLAGS.JOJO_DEAD_OR_GONE] = 1;
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //Win - [Big Dick+Thighs] (usable for dicks with cockarea > 56) (all 10 of them)
@@ -4781,7 +4785,7 @@ private function bigDickAndThighs():void {
 		}
 		if (CoC.instance.inCombat)
 			cleanupAfterCombat();
-		else doNext(camp.returnToCampUseOneHour);
+		else endEncounter();
 	}
 }
 
@@ -4859,7 +4863,7 @@ private function winAgainstDemoNSheilaForVaginas():void {
 	}
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //Scarred blade
@@ -4909,13 +4913,13 @@ private function takeScarredBlade():void {
 	clearOutput();
 	outputText("You grab the bloodthirsty saber and pull it from the ground. ");
 	flags[kFLAGS.SCARRED_BLADE_STATUS] = 0;
-	inventory.takeItem(weapons.SCARBLD, camp.returnToCampUseOneHour);
+	inventory.takeItem(weapons.SCARBLD, explorer.done);
 }
 private function leaveScarredBlade():void {
 	clearOutput();
 	outputText("You choose not to take the saber, leaving it to rust. ");
 	flags[kFLAGS.SCARRED_BLADE_STATUS] = -1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 }
 }

--- a/classes/classes/Scenes/NPCs/SidonieFollower.as
+++ b/classes/classes/Scenes/NPCs/SidonieFollower.as
@@ -4,15 +4,15 @@
  */
 package classes.Scenes.NPCs
 {
-	import classes.*;
-	import classes.GlobalFlags.kFLAGS;
-	import classes.Scenes.Areas.Plains.GnollPack;
-	import classes.Scenes.Camp.CampUpgrades;
-	import classes.Scenes.SceneLib;
-	import classes.BodyParts.Tail;
-	import classes.BodyParts.Wings;
-	
-	public class SidonieFollower extends NPCAwareContent
+import classes.*;
+import classes.BodyParts.Tail;
+import classes.BodyParts.Wings;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Areas.Plains.GnollPack;
+import classes.Scenes.Camp.CampUpgrades;
+import classes.Scenes.SceneLib;
+
+public class SidonieFollower extends NPCAwareContent
 	{
 		private function anyHermInCamp():Boolean {
 			return (flags[kFLAGS.IZMA_FOLLOWER_STATUS] == 1 && flags[kFLAGS.IZMA_NO_COCK] != 0) || (arianScene.arianFollower() && flags[kFLAGS.ARIAN_VAGINA] > 0 && flags[kFLAGS.ARIAN_COCK_SIZE] > 0) || (emberScene.followerEmber() && flags[kFLAGS.EMBER_GENDER] == 3);
@@ -41,7 +41,7 @@ package classes.Scenes.NPCs
 		public function meetingSidonieAtPlainsNo():void {
 			outputText("Nope. This seems a bit too risky, given their numbers. You continue on your way, hoping that the horse-morph doesn’t get it too rough if those gnolls catch her.\n\n");
 			flags[kFLAGS.SIDONIE_RECOLLECTION] = 18;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function wonGnollPackFight():void {
@@ -119,6 +119,7 @@ package classes.Scenes.NPCs
 			else player.createKeyItem("Radiant shard", 1,0,0,0);
 			outputText("\n\n<b>Before fully settling in your camp as if remembering something Sidonie pulls a shining shard from her inventory and hand it over to you as a gift. You acquired a Radiant shard!</b>");
 			flags[kFLAGS.SIDONIE_FOLLOWER] = 1;
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseFourHours);
 		}
 		
@@ -309,6 +310,7 @@ package classes.Scenes.NPCs
 				flags[kFLAGS.SIDONIE_RECOLLECTION] = 46;
 				if ((flags[kFLAGS.CAMP_CABIN_WOOD_RESOURCES] + 300) < SceneLib.campUpgrades.checkMaterialsCapWood()) flags[kFLAGS.CAMP_CABIN_WOOD_RESOURCES] += 300;
 				else flags[kFLAGS.CAMP_CABIN_WOOD_RESOURCES] = SceneLib.campUpgrades.checkMaterialsCapWood();
+				explorer.stopExploring();
 				doNext(camp.returnToCampUseFourHours);
 			}
 		}
@@ -417,7 +419,7 @@ package classes.Scenes.NPCs
 			outputText("After a relaxing nap, it seems like your body has absorbed most of her seed and is able to walk again. Waking up Sidonie with a kiss, you thank her for a wonderful fucking and disentangle from her embrace to return to your daily activities, a pleasant tingling on your butt left by the remaining horse seed left on your bum.\n\n");
 			player.orgasm();
 			player.slimeFeed();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function SidonieSexBlowHer():void {
 			clearOutput();
@@ -483,7 +485,7 @@ package classes.Scenes.NPCs
 			outputText(".\n\n");
 			player.orgasm();
 			player.slimeFeed();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function SidonieSex69():void {
 			clearOutput();
@@ -521,7 +523,7 @@ package classes.Scenes.NPCs
 			outputText("With that, you walk away from the Sidonie’s tent gleefully rubbing your horsecum-filled belly.\n\n");
 			player.orgasm();
 			player.slimeFeed();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 	}
 }

--- a/classes/classes/Scenes/NPCs/TedScenes.as
+++ b/classes/classes/Scenes/NPCs/TedScenes.as
@@ -2,17 +2,16 @@
  * ...
  * @author Ormael
  */
-package classes.Scenes.NPCs 
+package classes.Scenes.NPCs
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
-import classes.Scenes.SceneLib;
 
 public class TedScenes extends NPCAwareContent
 	{
 		
-				
-		public function TedScenes() 
+		
+		public function TedScenes()
 		{
 		}
 
@@ -60,7 +59,6 @@ public function introPostHiddenCave():void {
 		outputText("\"<i>Repent sinner...</i>\" and you just dodge in time throws at you his hammer.\n\n");
 	}
 	startCombat(new Ted());
-	doNext(playerMenu);
 }
 
 public function defeatedTedPostHiddenCave():void {

--- a/classes/classes/Scenes/Places/Boat.as
+++ b/classes/classes/Scenes/Places/Boat.as
@@ -26,6 +26,7 @@ public class Boat extends AbstractLakeContent
 			if(player.cor > 60) outputText(" or fuck");
 			outputText(".  The air is fresh, and the grass is cool and soft under your feet.   Soft waves lap against the muddy sand of the lake-shore, as if radiating outward from the lake.   You pass around a few bushes carefully, being wary of hidden 'surprises', and come upon a small dock.  The dock is crafted from old growth trees lashed together with some crude rope.  Judging by the appearance of the rope, it is very old and has not been seen to in quite some time.  Tied to the dock is a small rowboat, only about seven feet long and three feet wide.   The boat appears in much better condition than the dock, and appears to be brand new.\n\n");
 			outputText("<b>You have discovered the lake boat!</b>\n(You may return and use the boat to explore the lake's interior by using the 'places' menu.)");
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseOneHour);
 		}
 		public function boatExplore():void

--- a/classes/classes/Scenes/Places/Farm.as
+++ b/classes/classes/Scenes/Places/Farm.as
@@ -42,7 +42,7 @@ outputText("Whitney marches up to you as soon as you approach the farm, a stoic 
 	{
 		outputText("Whitney marches up to you as soon as you approach the farm, a stoic expression plastered across her face.");
 		outputText("\n\n\"<i>What the fuck do you think you're doing here [name]? After what you did to Marble you still think you're welcome here? Leave. <b>Now</b>.</i>\"");
-		doNext(camp.returnToCampUseOneHour);
+		doNext(explorer.done);
 		return;
 	}
 	if (flags[kFLAGS.FARM_DISABLED] == 2)
@@ -50,7 +50,7 @@ outputText("Whitney marches up to you as soon as you approach the farm, a stoic 
 		clearOutput();
 		outputText("Whitney marches up to you as soon as you approach the farm, a stoic expression plastered across her face.");
 		outputText("\n\n\"<i>What the fuck do you think you're doing here [name]? After what you did to Kelt you still think you're welcome here? Leave. <b>Now</b>.</i>\"");
-		doNext(camp.returnToCampUseOneHour);
+		doNext(explorer.done);
 		return;
 	}
 	
@@ -67,7 +67,7 @@ outputText("Whitney marches up to you as soon as you approach the farm, a stoic 
 			player.addStatusValue(StatusEffects.MetWhitney,1,1);
 			if(player.statusEffectv1(StatusEffects.MetWhitney) == 2) outputText("<b>You've been to the farm enough to easily find it.  You can return by selecting it from the places menu (and will no longer encounter it during random lake exploration)</b>.\n\n");
 		}
-		inventory.takeItem(consumables.CANINEP, camp.returnToCampUseOneHour);
+		inventory.takeItem(consumables.CANINEP, explorer.done);
 	}
 	//Repeat Offender
 	else {

--- a/classes/classes/Scenes/Places/HeXinDao/AdventurerGuild.as
+++ b/classes/classes/Scenes/Places/HeXinDao/AdventurerGuild.as
@@ -2,294 +2,130 @@
  * ...
  * @author Ormael and others
  */
-package classes.Scenes.Places.HeXinDao 
+package classes.Scenes.Places.HeXinDao
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.ItemBag;
 import classes.Scenes.SceneLib;
+import classes.internals.EnumValue;
 import classes.internals.SaveableState;
+
+import coc.view.ButtonDataList;
 
 public class AdventurerGuild extends HeXinDaoAbstractContent implements SaveableState
 	{
-		public static var Slot01:Number;
-		public static var Slot01Cap:Number;//imp skulls
-		public static var Slot02:Number;
-		public static var Slot02Cap:Number;//feral imp skulls
-		//Copper plate
-		public static var Slot03:Number;
-		public static var Slot03Cap:Number;//minotaur horns
-		public static var Slot04:Number;
-		public static var Slot04Cap:Number;//demon skulls
-		public static var Slot05:Number;
-		public static var Slot05Cap:Number;//feral tentacle beasts
-		//Iron plate
-		public static var Slot06:Number;
-		public static var Slot06Cap:Number;
-		public static var Slot07:Number;
-		public static var Slot07Cap:Number;
-		//Bronze plate
-		public static var Slot08:Number;
-		public static var Slot08Cap:Number;
-		public static var Slot09:Number;
-		public static var Slot09Cap:Number;
-		//Silver plate
-		public static var Slot10:Number;
-		public static var Slot10Cap:Number;
-		public static var Slot11:Number;
-		public static var Slot11Cap:Number;
-		public static var Slot12:Number;
-		public static var Slot12Cap:Number;
-		//Gold plate
-		public static var Slot13:Number;
-		public static var Slot13Cap:Number;
-		public static var Slot14:Number;
-		public static var Slot14Cap:Number;
-		public static var Slot15:Number;
-		public static var Slot15Cap:Number;
-		public static var Slot16:Number;
-		public static var Slot16Cap:Number;
-		//Platinum plate
-		public static var Slot17:Number;
-		public static var Slot17Cap:Number;
-		public static var Slot18:Number;
-		public static var Slot18Cap:Number;
-		public static var Slot19:Number;
-		public static var Slot19Cap:Number;
-		public static var Slot20:Number;
-		public static var Slot20Cap:Number;
-		//Mithril plate
-		public static var Slot21:Number;
-		public static var Slot21Cap:Number;
-		public static var Slot22:Number;
-		public static var Slot22Cap:Number;
-		public static var Slot23:Number;
-		public static var Slot23Cap:Number;
-		public static var Slot24:Number;
-		public static var Slot24Cap:Number;
-		public static var Slot25:Number;
-		public static var Slot25Cap:Number;
-		//Orichalcum plate
-		public static var Slot26:Number;
-		public static var Slot26Cap:Number;
-		public static var Slot27:Number;
-		public static var Slot27Cap:Number;
-		public static var Slot28:Number;
-		public static var Slot28Cap:Number;
-		public static var Slot29:Number;
-		public static var Slot29Cap:Number;
-		public static var Slot30:Number;
-		public static var Slot30Cap:Number;
-		//Adamantite plate
+		// Array of pairs [item type, guild rank]
+		private static const slotDefs:Array = [
+			//Copper plate 01-02
+			[useables.IMPSKLL, RANK_COPPER], // 01 imp skulls
+			[useables.FIMPSKL, RANK_COPPER], // 02 feral imp skulls
+			//Iron plate 03-05
+			[useables.MINOHOR, RANK_IRON],   // 03 minotaur horns
+			[useables.DEMSKLL, RANK_IRON],   // 04 demon skulls
+			[useables.SEVTENT, RANK_IRON],   // 05 feral tentacle beasts
+			//Bronze plate 06-07
+			[ItemType.NOTHING, RANK_BRONZE], // 06
+			[ItemType.NOTHING, RANK_BRONZE]  // 07
+			//Silver plate 08-09
+			//Gold plate 10-12
+			//Platinum plate 13-16
+			//Mithril plate 17-20
+			//Orichalcum plate 21-25
+			//Adamantite plate 26-30
+		];
+		public static var lootBag:ItemBag = new ItemBag(
+				// convert array of pairs to array of item types by picking each pair element 0
+				mapOneProp(slotDefs,"0"),
+				30
+		);
+		private static var itemIdToSlotIndex:Object = {};
 
 		public function stateObjectName():String {
 			return "AdventurerGuild";
 		}
 
 		public function resetState():void {
-			Slot01 = 0;
-			Slot01Cap = 0;
-			Slot02 = 0;
-			Slot02Cap = 0;
-			Slot03 = 0;
-			Slot03Cap = 0;
-			Slot04 = 0;
-			Slot04Cap = 0;
-			Slot05 = 0;
-			Slot05Cap = 0;
-			Slot06 = 0;
-			Slot06Cap = 0;
-			Slot07 = 0;
-			Slot07Cap = 0;
-			Slot08 = 0;
-			Slot08Cap = 0;
-			Slot09 = 0;
-			Slot09Cap = 0;
-			Slot10 = 0;
-			Slot10Cap = 0;
-			Slot11 = 0;
-			Slot11Cap = 0;
-			Slot12 = 0;
-			Slot12Cap = 0;
-			Slot13 = 0;
-			Slot13Cap = 0;
-			Slot14 = 0;
-			Slot14Cap = 0;
-			Slot15 = 0;
-			Slot15Cap = 0;
-			Slot16 = 0;
-			Slot16Cap = 0;
-			Slot17 = 0;
-			Slot17Cap = 0;
-			Slot18 = 0;
-			Slot18Cap = 0;
-			Slot19 = 0;
-			Slot19Cap = 0;
-			Slot20 = 0;
-			Slot20Cap = 0;
-			Slot21 = 0;
-			Slot21Cap = 0;
-			Slot22 = 0;
-			Slot22Cap = 0;
-			Slot23 = 0;
-			Slot23Cap = 0;
-			Slot24 = 0;
-			Slot24Cap = 0;
-			Slot25 = 0;
-			Slot25Cap = 0;
-			Slot26 = 0;
-			Slot26Cap = 0;
-			Slot27 = 0;
-			Slot27Cap = 0;
-			Slot28 = 0;
-			Slot28Cap = 0;
-			Slot29 = 0;
-			Slot29Cap = 0;
-			Slot30 = 0;
-			Slot30Cap = 0;
+			lootBag.resetState();
 		}
 
 		public function saveToObject():Object {
-			return {
-				"Slot01": Slot01,
-				"Slot01Cap": Slot01Cap,
-				"Slot02": Slot02,
-				"Slot02Cap": Slot02Cap,
-				"Slot03": Slot03,
-				"Slot03Cap": Slot03Cap,
-				"Slot04": Slot04,
-				"Slot04Cap": Slot04Cap,
-				"Slot05": Slot05,
-				"Slot05Cap": Slot05Cap,
-				"Slot06": Slot06,
-				"Slot06Cap": Slot06Cap,
-				"Slot07": Slot07,
-				"Slot07Cap": Slot07Cap,
-				"Slot08": Slot08,
-				"Slot08Cap": Slot08Cap,
-				"Slot09": Slot09,
-				"Slot09Cap": Slot09Cap,
-				"Slot10": Slot10,
-				"Slot10Cap": Slot10Cap,
-				"Slot11": Slot11,
-				"Slot11Cap": Slot11Cap,
-				"Slot12": Slot12,
-				"Slot12Cap": Slot12Cap,
-				"Slot13": Slot13,
-				"Slot13Cap": Slot13Cap,
-				"Slot14": Slot14,
-				"Slot14Cap": Slot14Cap,
-				"Slot15": Slot15,
-				"Slot15Cap": Slot15Cap,
-				"Slot16": Slot16,
-				"Slot16Cap": Slot16Cap,
-				"Slot17": Slot17,
-				"Slot17Cap": Slot17Cap,
-				"Slot18": Slot18,
-				"Slot18Cap": Slot18Cap,
-				"Slot19": Slot19,
-				"Slot19Cap": Slot19Cap,
-				"Slot20": Slot20,
-				"Slot20Cap": Slot20Cap,
-				"Slot21": Slot21,
-				"Slot21Cap": Slot21Cap,
-				"Slot22": Slot22,
-				"Slot22Cap": Slot22Cap,
-				"Slot23": Slot23,
-				"Slot23Cap": Slot23Cap,
-				"Slot24": Slot24,
-				"Slot24Cap": Slot24Cap,
-				"Slot25": Slot25,
-				"Slot25Cap": Slot25Cap,
-				"Slot26": Slot26,
-				"Slot26Cap": Slot26Cap,
-				"Slot27": Slot27,
-				"Slot27Cap": Slot27Cap,
-				"Slot28": Slot28,
-				"Slot28Cap": Slot28Cap,
-				"Slot29": Slot29,
-				"Slot29Cap": Slot29Cap,
-				"Slot30": Slot30,
-				"Slot30Cap": Slot30Cap
-			};
+			return lootBag.saveToObject();
 		}
 
 		public function loadFromObject(o:Object, ignoreErrors:Boolean):void {
 			if (o) {
-				Slot01 = o["Slot01"];
-				Slot01Cap = o["Slot01Cap"];
-				Slot02 = o["Slot02"];
-				Slot02Cap = o["Slot02Cap"];
-				Slot03 = o["Slot03"];
-				Slot03Cap = o["Slot03Cap"];
-				Slot04 = o["Slot04"];
-				Slot04Cap = o["Slot04Cap"];
-				Slot05 = o["Slot05"];
-				Slot05Cap = o["Slot05Cap"];
-				Slot06 = o["Slot06"];
-				Slot06Cap = o["Slot06Cap"];
-				Slot07 = o["Slot07"];
-				Slot07Cap = o["Slot07Cap"];
-				Slot08 = o["Slot08"];
-				Slot08Cap = o["Slot08Cap"];
-				Slot09 = o["Slot09"];
-				Slot09Cap = o["Slot09Cap"];
-				Slot10 = o["Slot10"];
-				Slot10Cap = o["Slot10Cap"];
-				Slot11 = o["Slot11"];
-				Slot11Cap = o["Slot11Cap"];
-				Slot12 = o["Slot12"];
-				Slot12Cap = o["Slot12Cap"];
-				Slot13 = o["Slot13"];
-				Slot13Cap = o["Slot13Cap"];
-				Slot14 = o["Slot14"];
-				Slot14Cap = o["Slot14Cap"];
-				Slot15 = o["Slot15"];
-				Slot15Cap = o["Slot15Cap"];
-				Slot16 = o["Slot16"];
-				Slot16Cap = o["Slot16Cap"];
-				Slot17 = o["Slot17"];
-				Slot17Cap = o["Slot17Cap"];
-				Slot18 = o["Slot18"];
-				Slot18Cap = o["Slot18Cap"];
-				Slot19 = o["Slot19"];
-				Slot19Cap = o["Slot19Cap"];
-				Slot20 = o["Slot20"];
-				Slot20Cap = o["Slot20Cap"];
-				Slot21 = o["Slot21"];
-				Slot21Cap = o["Slot21Cap"];
-				Slot22 = o["Slot22"];
-				Slot22Cap = o["Slot22Cap"];
-				Slot23 = o["Slot23"];
-				Slot23Cap = o["Slot23Cap"];
-				Slot24 = o["Slot24"];
-				Slot24Cap = o["Slot24Cap"];
-				Slot25 = o["Slot25"];
-				Slot25Cap = o["Slot25Cap"];
-				Slot26 = o["Slot26"];
-				Slot26Cap = o["Slot26Cap"];
-				Slot27 = o["Slot27"];
-				Slot27Cap = o["Slot27Cap"];
-				Slot28 = o["Slot28"];
-				Slot28Cap = o["Slot28Cap"];
-				Slot29 = o["Slot29"];
-				Slot29Cap = o["Slot29Cap"];
-				Slot30 = o["Slot30"];
-				Slot30Cap = o["Slot30Cap"];
+				if ("Slots" in o) {
+					lootBag.loadFromObject(o,ignoreErrors);
+				} else if ("Slot01" in o) {
+					resetState();
+					// old version: "Slot01".."Slot30", "Slot01Cap".."Slot30Cap"
+					for (var i:int = 0; i < lootBag.SlotCount; i++) {
+						var s:String = padStart(String(i + 1), 2, "0");
+						lootBag.Slots[i]     = numberOr(o["Slot" + s], 0);
+						lootBag.SlotCaps[i]  = numberOr(o["Slot" + s + "Cap"], 0);
+					}
+				} else {
+					resetState();
+				}
 			} else {
 				// loading from old save
 				resetState();
 			}
 		}
 
-		public function AdventurerGuild() 
+		public function AdventurerGuild()
 		{
 			Saves.registerSaveableState(this);
+			resetState();
+		}
+		
+		public static const GuildRanks:/*EnumValue*/Array = [];
+		public static const RANK_NONE:int                 = 0;
+		EnumValue.add(GuildRanks, RANK_NONE, "NONE", {
+			displayName: "None"
+		});
+		public static const RANK_COPPER:int = 1;
+		EnumValue.add(GuildRanks, RANK_COPPER, "COPPER", {
+			name: "Copper",
+			keyItem: "Adventurer Guild: Copper plate"
+		});
+		public static const RANK_IRON:int = 2;
+		EnumValue.add(GuildRanks, RANK_IRON, "IRON", {
+			name: "Iron",
+			keyItem: "Adventurer Guild: Iron plate"
+		});
+		public static const RANK_BRONZE:int = 3;
+		EnumValue.add(GuildRanks, RANK_BRONZE, "BRONZE", {
+			name: "Bronze",
+			keyItem: "Adventurer Guild: Bronze plate"
+		});
+		// "Adventurer Guild: Silver plate"
+		// "Adventurer Guild: Gold plate"
+		// "Adventurer Guild: Platinum plate"
+		// "Adventurer Guild: Mithril plate"
+		// "Adventurer Guild: Orichalcum plate"
+		// "Adventurer Guild: Adamantite plate"
+		
+		/** Set all SlotCaps for rank to cap */
+		public static function unlockSlotsForRank(rank:int, cap:int):void {
+			for (var slot:int = 0; slot < slotDefs.length; slot++) {
+				if (slotDefs[slot][1] == rank) lootBag.SlotCaps[slot] = cap;
+			}
+		}
+		public static function get playerGuildLevel():int {
+			for (var i:int = GuildRanks.length-1; i>0; i--) {
+				if (GuildRanks[i] && GuildRanks[i].keyItem && player.hasKeyItem(GuildRanks[i].keyItem) >= 0) return i;
+			}
+			return RANK_NONE;
+		}
+		public static function get playerInGuild():Boolean {
+			return playerGuildLevel > 0;
 		}
 		
 		public function BoardkeeperYangMain():void {
 			clearOutput();
-			if (player.hasKeyItem("Adventurer Guild: Copper plate") >= 0 || player.hasKeyItem("Adventurer Guild: Iron plate") >= 0) {// || player.hasKeyItem("Adventurer Guild: Bronze plate") >= 0 || player.hasKeyItem("Adventurer Guild: Silver plate") >= 0 || player.hasKeyItem("Adventurer Guild: Gold plate") >= 0 || player.hasKeyItem("Adventurer Guild: Platinum plate") >= 0
-				// || player.hasKeyItem("Adventurer Guild: Mithril plate") >= 0|| player.hasKeyItem("Adventurer Guild: Orichalcum plate") >= 0 || player.hasKeyItem("Adventurer Guild: Adamantite plate") >= 0
+			if (playerInGuild) {
 				outputText("Yang the job handler wait at you arm crossed. She looks bored like she has been there all day.\n\n");
 				outputText("\"<i>So [name] how can I help you today? Here to talk jobs or something else?</i>\"");
 				menu();
@@ -331,8 +167,7 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 				flags[kFLAGS.SPIRIT_STONES] -= 5;
 				statScreenRefresh();
 				player.createKeyItem("Adventurer Guild: Copper plate", 0, 0, 0, 0);
-				Slot01Cap = 10;
-				Slot02Cap = 10;
+				unlockSlotsForRank(RANK_COPPER, 10);
 				doNext(BoardkeeperYangMain);
 			}
 		}
@@ -369,13 +204,12 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					outputText("\"<i>Sorry [name] this job is only once per day. Come back tomorrow.</i>\"\n\n");
 				}
 				else if (player.statusEffectv1(StatusEffects.AdventureGuildQuests1) == 6) {
-					if (player.hasItem(useables.IMPSKLL, 5) || Slot01 >= 5) {
+					if (player.hasItem(useables.IMPSKLL, 5, true)) {
 						outputText("Yang examine the skulls to make sure they are imps then nods giving you your payment.\n\n");
 						outputText("\"<i>Good job [name] here is your payment.</i>\"\n\n");
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter1, 1, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests1, 1, 1);
-						if (Slot01 >= 5) Slot01 -= 5;
-						else player.destroyItems(useables.IMPSKLL, 5);
+						player.destroyItems(useables.IMPSKLL, 5, true);
 						flags[kFLAGS.SPIRIT_STONES] += 7;
 						statScreenRefresh();
 					}
@@ -390,13 +224,12 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.addStatusValue(StatusEffects.AdventureGuildQuests1, 1, 2);
 				}
 				else if (player.statusEffectv1(StatusEffects.AdventureGuildQuests1) == 3) {
-					if (player.hasItem(useables.IMPSKLL, 4) || Slot01 >= 4) {
+					if (player.hasItem(useables.IMPSKLL, 4, true)) {
 						outputText("Yang examine the skulls to make sure they are imps then nods giving you your payment.\n\n");
 						outputText("\"<i>Good job [name] here is your payment a special training scroll.</i>\"\n\n");
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter1, 1, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests1, 1, 1);
-						if (Slot01 >= 4) Slot01 -= 4;
-						else player.destroyItems(useables.IMPSKLL, 4);
+						player.destroyItems(useables.IMPSKLL, 4, true);
 						player.perkPoints += 1;
 					}
 					else {
@@ -410,7 +243,7 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.addStatusValue(StatusEffects.AdventureGuildQuests1, 1, 1);
 				}
 				else {
-					if (player.hasItem(useables.IMPSKLL, 3) || Slot01 >= 3) {
+					if (player.hasItem(useables.IMPSKLL, 3, true)) {
 						outputText("Yang examine the skulls to make sure they are imps then nods giving you your payment.\n\n");
 						outputText("\"<i>Good job [name] here is your payment. By the way I though you may want to be able to sense corruption, can be useful to hunt demons here have this amulet.</i>\"\n\n");
 						outputText("(<b>Acquired demon hunter amulet!</b>)\n\n");
@@ -420,8 +253,7 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 						player.addStatusValue(StatusEffects.AdventureGuildQuests1, 1, 1);
 						player.createKeyItem("Demon Hunter Amulet", 0, 0, 0, 0);
 						player.createPerk(PerkLib.SenseCorruption, 0, 0, 0, 0);
-						if (Slot01 >= 3) Slot01 -= 3;
-						else player.destroyItems(useables.IMPSKLL, 3);
+						player.destroyItems(useables.IMPSKLL, 3, true);
 					}
 					else {
 						outputText("The panda taps her foot on the ground.\n\n");
@@ -446,13 +278,12 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					outputText("\"<i>Sorry [name] this job is only once per day. Come back tomorrow.</i>\"\n\n");
 				}
 				else if (player.statusEffectv1(StatusEffects.AdventureGuildQuests2) == 6) {
-					if (player.hasItem(useables.SEVTENT, 3) || Slot05 >= 3) {
+					if (player.hasItem(useables.SEVTENT, 3, true)) {
 						outputText("You turn in the quest and Yang nods in appreciation.\n\n");
 						outputText("\"<i>Good job there. I hope those plants did not prove to much trouble. Here is your payment.</i>\"\n\n");
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter2, 1, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests2, 1, 1);
-						if (Slot05 >= 3) Slot05 -= 3;
-						else player.destroyItems(useables.SEVTENT, 3);
+						player.destroyItems(useables.SEVTENT, 3, true);
 						flags[kFLAGS.SPIRIT_STONES] += 8;
 						statScreenRefresh();
 					}
@@ -463,13 +294,12 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.addStatusValue(StatusEffects.AdventureGuildQuests2, 1, 2);
 				}
 				else if (player.statusEffectv1(StatusEffects.AdventureGuildQuests2) == 3) {
-					if (player.hasItem(useables.SEVTENT, 2) || Slot05 >= 2) {
+					if (player.hasItem(useables.SEVTENT, 2, true)) {
 						outputText("You turn in the quest and Yang nods in appreciation.\n\n");
 						outputText("\"<i>Good job [name] here is your payment a special training scroll.</i>\"\n\n");
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter2, 1, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests2, 1, 1);
-						if (Slot05 >= 2) Slot05 -= 2;
-						else player.destroyItems(useables.SEVTENT, 2);
+						player.destroyItems(useables.SEVTENT, 2, true);
 						player.perkPoints += 1;
 					}
 					else outputText("You try turn in the quest but Yang tells you you don’t have enough tentacles yet.\n\n");
@@ -479,7 +309,7 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.addStatusValue(StatusEffects.AdventureGuildQuests2, 1, 1);
 				}
 				else {
-					if (player.hasItem(useables.SEVTENT, 1) || Slot05 >= 1) {
+					if (player.hasItem(useables.SEVTENT, 1, true)) {
 						outputText("You turn in the quest and Yang nods in appreciation.\n\n");
 						outputText("\"<i>My my, I wasn’t sure I would ever see you back.</i>\"\n\n");
 						outputText("Seems she misjudged you then?\n\n");
@@ -489,8 +319,7 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter2, 1, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests2, 1, 1);
 						player.createPerk(PerkLib.SenseWrath, 0, 0, 0, 0);
-						if (Slot05 >= 1) Slot05 -= 1;
-						else player.destroyItems(useables.SEVTENT, 1);
+						player.destroyItems(useables.SEVTENT, 1, true);
 					}
 					else outputText("You try turn in the quest but Yang tells you you don’t have enough tentacles yet.\n\n");
 				}
@@ -512,13 +341,12 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					outputText("\"<i>Sorry [name] this job is only once per day. Come back tomorrow.</i>\"\n\n");
 				}
 				else if (player.statusEffectv2(StatusEffects.AdventureGuildQuests1) == 6) {
-					if (player.hasItem(useables.DEMSKLL, 3) || Slot04 >= 3) {
+					if (player.hasItem(useables.DEMSKLL, 3, true)) {
 						outputText("You turn in the quest and Yang nods.\n\n");
 						outputText("\"<i>Good job as usual here is your payment.</i>\"\n\n");
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter1, 2, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests1, 2, 1);
-						if (Slot04 >= 3) Slot04 -= 3;
-						else player.destroyItems(useables.DEMSKLL, 3);
+						player.destroyItems(useables.DEMSKLL, 3, true);
 						flags[kFLAGS.SPIRIT_STONES] += 8;
 						statScreenRefresh();
 					}
@@ -534,13 +362,12 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.addStatusValue(StatusEffects.AdventureGuildQuests1, 2, 2);
 				}
 				else if (player.statusEffectv2(StatusEffects.AdventureGuildQuests1) == 3) {
-					if (player.hasItem(useables.DEMSKLL, 2) || Slot04 >= 2) {
+					if (player.hasItem(useables.DEMSKLL, 2, true)) {
 						outputText("You turn in the quest and Yang nods.\n\n");
 						outputText("\"<i>Good job [name] here is your payment a special training scroll.</i>\"\n\n");
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter1, 2, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests1, 2, 1);
-						if (Slot04 >= 3) Slot04 -= 2;
-						else player.destroyItems(useables.DEMSKLL, 2);
+						player.destroyItems(useables.DEMSKLL, 2, true);
 						player.perkPoints += 1;
 					}
 					else {
@@ -555,7 +382,7 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.addStatusValue(StatusEffects.AdventureGuildQuests1, 2, 1);
 				}
 				else {
-					if (player.hasItem(useables.DEMSKLL, 1) || Slot04 >= 1) {
+					if (player.hasItem(useables.DEMSKLL, 1, true)) {
 						outputText("You display the proof of your victory.\n\n");
 						outputText("\"<i>Nice job [name] so about that special reward, it happens a traveling demon hunter has agreed to train whoever would kill demons in the art of slaying. Chika would you please come over? [name] cleared your bounty.</i>\"\n\n");
 						outputText("Chika appears to be a rattel morph with an eyepatch. Rattel, or honey badgers, are known for their ferocity; the set of throwing daggers and poison flasks hanging from her belt, the pair of scimitars on her side and the crossbow on her back tells everything you need about her, ");
@@ -569,8 +396,7 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter1, 2, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests1, 2, 1);
 						player.createPerk(PerkLib.DemonSlayer, 0.1, 0, 0, 0);
-						if (Slot04 >= 3) Slot04 -= 1;
-						else player.destroyItems(useables.DEMSKLL, 1);
+						player.destroyItems(useables.DEMSKLL, 1, true);
 					}
 					else {
 						outputText("The panda taps her foot on the ground.\n\n");
@@ -596,13 +422,12 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					outputText("\"<i>Sorry [name] this job is only once per day. Come back tomorrow.</i>\"\n\n");
 				}
 				else if (player.statusEffectv2(StatusEffects.AdventureGuildQuests2) == 6) {
-					if (player.hasItem(useables.FIMPSKL, 5) || Slot02 >= 5) {
+					if (player.hasItem(useables.FIMPSKL, 5, true)) {
 						outputText("You turn in the quest and Yang nods in appreciation.\n\n");
 						outputText("\"<i>Good job there. I heard those creatures are actually out there killing instead of raping, it’s quite chilling. Here is your payment.</i>\"\n\n");
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter2, 2, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests2, 2, 1);
-						if (Slot02 >= 5) Slot02 -= 5;
-						else player.destroyItems(useables.FIMPSKL, 5);
+						player.destroyItems(useables.FIMPSKL, 5, true);
 						flags[kFLAGS.SPIRIT_STONES] += 7;
 						statScreenRefresh();
 					}
@@ -613,13 +438,12 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.addStatusValue(StatusEffects.AdventureGuildQuests2, 2, 2);
 				}
 				else if (player.statusEffectv2(StatusEffects.AdventureGuildQuests2) == 3) {
-					if (player.hasItem(useables.FIMPSKL, 4) || Slot02 >= 4) {
+					if (player.hasItem(useables.FIMPSKL, 4, true)) {
 						outputText("You turn in the quest and Yang nods in appreciation.\n\n");
 						outputText("\"<i>Good job there. I heard those creatures are actually out there killing instead of raping, it’s quite chilling. Here is your payment a special training scroll.</i>\"\n\n");
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter2, 2, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests2, 2, 1);
-						if (Slot02 >= 4) Slot02 -= 4;
-						else player.destroyItems(useables.FIMPSKL, 4);
+						player.destroyItems(useables.FIMPSKL, 4, true);
 						player.perkPoints += 1;
 					}
 					else outputText("You try turn in the quest but Yang tells you you don’t have enough feral imp skulls yet.\n\n");
@@ -629,7 +453,7 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.addStatusValue(StatusEffects.AdventureGuildQuests2, 2, 1);
 				}
 				else {
-					if (player.hasItem(useables.FIMPSKL, 3) || Slot02 >= 3) {
+					if (player.hasItem(useables.FIMPSKL, 3, true)) {
 						outputText("You turn in the quest and Yang nods in appreciation.\n\n");
 						outputText("\"<i>My my, I wasn’t sure I would ever see you back.</i>\"\n\n");
 						outputText("Seems she misjudged you then?\n\n");
@@ -639,8 +463,7 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter2, 2, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests2, 2, 1);
 						player.createPerk(PerkLib.FeralHunter, 0.1, 0, 0, 0);
-						if (Slot02 >= 3) Slot02 -= 3;
-						else player.destroyItems(useables.FIMPSKL, 3);
+						player.destroyItems(useables.FIMPSKL, 3, true);
 					}
 					else outputText("You try turn in the quest but Yang tells you you don’t have enough feral imp skulls yet.\n\n");
 				}
@@ -662,13 +485,12 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					outputText("\"<i>Sorry [name] this job is only once per day. Come back tomorrow.</i>\"\n\n");
 				}
 				else if (player.statusEffectv3(StatusEffects.AdventureGuildQuests1) == 6) {
-					if (player.hasItem(useables.MINOHOR, 4) || Slot03 >= 4) {
+					if (player.hasItem(useables.MINOHOR, 4, true)) {
 						outputText("Yang count the horns then smile.\n\n");
 						outputText("\"<i>Well you did bag four out of four nice job. The guild asked me to pay you this reward money as usual for slaying bulls. Do come and find me later on for a new job, or for something else...</i>\"\n\n");
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter1, 3, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests1, 3, 1);
-						if (Slot03 >= 4) Slot03 -= 4;
-						else player.destroyItems(useables.MINOHOR, 4);
+						player.destroyItems(useables.MINOHOR, 4, true);
 						flags[kFLAGS.SPIRIT_STONES] += 8;
 						statScreenRefresh();
 					}
@@ -679,13 +501,12 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.addStatusValue(StatusEffects.AdventureGuildQuests1, 3, 2);
 				}
 				else if (player.statusEffectv3(StatusEffects.AdventureGuildQuests1) == 3) {
-					if (player.hasItem(useables.MINOHOR, 3) || Slot03 >= 3) {
+					if (player.hasItem(useables.MINOHOR, 3, true)) {
 						outputText("Yang count the horns then smile.\n\n");
 						outputText("\"<i>Well you did bag three out of three nice job. The guild asked me to pay you with this special training scroll for slaying bulls. Do come and find me later on for a new job, or for something else...</i>\"\n\n");
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter1, 3, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests1, 3, 1);
-						if (Slot03 >= 3) Slot03 -= 3;
-						else player.destroyItems(useables.MINOHOR, 3);
+						player.destroyItems(useables.MINOHOR, 3, true);
 						player.perkPoints += 1;
 					}
 					else outputText("\"<i>Hey [name], I counted those horns and clearly you forgot a few. Get out there and bring me the remaining ones.</i>\"\n\n");
@@ -695,15 +516,14 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.addStatusValue(StatusEffects.AdventureGuildQuests1, 3, 1);
 				}
 				else {
-					if (player.hasItem(useables.MINOHOR, 2) || Slot03 >= 2) {
+					if (player.hasItem(useables.MINOHOR, 2, true)) {
 						outputText("Yang count the horns then smile.\n\n");
 						outputText("\"<i>Well you indeed did bag two out of two. The guild asked me to pay you this specific tome. Betcha will find nice uses for these. Do come and find me later on for a new job, or for something else...</i>\"\n\n");
 						outputText("Yang gives you a telltale wink before handing you over your reward.\n\n");
 						if (player.hasKeyItem("Adventurer Guild: Copper plate") >= 0) player.addKeyValue("Adventurer Guild: Copper plate", 1, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuestsCounter1, 3, 1);
 						player.addStatusValue(StatusEffects.AdventureGuildQuests1, 3, 1);
-						if (Slot03 >= 2) Slot03 -= 2;
-						else player.destroyItems(useables.MINOHOR, 2);
+						player.destroyItems(useables.MINOHOR, 2, true);
 						inventory.takeItem(consumables.TCLEAVE, BoardkeeperYangQuest);
 						return;
 					}
@@ -972,9 +792,7 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.removeKeyItem("Adventurer Guild: Copper plate");
 					player.createKeyItem("Adventurer Guild: Iron plate", 0, 0, 0, 0);
 					flags[kFLAGS.SPIRIT_STONES] -= 10;
-					Slot03Cap = 10;
-					Slot04Cap = 10;
-					Slot05Cap = 10;
+					unlockSlotsForRank(RANK_IRON, 10);
 				}
 				else {
 					outputText("Yeah sure, you will get promoted. Or rather, you would like to but you lack the required spirit stones for the promotion fee.\n\n");
@@ -988,8 +806,7 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 					player.removeKeyItem("Adventurer Guild: Iron plate");
 					player.createKeyItem("Adventurer Guild: Bronze plate", 0, 0, 0, 0);
 					flags[kFLAGS.SPIRIT_STONES] -= 15;
-					Slot06Cap = 10;
-					Slot07Cap = 10;
+					unlockSlotsForRank(RANK_IRON, 10);
 				}
 				else {
 					outputText("Yeah sure, you will get promoted. Or rather you would like to but you lack the required spirit stones for the promotion fee.\n\n");
@@ -999,132 +816,34 @@ public class AdventurerGuild extends HeXinDaoAbstractContent implements Saveable
 			doNext(BoardkeeperYangMain);
 		}
 
-		public function questItemsBag():void {
+		public function questItemsBag(page:int = 0):void {
 			clearOutput();
 			outputText("Would you like to put some quest items into the bag, and if so, with ones?\n\n");
-			if (Slot01Cap > 0) outputText("<b>Imp Skulls:</b> "+Slot01+" / "+Slot01Cap+"\n");
-			if (Slot02Cap > 0) outputText("<b>Feral Imp Skulls:</b> "+Slot02+" / "+Slot02Cap+"\n");
-			if (Slot03Cap > 0) outputText("<b>Minotaur Horns:</b> "+Slot03+" / "+Slot03Cap+"\n");
-			if (Slot04Cap > 0) outputText("<b>Demon Skulls:</b> "+Slot04+" / "+Slot04Cap+"\n");
-			if (Slot05Cap > 0) outputText("<b>Severed Tentacles:</b> "+Slot05+" / "+Slot05Cap+"\n");
+			// TODO @aimozg item transfer menu?
+			var bdl:ButtonDataList = new ButtonDataList();
+			for (var i:int = 0; i < lootBag.SlotCount; i++) {
+				if (lootBag.SlotCaps[i] > 0) {
+					var itemType:ItemType = lootBag.itemTypes[i];
+					outputText("<b>"+itemType.shortName+":</b> "+lootBag.Slots[i] + " / "+lootBag.SlotCaps[i]+"\n");
+					
+					bdl.add("Store "+itemType.shortName, curry(storeItem, i, itemType))
+							.disableIf(!player.hasItem(itemType) || lootBag.Slots[i] >= lootBag.SlotCaps[i]);
+					bdl.add("Take "+itemType.shortName, curry(takeItem, i, itemType))
+							.disableIf(lootBag.Slots[i] == 0);
+				}
+			}
 			menu();
-			if (Slot01 < Slot01Cap) {
-				if (player.hasItem(useables.IMPSKLL, 1)) addButton(0, "ImpSkull", questItemsBagImpSkull1UP);
-				else addButtonDisabled(0, "ImpSkull", "You don't have any imp skulls to store.");
-			}
-			else addButtonDisabled(0, "ImpSkull", "You can't store more imp skulls in your bag.");
-			if (Slot01 > 0) addButton(1, "ImpSkull", questItemsBagImpSkull1Down);
-			else addButtonDisabled(1, "ImpSkull", "You don't have any imp skulls in your bag.");
-			if (Slot02 < Slot02Cap) {
-				if (player.hasItem(useables.FIMPSKL, 1)) addButton(2, "FeralImpS.", questItemsBagFeralImpSkull1Up);
-				else addButtonDisabled(2, "FeralImpS.", "You don't have any feral imp skulls to store.");
-			}
-			else addButtonDisabled(2, "FeralImpS.", "You can't store more feral imp skulls in your bag.");
-			if (Slot02 > 0) addButton(3, "FeralImpS.", questItemsBagFeralImpSkull1Down);
-			else addButtonDisabled(3, "FeralImpS.", "You don't have any feral imp skulls in your bag.");
-			if (Slot03 < Slot03Cap) {
-				if (player.hasItem(useables.MINOHOR, 1)) addButton(5, "MinoHorns", questItemsBagMinotaurHorns1Up);
-				else addButtonDisabled(5, "MinoHorns", "You don't have any minotaur horns to store.");
-			}
-			else addButtonDisabled(5, "MinoHorns", "You can't store more minotaur horns in your bag.");
-			if (Slot03 > 0) addButton(6, "MinoHorns", questItemsBagMinotaurHorns1Down);
-			else addButtonDisabled(6, "MinoHorns", "You don't have any minotaur horns in your bag.");
-			if (Slot04 < Slot04Cap) {
-				if (player.hasItem(useables.DEMSKLL, 1)) addButton(7, "DemonSkull", questItemsBagDemonSkull1Up);
-				else addButtonDisabled(7, "DemonSkull", "You don't have any demon skulls to store.");
-			}
-			else addButtonDisabled(7, "DemonSkull", "You can't store more demon skulls in your bag.");
-			if (Slot04 > 0) addButton(8, "DemonSkull", questItemsBagDemonSkull1Down);
-			else addButtonDisabled(8, "DemonSkull", "You don't have any demon skulls in your bag.");
-			if (Slot05 < Slot05Cap) {
-				if (player.hasItem(useables.SEVTENT, 1)) addButton(10, "SeveredTent", questItemsBagSeveredTentacle1Up);
-				else addButtonDisabled(10, "SeveredTent", "You don't have any severed tentacles to store.");
-			}
-			else addButtonDisabled(10, "SeveredTent", "You can't store more severed tentacles in your bag.");
-			if (Slot05 > 0) addButton(11, "SeveredTent", questItemsBagSeveredTentacle1Down);
-			else addButtonDisabled(11, "SeveredTent", "You don't have any severed tentacles in your bag.");
-			addButton(14, "Back", camp.campActions);
+			submenu(bdl, camp.campActions, page, false);
 		}
-		private function questItemsBagImpSkull1UP():void {
-			player.destroyItems(useables.IMPSKLL, 1);
-			Slot01 += 1;
-			doNext(questItemsBag);
+		private function storeItem(slot:int, itemType:ItemType):void {
+			player.destroyItems(itemType, 1);
+			lootBag.Slots[slot]++;
+			questItemsBag(submenuPage);
 		}
-		private function questItemsBagImpSkull1Down():void {
+		public function takeItem(slot:int, itemType:ItemType):void {
+			lootBag.Slots[slot]--;
 			outputText("\n");
-			Slot01 -= 1;
-			inventory.takeItem(useables.IMPSKLL, questItemsBag);
-		}
-		private function questItemsBagFeralImpSkull1Up():void {
-			player.destroyItems(useables.FIMPSKL, 1);
-			Slot02 += 1;
-			doNext(questItemsBag);
-		}
-		private function questItemsBagFeralImpSkull1Down():void {
-			outputText("\n");
-			Slot02 -= 1;
-			inventory.takeItem(useables.FIMPSKL, questItemsBag);
-		}
-		private function questItemsBagMinotaurHorns1Up():void {
-			player.destroyItems(useables.MINOHOR, 1);
-			Slot03 += 1;
-			doNext(questItemsBag);
-		}
-		private function questItemsBagMinotaurHorns1Down():void {
-			outputText("\n");
-			Slot03 -= 1;
-			inventory.takeItem(useables.MINOHOR, questItemsBag);
-		}
-		private function questItemsBagDemonSkull1Up():void {
-			player.destroyItems(useables.DEMSKLL, 1);
-			Slot04 += 1;
-			doNext(questItemsBag);
-		}
-		private function questItemsBagDemonSkull1Down():void {
-			outputText("\n");
-			Slot04 -= 1;
-			inventory.takeItem(useables.DEMSKLL, questItemsBag);
-		}
-		private function questItemsBagSeveredTentacle1Up():void {
-			player.destroyItems(useables.SEVTENT, 1);
-			Slot05 += 1;
-			doNext(questItemsBag);
-		}
-		private function questItemsBagSeveredTentacle1Down():void {
-			outputText("\n");
-			Slot05 -= 1;
-			inventory.takeItem(useables.SEVTENT, questItemsBag);
-		}
-
-		public function roomInExistingStack(itype:ItemType):Number {
-			switch (itype) {
-				case useables.IMPSKLL: if (Slot01 < Slot01Cap) return Slot01;
-					break;
-				case useables.FIMPSKL: if (Slot02 < Slot02Cap) return Slot02;
-					break;
-				case useables.MINOHOR: if (Slot03 < Slot03Cap) return Slot03;
-					break;
-				case useables.DEMSKLL: if (Slot04 < Slot04Cap) return Slot04;
-					break;
-				case useables.SEVTENT: if (Slot05 < Slot05Cap) return Slot05;
-					break;
-			}
-			return -1;
-		}
-		public function placeItemInStack(itype:ItemType):Number {
-			switch (itype) {
-				case useables.IMPSKLL: questItemsBagImpSkull1UP();
-					break;
-				case useables.FIMPSKL: questItemsBagFeralImpSkull1Up();
-					break;
-				case useables.MINOHOR: questItemsBagMinotaurHorns1Up();
-					break;
-				case useables.DEMSKLL: questItemsBagDemonSkull1Up();
-					break;
-				case useables.SEVTENT: questItemsBagSeveredTentacle1Up();
-					break;
-			}
-			return -1;
+			inventory.takeItem(itemType, questItemsBag);
 		}
 	}
 }

--- a/classes/classes/Scenes/Places/Owca.as
+++ b/classes/classes/Scenes/Places/Owca.as
@@ -72,7 +72,7 @@ private function gangbangVillageFirstGoRound():void {
 	else {
 		outputText("Using the vivid memory of your last encounter, you easily find Owca village; the first houses are in sight when you spot someone rushing to you.  You recognize Rebecc, the girl you first met in the plains and who begged you for your help.  She is smiling, her arms open for a welcoming embrace.  Before you even try to say something she is already hugging you, pressing her warm body against yours as she takes you in her arms.  She holds you tightly for a minute before kissing you everywhere affectionately; you haven't said a single word and your cheeks and lips are already bearing the mark of her lipstick.");
 		outputText("\n\n\"<i>Thank you!  Thank you so much, [name]!  You are a wonderful person!  What you did was noble and selfless.  Our people will remember you for years to come!</i>\"");
-		//[if corr >= 50] 
+		//[if corr >= 50]
 		if(player.cor > 50) outputText("  You can't help but smile internally.  Let her think that, if she wants.");
 		outputText("\n\nShe grabs your hand and drags you to her village, hopping joyfully as she keeps thanking you for your heroic gesture.  You finally reach her home; a handful of people join you, attracted by the noise she's been making.  People are everywhere showing unconditional gratitude, bowing down and muttering thankful words as you go by; it's almost as if they were intimidated - or ashamed - by someone worthier than them.  Eventually you are left alone with the charming farmer girl.");
 		outputText("\n\n\"<i>My home is yours, hero; alongside everyone else's.  You will always be welcome here.  Don't hesitate to come to my place; you must feel all dirty and sullied from these corrupted monsters.  Don't worry, I'll clean you up.</i>\"  She winks at you and walks into her house, leaving her door open as an invitation.");
@@ -84,7 +84,7 @@ private function gangbangVillageFirstGoRound():void {
 private function dontGoToZeVillage():void {
 	clearOutput();
 	flags[kFLAGS.DECLINED_TO_VISIT_REBECCS_VILLAGE]++;
-	camp.returnToCampUseOneHour();
+	explorer.done();
 }
 //First plea (Z)
 private function agreeToFollowRebecFirstTime():void {
@@ -104,7 +104,7 @@ private function agreeToFollowRebecFirstTime():void {
 			outputText("\n\nYou are shocked by this revelation. You wrap your arms around Rebecc's shoulders protectively, and tell her in a reassuring tone that ");
 			//[[if silly mode on]
 			if(silly()) outputText("she'll never have to worry about her asshole again.");
-			//[if silly mode off] 
+			//[if silly mode off]
 			else outputText("she will never be abused again.");
 			outputText("  If there's anything that can be done to hold off these evil creatures, you will do it.");
 		}
@@ -161,7 +161,7 @@ private function declineRebeccsPlea():void {
 	//[Attitude is set to 50]
 	if(flags[kFLAGS.OWCAS_ATTITUDE] > 5) flags[kFLAGS.OWCAS_ATTITUDE] -= 5;
 	flags[kFLAGS.TIMES_REFUSED_REBECCS_OFFER]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Accept plea (Z)
 private function acceptRebeccsPlea(firstTime:Boolean = false, sacrificed:Boolean = false):void {
@@ -190,6 +190,7 @@ private function acceptRebeccsPlea(firstTime:Boolean = false, sacrificed:Boolean
 private function intoTheDemonPit(sacrifice:Boolean = true):void {
 	clearOutput();
     spriteSelect(SpriteDb.s_vapula);
+	explorer.stopExploring();
 	//N is the number of hours left before night
 	if(model.time.hours < 21) {
 		var passed:int = 21 - model.time.hours;
@@ -255,7 +256,7 @@ private function fightZeDemons(sacrifice:Boolean = true):void {
 }
 
 
-	
+
 //Loss scene/Submit (gangrape) (Z)
 public function loseOrSubmitToVapula():void {
 	clearOutput();
@@ -350,6 +351,7 @@ public function loseOrSubmitToVapula():void {
 private function wakeUpAfterDemonGangBangs():void {
 	clearOutput();
     spriteSelect(null);
+	explorer.stopExploring();
 	model.time.hours = 7;
 	model.time.days++;
 	outputText("When you wake up, you are alone, and your restraints are broken.  You are sloshing in a pool of stinky juices; your mouth and ears are still full of it.  Your whole body is covered with a thin white layer that must certainly be dried spooge.  Underneath, you're nothing but bruises and every movement seems to hurt.  A few meters away, outside the pit, you notice your items and your gear.  The village itself appears to be empty... your best assumption is that the residents are hiding, either from shame at having sacrificed you or from awkwardness at the prospect of talking to a sloshing, crusty cumdumpster.  Wearily, you head back to your camp.");
@@ -363,10 +365,10 @@ private function wakeUpAfterDemonGangBangs():void {
 	player.addCurse("sen", 1, 2);
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 	//PC is redirected to camp, next morning. No nightly camp scenes or dreams.
 }
-	
+
 //Victory (Z)
 public function defeetVapulasHorde():void {
 	clearOutput();
@@ -453,7 +455,7 @@ public function rapeZeVapula():void {
 		else outputText(player.skinDescript());
 		outputText("!</i>\"  The poor demoness, cheek stained with semen, mutters an apology and proceeds to lick your [cock], suckling the tip, ");
 		if(player.hasBalls()) outputText("fondling your [balls], ");
-		//[if multicocks] 
+		//[if multicocks]
 		if(player.cockTotal() > 1) outputText("alternatively deepthroating or jerking every cock of yours, ");
 		outputText("warming up your dickflesh with her demonic tongue.  You enjoy her ministrations while staring Vapula in the eyes; she has trouble looking back at you as her body trembles and her eyes widen at your sheer display of depravity.  Your semen-dribbling shaft");
 		if(player.cockTotal() > 1) outputText("s harden and thicken ");
@@ -505,7 +507,7 @@ public function rapeZeVapula():void {
 		if(player.vaginalCapacity() > 80) outputText("His cock is lost in your vast cunt and you work him as hard as you can to feel him against your walls, his body convulsing and dazed eyes rolling against the wet, savage rape.  ");
 		outputText("You keep thrusting back and forth, treating the worthless horned boy like a disposable dildo.  As you pump him, you look at Vapula, warning her, \"<i>Don't turn your head.  If you ever look away or close your eyes you will regret it.</i>\" Overwhelmed by your dominance and subdued by the defeat, Vapula can only nod.");
 		outputText("\n\nYou keep working the incubus's hot cock in front of the once-powerful dominatrix, panting as you accelerate the pace until you finally reach your climax, clenching your thighs tightly to his fit body as your " +vaginaDescript()+ " clenches and spasms.  ");
-		//[if squirter] 
+		//[if squirter]
 		if(player.wetness() >= 5) outputText("The sound of spattering fluid fills the air as your cunt spurts its juices around the incubus's cock, coating him in your fragrant slime.  ");
 		outputText("Against your relentless milking pressure he stands no chance and he moans raggedly as he cums in tandem, still incapable of moving his body as your mixed juices dribble down him.");
 		outputText("\n\nNeedless to say, watching this rough session has brought Vapula to a new level of arousal; she is struggling to free her arms and finger herself, but her tight restraints only allow her to wriggle uncomfortably.  Her pussy is gushing of its own accord and she whimpers from time to time, unable to control her lust.");
@@ -519,7 +521,7 @@ public function rapeZeVapula():void {
 		outputText("\n\n\"<i>You!</i>\" you snap. \"<i>Fuck my ass.  Do a good job or I'll wring your neck.  The rest of you worthless spare pricks... gather around.</i>\"  You grip the incubus beneath you with your " +hipDescript()+ " as small, uncertain hands grasp you around your waist and something hot oozes moisture into your " +assholeDescript()+ ".  You thrust forwards and then backwards, simultaneously working the incubus cock whilst driving the imp's meat into your bowels.");
 		if (!recalling) player.buttChange(60,true,true,false);
 		outputText("  Around you more dicks present themselves as other demons slowly draw closer, and with the cock inside you rubbing your sensitive inner walls backwards and forwards you enthusiastically grab two other turgid members and pump them in tandem.  One of the dicks you have grabbed is a sensitive cat dick and the owner is quickly moaning as your fingers brush his hooks; as you feel him reach his peak you ruthlessly jerk him around so he is facing Vapula, and he helplessly spurts his load onto her jiggling frame.  The imp begins to pump harder as he finds his rhythm, stretching your ass wide as he takes you to his plug, rubbing against the huge incubus cock trapped in your " +vaginaDescript(0)+ ".  You laugh breathlessly and manically as the other demon in your grasp helplessly falls over his own peak, further soaking the horny ex-domniatrix.");
-		//[cunt nipples] 
+		//[cunt nipples]
 		if(player.hasFuckableNipples()) outputText("  Your freakish nipples moisten with excitement to the smell of man juice, and you feel your libido ratcheting up even higher.  Bending forward, you grab two other imps with smaller dicks, quickly guiding their lengths into your nipplecunts; they are small enough that you can mash their bodies against your soft flesh, doing all the work for them as your sensitive nubs are penetrated.");
 		outputText("\n\nVapula stares at you through the creamy liquid which now covers her face and tits.  The contact of all this hot demon seed against her untouched body is driving her crazy; after some futile squirming in a desperate attempt to quench her burning pussy, she is now openly sobbing in frustration.");
 		outputText("\n\n\"<i>You're.. you violate my pets... yet you won't deign to touch me.  Why?  D-don't you like my body?  Don't you like my cunt?  Please fuck me, fuck me fuck me, fuckmefuckme....<b>why won't you fuck me?  Please, I need to cum! Please!</b></i>\"");
@@ -546,6 +548,7 @@ public function rapeZeVapula():void {
 		if (!recalling) {
 			dynStats("str", 1, "tou", 1, "cor", 4);
 			player.addCurse("lib", 4, 2);
+			explorer.stopExploring();
 			model.time.hours = 7;
 			model.time.days++;
 			cleanupAfterCombat();
@@ -612,7 +615,7 @@ private function owcaMainScreenOn():void {
 	if (flags[kFLAGS.OWCAS_ATTITUDE] >= 10) addButton(3, "Tavern", owcaTavern).hint("Visit local tavern.");
 	else addButtonDisabled(3, "Tavern", "Req. 10%+ attitude.");
 	if (flags[kFLAGS.KINDRA_FOLLOWER] < 1) addButton(10, "LookAround", meetKindra).hint("Wander around the village.");
-	addButton(14, "Leave", camp.returnToCampUseOneHour).hint("Leave Owca.");
+	addButton(14, "Leave", explorer.done).hint("Leave Owca.");
 }
 
 public function meetKindra():void {
@@ -700,7 +703,7 @@ private function buyOwcaShit(bleh:ItemType,price:Number = 0):void {
 	outputText("The bartender hands you a bottle and grabs your gems before attending other clients, leaving you to your own business.\n\n");
 	inventory.takeItem(bleh, owcaTavern);
 }
-	
+
 //Herds (Z)
 private function herds():void {
 	clearOutput();
@@ -713,9 +716,9 @@ private function herds():void {
 	//[if attitude > 70]
 	if(flags[kFLAGS.OWCAS_ATTITUDE] > 70) {
 		outputText("\n\nThe villagers thank you for your hard work and one of them hands you a bottle of sheep milk.  \"<i>'Tis good for your health.  Don't worry, it won't... mutate you.</i>\"\n\n");
-		inventory.takeItem(consumables.SHEEPMK, camp.returnToCampUseOneHour);
+		inventory.takeItem(consumables.SHEEPMK, explorer.done);
 	}
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //Pit (Z)
@@ -763,7 +766,7 @@ private function rebeccBathScene():void {
 	outputText("\n\nShe grabs hold of a nearby soap and starts lathering it all over your naked body.  You can't see her hands under the moving milky surface but you feel very pleasant tingles in the most intimate places.  She tickles you a bit and you can't help but giggle some more as you feel her delicate hands working you over.");
 	outputText("\n\n\"<i>Shhh... Relax now, soldier.  I'll take care of everything.</i>\"");
 	outputText("\n\nShe first softly brushes your hair with her fingers and strokes your head, then massages every tense muscle at the edge of your face, making you sigh and moan in relief.  Before you even notice, her hands are squeezing and pinching the nape of your neck, completely releasing your tension.  You don't know where she learned to be so good at this, but it just feels so right.  Now her hands are moving downards...  Gods, she is so sweet, so delicate.  You let out another moan, making her chortle.  Putting her head just above yours, her perky tits press against your back.  You can feel her erect nipples gently scratching you as she slowly rubs her appreciable bosom against you; her expert ministrations are arousing you little by little");
-	if(player.gender == 0) outputText("."); 
+	if(player.gender == 0) outputText(".");
 	else {
 		//[if cock]
 		if(player.hasCock()) outputText("; your [cock] grows to full erect size");
@@ -778,7 +781,7 @@ private function rebeccBathScene():void {
 	//Lust +30, Corr -2, Lib +1, slimefeed
 	dynStats("lib", 1, "lus", 30, "cor", -2);
 	player.slimeFeed();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Rebecc Rape scene (for discerning penises) (Z)
 private function rapeRebecc(outside:Boolean = false):void {
@@ -824,7 +827,7 @@ private function rapeRebecc(outside:Boolean = false):void {
 		outputText("\n\nWet sounds fill the air as you thrust your needy cunt into Rebecc's own, your juices dribbling onto and into her, lubricating your unwilling toy.  She whines and again tries to struggle out of the merciless grip you have her in; the effect is to make her own cunt buck and thrust into yours, your slimy lips kissing and moving against each other, heightening your own pleasure and making you scissor into her all the more savagely, already working yourself to a high.  You shove her leg up ruthlessly high so you can really grind into her; you feel her tiny clit bump into your own " + clitDescript() + " and suck in your breath as Rebecc squeals.  Irritated with her constant noise, you bend into the prostrate sheep girl and slap her again, before roaming your hand down her lush front, your fingers landing upon a dark nipple.  You squeeze it as you rub your clits together, her warm flesh wobbling against yours, her own juices dribbling now as you push her relentlessly along the boundary between pain and pleasure until she arches her back and moans in miserable ecstasy, her cunt spasming a gush of girlcum onto you.  You reward her with another slap as she twists in her involuntary orgasm, so that your red hand mark has a partner upon the other side of her face.  It's a good look for her.");
 		//[big clit]
 		if(player.clitLength > 3) outputText("\n\nYou aren't done yet.  Your own clit has long since pushed out of its hood and is bulging with obscene need.  You rotate your hips, teasing Rebecc's dribbling entrance with it whilst immersing yourself in pleasure, rubbing every inch of your sensitive femcock over her lips and hole before forcing yourself against her own tiny pleasure button, making her twitch and moan.  Your lust stoked to incredible heights by the slick pressure on your clit and the sight and feeling of your yielding, insensate victim, you finally thrust it into her slick hole, eager for release.  Clutching her gelatinous ass and firm neck as you fuck her like a man, you're forced to grit your teeth against the unbearably pleasurable sensation of your clit rubbing on her tender inner walls.  Your " + vaginaDescript() + " drools in sympathy as you push your " + hipDescript() + " into the sheep girl and drive her into the ground, fucking her with your clit-dick as hard as you can.   Your pelvises beat a rough staccato against each other as you bring yourself all the way out and then thrust yourself in again, spattering your mixed juices everywhere as you pick up the pace.  Your [allbreasts] are pushed into her own soft pillows as you rub every inch of yourself over her, determined in your lust craze to violate all of this slut's teasing body.");
-		//[other] 
+		//[other]
 		else {
 			outputText("\n\nYou aren't done yet.  Your own clit has long since pushed out of its hood and is bulging with need.   You rotate your hips, teasing Rebecc's dribbling entrance with it whilst immersing yourself in pleasure, rubbing every inch of your sensitive female nub over her lips and hole before forcing yourself against her own tiny pleasure button, making her twitch and moan.  Casually you slap her face again, making her start; the movement translates through her body into your own needy sex as her lips involuntary shrink and rub against yours.  What a lovely sensation!  Your lust stoked to incredible heights by the slick pressure on your clit and the sight and feeling of your yielding, insensate victim, you thrust against her slick hole, eager for your own release.  You scissor her as hard and as violently as you can, slapping into her brutalized sex a few times before embedding yourself and rotating, striking her face carelessly again and again and again.  Her shuddering and sobbing only serves to heighten your pleasure.");
 		}
@@ -852,7 +855,7 @@ private function desperateVillages():void {
 	clearOutput();
 	outputText("As you approach the group of huts, you hear a vague rumble, as if many people were talking at the same time.  Walking closer, you see all the villagers gathering outside and arguing violently; among them, you spot your friend, Rebecc.  As soon as she sees you she hurries over with desperate, wet eyes.");
 	outputText("\n\n\"<i>They want to put you back into the pit by force!  I and some others have tried arguing with them but they won't hear anything!  The demons have been harassing us a lot due to the lack of sacrifices, please do something!</i>\"");
-	outputText("\n\nShe is rudely pushed aside by a tall muscular man with a pitchfork in his hand.  He starts talking in a slow, harsh voice.  \"<i>You supposed to be brave.  Go ahead.  Make sacrifice.  Or do we need to make you brave, be it against your own will?</i>\""); 
+	outputText("\n\nShe is rudely pushed aside by a tall muscular man with a pitchfork in his hand.  He starts talking in a slow, harsh voice.  \"<i>You supposed to be brave.  Go ahead.  Make sacrifice.  Or do we need to make you brave, be it against your own will?</i>\"");
 	outputText("\n\nIt seems that these villagers have grown weary of your repeated refusals; they are likely to react angrily if you deny them another sacrifice.");
 	outputText("\n\nDo you submit?");
 	//Yes/No. Yes leads to Accept Plea, Attitude raised by 10. No to Villagers Fight
@@ -903,7 +906,7 @@ private function torchOwcaMotherFuckers():void {
 	}
 	else doNext(torchUpVillagersAndLeave);
 }
-	
+
 //Fuck off village
 private function torchUpVillagersAndLeave():void {
 	clearOutput();
@@ -936,7 +939,7 @@ private function morningAfterRape():void {
 	outputText("\n\n\"<i>T-they forced you to be abused... I promise I didn't want that!  I tried to convince them... they wouldn't listen... they threw you to the pit... at least I made them give you back your belongings as usual... now you must hate me, don't you?  Oh, I'm so sorry!  It's all my fault!</i>\"");
 	outputText("\n\nWhat do you do?");
 	//Option: Forgive. Sets Attitude to 50, quest goes back to normal.
-	//Option: Rape. Leads to Rebecc Rape scene and ends the quest. 
+	//Option: Rape. Leads to Rebecc Rape scene and ends the quest.
 	//Option: Leave. Redirects PC to camp, next encounter leads to Rebecc's Last Plea
 	simpleChoices("Forgive",forgiveOwca,
 			"Rape", createCallBackFunction(rapeRebecc, false), "", null, "", null, "Leave", fuckThisShit);
@@ -964,7 +967,7 @@ private function fuckThisShit():void {
 	flags[kFLAGS.REBECCS_LAST_PLEA] = 1;
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 //Rebecc's Last Plea (Z)
 private function rebeccsLastPlea():void {
@@ -972,8 +975,8 @@ private function rebeccsLastPlea():void {
 	outputText("As you arrive at the border of the cursed village, you see someone is running in your direction.  You recognize Rebecc instantly; she seems to stumble and stagger at every step, and her face is tear-stricken.  Intrigued, you catch the crying woman by the waist as she runs past you sightlessly; she falls into your arms, nearly tripping as she abandons herself to your embrace.  Unsure of what to do, you ask her why she is panicking, though it takes a while before your words reach her.");
 	outputText("\n\n\"<i>They... they chose me!</i>\" she wails, choking back.  \"<i>They voted and I was chosen to be thrown in the pit!  They're angry at me for befriending you and I was blamed for the recent troubles with the demons!  They think you've abandoned us and I'm responsible for all this... they hate me!  They hate you too!  I'm going to be tied up, abused and broken... and everyone will pretend nothing happened!  I don't want to go to the pit; I don't know what to do!</i>\"");
 	outputText("\n\nWhat do you do?");
-	//(You could rape her.) //Leads to Rebecc Rape scene. 
-	//(You could face the villagers and demons in her stead.) 
+	//(You could rape her.) //Leads to Rebecc Rape scene.
+	//(You could face the villagers and demons in her stead.)
 	//(You could leave.) //End of quest.
 	simpleChoices("Rape Her",createCallBackFunction(rapeRebecc,true),
 			"Face Them All", faceDownHordes, "", null, "", null, "Leave", leaveRebeccToBeRaped);
@@ -985,7 +988,7 @@ private function leaveRebeccToBeRaped():void {
 	//[Owca Village removed from "Places" menu.]
 	outputText("\n\n(Owca has been removed from the 'Places' menu.)");
 	flags[kFLAGS.OWCA_UNLOCKED] = -1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //Option: Face Down the World (Z)
 private function faceDownHordes():void {
@@ -1023,7 +1026,7 @@ private function slaveToVapulaBadEnd():void {
 }
 
 //Subdue Vapula Scene - begins Vapula Follower Content(Z)
-//[Triggered if submissiveness reaches 0 when beating the horde.] 
+//[Triggered if submissiveness reaches 0 when beating the horde.]
 private function subdueVapula():void {
 	clearOutput();
 	outputText("At last, the final demon falls, ");

--- a/classes/classes/Scenes/Places/TelAdre/Loppe.as
+++ b/classes/classes/Scenes/Places/TelAdre/Loppe.as
@@ -285,7 +285,7 @@ private function NoWayLoppe():void {
 
 	outputText("\n\nShe drains her drink and stands up, walking out on you and her snack.");
 	flags[kFLAGS.LOPPE_DISABLED] = 1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[=Okay=]
@@ -311,7 +311,7 @@ private function noLoppesHouse():void {
 	outputText("Loppe gives a disappointed sigh, but smiles at you all the same.  \"<i>I understand... if you ever feel like talking some more, you can find me in the gym.  I need to keep myself in tip-top shape for my dancing shows, after all.</i>\"");
 	outputText("\n\nShe sighs again, picks up her last cookie, and leaves.");
 	//Loppe can now be found in the Gym
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[=Yes=]
@@ -452,7 +452,7 @@ private function talkWithLoppeAboutLoppe():void {
 	outputText("\n\n\"<i>I guess I'll see you later then.</i>\"");
 	//set LoppeChat = 1
 	flags[kFLAGS.TIMES_ASKED_LOPPE_ABOUT_LOPPE] = 1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Children (edited) (C)
@@ -494,7 +494,7 @@ private function noOpinionOnLoppeArt():void {
 	outputText("\n\n\"<i>Just making conversation,</i>\" you reply.");
 
 	outputText("\n\nLoppe nods, finishes her meal quietly, and departs.  \"<i>See you later, [name].</i>\"");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[=Don't Really Want Them=]
@@ -505,7 +505,7 @@ private function loppeIDontReallyWantKidsYouStupidTwat():void {
 	outputText("\n\n\"<i>I see...</i>\" Loppe says, a bit disappointed.  \"<i>Well, it's good to know your opinion on the matter.  If you'll excuse me, I should get back to my exercises.</i>\"");
 
 	outputText("\n\nYou watch her go, then casually remove yourself from your seat and exit.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -516,7 +516,7 @@ private function loppeKidsAreOkayIfYoureARabbitOrSumthin():void {
 	outputText("\n\n\"<i>So, you'll just leave that to chance?  Or are you waiting for that someone special as well?</i>\" Loppe asks.");
 	outputText("\n\nShe grins at you.  \"<i>No need to answer.  I'm sure you'll find someone special if you look.  Anyways, it's good to know your opinion on the matter.  If you'll excuse me, I should get back to my exercises.</i>\"");
 	outputText("\n\nShe rises from her seat and departs.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[=Someday=]
 private function loppeIWantKidsSomedayJeezeQuitHasslingMe():void {
@@ -526,7 +526,7 @@ private function loppeIWantKidsSomedayJeezeQuitHasslingMe():void {
 	outputText("\n\nYou slyly suggest that you'll tell her who you like as soon as she tells you.");
 	outputText("\n\nLoppe grins at you.  \"<i>I might be interested in someone, actually... anyway, it's good to know your opinion on the matter.  If you'll excuse me, I should get back to my exercises.</i>\"");
 	outputText("\n\nYou watch her go, then casually remove yourself from your seat and leave.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[=Soon=]
 private function loppeIWantKidsSoonOkayCanWeFuck():void {
@@ -540,7 +540,7 @@ private function loppeIWantKidsSoonOkayCanWeFuck():void {
 	outputText("\n\nWell, you'll keep that in mind.  Realizing how much time has gone past, you politely excuse yourself.");
 
 	outputText("\n\n\"<i>It was nice chatting with you, [name].  Come visit me soon,</i>\" Loppe says, giving you a little peck on the cheek.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Gossip (edited) (C)
@@ -578,7 +578,7 @@ private function gossipWithLoppeAboutUrta():void {
 	if(flags[kFLAGS.TIMES_FUCKED_URTA] <= 0 || flags[kFLAGS.URTA_COMFORTABLE_WITH_OWN_BODY] == -1) {
 		outputText("\"<i>Ah, so you've met Watch Captain Urta?  She's famous around here, you know; people say she's a legendary bare-knuckle brawler and one of the toughest guards on the force.  The only problem is that she's not really that easy to approach... I guess she prefers to keep to herself.  Although she acts very friendly with that pretty centauress, Edryn.</i>\"");
 		outputText("\n\nLoppe taps her lips thinking of what else she could add, but shrugs.  \"<i>I guess that's all I have on her - I don't really know her that well.  Sorry!</i>\"");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	else if(flags[kFLAGS.LOPPE_URTA_CHATS] == 0) {
 		outputText("Loppe smirks at you.  \"<i>I heard she's been getting along nicely with a certain outsider; you wouldn't happen to know anything about that, would you, [name]?</i>\"");
@@ -603,7 +603,7 @@ private function noLoppeWhosFuckingUrta():void {
 	clearOutput();
 	outputText("You shake your head, claiming that you have no idea what she's talking about.  Loppe looks at you, then shrugs, clearly not caring if you don't have any gossip on the subject to share.");
 	//end scene
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[=It's Me=]
 private function itsMeFuckingUrtaLoppe():void {
@@ -621,7 +621,7 @@ private function itsMeFuckingUrtaLoppe():void {
 	outputText("\n\n\"<i>Perhaps,</i>\" you laugh.");
 	outputText("\n\nLoppe grins encouragingly, as though her offer were completely serious.  \"<i>Well, anyways... I'd say you'd be in more position to gossip about her than I would.  </i>You<i> can tell </i>me<i> about her next time.  For now, I'm going to go work off these calories.</i>\"");
 	dynStats("lus", 10+player.lib/10, "scale", false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 	//End Scene
 }
 
@@ -678,7 +678,7 @@ private function dontLoppesHouse4Fucks():void {
 	outputText("Loppe raspberries you.  \"<i>You tell me you love herms with big horse cocks and now you won't have sex with me?  You're one big tease, [name].</i>\"");
 	outputText("\n\nThe dancer finishes her drink and leaves you, with a sly glance out of the corner of her eye.  It's unlikely that you've heard the last of this...");
 	//return to wherever
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[=Deny=]
@@ -688,7 +688,7 @@ private function denyToLoppeThatYouLoveZeHorsecock():void {
 	outputText("\n\n\"<i>Aww, sugar.  You're no fun...</i>\" Loppe says, pouting at your refusal to play along with her games.  \"<i>But you're really sweet, so I guess I can forgive you.</i>\"  The dancer gets up and gives you a quick peck on the cheek.  \"<i>I should get back to my training now.  I'll see you later!</i>\"");
 	outputText("\n\nLoppe waves and runs off to get back to her routine.");
 	//return to wherever location
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Scylla:
@@ -699,7 +699,7 @@ private function gossipWithLoppeAboutScylla():void {
 	outputText("\n\n\"<i>It's just that she's a nun, y'know?  Or at least looks like one.  I mean... I'm not sure if this is some kind of fetish of hers or she really is a nun, but it'd be just weird to have one sucking me dry.</i>\"");
 	outputText("\n\nSo, Loppe's got no naughty nun fetish.  It's a little surprising to hear her turn down a willing date, though.");
 	outputText("\n\n\"<i>No, I just don't like the idea of a nun blowing me.</i>\"  Loppe states matter-of-factly.  You feel strangely that there's more to this than Loppe's willing to say, but decide to drop it.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Jasun:
@@ -708,7 +708,7 @@ private function gossipWithLoppeAboutJasun():void {
 	outputText("\"<i>The male shark living in the pools of the gym?  Oh boy, is he self-obsessed.  He spends his days swimming and bodybuilding; looks almost cubical because of how much time he spends with the weights and things.  He's also an arrogant prat, but fortunately he's easy to ignore and he doesn't go sticking his nose into trouble.  Just brush him off and he's harmless.</i>\"");
 	outputText("\n\nSounds like Loppe has had to deal with him herself.");
 	outputText("\n\n\"<i>I went for a swim in the pools once, had the inconvenience of running into him,</i>\" Loppe replies.  \"<i>Bastard seems to hate anything and anyone that has a cock of their own; all I did was say hello - I wasn't even trying to flirt - and he tells me to stay away, calls me a floozy!  What a jerk.</i>\"");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function gossipWithLoppeAboutHeckel():void {
@@ -717,7 +717,7 @@ private function gossipWithLoppeAboutHeckel():void {
 	outputText("\n\nAt this, Loppe scowls.  \"<i>Oh, her?  Yeah, I've seen her once or twice.  Thinks she runs the gym.  Alpha bitch my sweet bunny ass...</i>\" she grumbles to herself.  \"<i>Her name's Heckel.  Don't know too much about her except she wandered in from the plains one day; she lives to prove she's stronger than everyone, and she's a real jerkass.  Why do you ask?</i>\"");
 	outputText("\n\nYou shrug. At that, she shakes her head.  \"<i>Maybe there's more than what you see with her, but she's too caught up in that precious 'queen bitch of the universe' routine of hers.  I don't mind catching, but I expect a little respect while I do it - I am not going to let anyone just throw me down, bust their nut in my ass and then fall asleep on me.</i>\"  She lets out an indignant huff at the thought.  \"<i>Plus, you try and compliment her on anything about her femininity, she goes nuts!  Personally, I wouldn't be too surprised to hear she used to be a guy and she's overcompensating since she grew a pussy and boobs.</i>\"");
 	outputText("\n\nLoppe obviously doesn't like her too much, and her expression warns you to cut the conversation short and thank her for the info.  \"<i>Sure thing, sugar.  Sorry, she and I... didn't exactly have a pleasant acquaintanceship.  I do my best to stay out of her way, but if she ever tries to bully me, well, I'll stand up for myself.</i>\"");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Edryn:
@@ -726,7 +726,7 @@ private function gossipWithLoppeAboutEdryn():void {
 	outputText("\"<i>That pretty centauress watchwoman that hangs in the Wet Bitch when she's off duty?  Yes, it's no secret that she specializes in particular sorts of wetwork for those with... compatible endowments,</i>\" Loppe says, giving you a lecherous wink.");
 	outputText("\n\nSomething in her look suggests a question to you.");
 	outputText("\n\n\"<i>Well... maybe I've used her once or twice,</i>\" the dancer admits.  \"<i>But she costs 200 gems a ride and, frankly, she thinks I overdo things too much, so she wouldn't have me back even if I wanted to pay that much.</i>\"  Loppe looks rather sheepish as she smiles nervously, then looks right at you.  \"<i>Well... I shouldn't need her anyways, right?  Not as long as you come see me once in a while.</i>\"");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Lottie:
@@ -744,7 +744,7 @@ private function gossipWithLoppeAboutLottie():void {
 	else {
 		outputText("\n\n\"<i>I thought about helping, but I'm not very good at training others.  I'm afraid if I did invite her to work out with me, and I mean actually work out, I'd kill her from exhaustion; I tend to get a bit carried away, and she is, well, let's just say she doesn't really look like she's ever tried seriously working out before.  I actually talked to her a little, once, and it looks like she's always tried fad dieting before now.</i>\"  Loppe smiles nervously.");
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Cotton:
@@ -753,7 +753,7 @@ private function gossipWithLoppeAboutCotton():void {
 	outputText("\"<i>That pretty horse-girl that's always practicing yoga?  Not really, but she looks friendly.  As does that beast in her shorts.</i>\"  Loppe flinches at the memory of it.  \"<i>I'm very familiar with Cotton's not so little friend... though you'll find out that size isn't everything, sugar.  For instance, can she last long enough to fuck every little ounce of energy out of you?  I don't think so...</i>\"");
 	outputText("\n\nUncharacteristically defensive... perhaps Loppe has a bit of a complex?");
 	outputText("\n\nThe dancer giggles, snapping you out of your musing.  \"<i>That technique she has is something, but mine's not bad either.  I'm game for some fun anytime, especially if it's with a cutie like you, sugar.</i>\" She reaches out to give your cheek a small caress.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Working (edited)
@@ -770,7 +770,7 @@ private function talkWithLoppeAboutWorking():void {
 	outputText("\n\n\"<i>Oh, ok.  I should get back to my exercises anyways.</i>\"  Loppe gets up and gives you a little peck on the cheek.  \"<i>It was nice chatting with you; come see me soon.</i>\"");
 	//set LoppeChat = 2
 	flags[kFLAGS.TIMES_ASKED_LOPPE_ABOUT_LOPPE] = 2;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Her Mother (edited)
@@ -804,11 +804,11 @@ private function chatWithLoppeAboutHerMom():void {
 	if (flags[kFLAGS.LOPPE_PC_MET_UMA] == 0)
 	{
 		addButton(0, "Visit Mom", telAdre.umasShop.firstVisitPart1);
-		addButton(1, "Mebbe Later", camp.returnToCampUseOneHour);
+		addButton(1, "Mebbe Later", explorer.done);
 	}
 	else
 	{
-		addButton(0, "Next", camp.returnToCampUseOneHour);
+		addButton(0, "Next", explorer.done);
 	}
 
 }
@@ -826,7 +826,7 @@ private function chatWithLoppeAboutLoppesVillage():void {
 	outputText("\n\nYou nod in understanding, moving the conversation back to her dancing.  \"<i>Well, there's no story to it, sugar; dancing is dancing.  It's just something we loved to do in the village.  Oh, there are stories behind individual dances, roles they're intended to be used to act out, but mostly it's just our favorite way of unwinding and cutting loose.  I always admired the beautiful dancers when I was growing up.  When I realized just how good on my feet I was, I started practicing and, well, here I am.</i>\"");
 
 	outputText("\n\nTo demonstrate, she finishes her last mouthful and hops nimbly from her chair to her feet.  \"<i>I'll see you soon, sweet.</i>\"");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Sex
@@ -1203,6 +1203,7 @@ private function loppeRidesPCCockFinal():void {
 	flags[kFLAGS.LOPPE_TIMES_SEXED]++;
 	loppeKnockupAttempt();
 	//3 hours pass.
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseFourHours);
 }
 
@@ -1295,6 +1296,7 @@ private function loppeWorshipsDicks():void {
 	player.trainStat("lib", +1, player.trainStatCap("lib",100));
 	player.trainStat("tou", +1, player.trainStatCap("tou",75));
 	flags[kFLAGS.LOPPE_TIMES_SEXED]++;
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseFourHours);
 }
 
@@ -1452,6 +1454,7 @@ private function getFuckedInYerTwatYaCunt():void {
 	dynStats("tou", .5, "lib", .5, "sen", -4);
 	player.trainStat("lib", +1, player.trainStatCap("lib",100));
 	player.trainStat("tou", +1, player.trainStatCap("tou",75));
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseFourHours);
 }
 
@@ -1619,6 +1622,7 @@ private function getButtFuckedNonHoarseByLoppe():void {
 	dynStats("tou", .5, "lib", .5, "sen", -4);
 	player.trainStat("lib", +1, player.trainStatCap("lib",100));
 	player.trainStat("tou", +1, player.trainStatCap("tou",75));
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseFourHours);
 }
 
@@ -1766,6 +1770,7 @@ private function getAssFuckedByLoppeAsACentaur():void {
 	player.trainStat("lib", +1, player.trainStatCap("lib",100));
 	player.trainStat("tou", +1, player.trainStatCap("tou",75));
 	flags[kFLAGS.LOPPE_TIMES_SEXED]++;
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseFourHours);
 }
 
@@ -1886,7 +1891,7 @@ private function letsLoppeGoCum():void {
 	flags[kFLAGS.LOPPE_DENIAL_COUNTER] = 3;
 	dynStats("lus", 30+player.lib/10, "scale", false);
 	flags[kFLAGS.LOPPE_TIMES_SEXED]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[=Hold=]
 private function superLoppeOrgasmDenialGo():void {
@@ -1928,7 +1933,7 @@ private function superLoppeOrgasmDenialGo():void {
 	}
 	dynStats("lus", 30+player.lib/10, "scale", false);
 	flags[kFLAGS.LOPPE_TIMES_SEXED]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -2033,6 +2038,7 @@ private function boobjobLoppe():void {
 		dynStats("tou", .5, "lib", .5, "sen", -4);
 		player.trainStat("lib", +1, player.trainStatCap("lib",100));
 		player.trainStat("tou", +1, player.trainStatCap("tou",75));
+		explorer.stopExploring();
 		doNext(camp.returnToCampUseFourHours);
 	}
 }
@@ -2150,7 +2156,7 @@ private function teaseLoppeNHJ():void {
 	//If FertileLoppe flag is not active, no special effects
 	//If FertileLoppe flag is active, PC who can become pregnant who uses the Goblin Machine at the Gym will become pregnant with Loppe-daughter if they use it within a week of playing this scene
 	dynStats("lus", 10+player.lib/5, "scale", false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //Suck (edited)(C)
@@ -2229,7 +2235,7 @@ private function teaseLoppeNSuck():void {
 	//[=Refuse=]
 	outputText("\n\nLoppe smiles at you, holding her cock in her hand.  \"<i>Alright then, sugar.  I'll be going in then; I have business to handle.  See you later!</i>\"");
 	dynStats("lus", 10+player.lib/5, "scale", false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 	player.slimeFeed();
 }
 
@@ -2245,7 +2251,7 @@ private function teaseLoppeKissRun():void {
 	outputText("\n\nYou advise her to order herself something sweet, sit back, relax, and just try to cool off - it'll go down on its own.  Eventually.");
 
 	dynStats("lus", 5+player.lib/20, "cor", .5);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function talkAboutKids():void {
@@ -2300,7 +2306,7 @@ private function tellUsagiAboutLoppeYes():void {
 	outputText("You guide the lagomorph to Tel'Adre and show her where Uma's shop is, but tell her to go in alone as you don't want to interrupt their reunion.[pg]");
 	outputText("“<i>I cannot thank you enough [name], I will forever be in your debt for this!</i>” she cries as she goes bounding toward Uma's shop. You smile as you head back to camp, you can wait for another day to hear from Loppe how the reunion went.[pg]");
 	usagiHasReturned = true;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function tellUsagiAboutLoppeNo():void {
@@ -2309,7 +2315,7 @@ private function tellUsagiAboutLoppeNo():void {
 		outputText("You decide not to tell her about Loppe and Uma surviving and now living in Tel'Adre for the moment.[pg]");
 	}
 	outputText("Kneeling down next to the lagomorph, you put a hand to her shoulder, trying to comfort her, but to no avail. She will not be consoled so easily so you bid her farewell and head back to camp.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function usagiReturns():void {
@@ -2492,6 +2498,7 @@ private function snuggleNap():void {
 	outputText("You wake slowly after about two hours to yourself lying next to Loppe, being cuddled by her. You feel a soft kick from her belly pressed against you and realise that must be what woke you. You look over at your lover, still snoozing like a baby. Weird, usually she wakes up before you. You slowly get up from her bed, careful not to wake your slumbering soulmate and get ready to leave. Bewfore you do, you watch her sleep with such a dreamy look on her face, as one of her hands unconsciously rubs her baby bump. The normally lust-driven bunny-girl, now reduced to the sleeping beauty before your eyes. You can’t help but feel proud of your handy work. You reach down and feel her pregnant belly, rubbing it softly. [pg]");
 	outputText("Suddenly, Loppe’s eyelids begin to flutter open. You are startled as she suddenly begins moving, trying to sit up. “Hmm... hello?” she says, clearly still half-asleep. You chuckle, helping her up, telling her you’re still here. She wipes the rheum from her eyes and turns to face you before a smile breaks across her face. “<i>Oh [name], I didn’t expect you to... yawns... still be here</i>”. She wraps her arms around you, pulling you in for a deep kiss. The two of you hold that kiss for a good long while before finally breaking it.[pg]");
 	outputText("“<i>Today was lovely, please, feel free to make this a habit.</i>” she says with a lazy smile. You thank her and tell her to take care of herself. At this, you bid your farewell and finally depart.")
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseTwoHours);
 }
 
@@ -2516,21 +2523,21 @@ private function loppePreggoMassage():void {
 	clearOutput();
 	outputText("SCENE NEEDS WRITING[pg]");
 	outputText("Give Loppe a nice massage to ease the tensions from those hyper kits she's lugging around[pg]");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function loppePreggoGetFucked():void {
 	clearOutput();
 	outputText("SCENE NEEDS WRITING[pg]");
 	outputText("Loppe gets fucked with emphasis on how kinky it is, already being pregnant[pg]");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function loppePreggoFuckPC():void {
 	clearOutput();
 	outputText("SCENE NEEDS WRITING[pg]");
 	outputText("Loppe slowly fucks PC with a lot of emphasis on trying to put one in the oven to have mutual preggo[pg]");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function pcGivesBirthToLoppeKits(womb:int = 0):void {

--- a/classes/classes/Scenes/Places/TelAdre/Niamh.as
+++ b/classes/classes/Scenes/Places/TelAdre/Niamh.as
@@ -197,7 +197,7 @@ private function drinkNiamhsBeerInTelAdre():void {
 		outputText(" breasts have had the last of their beer squeezed from them.  She sighs in relief, caressing her shrunken breasts; while still hovering at around G-cup size, they're much smaller than they are when the day starts for her.  \"<i>Me thanks for the business; ye got the last mug for today.  Still, I'll be here tomorrow, full as ever.</i>\" She sighs softly.  \"<i>I regret to say that Niamh's Black Cat Beer doesn't look to be going out of business anytime soon.</i>\"  She stands and gathers her coat, slipping her arms into the sleeves.  The nimble girl draws the garment across her buxom chest, buttoning the slightly strained buttons with deceptive ease.  Dressed properly, she starts away, a bag full of gems bouncing against her swaying hips. You watch her go, staring at her back until she walks out the door.");
 	}
 	flags[kFLAGS.MET_NIAMH]++;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[To Go]
@@ -249,7 +249,7 @@ private function talkToNiamh():void {
 	var beer:Function =null;
 	if(player.gems >= 2)
 		beer = getANiamhBeer;
-	simpleChoices("Beer", beer, "", null, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+	simpleChoices("Beer", beer, "", null, "", null, "", null, "Leave", explorer.done);
 }
 //Leave
 private function leaveNiamh():void {
@@ -361,7 +361,7 @@ private function giveNiamphBimboLiquer():void {
 	//}
 	flags[kFLAGS.NIAMH_MOVED_OUT_COUNTER] = 25;
 	dynStats("cor", 10);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //24 hours later, random encounter on the Plains
@@ -394,7 +394,7 @@ public function niamhPostTelAdreMoveOut():void {
 private function niamhCorruptMobileSnackTurnDown():void {
 	clearOutput();
 	outputText("You turn her down, fabricating a little tale about how you just got done drinking a delicious beverage, and you couldn't possibly have anything more.  She nods sagely, pauses, and loudly belches.  Even in her soused state, she retains some semblance of manners, so she chuckles nervously while moving a hand to her lips.  \"<i>Sorry 'bout tha'...</i>\" she mutters, slinking off.  You have a feeling you'll see her again.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[yup]
 private function niamhCorruptedMobileSnackDrinkTime():void {
@@ -432,7 +432,7 @@ private function niamhCorruptedMobileSnackDrinkTime():void {
 		blackCatBeerEffects(player,false,true);
 		//[end encounter]
 	}*/
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function bimboChampagne(player:Player,clearScreen:Boolean,intro:Boolean):void {
 	if(clearScreen) clearOutput();
@@ -550,7 +550,7 @@ private function drinkFromZeTap():void {
 
 	outputText("\n\nYou push yourself upright and assure the pretty catgirl that you feel, like, super-duper wonderful!  You punctuate this declaration with a burp as the sudden motion makes all the yummy bubbles in your belly dance, and then you giggle at how naughty that was.");
 	bimboChampagne(player,false,false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //grabbing Bim Cham in a to-go box
@@ -561,7 +561,7 @@ private function getBimboChampFromNiamh():void {
 	outputText("\n\nPushing that slightly scary thought to the side, you lean in, firmly grasping one stiff nipple and forcing it to the mouth of your container.  Ignoring her increasingly loud and frequent groans, you dutifully milk the bubbly into the flask, stopper it up, and rise.  Niamh tries to follow you, too aroused by the milking to resist her carnal urges, but you easily push her to the side, her ponderous melons throwing her off balance.");
 	outputText("\n\nShe lands into a big pile of similarly blonde and giggling girls who waste no time in swarming her.  You chuckle and shake your head.  Perhaps you'll come back later.\n\n");
 	//bimbo champagne aqua-aired
-	inventory.takeItem(consumables.BIMBOCH, camp.returnToCampUseOneHour);
+	inventory.takeItem(consumables.BIMBOCH, explorer.done);
 }
 
 //[Bazaar sex]
@@ -582,7 +582,7 @@ private function bazaarSex():void {
 		dynStats("int", -.5, "sen", -2);
 	//}
 	//Succubi NYI
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -635,7 +635,7 @@ private function leaveWithBeerTits():void {
 	clearOutput();
 	outputText("The offer is tempting but right now you'd much rather deal with your boozy boobs privately.  You take off while trying to keep your [armor] modestly in place over your tits but it's difficult.  Your nipples constantly leak and drip a trail of alcohol all the way back to camp.  Thankfully by the time you arrive the effects seem to have mostly worn off.  Your nipples return to dripping milk, but although they've shrunk back down a bit they don't quite shrink all the way, leaving you with somewhat larger endowments than you had before.");
 	player.growTits(2, player.bRows(), false, 2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 // [SELL YOUR BOOZE]
@@ -665,7 +665,7 @@ private function sellYourBooze():void {
 		player.growTits(2, player.bRows(), false, 2);
 		outputText("\n\nYou feel flushed from the sensations, but finally you run dry.  Your breasts have shrunk back down, but they still feel a little larger than they were earlier.  As little droplets of milk instead of booze return to dripping from your nipples, Niamh hands you your cut of the gems you earned from the sales.");
 		//[LEAVE]
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	//If lust is high
 	else {
@@ -886,7 +886,7 @@ private function barBeerOrgyTits():void {
 		player.growTits(2, player.bRows(), false, 2);
 	}
 	player.orgasm();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 

--- a/classes/classes/Scenes/QuestLib.as
+++ b/classes/classes/Scenes/QuestLib.as
@@ -1,0 +1,105 @@
+package classes.Scenes {
+import classes.BaseContent;
+import classes.Scenes.API.AbstractQuest;
+import classes.Scenes.Places.HeXinDao.AdventurerGuild;
+import classes.Scenes.Quests.FactoryQuest;
+import classes.Scenes.Quests.SimpleGuildQuest;
+import classes.Scenes.Quests.ZetazQuest;
+import classes.StatusEffects;
+
+public class QuestLib extends BaseContent {
+	
+	// Quest groups
+	public static const QGRP_MAIN:String   = "Main";
+	public static const QGRP_SIDE:String   = "Side";
+	public static const QGRP_AGUILD:String = "Adv. Guild";
+	public static const QGRP_OTHER:String  = "Other";
+	
+	// Main quets
+	public const MQ_Factory:FactoryQuest = new FactoryQuest();
+	public const MQ_Zetaz:ZetazQuest = new ZetazQuest();
+	
+	// Adv. Guild quests
+	
+	public const AGQ_Imps:SimpleGuildQuest      =
+						 new SimpleGuildQuest(
+								 "AGQ_Imps",
+								 "Imps Hunt",
+								 AdventurerGuild.RANK_COPPER,
+								 useables.IMPSKLL,[3, 4, 5],
+								 StatusEffects.AdventureGuildQuests1,1
+						 );
+	public const AGQ_Demons:SimpleGuildQuest    =
+						 new SimpleGuildQuest(
+								 "AGQ_Demons",
+								 "Demons Hunt",
+								 AdventurerGuild.RANK_IRON,
+								 useables.DEMSKLL,[1, 2, 3],
+								 StatusEffects.AdventureGuildQuests1,2
+						 );
+	public const AGQ_Minotaurs:SimpleGuildQuest =
+						 new SimpleGuildQuest(
+								 "AGQ_Minotaurs",
+								 "Minotaurs Hunt",
+								 AdventurerGuild.RANK_COPPER,
+								 useables.MINOHOR,[2, 3, 4],
+								 StatusEffects.AdventureGuildQuests1,3
+						 );
+	public const AGQ_FeralImps:SimpleGuildQuest =
+						 new SimpleGuildQuest(
+								 "AGQ_FeralImps",
+								 "Feral Imps Hunt",
+								 AdventurerGuild.RANK_COPPER,
+								 useables.FIMPSKL,[3, 4, 5],
+								 StatusEffects.AdventureGuildQuests2,2
+						 );
+	public const AGQ_FeralTB:SimpleGuildQuest   =
+						 new SimpleGuildQuest(
+								 "AGQ_FeralTB",
+								 "Feral Tentacle Beasts Hunt",
+								 AdventurerGuild.RANK_COPPER,
+								 useables.SEVTENT, [1, 2, 3],
+								 StatusEffects.AdventureGuildQuests2, 1
+						 );
+	public const AGQ_Gel:SimpleGuildQuest       =
+						 new SimpleGuildQuest(
+								 "AGQ_Gel",
+								 "Green Gel Gathering",
+								 AdventurerGuild.RANK_COPPER,
+								 useables.GREENGL, [3, 4, 5],
+								 StatusEffects.AdventureGuildQuests4, 2
+						 );
+	public const AGQ_Chitin:SimpleGuildQuest    =
+						 new SimpleGuildQuest(
+								 "AGQ_Chitin",
+								 "Black Chitin Gathering",
+								 AdventurerGuild.RANK_COPPER,
+								 useables.B_CHITN, [3, 4, 5],
+								 StatusEffects.AdventureGuildQuests4, 1
+						 );
+	
+	public function allQuests(group:String=null):/*AbstractQuest*/Array {
+		if (group != null) {
+			return AbstractQuest.ALL_QUESTS_LIST.filter(function (q:AbstractQuest, i:*, j:*):Boolean {
+				return q.group == group;
+			});
+		} else {
+			return AbstractQuest.ALL_QUESTS_LIST.slice();
+		}
+	}
+	public function allKnownQuests(group:String=null):/*AbstractQuest*/Array {
+		if (group != null) {
+			return AbstractQuest.ALL_QUESTS_LIST.filter(function (q:AbstractQuest, i:*, j:*):Boolean {
+				return q.group == group && q.isKnown;
+			});
+		} else {
+			return AbstractQuest.ALL_QUESTS_LIST.filter(function (q:AbstractQuest, i:*, j:*):Boolean {
+				return q.isKnown;
+			});
+		}
+	}
+	
+	public function QuestLib() {
+	}
+}
+}

--- a/classes/classes/Scenes/Questlog.as
+++ b/classes/classes/Scenes/Questlog.as
@@ -2,33 +2,51 @@
  * ...
  * @author Ormael
  */
-package classes.Scenes 
+package classes.Scenes
 {
 import classes.BaseContent;
 import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.API.AbstractQuest;
 import classes.StatusEffects;
 
 public class Questlog extends BaseContent
 	{
 		
-		public function Questlog() 
+		public function Questlog()
 		{}
+		
+		public function printQuest(quest:AbstractQuest):void {
+			if (!quest.isKnown) {
+				var hint:String = quest.hintToUnlock;
+				outputText("<b>???</b>");
+				if (hint) outputText(" <i>("+hint+")</i>");
+				outputText("\n");
+			} else {
+				outputText("<b>"+quest.title+" ("+quest.statusName(true)+")</b>: ");
+				outputText(quest.description);
+				if (quest.objectives().length > 0) {
+					outputText("<ul><li>" +
+							quest.formattedObjectives(true).join("</li><li>") +
+							"</li></ul>"
+					);
+				} else {
+					outputText("\n");
+				}
+			}
+		}
+		public function printQuestGroup(group:String):void {
+			for each(var quest:AbstractQuest in questLib.allQuests(group)) {
+				printQuest(quest);
+			}
+		}
 		
 		public function accessQuestlogMainMenu():void {
 			clearOutput();
-			outputText("List of all not-started, not yet completed and completed quests. After finishing each of them PC could pick reward but... <i>You only need to click once fool</i>\n");
-			outputText("\n<u><b>Main Quests</b></u>");
-			outputText("\n<b>Shut Down Everything:</b> ");
-			if (flags[kFLAGS.FACTORY_OMNIBUS_DEFEATED] == 2) outputText("Completed (Reward taken)");
-			else if (SceneLib.dungeons.checkFactoryClear()) outputText("Completed");
-			else if (flags[kFLAGS.FACTORY_FOUND] > 0) outputText("In Progress");
-			else outputText("Not Started");
-			outputText("\n<b>You're in Deep:</b> ");
-			if (flags[kFLAGS.DEFEATED_ZETAZ] > 1) outputText("Completed (Reward taken)");
-			else if (SceneLib.dungeons.checkDeepCaveClear()) outputText("Completed");
-			else if (flags[kFLAGS.DISCOVERED_DUNGEON_2_ZETAZ] > 0) outputText("In Progress");
-			else outputText("Not Started");
-			outputText("\n<b>Chimera Squad:</b> ");
+			outputText("List of all not-started, not yet completed and completed quests. After finishing each of them PC could pick reward but... <i>You only need to click once fool</i>");
+			
+			outputText("\n\n<u><b>Main Quests</b></u>\n");
+			printQuestGroup(QuestLib.QGRP_MAIN);
+			outputText("<b>Chimera Squad:</b> ");
 			if (flags[kFLAGS.DEMON_LABORATORY_DISCOVERED] > 1) outputText("Completed (Reward taken)");
 			else if (SceneLib.dungeons.checkDemonLaboratoryClear()) outputText("Completed");
 			else if (flags[kFLAGS.DEMON_LABORATORY_DISCOVERED] == 1) outputText("In Progress");
@@ -38,7 +56,9 @@ public class Questlog extends BaseContent
 			else if (SceneLib.dungeons.checkLethiceStrongholdClear()) outputText("Completed");
 			else if (flags[kFLAGS.D3_DISCOVERED] > 0) outputText("In Progress (to complete this quest PC must beat either Basilisk Boss or Mirror Demon)");
 			else outputText("Not Started");
-			outputText("\n\n<u><b>Side Quests</b></u>");
+			
+			outputText("\n\n<u><b>Side Quests</b></u>\n");
+			printQuestGroup(QuestLib.QGRP_SIDE);
 			outputText("\n<b>Friend of the Sand Witches:</b> ");
 			if (flags[kFLAGS.DISCOVERED_WITCH_DUNGEON] == 2) outputText("Completed (Reward taken)");
 			else if (SceneLib.dungeons.checkSandCaveClear()) outputText("Completed");
@@ -68,6 +88,7 @@ public class Questlog extends BaseContent
 			else if (SceneLib.dungeons.checkDenOfDesireClear()) outputText("Completed");
 			else if (flags[kFLAGS.DEN_OF_DESIRE_BOSSES] > 1) outputText("In Progress");
 			else outputText("Not Started");
+			
 			outputText("\n\n<u><b>River Dungeon Exploration</b></u>");
 			outputText("\n<b>1st Floor:</b> ");
 			if (SceneLib.dungeons.checkRiverDungeon1stFloorClear()) {
@@ -94,40 +115,15 @@ public class Questlog extends BaseContent
 			}
 			else outputText("Not Started/In Progress");
 			outputText("\n<i><b>5th Floor:</b> Soon</i>");
-			outputText("\n\n<u><b>Adventure Guild Quests</b></u>");
-			outputText("\n<b>Imps Hunt:</b> ");
-			if (player.statusEffectv1(StatusEffects.AdventureGuildQuests1) == 2 || player.statusEffectv1(StatusEffects.AdventureGuildQuests1) == 4 || player.statusEffectv1(StatusEffects.AdventureGuildQuests1) == 7) outputText("Completed (for today)");
-			else if (player.statusEffectv1(StatusEffects.AdventureGuildQuests1) == 1 || player.statusEffectv1(StatusEffects.AdventureGuildQuests1) == 3 || player.statusEffectv1(StatusEffects.AdventureGuildQuests1) == 6) outputText("In Progress");
-			else outputText("Not Started");
-			outputText("\n<b>Demons Hunt:</b> ");
-			if (player.statusEffectv2(StatusEffects.AdventureGuildQuests1) == 2 || player.statusEffectv2(StatusEffects.AdventureGuildQuests1) == 4 || player.statusEffectv2(StatusEffects.AdventureGuildQuests1) == 7) outputText("Completed (for today)");
-			else if (player.statusEffectv2(StatusEffects.AdventureGuildQuests1) == 1 || player.statusEffectv2(StatusEffects.AdventureGuildQuests1) == 3 || player.statusEffectv2(StatusEffects.AdventureGuildQuests1) == 6) outputText("In Progress");
-			else outputText("Not Started");
-			outputText("\n<b>Minotaurs Hunt:</b> ");
-			if (player.statusEffectv3(StatusEffects.AdventureGuildQuests1) == 2 || player.statusEffectv3(StatusEffects.AdventureGuildQuests1) == 4 || player.statusEffectv3(StatusEffects.AdventureGuildQuests1) == 7) outputText("Completed (for today)");
-			else if (player.statusEffectv3(StatusEffects.AdventureGuildQuests1) == 1 || player.statusEffectv3(StatusEffects.AdventureGuildQuests1) == 3 || player.statusEffectv3(StatusEffects.AdventureGuildQuests1) == 6) outputText("In Progress");
-			else outputText("Not Started");
-			outputText("\n<b>Feral Imps Hunt:</b> ");
-			if (player.statusEffectv2(StatusEffects.AdventureGuildQuests2) == 2 || player.statusEffectv2(StatusEffects.AdventureGuildQuests2) == 4 || player.statusEffectv2(StatusEffects.AdventureGuildQuests2) == 7) outputText("Completed (for today)");
-			else if (player.statusEffectv2(StatusEffects.AdventureGuildQuests2) == 1 || player.statusEffectv2(StatusEffects.AdventureGuildQuests2) == 3 || player.statusEffectv2(StatusEffects.AdventureGuildQuests2) == 6) outputText("In Progress");
-			else outputText("Not Started");
-			outputText("\n<b>Feral Tentacle Beasts Hunt:</b> ");
-			if (player.statusEffectv1(StatusEffects.AdventureGuildQuests2) == 2 || player.statusEffectv1(StatusEffects.AdventureGuildQuests2) == 4 || player.statusEffectv1(StatusEffects.AdventureGuildQuests2) == 7) outputText("Completed (for today)");
-			else if (player.statusEffectv1(StatusEffects.AdventureGuildQuests2) == 1 || player.statusEffectv1(StatusEffects.AdventureGuildQuests2) == 3 || player.statusEffectv1(StatusEffects.AdventureGuildQuests2) == 6) outputText("In Progress");
-			else outputText("Not Started");
-			outputText("\n<i><b>Feral Demons Hunt:</b> Soon</i>");
-			outputText("\n<b>Green Gel Gathering:</b> ");
-			if (player.statusEffectv2(StatusEffects.AdventureGuildQuests4) == 2 || player.statusEffectv2(StatusEffects.AdventureGuildQuests4) == 5) outputText("Completed (for today)");
-			else if (player.statusEffectv2(StatusEffects.AdventureGuildQuests4) == 1 || player.statusEffectv2(StatusEffects.AdventureGuildQuests4) == 4) outputText("In Progress");
-			else outputText("Not Started");
-			outputText("\n<b>Black Chitin Gathering:</b> ");
-			if (player.statusEffectv1(StatusEffects.AdventureGuildQuests4) == 2 || player.statusEffectv1(StatusEffects.AdventureGuildQuests4) == 5) outputText("Completed (for today)");
-			else if (player.statusEffectv1(StatusEffects.AdventureGuildQuests4) == 1 || player.statusEffectv1(StatusEffects.AdventureGuildQuests4) == 4) outputText("In Progress");
-			else outputText("Not Started");
-			outputText("\n<i><b>Spider-silk Gathering:</b> Very Soon</i>");
-			//outputText("\n<i><b>Dragonscale Gathering:</b> Soon</i>");
-			outputText("\n<i><b>Ebonbloom Gathering:</b> Soon</i>");
-			//outputText("\n<i><b>World Tree Branch Gathering:</b> Soon</i>");
+
+			outputText("\n\n<u><b>Adventure Guild Quests</b></u>\n");
+			printQuestGroup(QuestLib.QGRP_AGUILD);
+			outputText("<i><b>Feral Demons Hunt:</b> Soon</i>\n");
+			outputText("<i><b>Spider-silk Gathering:</b> Very Soon</i>\n");
+			//outputText("<i><b>Dragonscale Gathering:</b> Soon</i>\n");
+			outputText("<i><b>Ebonbloom Gathering:</b> Soon</i>\n");
+			//outputText("<i><b>World Tree Branch Gathering:</b> Soon</i>\n");
+			
 			outputText("\n\n<u><b>Twilight of the Gods</b></u>");
 			outputText("\n<b>Feral Imps Capture:</b> ");
 			if (flags[kFLAGS.GALIA_LVL_UP] >= 0.5) outputText("Completed");
@@ -137,9 +133,13 @@ public class Questlog extends BaseContent
 			outputText("\n<i><b>Feral Tentacle Beasts Capture:</b> Very Soon</i>");
 			/*if () outputText("\n\n<u><b>The New Dawn</b></u>");
 			else outputText("\n<b>???</b>");*/
+			
+			outputText("\n\n<u><b>Other Quests</b></u>\n");
+			printQuestGroup(QuestLib.QGRP_OTHER);
+			
 			menu();
-			if (SceneLib.dungeons.checkFactoryClear() && flags[kFLAGS.FACTORY_OMNIBUS_DEFEATED] < 2) addButton(0, "Factory", takeRewardForFactory);
-			if (SceneLib.dungeons.checkDeepCaveClear() && flags[kFLAGS.DEFEATED_ZETAZ] < 2) addButton(1, "Deep Cave", takeRewardForDeepCave);
+			if (questLib.MQ_Factory.factoryCleared && !questLib.MQ_Factory.perkRewardTaken) addButton(0, "Factory", takeRewardForFactory);
+			if (questLib.MQ_Zetaz.dungeonCleared && !questLib.MQ_Zetaz.perkRewardTaken) addButton(1, "Deep Cave", takeRewardForDeepCave);
 			if (SceneLib.dungeons.checkDemonLaboratoryClear() && flags[kFLAGS.DEMON_LABORATORY_DISCOVERED] < 2) addButton(2, "Demon Laboratory", takeRewardForDemonLaboratory);
 			//button 4 - ?Demon Mine?
 			if (SceneLib.dungeons.checkLethiceStrongholdClear() && flags[kFLAGS.LETHICE_DEFEATED] < 2) addButton(3, "Stronghold", takeRewardForStronghold);

--- a/classes/classes/Scenes/Quests/FactoryQuest.as
+++ b/classes/classes/Scenes/Quests/FactoryQuest.as
@@ -1,0 +1,106 @@
+package classes.Scenes.Quests {
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.API.AbstractQuest;
+import classes.Scenes.QuestLib;
+import classes.Scenes.SceneLib;
+
+public class FactoryQuest extends AbstractQuest {
+	public function FactoryQuest() {
+		super("MQFactory", QuestLib.QGRP_MAIN, "Shut Down Everything");
+	}
+	
+	override public function get description():String {
+		return "";
+	}
+	public function get questStarted():Boolean {
+		return flags[kFLAGS.MARAE_QUEST_START] >= 0.5;
+	}
+	public function get factoryFound():Boolean {
+		return flags[kFLAGS.FACTORY_FOUND] > 0;
+	}
+	public function get bossDefeated():Boolean {
+		return flags[kFLAGS.FACTORY_OMNIBUS_DEFEATED] > 0;
+	}
+	public function get factoryShutdownOrDestroyed():Boolean {
+		return flags[kFLAGS.FACTORY_SHUTDOWN] > 0;
+	}
+	public function get factoryShutdown():Boolean {
+		return flags[kFLAGS.FACTORY_SHUTDOWN] == 1
+	}
+	public function get factoryDestroyed():Boolean {
+		return flags[kFLAGS.FACTORY_SHUTDOWN] == 2
+	}
+	public function get maraeReportedPure():Boolean {
+		return flags[kFLAGS.MARAE_QUEST_COMPLETE] > 0
+	}
+	public function get maraeReportedCorrupt():Boolean {
+		return flags[kFLAGS.MET_MARAE_CORRUPTED] > 0
+	}
+	public function get factoryCleared():Boolean {
+		return SceneLib.dungeons.checkFactoryClear();
+	}
+	public function get perkRewardTaken():Boolean {
+		return flags[kFLAGS.FACTORY_OMNIBUS_DEFEATED] == 2;
+	}
+	override public function objectives():Array {
+		if (status != STATUS_IN_PROGRESS) return [];
+		var obj1:Array  = [STATUS_IN_PROGRESS, "Find the factory at the foot of the mountains."];
+		var obj2:Array  = [STATUS_NOT_STARTED, "Defeat the factory boss."];
+		var obj3:Array  = [STATUS_NOT_STARTED, "Clear the factory."];
+		var obj4a:Array = [STATUS_UNKNOWN, "Option A: Shut down the factory."];
+		var obj4b:Array = [STATUS_UNKNOWN, "Option B: Destroy the factory."];
+		var obj6:Array  = [STATUS_NOT_STARTED, "Report to Marae."];
+		var obj7:Array  = [STATUS_NOT_STARTED, "Take rewards from camp menu."];
+		if (factoryFound) {
+			obj1[0] = STATUS_COMPLETED;
+			obj2[0] = STATUS_IN_PROGRESS;
+			obj3[0] = STATUS_IN_PROGRESS;
+			if (bossDefeated) {
+				obj2[0]  = STATUS_COMPLETED;
+				obj4a[0] = STATUS_IN_PROGRESS;
+				obj4b[0] = STATUS_IN_PROGRESS;
+				if (factoryShutdown) {
+					obj4a[0] = STATUS_COMPLETED;
+					obj4b[0] = STATUS_FAILED;
+					obj6[0]  = STATUS_IN_PROGRESS;
+					if (maraeReportedPure) {
+						obj6[0] = STATUS_COMPLETED;
+					}
+				} else if (factoryDestroyed) {
+					obj4a[0] = STATUS_FAILED;
+					obj4b[0] = STATUS_COMPLETED;
+					obj6[0]  = STATUS_IN_PROGRESS;
+					if (maraeReportedCorrupt) {
+						obj6[0] = STATUS_COMPLETED;
+					}
+				}
+				if (factoryCleared) {
+					obj3[0] = STATUS_COMPLETED;
+					obj7[0] = STATUS_IN_PROGRESS;
+					if (perkRewardTaken) {
+						obj7[0] = STATUS_COMPLETED;
+					}
+				}
+			}
+		}
+		return [
+			obj1,
+			obj2,
+			obj4a,
+			obj4b,
+			obj6,
+			obj3,
+			obj7
+		]
+	}
+	override public function get status():int {
+		if (perkRewardTaken && (maraeReportedPure || maraeReportedCorrupt)) return STATUS_COMPLETED;
+		if (questStarted) return STATUS_IN_PROGRESS;
+		return STATUS_UNKNOWN;
+	}
+	override public function get hintToUnlock():String {
+		if (flags[kFLAGS.MET_MARAE] > 0) return "Visit Marae. Don't be too corrupt, or be a corrupted race."
+		return "Visit the lake island.";
+	}
+}
+}

--- a/classes/classes/Scenes/Quests/SimpleGuildQuest.as
+++ b/classes/classes/Scenes/Quests/SimpleGuildQuest.as
@@ -1,0 +1,113 @@
+package classes.Scenes.Quests {
+import classes.ItemType;
+import classes.Scenes.API.AbstractQuest;
+import classes.Scenes.Places.HeXinDao.AdventurerGuild;
+import classes.Scenes.QuestLib;
+import classes.StatusEffectType;
+
+/**
+ * Adventure guild delivery quest
+ */
+public class SimpleGuildQuest extends AbstractQuest {
+	// Status effect codes
+	private static const SE_T1_NOT_STARTED:int = 0;
+	private static const SE_T1_STARTED:int     = 1;
+	private static const SE_T1_COMPLETED:int   = 2;
+	private static const SE_T2_STARTED:int     = 3;
+	private static const SE_T2_COMPLETED:int   = 4;
+	private static const SE_T3_STARTED:int     = 6;
+	private static const SE_T3_COMPLETED:int   = 7;
+	
+	private var _guildLevel:int;
+	private var _item:ItemType;
+	private var _numbers:/*int*/Array;
+	private var _setype:StatusEffectType;
+	private var _valueIndex:int;
+	
+	public function SimpleGuildQuest(
+			id:String,
+			title:String,
+			/** 1: copper, 2: iron, ... */
+			guildLevel:int,
+			item:ItemType,
+			/** [ t1number, t2number, t3number ] */
+			numberByTier:/*int*/Array,
+			statusEffectType:StatusEffectType,
+			valueIndex:int
+	) {
+		super(id, QuestLib.QGRP_AGUILD, title);
+		this._guildLevel = guildLevel;
+		this._item       = item;
+		this._numbers    = numberByTier;
+		this._setype     = statusEffectType;
+		this._valueIndex = valueIndex;
+	}
+	
+	protected function get statusValue():Number {
+		return player.getStatusValue(_setype, _valueIndex);
+	}
+	
+	override public function get description():String {
+		var s:String = "Bring " + item.longName + " x " + quantity+". "
+		if (status == STATUS_COMPLETED) s += "You can repeat this quest tomorrow. "
+		return s;
+	}
+	
+	override public function get hintToUnlock():String {
+		var playerGuildLevel:int = AdventurerGuild.playerGuildLevel;
+		if (playerGuildLevel == 0)
+			return "Join the Adventurers Guild"
+		if (playerGuildLevel < guildLevel)
+			return "Reach  Adventurers Guild "+AdventurerGuild.GuildRanks[guildLevel].name+"rank";
+		return "Visit Yang";
+	}
+	override public function objectives():Array {
+		var status:int = this.status;
+//		if (status == STATUS_NOT_STARTED)
+//			return [[STATUS_IN_PROGRESS, "Visit Yang"]];
+		if (status != STATUS_IN_PROGRESS) return [];
+		var pcount:int = player.itemCount(item, true);
+		var need:int = quantity;
+		var obj1:String = item.shortName + " " + pcount + "/" + need;
+		var obj2:String = "Return to Yang";
+		if (pcount < need) {
+			return [
+				[STATUS_IN_PROGRESS, obj1],
+				[STATUS_NOT_STARTED, obj2]
+			]
+		} else {
+			return [
+				[STATUS_COMPLETED, obj1],
+				[STATUS_IN_PROGRESS, obj2]
+			]
+		}
+	}
+	
+	public function get guildLevel():int { return _guildLevel }
+	public function get item():ItemType { return _item }
+	public function get quantity():int { return tierQuantity(tier) }
+	public function get tier():int {
+		var value:Number = statusValue;
+		if (value == SE_T1_NOT_STARTED || value == SE_T1_STARTED || value == SE_T1_COMPLETED) return 1;
+		if (value == SE_T2_STARTED || value == SE_T2_COMPLETED) return 2;
+		if (value == SE_T3_STARTED || value == SE_T3_COMPLETED) return 3;
+		return 0;
+	}
+	public function tierQuantity(tier:int):int {
+		if (tier <= 0 || tier > 3) return -1;
+		return _numbers[tier - 1];
+	}
+	override public function get status():int {
+		if (AdventurerGuild.playerGuildLevel < guildLevel) return STATUS_UNKNOWN;
+		if (!player.hasStatusEffect(_setype)) return STATUS_UNKNOWN;
+		var value:Number = statusValue;
+		if (value == SE_T1_NOT_STARTED) return STATUS_NOT_STARTED;
+		if (value == SE_T1_STARTED || value == SE_T2_STARTED || value == SE_T3_STARTED) return STATUS_IN_PROGRESS;
+		// Because you can start next quest tier right away, completed II = not started III
+		if (value == SE_T1_COMPLETED || value == SE_T2_COMPLETED) return STATUS_NOT_STARTED;
+		if (value == SE_T3_COMPLETED) return STATUS_COMPLETED;
+		return STATUS_INVALID;
+	}
+	
+}
+}

--- a/classes/classes/Scenes/Quests/ZetazQuest.as
+++ b/classes/classes/Scenes/Quests/ZetazQuest.as
@@ -1,0 +1,73 @@
+package classes.Scenes.Quests {
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.API.AbstractQuest;
+import classes.Scenes.QuestLib;
+import classes.Scenes.SceneLib;
+
+public class ZetazQuest extends AbstractQuest {
+	public function ZetazQuest() {
+		super("MQZetaz", QuestLib.QGRP_MAIN, "You're in Deep");
+	}
+	
+	public function get canStart():Boolean {
+		return SceneLib.dungeons.canFindDeepCave();
+	}
+	public function get dungeonFound():Boolean {
+		return flags[kFLAGS.DISCOVERED_DUNGEON_2_ZETAZ] > 0;
+	}
+	public function get bossDefeated():Boolean {
+		return flags[kFLAGS.DEFEATED_ZETAZ] > 0;
+	}
+	public function get dungeonCleared():Boolean {
+		return SceneLib.dungeons.checkDeepCaveClear();
+	}
+	public function get perkRewardTaken():Boolean {
+		return flags[kFLAGS.DEFEATED_ZETAZ] > 1;
+	}
+	override public function get description():String {
+		return "";
+	}
+	
+	override public function objectives():Array {
+		if (status == STATUS_NOT_STARTED) return [
+			[STATUS_NOT_STARTED, "Search the Deepwoods."]
+		];
+		if (status != STATUS_IN_PROGRESS) return [];
+		var obj1:Array = [STATUS_IN_PROGRESS, "Search the Deepwoods."];
+		var obj2:Array = [STATUS_NOT_STARTED, "Defeat Zetaz."];
+		var obj3:Array = [STATUS_NOT_STARTED, "Clear the Deep Cave."];
+		var obj4:Array = [STATUS_NOT_STARTED, "Take rewards from camp menu."];
+		if (dungeonFound) {
+			obj1[0] = STATUS_COMPLETED;
+			obj2[0] = STATUS_IN_PROGRESS;
+			obj3[0] = STATUS_IN_PROGRESS;
+			if (bossDefeated) {
+				obj2[0] = STATUS_COMPLETED;
+				if (dungeonCleared) {
+					obj3[0] = STATUS_COMPLETED;
+					obj4[0] = STATUS_IN_PROGRESS;
+					if (perkRewardTaken) {
+						obj4[0] = STATUS_COMPLETED;
+					}
+				}
+			}
+		}
+		return [
+				obj1,
+				obj2,
+				obj3
+		]
+	}
+	
+	override public function get status():int {
+		if (perkRewardTaken) return STATUS_COMPLETED;
+		if (dungeonFound) return STATUS_IN_PROGRESS;
+		if (canStart) return STATUS_NOT_STARTED;
+		return STATUS_UNKNOWN;
+	}
+	
+	override public function get hintToUnlock():String {
+		return "Complete previous quest";
+	}
+}
+}

--- a/classes/classes/Scenes/Soulforce.as
+++ b/classes/classes/Scenes/Soulforce.as
@@ -862,7 +862,6 @@ public class Soulforce extends BaseContent
 		else SceneLib.tyrantia.firstEncounter();
 	}
 	public function tigerSharkGal():void {
-		player.createStatusEffect(StatusEffects.NearWater,0,0,0,0);
 		SceneLib.izmaScene.meetIzmaAtLake();
 	}
 	public function shyHealer():void {
@@ -870,7 +869,6 @@ public class Soulforce extends BaseContent
 		else SceneLib.dianaScene.repeatEnc();
 	}
 	public function germanCow():void {
-		player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
 		SceneLib.isabellaScene.isabellaGreeting();
 	}
 	public function sneakOnThePlane():void {

--- a/classes/classes/Scenes/TestMenu.as
+++ b/classes/classes/Scenes/TestMenu.as
@@ -17,7 +17,6 @@ import classes.Scenes.Dungeons.D3.SuccubusGardener;
 import classes.Scenes.Dungeons.DesertCave.SandMother;
 import classes.Scenes.Dungeons.EbonLabyrinth.*;
 import classes.Scenes.Explore.Pierce;
-import classes.Scenes.Explore.TheDummy;
 import classes.Scenes.Monsters.Malikore;
 import classes.Scenes.NPCs.Alvina;
 import classes.Scenes.NPCs.Aria;
@@ -38,6 +37,7 @@ import classes.Scenes.Places.HeXinDao.AdventurerGuild;
 import classes.Stats.Buff;
 
 import coc.view.ButtonDataList;
+
 use namespace CoC;
 
 public class TestMenu extends BaseContent
@@ -99,7 +99,7 @@ public class TestMenu extends BaseContent
 		bd.add("ClickItTwice", golemArmy, "Golem Army and Ascension: Additional Organ Mutation/Prestige perks correction pre global save upgrade on new public build.");
 		submenu(bd, SoulforceCheats, 0, false);
 	}
-		
+	
 	private function cheatTesting():void {
 		clearOutput();
 		outputText("Cheats made specifically for the testing needs. Use only if you're sure what you're doing - outdated test-cheats may break something and nobody will look into such bugs.");
@@ -649,15 +649,12 @@ public class TestMenu extends BaseContent
 		doNext(SoulforceCheats);
 	}
 	public function AddMaxBackpack2():void {
-		if (player.hasKeyItem("Adventurer Guild: Copper plate") >= 0 && AdventurerGuild.Slot01Cap < 10) {
-			AdventurerGuild.Slot01Cap = 10;
-			AdventurerGuild.Slot02Cap = 10;
+		if (AdventurerGuild.playerGuildLevel > AdventurerGuild.RANK_COPPER && AdventurerGuild.lootBag.SlotCaps[0] < 10) {
+			AdventurerGuild.unlockSlotsForRank(AdventurerGuild.RANK_IRON, 10);
 		}
-		if (player.hasKeyItem("Adventurer Guild: Iron plate") >= 0 && AdventurerGuild.Slot03Cap < 10) {
-			AdventurerGuild.Slot01Cap = 10;
-			AdventurerGuild.Slot02Cap = 10;
-			AdventurerGuild.Slot03Cap = 10;
-			AdventurerGuild.Slot04Cap = 10;
+		if (AdventurerGuild.playerGuildLevel > AdventurerGuild.RANK_COPPER && AdventurerGuild.lootBag.SlotCaps[2] < 10) {
+			AdventurerGuild.unlockSlotsForRank(AdventurerGuild.RANK_COPPER, 10);
+			AdventurerGuild.unlockSlotsForRank(AdventurerGuild.RANK_IRON, 10);
 		}
 		doNext(SoulforceCheats);
 	}

--- a/classes/classes/StatusEffectClass.as
+++ b/classes/classes/StatusEffectClass.as
@@ -1,6 +1,5 @@
 ﻿package classes
 {
-import classes.CoC;
 import classes.internals.Utils;
 
 public class StatusEffectClass extends Utils
@@ -25,6 +24,13 @@ public class StatusEffectClass extends Utils
 	public function get host():Creature
 	{
 		return _host;
+	}
+	public function value(index:int):Number {
+		if (index == 1) return value1;
+		if (index == 2) return value2;
+		if (index == 3) return value3;
+		if (index == 4) return value4;
+		return 0;
 	}
 	/**
 	 * Returns null if host is not a Player

--- a/classes/classes/StatusEffects.as
+++ b/classes/classes/StatusEffects.as
@@ -238,6 +238,8 @@ import classes.StatusEffects.VampireThirstEffect;
 
 		// Non-combat player perks
 		public static const AdvancingCamp:StatusEffectType                 	= mk("AdvancingCamp");
+		// value1-4: quests statuses
+		// 1: started I, 2: completed I, 3: started II, 4: completed II, 6: started III, 7: completed III
 		public static const AdventureGuildQuests1:StatusEffectType          = mk("Adventure Guild Quests 1");//Imps Hunt / Demons Hunt / Minotaurs Hunt / x
 		public static const AdventureGuildQuests2:StatusEffectType          = mk("Adventure Guild Quests 2");//Feral Tentacle Beasts Hunt / Feral Imps Hunt / x / x
 		public static const AdventureGuildQuests3:StatusEffectType          = mk("Adventure Guild Quests 3");//x / x / x / x

--- a/classes/classes/display/PerkMenu.as
+++ b/classes/classes/display/PerkMenu.as
@@ -958,7 +958,9 @@ public class PerkMenu extends BaseContent {
 		}
 		outputText("\n");
 	}
+	public var preferOld:Boolean = false;
 	public function newPerkMenu(category:*=null):void {
+		preferOld = false;
 		mainView.toolTipView.hide();
 		clearOutput();
 		outputText("You have <b>"+numberOfThings(player.perkPoints, "perk point")+"</b>.\n\n");

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -805,6 +805,14 @@ public class Utils extends Object
 		public static function trimSides(s:String):String {
 			return trimLeft(trimRight(s));
 		}
+		public static function padStart(s:String, length:int, padChar:String = ' '):String {
+			while (s.length < length) s = padChar + s;
+			return s;
+		}
+		public static function padEnd(s:String, length:int, padChar:String = ' '):String {
+			while (s.length < length) s = s + padChar;
+			return s;
+		}
 		public static function tieredBonus(stat:Number, step:Number, tier1:Number):Number {
 		  var tier:Number = Math.floor( (stat-tier1)/step + 1 );
 		  var offset:Number = step*( (tier+1)*tier / 2); // Calculates sum of tier boundaries

--- a/classes/coc/view/Block.as
+++ b/classes/coc/view/Block.as
@@ -296,13 +296,17 @@ public class Block extends Sprite {
 		return e;
 	}
 	public function addElementAbove(e:DisplayObject, reference:DisplayObject, hint:Object = null):DisplayObject {
-		var i:int = getElementIndex(reference) + 1;
-		addElementAt(e, i, hint);
+		var i:int = getElementIndex(reference);
+		if (i < 0) i = 0; // above none = below all
+		var j:int = getElementIndex(e);
+		if (i != j) addElementAt(e, i, hint);
 		return e;
 	}
 	public function addElementBelow(e:DisplayObject, reference:DisplayObject, hint:Object = null):DisplayObject {
-		var i:int = getElementIndex(reference);
-		addElementAt(e, i, hint);
+		var i:int = getElementIndex(reference) - 1;
+		if (i < 0) i = numElements; // below none = above all
+		var j:int = getElementIndex(e);
+		if (i != j) addElementAt(e, i, hint);
 		return e;
 	}
 
@@ -313,6 +317,7 @@ public class Block extends Sprite {
 	}
 	
 	public function getElementIndex(e:DisplayObject):int {
+		if (!e) return -1;
 		var i:int = -1;
 		try {
 			i = _container.getChildIndex(e);

--- a/classes/coc/view/SimpleTween.as
+++ b/classes/coc/view/SimpleTween.as
@@ -91,7 +91,10 @@ public class SimpleTween {
     }
     
     public function then(callback:Function):void {
-        if (!_active) return;
+        if (!_active) {
+            callback();
+            return;
+        }
         if (_onEnd != null) {
             var oldOnEnd:Function = _onEnd;
             _onEnd = function():void {


### PR DESCRIPTION
* Map exploration: Battlefield (B, O), Desert (O, I), Lake, Plains
* Some quests show detailed objectives
* XP popups have gray outline to be visible on dark bgs
* Perk menu style sticks until game restart

Code changes:
* New Quest system - more organized way to report quest completion and objectives. See FactoryQuest and ZetazQuest for example implementations.
* New class - ItemBag. Holds multiple slots, each slot is locked to special item. Adv.Guild loot bag uses this class.
* Adv.Guild save data changed from Slot01..Slot30, Slot01Cap..Slot30Cap to arrays. Old saves are imported.
* Exploration engine reports error if any encounter doesn't have "kind"
* Can limit max depth with calling explorer.prepareArea()