### PR TITLE
Update

### DIFF
--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -2567,7 +2567,7 @@ public static const TEMPLE_OF_THE_DIVINE_FERA:int                               
 public static const GOLEMANCER_PERM_GOLEMS:int	                                    = 2559;
 public static const IN_COMBAT_PLAYER_GOLEM_ATTACKED:int	                            = 2560;
 public static const IN_COMBAT_PLAYER_ELEMENTAL_ATTACKED:int                         = 2561;
-public static const SOUL_SENSE_ANTHILL:int                         					= 2562;
+public static const SOUL_SENSE_ANTHILL:int                         					= 2562; // No longer used
 public static const FISHES_STORED_AT_FISHERY:int                         			= 2563;
 public static const PATCHOULI_FOLLOWER:int                         					= 2564;
 public static const PATCHOULI_GIRL_OR_MORPH:int                                   	= 2565;

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -2469,7 +2469,7 @@ public static const ELEMENTAL_ARROWS:int                                 		    =
 public static const SOUL_SENSE_TAMANI:int                  		                    = 2461; // No longer used
 public static const SOUL_SENSE_TAMANI_DAUGHTERS:int                                 = 2462; // No longer used
 public static const SOUL_SENSE_KITSUNE_MANSION:int                                  = 2463; // No longer used
-public static const SOUL_SENSE_IZUMI:int                    		                = 2464;
+public static const SOUL_SENSE_IZUMI:int                    		                = 2464; // No longer used
 public static const ARIAN_SCALES:int                            			        = 2465;
 public static const SEXUAL_FLUIDS_LEVEL:int                            		        = 2466;
 public static const HIDDEN_CAVE_FOUND:int          		                            = 2467;
@@ -2806,7 +2806,7 @@ public static const DISCOVERED_INNER_DESERT:int                                 
 public static const ELVEN_THORNSHOT_ENABLED:int                                   	= 2798;
 public static const ELVEN_TWINSHOT_ENABLED:int                                   	= 2799;
 public static const LUNA_TRIED_WORKING_AS_BARMAID:int								= 2800; // if the player didn't hire Luna at first, they suggest she try working at the Wet Bitch. If so, the player can ask Aunt Nancy how *that* went to read a funny scene
-public static const SOUL_SENSE_MINOTAUR_SONS:int                                    = 2801;
+public static const SOUL_SENSE_MINOTAUR_SONS:int                                    = 2801; // No longer used
 public static const E_ICHOR_PITY_SYSTEM:int                                   		= 2802;
 public static const NECROMANCER_SKELETONS:int                                   	= 2803;
 public static const IN_COMBAT_PLAYER_SKELETONS_ATTACKED:int                         = 2804;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -6122,20 +6122,25 @@ use namespace CoC;
 			return expToLevelUp;
 		}
 		public function mineXP(XP:Number = 0):void {
-			while (XP > 0) {
-				if (XP == 1) {
-					miningXP++;
-					XP--;
-				}
-				else {
-					miningXP += XP;
-					XP -= XP;
-				}
-				//Level dat shit up!
-				if (miningLevel < maxMiningLevel() && miningXP >= MiningExpToLevelUp()) {
-					outputText("\n\n<b>Mining skill leveled up to " + (miningLevel + 1) + "!</b>");
+			if (XP == 0) return;
+			var oldRatio:Number = miningXP / MiningExpToLevelUp();
+			miningXP += XP;
+			game.mainView.notificationView.popupProgressBar2(
+					"mineXP","mineXP",
+					"Mining XP +"+XP,
+					oldRatio,
+					miningXP / MiningExpToLevelUp()
+			);
+			while (miningLevel < maxMiningLevel()) {
+				var toNextLevel:Number = MiningExpToLevelUp();
+				if (miningXP > toNextLevel) {
 					miningLevel++;
-					miningXP = 0;
+					outputText("\n\n<b>Mining skill leveled up to " + miningLevel + "!</b>");
+					game.mainView.notificationView.popupIconText(
+							"mineXP","mineXP",
+							"Mining skill leveled up to " + miningLevel + "!"
+					);
+					miningXP -= toNextLevel;
 				}
 			}
 		}
@@ -6164,20 +6169,25 @@ use namespace CoC;
 			return expToLevelUp;
 		}
 		public function farmXP(XP:Number = 0):void {
-			while (XP > 0) {
-				if (XP == 1) {
-					farmingXP++;
-					XP--;
-				}
-				else {
-					farmingXP += XP;
-					XP -= XP;
-				}
-				//Level dat shit up!
-				if (farmingLevel < maxFarmingLevel() && farmingXP >= FarmExpToLevelUp()) {
-					outputText("\n\n<b>Farming skill leveled up to " + (farmingLevel + 1) + "!</b>");
+			if (XP == 0) return;
+			var oldRatio:Number = farmingXP / FarmExpToLevelUp();
+			farmingXP += XP;
+			game.mainView.notificationView.popupProgressBar2(
+					"farmXP","farmXP",
+					"Farming XP +"+XP,
+					oldRatio,
+					farmingXP / FarmExpToLevelUp()
+			);
+			while (farmingLevel < maxFarmingLevel()) {
+				var toNextLevel:Number = FarmExpToLevelUp();
+				if (farmingXP > toNextLevel) {
 					farmingLevel++;
-					farmingXP = 0;
+					outputText("\n\n<b>Farming skill leveled up to " + farmingLevel + "!</b>");
+					game.mainView.notificationView.popupIconText(
+							"farmXP","farmXP",
+							"Farming skill leveled up to " + farmingLevel + "!"
+					);
+					farmingXP -= toNextLevel;
 				}
 			}
 		}
@@ -6221,20 +6231,25 @@ use namespace CoC;
 			return expToLevelUp;
 		}
 		public function herbXP(XP:Number = 0):void {
-			while (XP > 0) {
-				if (XP == 1) {
-					herbalismXP++;
-					XP--;
-				}
-				else {
-					herbalismXP += XP;
-					XP -= XP;
-				}
-				//Level dat shit up!
-				if (herbalismLevel < maxHerbalismLevel() && herbalismXP >= HerbExpToLevelUp()) {
-					outputText("\n\n<b>Herbalism skill leveled up to " + (herbalismLevel + 1) + "!</b>");
+			if (XP == 0) return;
+			var oldRatio:Number = herbalismXP / HerbExpToLevelUp();
+			herbalismXP += XP;
+			game.mainView.notificationView.popupProgressBar2(
+					"herbXP","herbXP",
+					"Herbalism XP +"+XP,
+					oldRatio,
+					herbalismXP / HerbExpToLevelUp()
+			);
+			while (herbalismLevel < maxHerbalismLevel()) {
+				var toNextLevel:Number = HerbExpToLevelUp();
+				if (herbalismXP > toNextLevel) {
 					herbalismLevel++;
-					herbalismXP = 0;
+					outputText("\n\n<b>Herbalism skill leveled up to " + herbalismLevel + "!</b>");
+					game.mainView.notificationView.popupIconText(
+							"herbXP","herbXP",
+							"Herbalism skill leveled up to " + herbalismLevel + "!"
+					);
+					herbalismXP -= toNextLevel;
 				}
 			}
 		}

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -6141,7 +6141,7 @@ use namespace CoC;
 							"Mining skill leveled up to " + miningLevel + "!"
 					);
 					miningXP -= toNextLevel;
-				}
+				} else break;
 			}
 		}
 
@@ -6188,7 +6188,7 @@ use namespace CoC;
 							"Farming skill leveled up to " + farmingLevel + "!"
 					);
 					farmingXP -= toNextLevel;
-				}
+				} else break;
 			}
 		}
 
@@ -6250,7 +6250,7 @@ use namespace CoC;
 							"Herbalism skill leveled up to " + herbalismLevel + "!"
 					);
 					herbalismXP -= toNextLevel;
-				}
+				} else break;
 			}
 		}
 

--- a/classes/classes/SaveUpdater.as
+++ b/classes/classes/SaveUpdater.as
@@ -1675,7 +1675,6 @@ public class SaveUpdater extends NPCAwareContent {
 				flags[kFLAGS.MOD_SAVE_VERSION] = 36.016;
 			}
 			if (flags[kFLAGS.MOD_SAVE_VERSION] < 36.017) {
-				flags[kFLAGS.SOUL_SENSE_ANTHILL] = 0; //Izma fishery cleanup.
 				// convert old buff tags to new ("item_"+itemid)
 				const ItemBuffsRename:Array = [
 					["RingOfWisdom", jewelries.RINGWIS.tagForBuffs],

--- a/classes/classes/SaveUpdater.as
+++ b/classes/classes/SaveUpdater.as
@@ -408,8 +408,6 @@ public class SaveUpdater extends NPCAwareContent {
 	}
 	
 	public function bringBackEncoutersForSouless():void {
-		if (flags[kFLAGS.SOUL_SENSE_IZUMI] >= 3) flags[kFLAGS.SOUL_SENSE_IZUMI] = 2;
-		if (flags[kFLAGS.SOUL_SENSE_MINOTAUR_SONS] >= 3) flags[kFLAGS.SOUL_SENSE_MINOTAUR_SONS] = 2;
 	}
 
 	public function fixFlags():void {

--- a/classes/classes/Scenes/API/ExplorationEngine.as
+++ b/classes/classes/Scenes/API/ExplorationEngine.as
@@ -27,9 +27,12 @@ public class ExplorationEngine extends BaseContent {
 	
 	private function filterUnique(e:SimpleEncounter):Boolean {
 		if (e.unique) {
+			var group:String = e.unique as String;
 			for (var i:int = 0; i < N; i++) {
-				if (flatList[i] && !flatList[i].isCleared && flatList[i].encounter == e) {
-					return false;
+				if (flatList[i] && !flatList[i].isCleared && flatList[i].encounter) {
+					if (flatList[i].encounter == e || (group && flatList[i].encounter.unique == e.unique)) {
+						return false;
+					}
 				}
 			}
 		}

--- a/classes/classes/Scenes/API/ExplorationEngine.as
+++ b/classes/classes/Scenes/API/ExplorationEngine.as
@@ -89,6 +89,12 @@ public class ExplorationEngine extends BaseContent {
 	public var canInventory:Boolean  = true;
 	public var canSoulSense:Boolean  = true;
 	/**
+	 * function(e:ExplorationEntry):Boolean.
+	 * If returns true, that encounter can be revealed with Soul Sense skill.
+	 * Default: all NPC-tagged encounters.
+	 */
+	public var soulSenseCheck:Function = defaultSoulseSenseCheck;
+	/**
 	 * function(e:ExplorationEntry):Boolean, called BEFORE the encounter.
 	 * If it returns true, do not continue with the exploration UI
 	 */
@@ -161,6 +167,7 @@ public class ExplorationEngine extends BaseContent {
 		nextNodes    = [];
 		onMenu       = null;
 		onEncounter  = null;
+		soulSenseCheck = defaultSoulseSenseCheck;
 	}
 	public function markEncounterDone():void {
 		if (initialized && currentEntry != null) {
@@ -692,6 +699,9 @@ public class ExplorationEngine extends BaseContent {
 	public function soulSenseCost():Number {
 		return 100;
 	}
+	public static function defaultSoulseSenseCheck(e:ExplorationEntry):Boolean {
+		return e.kind == "npc";
+	}
 	public function doSoulSense():void {
 		player.soulforce -= soulSenseCost();
 		statScreenRefresh();
@@ -700,13 +710,13 @@ public class ExplorationEngine extends BaseContent {
 		var message:String = "";
 		for (var i:int = 0; i < N; i++) {
 			var e:ExplorationEntry = flatList[i];
-			if (e.isDisabled) continue;
-			if (e.kind == "npc" && !e.isFullyRevealed) {
+			if (e.isDisabled || e.isFullyRevealed) continue;
+			if (soulSenseCheck(e)) {
 				candidates.push(e);
 			}
 		}
 		if (candidates.length == 0) {
-			message = "You reach out, but your soul sense detects no one.";
+			message = "You reach out, but your soul sense detects nothing special.";
 		} else {
 			e = Utils.randomChoice(candidates);
 			e.incReveal();

--- a/classes/classes/Scenes/API/ExplorationEngine.as
+++ b/classes/classes/Scenes/API/ExplorationEngine.as
@@ -108,9 +108,9 @@ public class ExplorationEngine extends BaseContent {
 	 *
 	 * Known area tags:
 	 * - generic: "plants", "water"
-	 * - area group: "forest", "desert", "battlefield", "lake"
+	 * - area group: "forest", "desert", "battlefield", "lake", "mountains"
 	 * - specific area: "explore", "lakeBeach", "forestInner", "forestOuter", "deepwoods", "desertInner", "desertOuter",
-	 *   "battlefieldBoundary", "battlefieldOuter"
+	 *   "battlefieldBoundary", "battlefieldOuter", "caves", "bog", "swamp", "hills", "mountainsLow", "mountainsMid"
 	 *
 	 * @example
 	 *
@@ -335,6 +335,11 @@ public class ExplorationEngine extends BaseContent {
 	 *                       40% to reveal 4
 	 */
 	public function revealMultiple(n:Number):void {
+		if (isNaN(n) || n <= 0) return;
+		if (n == -Infinity) {
+			revealAll();
+			return;
+		}
 		var i:int = n | 0;
 		if (Math.random() < n - i) i++;
 		while (i-- > 0) {
@@ -679,11 +684,13 @@ public class ExplorationEngine extends BaseContent {
 		// +1 reveal per 100 area explorations
 		n += timesExplored / 100;
 		
-		// +1 reveal per 10 wisdom, scaled with NG+ level and area level
+		// Wisdom-based reveal:
+		// * first reveal costs 10 wisdom, scaled with NG+ and area level
+		// * each following reveal costs 5% more wis
 		var wisFactor:Number = 10;
-		wisFactor *= 1 + (areaLevel - 1) / 99; // x1 on area level 1, x2 on area level 100
+		wisFactor *= 1 + 4 * (areaLevel - 1) / 99; // x1 on area level 1, x4 on area level 100
 		wisFactor *= (1 + 0.2 * CoC.instance.newGamePlusMod()); // +20% per NG level
-		n += player.wis / wisFactor;
+		n += solveSum(player.wis, wisFactor, wisFactor*0.05);
 		
 		// +1 reveal per Eyes of the Hunter rank
 		if (player.hasPerk(PerkLib.EyesOfTheHunterNovice)) n += 1;

--- a/classes/classes/Scenes/API/ExplorationEngine.md
+++ b/classes/classes/Scenes/API/ExplorationEngine.md
@@ -14,7 +14,7 @@ ExplorationEngine works with existing GroupEncounter, but they need to have extr
 * `label` (String or function returning String, optional). Map label - default is encounter `name` capitalized.
 * `hint` (String or function returning String, optional). Displayed in the tooltip when hovering over the fully revealed encounter.
 * `special` (Boolean, optional). Encounter with `special: true` have priority to appear on the road end.
-* `unique` (Boolean, optional). Only one encounter with `unique: true` can appear on a map (but not guaranteed to).
+* `unique` (Boolean|String, optional). If `unique: true`, then only one such encounter can appear on a map. If `unique` is a String indicating encounter group, only one encounter of that group can appear.
 * `reenter` (Boolean, optional). You can re-enter the encounter after finishing it (until you go forward).
 
 Example:

--- a/classes/classes/Scenes/Areas/Bog.as
+++ b/classes/classes/Scenes/Areas/Bog.as
@@ -6,10 +6,9 @@ package classes.Scenes.Areas
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.API.Encounters;
+import classes.Scenes.API.ExplorationEntry;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Bog.*;
-import classes.Scenes.Combat.SpellsBlood.LifestealEnchantmentSpell;
-import classes.Scenes.Dungeons.DemonLab;
 import classes.Scenes.NPCs.EtnaFollower;
 import classes.Scenes.SceneLib;
 
@@ -142,11 +141,15 @@ public class Bog extends BaseContent
 
 		public function exploreBog():void
 		{
-			clearOutput();
-			flags[kFLAGS.BOG_EXPLORED]++;
-			doNext(camp.returnToCampUseOneHour);
-			bogEncounter.execEncounter();
-			flushOutputTextToGUI();
+			explorer.prepareArea(bogEncounter);
+			explorer.setTags("bog");
+			explorer.prompt = "You explore the dark bog.";
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				flags[kFLAGS.BOG_EXPLORED]++;
+			}
+			explorer.leave.hint("Leave the dark bog");
+			explorer.skillBasedReveal(23, flags[kFLAGS.BOG_EXPLORED]);
+			explorer.doExplore();
 		}
 	
 		public function bogChance():Number {
@@ -157,7 +160,7 @@ public class Bog extends BaseContent
 
 		private function findNothing():void {
 			outputText("You wander around through the humid muck, but you don't run into anything interesting.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function findChest():void {
@@ -170,7 +173,7 @@ public class Bog extends BaseContent
 			player.gems += gemsFound;
 			statScreenRefresh();
 			outputText("\n\n<b>You now have " + num2Text(inventory.itemStorageDirectGet().length) + " storage item slots at camp.</b>");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function zenjiEncounterFn():void {

--- a/classes/classes/Scenes/Areas/Caves/DarkSlimeScene.as
+++ b/classes/classes/Scenes/Areas/Caves/DarkSlimeScene.as
@@ -22,7 +22,7 @@ public class DarkSlimeScene extends BaseContent
             outputText("You didn’t find any and if you did you would have pumped it out until it ran dry.\n\n");
             outputText("\"<i>Well darn, if you spot a fleshling do share!</i>\"");
             outputText("Well that was easy… you can only guess slimes don’t get much out of other slimes’ bodies. You proceed deeper into the caves unhindered, though, you wish you indeed had found someone to milk the fluids off.\n\n");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         }
         //regular scene

--- a/classes/classes/Scenes/Areas/Desert.as
+++ b/classes/classes/Scenes/Areas/Desert.as
@@ -322,6 +322,9 @@ use namespace CoC;
 		public function exploreDesert():void
 		{
 			explorer.prepareArea(desertEncounter);
+			explorer.soulSenseCheck = function (e:ExplorationEntry):Boolean {
+				return e.kind == "npc" || e.encounter.encounterName() == "ants";
+			}
 			explorer.setTags("desert", "desertOuter");
 			explorer.prompt = "You explore the outer desert.";
 			explorer.onEncounter = function(e:ExplorationEntry):void {

--- a/classes/classes/Scenes/Areas/Desert.as
+++ b/classes/classes/Scenes/Areas/Desert.as
@@ -396,6 +396,7 @@ use namespace CoC;
 		}
 
 		public function nailsEncounter():void {
+			clearOutput();
 			var extractedNail:int = 5 + rand(player.inte / 5) + rand(player.str / 10) + rand(player.tou / 10) + rand(player.spe / 20) + 5;
 			flags[kFLAGS.ACHIEVEMENT_PROGRESS_SCAVENGER] += extractedNail;
 			flags[kFLAGS.CAMP_CABIN_NAILS_RESOURCES] += extractedNail;
@@ -405,6 +406,7 @@ use namespace CoC;
 			outputText("\n\nNails: ");
 			if (flags[kFLAGS.CAMP_CABIN_NAILS_RESOURCES] > SceneLib.campUpgrades.checkMaterialsCapNails()) flags[kFLAGS.CAMP_CABIN_NAILS_RESOURCES] = SceneLib.campUpgrades.checkMaterialsCapNails();
 			outputText(flags[kFLAGS.CAMP_CABIN_NAILS_RESOURCES]+"/" + SceneLib.campUpgrades.checkMaterialsCapNails() + "");
+			endEncounter();
 		}
 
 		public function wstaffEncounter():void {

--- a/classes/classes/Scenes/Areas/Desert/AntsScene.as
+++ b/classes/classes/Scenes/Areas/Desert/AntsScene.as
@@ -260,10 +260,6 @@ public class AntsScene extends BaseContent
 			else {
 				outputText("Your feet bring you back to the ant colony and the guard motions you down the only lit tunnel once more.  You enter the colosseum, and as you step out into the cavern, you are greeted, again, by a thin male ant-morph holding a clipboard.  He looks up at you.");
 				outputText("\n\n\"<i>Oh good, you're here.  I was beginning to think you were a coward.</i>\"  Before you can respond to his insult, he cuts you off.  \"<i>We're ready to start when you are.  Let's hope you survive longer than the last guy.</i>\"");
-				if (player.hasPerk(PerkLib.SoulSense) && !flags[kFLAGS.SOUL_SENSE_ANTHILL]) {
-					outputText("\n\n<b>Now you can find the colony using soul sense!</b>\n\n");
-					flags[kFLAGS.SOUL_SENSE_ANTHILL] = 1;
-				}
 			}
 			//[Fight] [Leave]
 			simpleChoices("Fight", antColiseumFight, "", null, "", null, "", null, "Leave", leaveAntColony);

--- a/classes/classes/Scenes/Areas/HighMountains.as
+++ b/classes/classes/Scenes/Areas/HighMountains.as
@@ -5,9 +5,9 @@ package classes.Scenes.Areas {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.API.Encounters;
+import classes.Scenes.API.ExplorationEntry;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.HighMountains.*;
-import classes.Scenes.Dungeons.DemonLab;
 import classes.Scenes.Monsters.LightElfScene;
 import classes.Scenes.NPCs.EtnaFollower;
 import classes.Scenes.SceneLib;
@@ -155,16 +155,20 @@ public class HighMountains extends BaseContent {
         clearOutput();
         outputText("While exploring the mountain, you come across a relatively safe way to get at its higher reaches.  You judge that with this route you'll be able to get about two thirds of the way up the mountain.  With your newfound discovery fresh in your mind, you return to camp.\n\n(<b>High Mountain exploration location unlocked!</b>)");
         flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN]++;
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Explore High Mountain
     public function exploreHighMountain():void {
-        clearOutput();
-        doNext(camp.returnToCampUseOneHour);
-        flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN]++;
-        highMountainsEncounter.execEncounter();
-        flushOutputTextToGUI();
+        explorer.prepareArea(highMountainsEncounter);
+        explorer.setTags("mountain","highMountain");
+        explorer.prompt = "You explore the high mountains.";
+        explorer.onEncounter = function(e:ExplorationEntry):void {
+            flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN]++;
+        }
+        explorer.leave.hint("Leave the high mountains");
+        explorer.skillBasedReveal(55, flags[kFLAGS.DISCOVERED_HIGH_MOUNTAIN]);
+        explorer.doExplore();
     }
 
 	public function highMountainsChance():Number {
@@ -252,7 +256,7 @@ public class HighMountains extends BaseContent {
         spriteSelect(SpriteDb.s_chickenHarpy);
         outputText("At the polite decline of her offer, the chicken harpy gives a warm smile before picking her cart back up and continuing along the path through the mountains.");
         outputText("\n\nYou decide to take your own path, heading back to camp while you can.");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     public function caveScene():void {
@@ -264,7 +268,7 @@ public class HighMountains extends BaseContent {
         outputText("Tentatively you put one hand on place");
         if (!player.isRace(Races.AVIAN, 1, false)) {
             outputText(", but absolutely nothing happens. Maybe the magic or whatever that thing was supposed to do stopped working long ago? In any case, you had enough looking for a while, and since you’re not getting anything useful from there, you resume your walk.\n\n");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
         } else {
             outputText(" and gasp in surprise as the figures depicting the creatures at the sides of the alcove recede as you do so, leaving in place two smaller alcoves with two statuettes on them.\n\n");
             outputText("The first one, made on brass and bronze, depicts a fierce looking gryphon in an assault stance. Every bit of the artifact emanates an unnatural strength. On the other side, a statue made of alabaster and ruby gemstones is shaped as a graceful peacock. Strangely, besides being pretty, the way it’s crafted gives you a weird, mystic feel.\n\n");
@@ -279,14 +283,14 @@ public class HighMountains extends BaseContent {
         outputText("Picking the brass-forged statuette, you immediately feel how its energy rushes through your avian body, invigorating it with an unknown force. Carefully putting it on your bag, you see how the other one is stored away by the hidden mechanism.\n\n");
         outputText("With nothing useful left to you here, you resume your walk and return to your camp with the gryphon idol on your bag.\n\n");
         player.createKeyItem("Gryphon Statuette", 0, 0, 0, 0);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     public function caveScenePeacock():void {
         outputText("Picking the alabaster statuette, you immediately feel how its energy rushes through your avian body, invigorating it with an unknown force. Carefully putting it on your bag, you see how the other one is stored away by the hidden mechanism.\n\n");
         outputText("With nothing useful left to you here, you resume your walk and return to your camp with the peacock idol on your bag.\n\n");
         player.createKeyItem("Peacock Statuette", 0, 0, 0, 0);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 }
 }

--- a/classes/classes/Scenes/Areas/HighMountains/IzumiScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/IzumiScene.as
@@ -121,7 +121,7 @@ import classes.Stats.Buff;
 			outputText("Spelunking in random caves around these parts is probably not the best idea; especially considering the kinds of creatures that you keep tripping over whenever you <i>do</i> decide to poke your nose somewhere it doesn't belong.\n\n");
 			
 			outputText("You head back to camp, having found nothing else of interest.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		// Already met, dun wanna get oniraepd again plz
@@ -130,7 +130,7 @@ import classes.Stats.Buff;
 			clearOutput();
 
 			outputText("You decide discretion is the better part of valour and choose not to barge into the strange woman's cave again, opting to slip away before she notices you hanging around outside her home.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		// Introduce the fuckhuge oni
@@ -381,7 +381,7 @@ import classes.Stats.Buff;
 
 			outputText("Spotting an opening, you decide to beat a hasty retreat, as far away from the immense woman as possible.\n\n");
 
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		/**
 		 * FIGHT SHIT
@@ -556,7 +556,7 @@ import classes.Stats.Buff;
 			outputText("\"<i>Well, that was fun.</i>\"  Izumi says, sitting up and dusting off her palms, dismissively.  \"<i>I’m assuming you’re not up to a rematch just yet from the way you’re shaking.</i>\"  She picks up her pipe and takes a drag, shooting you a knowing grin.  \"<i>Feel free to drop by again, though.  You know, in case you wanted to tell me off... or maybe if you just want me to bully you some more.</i>\" \n\n");
 
 			player.sexReward("no", "Dick");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		protected function surrenderMediumCock():void
@@ -621,7 +621,7 @@ import classes.Stats.Buff;
 			outputText(" cum, staring at the cavern roof and panting madly for a good few minutes afterwards.  Once you regain the use of your legs, you retrieve your clothes and wander back to camp in a daze.\n\n");
 
 			player.sexReward("no", "Dick");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		// Male/Herm be a jerk about it split
@@ -653,7 +653,7 @@ import classes.Stats.Buff;
 			outputText("\"<i>So, you learned something today, right?  Next time, just do what I say, and the results are much more... fun.</i>\" She smiles, then turns away.  Retrieving your clothes, you drag yourself back to camp, feeling decidedly shaky.\n\n");
 
 			player.sexReward("no", "Dick");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		// Urtadicks itt
@@ -704,7 +704,7 @@ import classes.Stats.Buff;
 			outputText("Izumi returns to her tent and lights up her pipe, unceremoniously abandoning you there on the cave floor, apparently done with you for now.  Still, it’s some time before you are able to drag yourself to your feet and stumble home to your camp, wondering how long it’ll be before you can see straight again...\n\n");
 
 			player.sexReward("no", "Dick");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		protected function izumiSurrenderFemale():void
@@ -929,7 +929,7 @@ import classes.Stats.Buff;
 			}
 
 			player.sexReward("Default","Default",true,false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		// Female surrender, ask player if which variant they want
@@ -989,7 +989,7 @@ import classes.Stats.Buff;
 			outputText("You jerk upright with a start, warm bedding falling away from your body, the last few hours slowly beginning to filter through the sleepy haze clouding your thoughts.  Izumi seems to have worn herself out too, splayed out across the floor beside you.  You look around, gathering your bearings before deciding a sneaky exit from the Oni’s home is your best course of action...\n\n");
 
 			player.sexReward("Default","Default",true,false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		/**

--- a/classes/classes/Scenes/Areas/HighMountains/IzumiScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/IzumiScene.as
@@ -66,11 +66,6 @@ import classes.Stats.Buff;
 				}
 				outputText("As you wander the wasted landscape searching for anything of interest, you find yourself face to face with a familiar large boulder; the same one hiding the entrance to Izumi’s cave.  Once again, you become aware of a strange sound on the edge of your hearing.  Carefully positioning yourself at the gap between the boulder and the cave entrance, you turn your ear to the source of the noise and manage to pick out what it is that you’re hearing; somebody is loudly humming, the same lively tune you heard during your previous visit.\n\n");
 				outputText("Considering how your last visit to the cave ended, you hesitate for a moment and wonder if you should push forward to enter Izumi’s home... or if turning back to camp would be a wiser decision.\n\n");
-				if (player.hasPerk(PerkLib.SoulSense) && flags[kFLAGS.SOUL_SENSE_IZUMI] < 2) flags[kFLAGS.SOUL_SENSE_IZUMI]++;
-				if (flags[kFLAGS.SOUL_SENSE_IZUMI] == 2) {
-					flags[kFLAGS.SOUL_SENSE_IZUMI]++;
-					outputText("\n\n<b>You have met her enough times to be able to find her in the future when using soul sense. (Removes Izumi from high mountains explore encounters pool!)</b>\n\n");
-				}
 				menu();
 				addButton(0, "Enter", enterAfterMet);
 				addButton(1, "Leave", nopeLeavePlz);

--- a/classes/classes/Scenes/Areas/HighMountains/MinervaScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/MinervaScene.as
@@ -150,7 +150,7 @@ private function ignoreMinervasPath():void {
 	clearOutput();
 	outputText("Deciding to play it safe, you turn away from the new path and continue your search elsewhere.");
 	// PC returns to camp.
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[Take Path]
 private function takeMinervasPath():void {
@@ -238,7 +238,7 @@ private function leaveMinervasFirstEncounter():void {
 	clearOutput();
 	outputText("You decide that you don't want to risk going into Minerva's lair as, for all you know, it could be a trap.  Therefore, you turn around and skedaddle back down the mountain.  As you leave, Minerva turns and watches you for a bit, a sad look on her face before she turns back and heads inside her home, alone.");
 	// PC returns to camp.
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //1-2 Repeat Encounter 1.  Use any time.
@@ -378,7 +378,7 @@ private function rejectMinervasLove():void {
 	outputText("\n\nSlowly, you get up, looking away from the curvy siren as you step out of the pool and leaving Minerva's tower.  Hopefully she won't be upset for too long, it would be best to check up on her later.  As you go, you swear you hear her let out a sob, the pain of your rejection clear as the mist that floats around the mountain.");
 	// PC returns to camp.
 	flags[kFLAGS.MINERVA_LOVE] = -1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -422,7 +422,7 @@ public function genericMenu(display:Boolean = false):void {
 		.disableIf(player.cor < 50 - player.corruptionTolerance, "You're not corrupted enough.", "???")
 		.disableIf(flags[kFLAGS.MET_MINERVA] < 4, "You need to visit her a bit more often for this", "???")
 		.disableIf(!debug, "Not released yet. Requires to enable debug mode (settings) to view. Sorry, the text is not good enough yet.");
-	addButton(14, "Leave", camp.returnToCampUseOneHour);
+	addButton(14, "Leave", explorer.done);
 }
 
 //1-2 Repeatable Cute, Romantic Encounter. Only if PC accepted Minerva's feelings. Add to normal encounters.
@@ -559,7 +559,7 @@ private function talkingToMinervaAboutBackstory():void {
         if (flags[kFLAGS.MINERVA_BACKSTORY_LEARNED] == 0)
 		    flags[kFLAGS.MINERVA_BACKSTORY_LEARNED] = 1;
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -580,7 +580,7 @@ private function talkAboutTheSpringWithMinerva():void {
 	outputText("\n\nReturning her shining smile, you promise to come back and visit soon, then head out and start the hike back toward your camp.");
 	// PC returns to camp.
 	dynStats("lus", 10+player.lib/10, "scale", false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //3-3 Talking Scene 3 - talks about her shark girl daughter
@@ -602,7 +602,7 @@ private function talkWithMinervaAboutSharkGirlDaughter():void {
     outputText("\n\nThe two of you stay like this for a while, just spending a little time together before you decide you must return to camp and your quest.  Saying your goodbyes, you give Minerva a kiss before heading home.");
     if (flags[kFLAGS.MINERVA_BACKSTORY_LEARNED] == 1)
         flags[kFLAGS.MINERVA_BACKSTORY_LEARNED] = 2;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -621,7 +621,7 @@ private function talkToMinervaAboutHerCorruption():void {
 	outputText("\n\nThe two of you stay like this for a while, just spending some time together, before you decide you must return to camp and your quest.  Saying your goodbyes, you give Minerva a kiss before heading home.");
 	flags[kFLAGS.MINERVA_PURIFICATION_PROGRESS] = 1;
 	// PC returns to camp
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //3-5 Motherhood
@@ -669,7 +669,7 @@ private function minervaMotherhood():void {
 	
 	outputText("\n\nLooking around, you see how late it has gotten and swiftly get up, Minerva's right; you have to get back to your great quest!  Looking at the siren one last time, you tell her that you will be sure to come and visit again later.");
 	// PC returns to camp.
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //3-6 Bath Time - romance only
@@ -709,7 +709,7 @@ public function bathTimeWithMinerva():void {
 	// PC returns to camp.
 	dynStats("lus", 10+player.lib/10, "scale", false);
 	fatigue(-30);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 
@@ -1440,7 +1440,7 @@ internal function loseToMinerva():void {
 		// return PC to options- no combat option
 		// PC gains 1 Purity peach
 		monster.createStatusEffect(StatusEffects.PeachLootLoss,0,0,0,0);
-		inventory.takeItem(consumables.PURPEAC, camp.returnToCampUseOneHour);
+		inventory.takeItem(consumables.PURPEAC, explorer.done);
 		cleanupAfterCombat();
 	}
 	//PC loss by Lust
@@ -1493,12 +1493,12 @@ public function eatSomethingYouCunt():void {
 private function getPurePeach():void {
 	clearOutput();
 	outputText("You walk over to the fruit trees surrounding the spring, examining the strange treats.  You decide that one ripe fruit, one resembling a peach, is the best choice, and pluck it from the tree.  Thanking Minerva for letting you have it, you stow it away safely and head back to camp.\n\n");
-	inventory.takeItem(consumables.PURPEAC, camp.returnToCampUseOneHour);
+	inventory.takeItem(consumables.PURPEAC, explorer.done);
 }
 private function getMint():void {
 	clearOutput();
 	outputText("There are many strange herbs growing around the spring, fed by whatever power resides in the water.  Finally, you locate a sprig of something that resembles mint, but silver in color, and decide to pluck it.  Stowing it carefully amongst your belongings, you thank Minerva for sharing the contents of her 'garden' with you and then head back to camp.");
-	inventory.takeItem(consumables.C__MINT, camp.returnToCampUseOneHour);
+	inventory.takeItem(consumables.C__MINT, explorer.done);
 }
 
 //Spring Water
@@ -1519,12 +1519,12 @@ private function drinkDirectly():void {
 	player.refillHunger(15);
 	if(player.cor > 50) dynStats("cor", -1);
 	if(player.cor > 75) dynStats("cor", -1);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 private function getBottle():void {
 	clearOutput();
 	outputText("Pulling out a small waterskin, you dip it into the crystal clear water, filling the container with the cool, clean spring water before placing it in your pack.  ");
-	inventory.takeItem(consumables.S_WATER, camp.returnToCampUseOneHour);
+	inventory.takeItem(consumables.S_WATER, explorer.done);
 }
 
 private function sleepWithMinerva():void {

--- a/classes/classes/Scenes/Areas/HighMountains/MinotaurMobScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/MinotaurMobScene.as
@@ -53,11 +53,6 @@ public function meetMinotaurSons():void {
 	spriteSelect(SpriteDb.s_minotaurSons);
 	dynStats("lus", 10, "scale", false);
 	flags[kFLAGS.MINOTAUR_SONS_TIMES_MET]++;
-	if (player.hasPerk(PerkLib.SoulSense) && flags[kFLAGS.SOUL_SENSE_MINOTAUR_SONS] < 2) flags[kFLAGS.SOUL_SENSE_MINOTAUR_SONS]++;
-	if (flags[kFLAGS.SOUL_SENSE_MINOTAUR_SONS] == 2) {
-		flags[kFLAGS.SOUL_SENSE_MINOTAUR_SONS]++;
-		outputText("\n\n<b>You have met them enough times to be able to find them in the future when using soul sense. (Removes Minotaur Sons from high mountains explore encounters pool!)</b>\n\n");
-	}
 	//First Meeting
 	if(flags[kFLAGS.MINOTAUR_SONS_TIMES_MET] == 1) {
 		//(Non-Addicted)

--- a/classes/classes/Scenes/Areas/HighMountains/MinotaurMobScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/MinotaurMobScene.as
@@ -2,7 +2,6 @@
 import classes.*;
 import classes.BodyParts.Tail;
 import classes.GlobalFlags.kFLAGS;
-import classes.Scenes.SceneLib;
 import classes.display.SpriteDb;
 
 public class MinotaurMobScene extends BaseContent implements TimeAwareInterface {
@@ -247,7 +246,7 @@ private function runFromMinotaurs():void {
 	//ESCAPE!
 	if((player.canFly() && player.spe > rand(40)) || (!player.canFly() && player.spe > rand(60))) {
 		outputText("A furry arm nearly catches your [leg], but you slip free and quickly escape your lusty brood.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	//FAIL:
 	else {
@@ -412,6 +411,7 @@ private function nonAddictMinotaurGangBang():void {
     if (CoC.instance.inCombat) cleanupAfterCombat();
     else {
 		outputText("\n\n");
+		explorer.stopExploring();
 		inventory.takeItem(ItemType.lookupItem(flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID]), camp.returnToCampUseEightHours);
 	}
 }
@@ -504,6 +504,7 @@ private function loseToMinoMobVeryPregnant():void {
 	player.sexReward("cum","Vaginal");
 	dynStats("spe", -.5, "int", -.5, "lib", .5, "sen", .5, "cor", 1);
 	player.minoCumAddiction(15);
+	explorer.stopExploring();
     if (CoC.instance.inCombat) cleanupAfterCombat();
     else doNext(camp.returnToCampUseEightHours);
 }
@@ -608,6 +609,7 @@ private function analSpearSemiPregMinotaurGangbang():void {
 	player.sexReward("cum","Vaginal");
 	dynStats("spe", -.5, "int", -.5, "lib", .5, "sen", .5, "cor", 1);
 	player.minoCumAddiction(15);
+	explorer.stopExploring();
     if (CoC.instance.inCombat) cleanupAfterCombat();
     else doNext(camp.returnToCampUseEightHours);
 }
@@ -747,7 +749,7 @@ private function victoryMinotaurGangTitFuck():void {
     if (CoC.instance.inCombat) cleanupAfterCombat();
     else {
 		outputText("\n\n");
-		inventory.takeItem(ItemType.lookupItem(flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID]), camp.returnToCampUseOneHour);
+		inventory.takeItem(ItemType.lookupItem(flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID]), explorer.done);
 	}
 }
 
@@ -843,7 +845,7 @@ private function victoryAllThePenetrationsMinotaurGangBang():void {
 	player.minoCumAddiction(20);
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //*[Victory - Make minitaur oral (M/F/H)]
@@ -959,7 +961,7 @@ private function forceMinitaurToGiveOral(choice:Number = 0):void {
 	dynStats("sen", -1);
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //*[Victory- BJ + Nipplefucking] (boring, samey, not actually punishment again, could have been shoving very long nipples into urethras) (edited)
@@ -1026,7 +1028,7 @@ private function victoryBJNippleFuckMinotaurGang():void {
 	player.minoCumAddiction(10);
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //Bad End Scene:

--- a/classes/classes/Scenes/Areas/HighMountains/NekobakeInn.as
+++ b/classes/classes/Scenes/Areas/HighMountains/NekobakeInn.as
@@ -4,7 +4,7 @@ import classes.BodyParts.*;
 import classes.lists.BreastCup;
 
 public class NekobakeInn extends BaseContent implements TimeAwareInterface {
-		
+	
 	public function NekobakeInn() {
 		EventParser.timeAwareClassAdd(this);
 	}
@@ -31,7 +31,7 @@ public class NekobakeInn extends BaseContent implements TimeAwareInterface {
 	private function avoidTheInn():void {
 		clearOutput();
 		outputText("Yeah, no. This place looks like a trap, smells like a trap and is probably a trap. Better move away from here as fast as possible. On this, you head back to camp.[pg]");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function enterTheInn():void {
@@ -49,7 +49,7 @@ public class NekobakeInn extends BaseContent implements TimeAwareInterface {
 		clearOutput();
 		outputText("A little unsure about your initial choice, you decide it would be wise not to linger and say you just wanted in to see what's inside and will be on your way. The ladies in yukata sigh in a united disappointment but bid you a good day as you leave, requesting you to come back soon.[pg]");
 
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 
 	private function transform():void {
@@ -175,6 +175,7 @@ public class NekobakeInn extends BaseContent implements TimeAwareInterface {
 		}
 		player.dynStats("cor", 20, "spe", 5, "tou", 5, "lib", 5);
 
+		explorer.stopExploring();
 		doNext(camp.returnToCampUseFourHours);
 	}
 

--- a/classes/classes/Scenes/Areas/HighMountains/PhoenixScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/PhoenixScene.as
@@ -1,4 +1,4 @@
-package classes.Scenes.Areas.HighMountains 
+package classes.Scenes.Areas.HighMountains
 {
 import classes.*;
 import classes.BodyParts.Hips;
@@ -10,7 +10,7 @@ import classes.Scenes.SceneLib;
 
 public class PhoenixScene extends BaseContent
 	{
-				
+		
 		//" + (player.cocks.length == 1 ? "": "") + "
 		public function PhoenixScene() {}
 
@@ -150,7 +150,7 @@ public class PhoenixScene extends BaseContent
 			outputText("\n\nYour " + cockDescript() + " explodes, pumping a thick load into the shocked quasi-phoenix’s mouth. She gags on your cum, finally swallowing it as the last of your sperm drips into her mouth. With a grin, you tell her what a good job she did as you withdraw your [cock] from her grip. With little rivulets of cum dripping down her face, the halfbreed collapses onto her back, rapidly fingering herself.");
 			flags[kFLAGS.PHOENIX_WANKED_COUNTER]++;
 			player.sexReward("Default","Default",true,false);
-			cleanupAfterCombat();			
+			cleanupAfterCombat();
 		}
 		
 		public function rideVaginal():void {
@@ -265,6 +265,7 @@ public class PhoenixScene extends BaseContent
 			player.addCurse("str",2,2);
 			player.sexReward("cum","Anal");
 			player.addCurse("tou", 2, 2);
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseFourHours);
 		}
 		

--- a/classes/classes/Scenes/Areas/Lake.as
+++ b/classes/classes/Scenes/Areas/Lake.as
@@ -105,25 +105,51 @@ use namespace CoC;
 				kind  : 'item',
 				call: findWFruit
 			}, {
-				name: "nothing",
+				name  : "nothing",
 				label : "walk",
-				kind: "walk",
+				kind  : "walk",
 				chance: 0.4,
-				call: findNothing
+				call  : findNothing
 			}, {
-				name: "holystuff",
-				label : "Holy Weapon",
+				name: "holysword",
+				label : "Holy Sword",
 				kind  : 'item',
-				when: function ():Boolean {
-					return !player.hasStatusEffect(StatusEffects.BlessedItemAtTheLake) && (
-							!player.hasStatusEffect(StatusEffects.TookBlessedSword) && !player.hasStatusEffect(StatusEffects.BSwordBroken) ||
-							!player.hasStatusEffect(StatusEffects.TookBlessedBow) && !player.hasStatusEffect(StatusEffects.BBowBroken) && player.hasPerk(PerkLib.JobRanger) ||
-							!player.hasStatusEffect(StatusEffects.TookBlessedStaff) && !player.hasStatusEffect(StatusEffects.BStaffBroken) && player.hasPerk(PerkLib.JobSorcerer) ||
-							!player.hasStatusEffect(StatusEffects.TookBlessedShield) && !player.hasStatusEffect(StatusEffects.BShieldBroken) && player.hasPerk(PerkLib.JobGuardian)
-					)
+				chance: 0.05,
+				unique: 'holyitem', // only one enc with unique:holyitem can appear
+				when: function():Boolean {
+					return !player.hasStatusEffect(StatusEffects.BlessedItemAtTheLake) && !player.hasStatusEffect(StatusEffects.TookBlessedSword) && !player.hasStatusEffect(StatusEffects.BSwordBroken);
 				},
-				chance: 0.2,
-				call: findBlesedItemEncounterFn
+				call: findBlesedSword
+			}, {
+				name: "holybow",
+				label : "Holy Bow",
+				kind  : 'item',
+				chance: 0.05,
+				unique: 'holyitem', // only one enc with unique:holyitem can appear
+				when: function():Boolean {
+					return !player.hasStatusEffect(StatusEffects.BlessedItemAtTheLake) && !player.hasStatusEffect(StatusEffects.TookBlessedBow) && !player.hasStatusEffect(StatusEffects.BBowBroken) && player.hasPerk(PerkLib.JobRanger);
+				},
+				call: findBlesedBow
+			}, {
+				name: "holystaff",
+				label : "Holy Staff",
+				kind  : 'item',
+				chance: 0.05,
+				unique: 'holyitem', // only one enc with unique:holyitem can appear
+				when: function():Boolean {
+					return !player.hasStatusEffect(StatusEffects.BlessedItemAtTheLake) && !player.hasStatusEffect(StatusEffects.TookBlessedStaff) && !player.hasStatusEffect(StatusEffects.BStaffBroken) && player.hasPerk(PerkLib.JobSorcerer);
+				},
+				call: findBlesedStaff
+			}, {
+				name: "holyshield",
+				label : "Holy Shield",
+				kind  : 'item',
+				chance: 0.05,
+				unique: 'holyitem', // only one enc with unique:holyitem can appear
+				when: function():Boolean {
+					return !player.hasStatusEffect(StatusEffects.BlessedItemAtTheLake) && !player.hasStatusEffect(StatusEffects.TookBlessedShield) && !player.hasStatusEffect(StatusEffects.BShieldBroken) && player.hasPerk(PerkLib.JobGuardian);
+				},
+				call: findBleseShield
 			}, {
 				name: "ponies",
 				label : "Ponies",
@@ -367,28 +393,21 @@ use namespace CoC;
 			fetishCultistScene.fetishCultistEncounter();
 		}
 
-		private function findBlesedItemEncounterFn():void {
-			if (!player.hasStatusEffect(StatusEffects.TookBlessedSword) && !player.hasStatusEffect(StatusEffects.BSwordBroken) && rand(5) == 0) {// && player.hasPerk(PerkLib.JobWarrior)
-				player.createStatusEffect(StatusEffects.BlessedItemAtTheLake, 0, 0, 0, 0);
-				swordInStone.findSwordInStone();
-				return;
-			}
-			if (!player.hasStatusEffect(StatusEffects.TookBlessedBow) && !player.hasStatusEffect(StatusEffects.BBowBroken) && player.hasPerk(PerkLib.JobRanger) && rand(3) == 0) {
-				player.createStatusEffect(StatusEffects.BlessedItemAtTheLake, 0, 0, 0, 0);
-				swordInStone.findBowInStone();
-				return;
-			}
-			if (!player.hasStatusEffect(StatusEffects.TookBlessedStaff) && !player.hasStatusEffect(StatusEffects.BStaffBroken) && player.hasPerk(PerkLib.JobSorcerer) && rand(3) == 0) {
-				player.createStatusEffect(StatusEffects.BlessedItemAtTheLake, 0, 0, 0, 0);
-				swordInStone.findStaffInStone();
-				return;
-			}
-			if (!player.hasStatusEffect(StatusEffects.TookBlessedShield) && !player.hasStatusEffect(StatusEffects.BShieldBroken) && player.hasPerk(PerkLib.JobGuardian) && rand(3) == 0) {
-				player.createStatusEffect(StatusEffects.BlessedItemAtTheLake, 0, 0, 0, 0);
-				swordInStone.findShieldInStone();
-				return;
-			}
-			findNothing();
+		private function findBlesedSword():void {
+			player.createStatusEffect(StatusEffects.BlessedItemAtTheLake, 0, 0, 0, 0);
+			swordInStone.findSwordInStone();
+		}
+		private function findBlesedBow():void {
+			player.createStatusEffect(StatusEffects.BlessedItemAtTheLake, 0, 0, 0, 0);
+			swordInStone.findBowInStone();
+		}
+		private function findBlesedStaff():void {
+			player.createStatusEffect(StatusEffects.BlessedItemAtTheLake, 0, 0, 0, 0);
+			swordInStone.findStaffInStone();
+		}
+		private function findBleseShield():void {
+			player.createStatusEffect(StatusEffects.BlessedItemAtTheLake, 0, 0, 0, 0);
+			swordInStone.findShieldInStone();
 		}
 
 		private function walkAroundLake():void {

--- a/classes/classes/Scenes/Areas/Mountain.as
+++ b/classes/classes/Scenes/Areas/Mountain.as
@@ -10,6 +10,7 @@ import classes.BodyParts.Tail;
 import classes.BodyParts.Tongue;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.API.Encounters;
+import classes.Scenes.API.ExplorationEntry;
 import classes.Scenes.API.FnHelpers;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.HighMountains.*;
@@ -637,6 +638,17 @@ public class Mountain extends BaseContent
 		}
 		//Explore Mountain
 		public function exploreMountain():void {
+			/*
+			explorer.prepareArea(mountainEncounter);
+			explorer.setTags("mountain","mountainMid");
+			explorer.prompt = "You explore the mountain.";
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				player.exploredMountain++;
+			}
+			explorer.leave.hint("Leave the forest outskirts");
+			explorer.skillBasedReveal(30, player.exploredMountain);
+			explorer.doExplore();
+			 */
 			clearOutput();
 			doNext(camp.returnToCampUseOneHour);
 			player.exploredMountain++;
@@ -644,6 +656,17 @@ public class Mountain extends BaseContent
 			flushOutputTextToGUI();
 		}
 		public function exploreLowMountain():void {
+			/*
+			explorer.prepareArea(lowMountainEncounter);
+			explorer.setTags("mountain","mountainLow");
+			explorer.prompt = "You explore the low mountains.";
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				flags[kFLAGS.DISCOVERED_LOW_MOUNTAIN]++;
+			}
+			explorer.leave.hint("Leave the low mountains");
+			explorer.skillBasedReveal(15, flags[kFLAGS.DISCOVERED_LOW_MOUNTAIN]);
+			explorer.doExplore();
+			 */
 			clearOutput();
 			doNext(camp.returnToCampUseOneHour);
 			flags[kFLAGS.DISCOVERED_LOW_MOUNTAIN]++;
@@ -651,11 +674,15 @@ public class Mountain extends BaseContent
 			flushOutputTextToGUI();
 		}
 		public function exploreHills():void {
-			clearOutput();
-			doNext(camp.returnToCampUseOneHour);
-			flags[kFLAGS.DISCOVERED_HILLS]++;
-			hillsEncounter.execEncounter();
-			flushOutputTextToGUI();
+			explorer.prepareArea(hillsEncounter);
+			explorer.setTags("hills");
+			explorer.prompt = "You explore the hills.";
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				flags[kFLAGS.DISCOVERED_HILLS]++;
+			}
+			explorer.leave.hint("Leave the hills");
+			explorer.skillBasedReveal(5, flags[kFLAGS.DISCOVERED_HILLS]);
+			explorer.doExplore();
 		}
 		public function ceraphFn():void {
 			//Rarer 'nice' Ceraph encounter
@@ -707,7 +734,7 @@ public class Mountain extends BaseContent
 						outputText("You stumble in your attempt to escape and realize that you are completely helpless.  The minotaur towers over you and heaves his ax for a <i>coup de grâce</i>.  As he readies the blow, another beast-man slams into him from the side.  The two of them begin to fight for the honor of raping you, giving you the opening you need to escape.  You quietly sneak away while they fight – perhaps you should avoid the mountains for now?\n\n");
 					}
 					player.createStatusEffect(StatusEffects.TF2, 0, 0, 0, 0);
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 					return;
 				}
 				//Mino gangbang
@@ -778,7 +805,7 @@ public class Mountain extends BaseContent
 			outputText("You carefully put the pieces of the Derpnade Launcher in your back and head back to your camp.\n\n");
 			player.addStatusValue(StatusEffects.TelAdreTripxi, 2, 1);
 			player.createKeyItem("Derpnade Launcher", 0, 0, 0, 0);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function partsofLactoBlasters():void {
 			clearOutput();
@@ -786,20 +813,20 @@ public class Mountain extends BaseContent
 			outputText("You carefully put the pieces of the Lactoblasters in your back and head back to your camp.\n\n");
 			player.addStatusValue(StatusEffects.TelAdreTripxi, 2, 1);
 			player.createKeyItem("Lactoblasters", 0, 0, 0, 0);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function discoverLM():void {
 			clearOutput();
 			outputText("While exploring the hill you come upon a particular trail. It looks to lead deeper into the mountain range. Having met the many unsavory denizens of the hill already you clench your fist ready for a new challenge as you take up the trail toward the mountain. The atmosphere changes quickly as plants become scarcer and rocky formation more common. ");
 			outputText("Caves previously a rare occurrence now are a regular sight. You have found the way to the low mountain range area.\n\n(<b>Low Mountain exploration location unlocked!</b>)");
 			flags[kFLAGS.DISCOVERED_LOW_MOUNTAIN]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function discoverM():void {
 			clearOutput();
 			outputText("As you explore the low mountain range you hear thunder booming overhead, shaking you out of your thoughts.  High above, dark clouds encircle a distant mountain peak.  You get an ominous feeling in your gut as you gaze up at it. Forward is a path leading deeper higher into the mountains and possibly harder trials.\n\n<b>You've discovered the Mountain!</b>");
 			player.exploredMountain = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function hike():void {
 			clearOutput();
@@ -811,7 +838,7 @@ public class Mountain extends BaseContent
 				outputText("During your hike into the mountains, your depraved mind keeps replaying your most obcenely warped sexual encounters, always imagining new perverse ways of causing pleasure.\n\nIt is a miracle no predator picked up on the strong sexual scent you are emitting.");
 				dynStats("tou", .25, "spe", .5, "lib", .25, "lus", player.lib / 10);
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function hikeh():void {
 			clearOutput();
@@ -823,7 +850,7 @@ public class Mountain extends BaseContent
 				outputText("During your hike into the hills, your depraved mind keeps replaying your most obcenely warped sexual encounters, always imagining new perverse ways of causing pleasure.\n\nIt is a miracle no predator picked up on the strong sexual scent you are emitting.");
 				dynStats("tou", .2, "spe", .4, "lib", .2, "lus", player.lib / 12);
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function joinBeingAMinoCumSlut():void
 		{
@@ -953,7 +980,7 @@ public class Mountain extends BaseContent
 			}
 			//(Acquired minotaur cum!)
 			model.time.hours++;
-			inventory.takeItem(consumables.MINOCUM, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.MINOCUM, explorer.done);
 		}
 
 		private function watchAMinoCumSlut():void
@@ -976,7 +1003,7 @@ public class Mountain extends BaseContent
 			outputText("\n\nAs you look at the two cum-covered creatures laying there in their exhausted sex-induced stupors, the minotaur's thick horse-cock now slowly deflating, you realize that you've been touching yourself.  You make yourself stop in disgust.");
 			outputText("\n\nOnly now do you notice other faces peeking over ledges and ridges.  You count at least two goblins and one imp who quickly pull back.  From the sounds, they were busy getting themselves off.  Apparently this isn't an uncommon show, and the locals enjoy it immensely.");
 			dynStats("lus", 25, "scale", false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		private function continueMinoVoyeurism():void {
@@ -996,7 +1023,7 @@ public class Mountain extends BaseContent
 				outputText("  Apparently this isn't an uncommon show, and the locals enjoy it immensely.");
 			//Lust!
 			dynStats("lus", 5 + player.lib / 20 + player.racialScore(Races.MINOTAUR, false) + player.racialScore(Races.COW, false), "scale", false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 	}
 }

--- a/classes/classes/Scenes/Areas/Mountain.as
+++ b/classes/classes/Scenes/Areas/Mountain.as
@@ -155,7 +155,7 @@ public class Mountain extends BaseContent
 				kind : 'monster',
 				night : false,
 				when: function ():Boolean {
-					return flags[kFLAGS.MINOTAUR_SONS_TRIBE_SIZE] >= 3 && player.hasVagina() && flags[kFLAGS.SOUL_SENSE_MINOTAUR_SONS] < 3;
+					return flags[kFLAGS.MINOTAUR_SONS_TRIBE_SIZE] >= 3 && player.hasVagina();
 				},
 				call: minotaurMobScene.meetMinotaurSons,
 				mods: [SceneLib.exploration.furriteMod]
@@ -551,9 +551,6 @@ public class Mountain extends BaseContent
 				label : "Izumi",
 				kind  : 'npc',
 				unique: true,
-				when: function ():Boolean {
-					return flags[kFLAGS.SOUL_SENSE_IZUMI] < 3;
-				},
 				call: izumiScenes.encounter
 			}, {
 				name: "harpy",
@@ -651,6 +648,9 @@ public class Mountain extends BaseContent
 		}
 		public function exploreHills():void {
 			explorer.prepareArea(hillsEncounter);
+			explorer.soulSenseCheck = function(e:ExplorationEntry):Boolean {
+				return e.kind == 'npc' || e.encounterName == 'minomob';
+			}
 			explorer.setTags("hills");
 			explorer.prompt = "You explore the hills.";
 			explorer.onEncounter = function(e:ExplorationEntry):void {

--- a/classes/classes/Scenes/Areas/Mountain.as
+++ b/classes/classes/Scenes/Areas/Mountain.as
@@ -192,11 +192,7 @@ public class Mountain extends BaseContent
 				night : false,
 				chance: mountainChance,
 				when:function ():Boolean {
-					return !SceneLib.ceraphFollowerScene.ceraphIsFollower()
-							/* [INTERMOD:8chan]
-							&& flags[kFLAGS.CERAPH_KILLED] == 0
-							 */
-							/*&& game.fetishManager.compare(FetishManager.FETISH_EXHIBITION)*/;
+					return !SceneLib.ceraphFollowerScene.ceraphIsFollower();
 				},
 				call:ceraphFn,
 				mods:[fn.ifLevelMin(2)]
@@ -225,7 +221,7 @@ public class Mountain extends BaseContent
 			}, {
 				name:"hikeh",
 				chance:0.2,
-				kind:'hike',
+				kind:'walk',
 				call:hikeh
 			}, {
 				name: "mimic",
@@ -242,14 +238,8 @@ public class Mountain extends BaseContent
 				},
 				call: SceneLib.exploration.demonLabProjectEncounters
 			}*/);
-			_lowmountainEncounter = Encounters.group("low mountains", {
-				//General Angels, Goblin and Imp Encounters
-				name: "common",
-				chance: 0.5,
-				call: function ():void{
-					SceneLib.exploration.genericGobImpAngEncounters();
-				}
-			}, {
+			_lowmountainEncounter = Encounters.group("low mountains",
+					SceneLib.exploration.commonEncounters.withChanceFactor(0.1), {
 				//Helia monogamy fucks
 				name  : "helcommon",
 				label : "Helia",
@@ -343,7 +333,7 @@ public class Mountain extends BaseContent
 			},{
 				name:"hhound_master",
 				label : "Hellhound Master",
-				kind  : 'event',
+				kind  : 'npc',
 				unique: true,
 				night : false,
 				chance:2,
@@ -427,7 +417,7 @@ public class Mountain extends BaseContent
 			}, {
 				name  : "mindbreaker",
 				label : "Mindbreakers Cave",
-				kind  : 'npc',
+				kind  : 'place',
 				unique: true,
 				call  : SceneLib.mindbreaker.findMindbreaker,
 				chance: findMindbreakerChance,
@@ -447,7 +437,7 @@ public class Mountain extends BaseContent
 			}, {
 				name:"hike",
 				label : "Hike",
-				kind  : 'hike',
+				kind  : 'walk',
 				chance:0.2,
 				call:hike
 			}, {
@@ -638,25 +628,17 @@ public class Mountain extends BaseContent
 		}
 		//Explore Mountain
 		public function exploreMountain():void {
-			/*
 			explorer.prepareArea(mountainEncounter);
 			explorer.setTags("mountain","mountainMid");
 			explorer.prompt = "You explore the mountain.";
 			explorer.onEncounter = function(e:ExplorationEntry):void {
 				player.exploredMountain++;
 			}
-			explorer.leave.hint("Leave the forest outskirts");
+			explorer.leave.hint("Leave the mountain");
 			explorer.skillBasedReveal(30, player.exploredMountain);
 			explorer.doExplore();
-			 */
-			clearOutput();
-			doNext(camp.returnToCampUseOneHour);
-			player.exploredMountain++;
-			mountainEncounter.execEncounter();
-			flushOutputTextToGUI();
 		}
 		public function exploreLowMountain():void {
-			/*
 			explorer.prepareArea(lowMountainEncounter);
 			explorer.setTags("mountain","mountainLow");
 			explorer.prompt = "You explore the low mountains.";
@@ -666,12 +648,6 @@ public class Mountain extends BaseContent
 			explorer.leave.hint("Leave the low mountains");
 			explorer.skillBasedReveal(15, flags[kFLAGS.DISCOVERED_LOW_MOUNTAIN]);
 			explorer.doExplore();
-			 */
-			clearOutput();
-			doNext(camp.returnToCampUseOneHour);
-			flags[kFLAGS.DISCOVERED_LOW_MOUNTAIN]++;
-			lowMountainEncounter.execEncounter();
-			flushOutputTextToGUI();
 		}
 		public function exploreHills():void {
 			explorer.prepareArea(hillsEncounter);

--- a/classes/classes/Scenes/Areas/Mountain/HellHoundScene.as
+++ b/classes/classes/Scenes/Areas/Mountain/HellHoundScene.as
@@ -182,7 +182,7 @@ public class HellHoundScene extends BaseContent
 			clearOutput();
 			outputText("You force the presence out of your mind.  You feel almost a bit lost after it disappears, but giving yourself over to foreign control can never be a good idea, can it?");
 			//end event, A can repeat later.
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //choose yes (C)
@@ -212,7 +212,7 @@ public class HellHoundScene extends BaseContent
 			outputText(" You extract Marae's lethicite from your pack, and wonder if you really want to trade it for the hellfire he offered.");
 			//advance to repeat version
 			flags[kFLAGS.HELLHOUND_MASTER_PROGRESS] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //Choose no (E)
@@ -221,7 +221,7 @@ public class HellHoundScene extends BaseContent
 			clearOutput();
 			outputText("You push the presence out of your mind.  Maybe later you'll collect the hellfire, but for now you'd rather keep the lethicite.");
 			//end event, D can repeat.
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //Choose yes (F)
@@ -269,7 +269,7 @@ public class HellHoundScene extends BaseContent
 			player.createPerk(PerkLib.Hellfire, 0, 0, 0, 0);
 			//Hellhounds no longer encounterable.
 			flags[kFLAGS.HELLHOUND_MASTER_PROGRESS]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //Merae's Lethicite

--- a/classes/classes/Scenes/Areas/Mountain/MinotaurScene.as
+++ b/classes/classes/Scenes/Areas/Mountain/MinotaurScene.as
@@ -7,8 +7,6 @@ import classes.Scenes.SceneLib;
 import classes.display.SpriteDb;
 import classes.internals.ChainedDrop;
 
-import coc.view.ButtonDataList;
-
 public class MinotaurScene extends BaseContent {
 
 public function minoVictoryRapeChoices():void {
@@ -544,7 +542,7 @@ public function minoPheromones():void {
 		function ignoreMino():void {
 			outputText("This pathetic excuse for a male isn't worth your time.[pg]");
 			outputText("You decide to skip on him and look for a more defiant toy to break heading back toward your camp.")
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		function fightMino():void {
 			outputText("You make a fearsome howl as you charge after him forcing the bull to fight and defend himself as best he can.");
@@ -618,6 +616,7 @@ public function getRapedVagAss():void {
 	outputText("The bull-man relaxes for a moment, then shoves you off of him and to the cold ground. You pass out as a strange sense of euphoria washes over you while copious quantities of monstrous cum escape your distended ");
 	if(player.hasVagina()) outputText("pussy.");
 	else outputText("asshole.");
+	explorer.stopExploring();
     if (CoC.instance.inCombat) {
 		if (inDungeon)
             rapeEndingEL();
@@ -660,6 +659,7 @@ private function getOralRapedByMinotaur():void {
 	player.sexReward("cum","Lips");
 	dynStats("sen", 1);
 	minoCumAddiction(10);
+	explorer.stopExploring();
     if (CoC.instance.inCombat) {
 		if (inDungeon)
             rapeEndingEL();
@@ -871,7 +871,7 @@ public function minoAddictionBadEndEncounter():void {
 		if(player.inte > 40) outputText("A tiny voice speaks up, warning you that it would be hard to get away from such a gathering.  ");
 		outputText("Do you follow the minotaur-scent like the addict that you are?");
 		//[Yes] [No]
-		doYesNo(minoAddictionBadEnd2,camp.returnToCampUseOneHour);
+		doYesNo(minoAddictionBadEnd2,explorer.done);
 	}
 }
 

--- a/classes/classes/Scenes/Areas/Mountain/Salon.as
+++ b/classes/classes/Scenes/Areas/Mountain/Salon.as
@@ -1,8 +1,8 @@
 ﻿package classes.Scenes.Areas.Mountain{
 import classes.*;
-	import classes.BodyParts.Hair;
-	import classes.GlobalFlags.kFLAGS;
-    import classes.display.SpriteDb;
+import classes.BodyParts.Hair;
+import classes.GlobalFlags.kFLAGS;
+import classes.display.SpriteDb;
 
 public class Salon extends BaseContent implements TimeAwareInterface {
 
@@ -36,7 +36,7 @@ public class Salon extends BaseContent implements TimeAwareInterface {
 public function hairDresser():void {
 	clearOutput();
 	outputText("While exploring the mountain, you find a cleverly concealed doorway.  From inside you can hear the sound of blades being sharpened.  Do you enter the doorway?");
-	doYesNo(salonGreeting,camp.returnToCampUseOneHour);
+	doYesNo(salonGreeting,explorer.done);
 }
 	public function isDiscovered():Boolean {
 		return player.hasStatusEffect(StatusEffects.HairdresserMeeting);
@@ -78,7 +78,7 @@ private function salonPaymentMenu():void {
 	addButton(3, "Minotaur", gloryholeMinotaur).hint("Suck that huge minotaur cock!");
 	addButton(4, "Incubus", gloryholeIncubus).hint("Suck that incubus cock. It gives off that pleasant spicy scent.");
 	if (flags[kFLAGS.CAN_BUY_MINOCUM] > 0) addButton(8, "Buy MinoCum", buyMinoCum).hint("Buy a bottle of minotaur cum for 60 gems?");
-	addButton(14, "Leave", camp.returnToCampUseOneHour);
+	addButton(14, "Leave", explorer.done);
 }
 
 		private function buyMinoCum():void{
@@ -96,7 +96,7 @@ private function salonPaymentMenu():void {
 				player.gems -= 60;
 				outputText("You happily give Lynnette 60 gems and pick up the bottle full of glistening, heavenly cum.  ");
 				statScreenRefresh();
-				inventory.takeItem(consumables.MINOCUM, camp.returnToCampUseOneHour);
+				inventory.takeItem(consumables.MINOCUM, explorer.done);
 			}
 		}
 
@@ -130,7 +130,7 @@ public function salonPurchaseMenu():void {
 	if (player.hairLength > 2 && !Hair.Types[player.hairType].ignoresStyle) addButton(10, "Haircut", changeHairStyle);
 	else if (Hair.Types[player.hairType].ignoresStyle) addButtonDisabled(10, "Haircut", "Your current hair can't have its style changed!");
 	else if (player.hairLength <= 2) addButtonDisabled(10, "Haircut", "Your current hair length is too short!");
-	addButton(14,"Leave",camp.returnToCampUseOneHour);
+	addButton(14,"Leave",explorer.done);
 }
 
 private function hairDresserGreeting():void {
@@ -364,7 +364,7 @@ private function cut(newLen:int):void {
 	outputText("Lynnette and her daughters crowd around you with razor-sharp scissors, effortlessly paring down your " + hairDescript() + ".  When they've finished, you're left with ");
 	player.hairLength = newLen;
 	outputText(hairDescript() + ".");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function hairGrow():void {
@@ -381,7 +381,7 @@ private function hairGrow():void {
 	var growth:Number = rand(3) + 3;
 	player.hairLength += growth;
 	outputText(num2Text(growth) + " more inches of [haircolor] hair.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function removeHair():void {
@@ -390,12 +390,12 @@ private function removeHair():void {
 	outputText("Lynnette instructs you to take a seat and instructs her daughters to pare down your hair down to short length. They effortlessly cut your hair to short length. Next, Lynnette applies a special cream all over your [hair].  Your hair starts to stiffen and falls out.  She gives your head a good cleaning afterwards.\n\n");
 	outputText("<b>You no longer have a hair!</b>");
 	player.hairLength = 0;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 		private function buyDye(itype:ItemType):void{
 			clearOutput();
-			inventory.takeItem(itype, camp.returnToCampUseOneHour);
+			inventory.takeItem(itype, explorer.done);
 		}
 
 private function dyeMenu():void {
@@ -434,7 +434,7 @@ private function cutBeard():void {
 	outputText("Lynnette and her daughters crowd around you with razor-sharp scissors, effortlessly paring down your " + beardDescript() + ".  When they've finished, you're left with ");
 	player.beardLength = 0.01;
 	outputText(beardDescript() + ".");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function growBeard(mode:int = 0):void {
@@ -467,7 +467,7 @@ private function growBeard(mode:int = 0):void {
 			outputText(num2Text(growth) + " more "+Measurements.inchesOrCentimetres(growth));
 			outputText(" of [haircolor] beard.");
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function changeBeardStyle():void {
@@ -487,7 +487,7 @@ private function chooseBeardStyleFinalize(choiceStyle:int = 0):void {
 	outputText("Lynnette and her daughters begin to mess with your beard with razor-sharp scissors and white fluid while they work to change your beard into what you've wanted.\n\n");
 	player.beardStyle = choiceStyle;
 	outputText("After a while, you now have " + player.beardDescript() + "!");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function changeHairStyle():void {
@@ -514,7 +514,7 @@ private function chooseHairStyleFinalize(choiceStyle:int = 0):void {
 	outputText("Lynnette and her daughters begin to mess with your hair with razor-sharp scissors and white fluid while they work to change your hairstyle into what you've wanted.\n\n");
 	player.hairStyle = choiceStyle;
 	outputText("After a while, you now have " + player.hairStyleDescript() + "!");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function removeBeard():void {
@@ -524,7 +524,7 @@ private function removeBeard():void {
 	outputText("<b>You no longer have a beard!</b>");
 	player.beardStyle = 0;
 	player.beardLength = 0;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function minotaurCumBukkakeInSalon():void {
@@ -637,7 +637,7 @@ private function mudFacial():void {
 
 	outputText("With that finished, the crowd of busty, green-skinned women disperses to leave you in peace.  Time drags on, but eventually the mud hardens and cracks.  As if on cue, tiny hands emerge with wet rags to scrub your face clean.  Once they've finished, you feel like a whole new you! (+10 femininity)");
 	player.modFem(100,10);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 private function sandFacial():void {
@@ -647,7 +647,7 @@ private function sandFacial():void {
 
 	outputText("After a while the goblin girls come back and clean the stuff from your face. (+10 masculinity)");
 	player.modFem(0,10);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 /*
 public static const LYNNETTE_PREGNANCY_CYCLE:int                                    = 1022; //0-3 = pregnant. 4-6 = not.

--- a/classes/classes/Scenes/Areas/Mountain/WormsScene.as
+++ b/classes/classes/Scenes/Areas/Mountain/WormsScene.as
@@ -1,7 +1,7 @@
-//const EVER_INFESTED:int = 787;	
+//const EVER_INFESTED:int = 787;
 //const CAME_WORMS_AFTER_COMBAT:int = 788;
 /*
- LICENSE 
+ LICENSE
  
 This license grants Fenoxo, creator of this game usage of the works of
 Dxasmodeus in this product. Dxasmodeus grants Fenoxo and the coders assigned by him to this project permission to alter the text to conform with current and new game functions, only. Dxasmodeus retains exclusive rights to alter or change the core contents of the events and no other developer may alter, change or use the events without permission from dxasmodeus. Fenoxo agrees to include Dxasmodeus' name in the credits with indications to the specific contribution made to the licensor. This license must appear
@@ -25,16 +25,16 @@ As Fenoxo has made his game code open source, this license DOES NOT transfer to 
 
 For further information and license requests, Dxasmodeus may be contacted through private message at the Futanari Palace. http://www.futanaripalace.com/forum.php. */
 
-package classes.Scenes.Areas.Mountain 
+package classes.Scenes.Areas.Mountain
 {
-	import classes.*;
-	import classes.GlobalFlags.*;
-    import classes.display.SpriteDb;
-	
-	public class WormsScene extends BaseContent
+import classes.*;
+import classes.GlobalFlags.*;
+import classes.display.SpriteDb;
+
+public class WormsScene extends BaseContent
 	{
 		
-		public function WormsScene() 
+		public function WormsScene()
 		{
 		}
 		
@@ -47,7 +47,7 @@ package classes.Scenes.Areas.Mountain
 				outputText("You stop dead in your tracks, wondering what this swarm will do. After a few tense moments, the mass crawls away in a direction opposite of both you and your current path. You breathe a sigh of relief as you are confident that no good could have come from confronting such a zoological travesty.");
 				dynStats("lus", -10, "scale", false);
 				player.createStatusEffect(StatusEffects.MetWorms, 0, 0, 0, 0);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else if (player.hasCock()) {
 				outputText("Minding your own business, you make your way through the mountain and you find yourself stopped by another mass of the sickly worms. The collective stops, apparently sensing your presence and briefly ebbs in your direction. After a few tense moments, the mass begins moving again... straight towards you at an alarming rate!\n\n");
@@ -56,7 +56,7 @@ package classes.Scenes.Areas.Mountain
 			}
 			else {
 				outputText("Making your way, you stumble on another gross mass of worms. The countless struggling creatures bar the path before you. Again, you freeze in place as the horror gropes about on the ground. It appears to have no real interest in your presence and it makes its way in a direction other than yours, much to your relief.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -72,7 +72,7 @@ package classes.Scenes.Areas.Mountain
 			outputText("You actually think it's kind of a hot idea, and wonder if such creatures actually exist in this land as you make your way back to camp.");
 			outputText("\n\n<b>If you ever change your mind, you can toggle from Fetishes menu in game settings.</b>");
 			player.createStatusEffect(StatusEffects.WormsOn, 0, 0, 0, 0);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function wormsPartiallyOn():void {
@@ -81,7 +81,7 @@ package classes.Scenes.Areas.Mountain
 			outputText("\n\n<b>If you ever change your mind, you can toggle from Fetishes menu in game settings.</b>");
 			player.createStatusEffect(StatusEffects.WormsOn, 0, 0, 0, 0);
 			player.createStatusEffect(StatusEffects.WormsHalf, 0, 0, 0, 0);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function wormsOff():void {
@@ -89,9 +89,9 @@ package classes.Scenes.Areas.Mountain
 			outputText("You shudder in revulsion and figure the sign to be the result of someone's perverted fantasy.");
 			outputText("\n\n<b>If you ever change your mind, you can toggle from Fetishes menu in game settings.</b>");
 			player.createStatusEffect(StatusEffects.WormsOff, 0, 0, 0, 0);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-			
+		
 		private function wormsConfront():void {
 			spriteSelect(SpriteDb.s_dickworms);
 			clearOutput();
@@ -110,7 +110,7 @@ package classes.Scenes.Areas.Mountain
 			clearOutput();
 			if(player.spe > rand(35)) {
 				outputText("Your instincts overwhelm you and you immediately turn around and run like hell in the opposite direction. You look behind you as your heart feels as if it is about to burst only to discover that the creature did not follow you. You take a moment to catch your breath and consider yourself fortunate.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else {
 				outputText("You turn to run, but before your [feet] can get you away, the worms are upon you!  You turn to face them, lest they launch onto your unprotected back.");
@@ -165,6 +165,7 @@ package classes.Scenes.Areas.Mountain
 					}
 				}
 			}
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 			
 		}
@@ -191,7 +192,7 @@ package classes.Scenes.Areas.Mountain
 				//clear status
 				CoC.instance.inCombat = false;
 				clearStatuses(false);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			if(player.statStore.hasBuff("SheilaCorruption")) {

--- a/classes/classes/Scenes/Areas/Swamp.as
+++ b/classes/classes/Scenes/Areas/Swamp.as
@@ -5,11 +5,10 @@ package classes.Scenes.Areas
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
-import classes.CoC;
 import classes.Scenes.API.Encounters;
+import classes.Scenes.API.ExplorationEntry;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Swamp.*;
-import classes.Scenes.Dungeons.DemonLab;
 import classes.Scenes.NPCs.BelisaFollower;
 import classes.Scenes.NPCs.EtnaFollower;
 import classes.Scenes.NPCs.LilyFollower;
@@ -176,11 +175,15 @@ use namespace CoC;
 
 		public function exploreSwamp():void
 		{
-			clearOutput();
-			flags[kFLAGS.TIMES_EXPLORED_SWAMP]++;
-			doNext(camp.returnToCampUseOneHour);
-			swampEncounter.execEncounter();
-			flushOutputTextToGUI();
+			explorer.prepareArea(swampEncounter);
+			explorer.setTags("swamp");
+			explorer.prompt = "You explore the wet swamplands.";
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				flags[kFLAGS.TIMES_EXPLORED_SWAMP]++;
+			}
+			explorer.leave.hint("Leave the wet swamplands");
+			explorer.skillBasedReveal(13, flags[kFLAGS.TIMES_EXPLORED_SWAMP]);
+			explorer.doExplore();
 		}
 
 		public function swampChance():Number {
@@ -198,7 +201,7 @@ use namespace CoC;
 			clearOutput();
 			outputText("While exploring the swamps, you find yourself into a particularly dark, humid area of this already fetid biome.  You judge that you could find your way back here pretty easily in the future, if you wanted to.  With your newfound discovery fresh in your mind, you return to camp.\n\n(<b>Bog exploration location unlocked!</b>)");
 			flags[kFLAGS.BOG_EXPLORED]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function partsofM1Cerberus():void {
@@ -207,7 +210,7 @@ use namespace CoC;
 			outputText("You carefully put the pieces of the M1 Cerberus in your back and head back to your camp.\n\n");
 			player.addStatusValue(StatusEffects.TelAdreTripxi, 2, 1);
 			player.createKeyItem("M1 Cerberus", 0, 0, 0, 0);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 	}

--- a/classes/classes/Scenes/Areas/Swamp/FemaleSpiderMorphScene.as
+++ b/classes/classes/Scenes/Areas/Swamp/FemaleSpiderMorphScene.as
@@ -76,7 +76,7 @@ public class FemaleSpiderMorphScene extends BaseContent implements TimeAwareInte
 			//Selecting has a 50% chance of displaying the following:
 			if (rand(2) == 0) {
 				outputText("You turn around and flee before she can get any closer.  After running for a few moments, you realize the spider-woman isn't trying to pursue you at all.  The last image you see of her is her looking down at the ground with an expression of incredible melancholy.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			//The other 50% will start combat and then immediately attempt to run.
 			else {
@@ -98,7 +98,7 @@ public class FemaleSpiderMorphScene extends BaseContent implements TimeAwareInte
 					outputText("After you've both had your fill of talk, the spider-girl asks, \"<i>I-I w-was wondering if you'd do me a favor... I have certain... urges, and");
 					if (player.gender == 0) {
 						outputText(" o-oh never mind, you're genderless... crap.</i>\"  She blushes and lifts her abdomen, shooting a web into the trees that she uses to escape from the awkward situation.  You're left utterly alone, once again.");
-						doNext(camp.returnToCampUseOneHour);
+						endEncounter();
 						return;
 					}
 					outputText(" well, you're the first sane person I've had a chance to ask.  Oh fuck it, can I tie you up and fuck you? Please?</i>\"\n\n");
@@ -108,7 +108,7 @@ public class FemaleSpiderMorphScene extends BaseContent implements TimeAwareInte
 				//(OPTION 2 - GIFT)
 				else {
 					outputText("After you've both had your fill of talk, the spider-girl smiles and gives you a gentle hug.  She trills, \"<i>Thank you so much for talking to me!  It feels so good to actually... communicate with someone again.  I can't thank you enough, but here, take this.  Maybe it will help you on your journey.</i>\"\n\n");
-					inventory.takeItem(consumables.S_GOSSR, camp.returnToCampUseOneHour);
+					inventory.takeItem(consumables.S_GOSSR, explorer.done);
 				}
 			}
 			//*Try to Talk - Aggressive Variant
@@ -136,7 +136,7 @@ public class FemaleSpiderMorphScene extends BaseContent implements TimeAwareInte
 		{
 			clearOutput();
 			outputText("You tell the lusty spider-morph that you're not interested in having sex with her now, and though she looks crestfallen, she nods understandingly and zips up a line of webbing into the trees before the situation can become any more awkward.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 
@@ -551,7 +551,7 @@ public class FemaleSpiderMorphScene extends BaseContent implements TimeAwareInte
 			else outputText("You leave her there with her hands and feet completely restrained.  Sucks to be her.");
 			player.sexReward("vaginalFluids","Vaginal");
             if (!CoC.instance.inCombat)
-                doNext(camp.returnToCampUseOneHour);
+                endEncounter();
 			else cleanupAfterCombat();
 		}
 
@@ -618,7 +618,7 @@ public class FemaleSpiderMorphScene extends BaseContent implements TimeAwareInte
 			player.sexReward("vaginalFluids","Dick");
 			pregnancy.knockUpForce(PregnancyStore.PREGNANCY_PLAYER, PregnancyStore.INCUBATION_SPIDER - 200); //Spiders carry for half as long as the player does for some reason
             if (!CoC.instance.inCombat)
-                doNext(camp.returnToCampUseOneHour);
+                endEncounter();
 			else cleanupAfterCombat();
 		}
 
@@ -690,7 +690,7 @@ public class FemaleSpiderMorphScene extends BaseContent implements TimeAwareInte
 			}
 			player.sexReward("vaginalFluids","Dick");
             if (!CoC.instance.inCombat)
-                doNext(camp.returnToCampUseOneHour);
+                endEncounter();
 			else cleanupAfterCombat();
 		}
 
@@ -703,7 +703,7 @@ public class FemaleSpiderMorphScene extends BaseContent implements TimeAwareInte
 
 			outputText("You're left scratching your head when you realize they were your own children, birthed by the spider-morph you fucked not so long ago.\n\n");
 			pregnancy.knockUpForce(); //Clear Spidermorph pregnancy
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 	}
 }

--- a/classes/classes/Scenes/Areas/Swamp/MaleSpiderMorphScene.as
+++ b/classes/classes/Scenes/Areas/Swamp/MaleSpiderMorphScene.as
@@ -32,7 +32,7 @@ public class MaleSpiderMorphScene extends BaseContent
 			else {
 				outputText("He breaks into a smile and says, \"<i>Hi there!  I haven't seen anyone else with a shred of sanity in FOREVER.  Would you mind just, talking with me?</i>\"");
 				//[Fight] [Talk] [Leave]
-				simpleChoices("Fight", fightSpiderBoy, "Talk", talkToSpiderBoy, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+				simpleChoices("Fight", fightSpiderBoy, "Talk", talkToSpiderBoy, "", null, "", null, "Leave", explorer.done);
 			}
 		}
 
@@ -55,11 +55,11 @@ public class MaleSpiderMorphScene extends BaseContent
 			if (rand(6) != 0) {
 				outputText("If you ever want to have your own venom or webbing, eat as much of it as you can.  Who knows, maybe it'll help you take down the demons somehow?</i>\"\n\n");
 				outputText("He stands and gives you a bundle of pink fibers with a nervous bow.  You look down at the gossamer strands in your hands, and when you glance back up, he's gone.  ");
-				inventory.takeItem(consumables.S_GOSSR, camp.returnToCampUseOneHour);
+				inventory.takeItem(consumables.S_GOSSR, explorer.done);
 			} else {
 				outputText("Spider webs are tougher than steel.  A skilled artisan can make an excellent fabric using it.  Or you can just twist it into a rope.  Who knows, maybe it'll help you take down the demons somehow?</i>\"\n\n");
 				outputText("He stands and gives you a bundle of white fibers with a nervous bow.  You look down at the gossamer strands in your hands, and when you glance back up, he's gone.  ");
-				inventory.takeItem(useables.T_SSILK, camp.returnToCampUseOneHour);
+				inventory.takeItem(useables.T_SSILK, explorer.done);
 			}
 		}
 

--- a/classes/classes/Scenes/Areas/Swamp/Rogar.as
+++ b/classes/classes/Scenes/Areas/Swamp/Rogar.as
@@ -119,6 +119,7 @@ public function encounterRogarSwamp():void {
 			//set Ro'gar phase = 2
 			flags[kFLAGS.ROGAR_PHASE] = 2;
 			dynStats("lus", 30, "scale", false);
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 			return;
 		}
@@ -132,6 +133,7 @@ public function encounterRogarSwamp():void {
 			outputText("  You just grin and shake your head at his politeness.  \"<i>It's been too long since I got ta talk with any decent folk.</i>\" Ro'gar says, grinning.  Soon you both have empty mugs.  You can't help but sway where you sit from the alcohol, stronger than anything you've had before.  Ro'gar gives a hearty laugh at you, clearly enjoying your inebriated state.  \"<i>You don't look the heavy drinkin' type.</i>\" Ro'gar smirks, as you sway.  Frowning, you assure him that you can handle it, all the while punctuating your sentences with small hiccups which cause both of you to break out in laughter.  \"<i>Ya know, I've been in this swamp here for so long.  I'm getting' the itch ta go out inta the world and find greener grass, if'n ya know what I'm sayin'.  Listenin' to yer stories about yer travels ain't helpin' none, either.</i>\"  His tone of voice is distant, almost sounding disappointed with himself.  He gets to his feet with a grunt as he rises.  \"<i>Yer lookin' like yer needin' some shut eye.</i>\"  He helps you to your feet; you manage to get your balance somehow and walk to the door.  \"<i>Y'alright?</i>\" he asks, looking you over.  Through a dumb grin you manage to assure him that you're fine.  \"<i>Well allll-right.</i>\"  Ro'gar nods at you as you turn to leave.  \"<i>Ya take care now.</i>\"  He watches you walk off with concern in his eyes, but you make it back to camp just fine.\n\n");
 			//set Ro'gar phase = 2
 			flags[kFLAGS.ROGAR_PHASE] = 2;
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 			return;
 		}
@@ -172,7 +174,7 @@ public function encounterRogarSwamp():void {
 		//((high femininity or breasts >=B-cup))
 		if(player.biggestTitSize() >= 2) {
 			outputText("You travel to Ro'gar's hut using the map again, your memory of the earlier trip making the passage much smoother.  When you knock on the door, though, you receive no answer.  In fact, the hut is eerily silent.  Trying the handle, you find the door unlatched.  You peer inside and discover that not only is it quiet and dark, quite a bit is missing.  Ro'gar is nowhere to be found, along with most of his belongings.  Looking around, you find no sign of distress or struggle.  It doesn't seem like anything happened to him.  Perhaps he moved?  Either way, he's not here now and it doesn't look like he's coming back anytime soon.  As you head back to camp you wonder if you'll ever see him again.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//move Ro'gar to Wet Bitch, set Ro'gar phase = 3
 			flags[kFLAGS.ROGAR_PHASE] = 3;
 		}
@@ -193,7 +195,7 @@ public function encounterRogarSwamp():void {
 			if(player.statusEffectv1(StatusEffects.TelAdre) <= 0) {
 				outputText("You apologize to Ro'gar; your mind draws a complete blank on the question.  The orc pouts with disappointment.  \"<i>I reckon I could just wander until I find somewhere...</i>\"  You shake your head and suggest he wait here where he's already established, but promise you'll be keeping an eye out for anywhere that might suit him.  Ro'gar beams at the reassurance, his pout twisting into a grin.  \"<i>Mighty fine of you!</i>\"  His thick arms wrap around you in a bear hug over the table.  You spend the rest of your visit chatting with the burly orc, careful to avoid any topics that might stir his wanderlust.\n\n");
 				//end scene without updating Ro'gar phase
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			//(if player has been to Tel'Adre)
 			else {
@@ -218,7 +220,7 @@ public function encounterRogarSwamp():void {
 					outputText("You leave Ro'gar to finish packing his things for now.");
 					//set Ro'gar phase = 3
 					flags[kFLAGS.ROGAR_PHASE] = 3;
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 				}
 				//(if Dirt Mc Girt = 2)
 				else {
@@ -234,7 +236,7 @@ public function encounterRogarSwamp():void {
 					//+lust, set Ro'gar phase = 3
 					dynStats("lus", 30, "scale", false);
 					flags[kFLAGS.ROGAR_PHASE] = 3;
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 				}
 			}
 		}
@@ -250,7 +252,7 @@ private function dontWaitForRogar():void {
 	outputText("Instead, you find only more mud.  You return to camp.");
 	//<set Crying Game = 1>
 	flags[kFLAGS.ROGAR_DISABLED] = 1;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //((Yes))
@@ -278,6 +280,7 @@ private function waitForChunkyOrcLoe():void {
 		outputText("<b>You can now find Ro'gar's hut when wandering the swamp occasionally!</b>");
 		//pass 2 hours, set Ro'gar phase flag = 1
 		flags[kFLAGS.ROGAR_PHASE] = 1;
+		explorer.stopExploring();
 		doNext(camp.returnToCampUseTwoHours);
 	}
 }
@@ -294,6 +297,7 @@ private function ewwwRogarIsGay():void {
 	outputText("Declining in a clipped manner, you get to your feet and make for the door, doing your best to ignore Ro'gar's disappointed face.  He calls out to you, but it only falls on deaf ears as you shut the door quickly behind you, your legs powering through the swamp as you run with all the speed you can muster.  Only once you get back to camp do you realize you've lost the crude map... either in Ro'gar's hut or in the trackless swamp.");
 	//<set Crying Game = 1>
 	flags[kFLAGS.ROGAR_DISABLED] = 1;
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseTwoHours);
 }
 
@@ -305,6 +309,7 @@ private function noSlowBroIDontWantPokeSex():void {
 	//<Continue without sex, set Dirt Mc Girt flag = 1 and Ro'gar phase = 2>
 	flags[kFLAGS.ROGAR_DIRT] = 1;
 	flags[kFLAGS.ROGAR_PHASE] = 2;
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseTwoHours);
 }
 
@@ -341,9 +346,12 @@ private function okayBroLetsHaveAGayCarwash():void {
 	// set Dirt Mc Girt flag = 2 and Ro'gar phase = 2>
 	flags[kFLAGS.ROGAR_DIRT] = 2;
 	flags[kFLAGS.ROGAR_PHASE] = 2;
-	if(player.inte < 30) doNext(camp.returnToCampUseTwoHours);
+	if(player.inte < 30) {
+		explorer.stopExploring();
+		doNext(camp.returnToCampUseTwoHours);
+	}
 	//lose 3 hours instead of 1 if int<30
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 }
 
 //((Third phase)) ([Cloaked Figure] button in Wet Bitch; Ro'gar phase = 3) (edited)
@@ -400,7 +408,7 @@ public function rogarThirdPhase():void {
 			//set Ro'gar phase = 4 and Ro'roh Raggy = 0
 			flags[kFLAGS.ROGAR_PHASE] = 4;
 			flags[kFLAGS.ROGAR_WARNING] = 0;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		//(else if Dirt Mc Girt = 1)
 		else if(flags[kFLAGS.ROGAR_DIRT] == 1) {
@@ -408,7 +416,7 @@ public function rogarThirdPhase():void {
 			//set Ro'gar phase = 4 and Ro'roh Raggy = 0, Acquire 1x Bro Brew
 			flags[kFLAGS.ROGAR_PHASE] = 4;
 			flags[kFLAGS.ROGAR_WARNING] = 0;
-			inventory.takeItem(consumables.BROBREW, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.BROBREW, explorer.done);
 		}
 		//(else if Dirt Mc Girt = 2)
 		else {
@@ -417,7 +425,7 @@ public function rogarThirdPhase():void {
 			if(player.gender == 2 || player.gender == 0) {
 				outputText("  It stops on your bare mons, and Ro'gar's eyes widen.  \"<i>Wh-wha... there's nothin' here!</i>\"  You color and nod.  His mouth hangs open for a long minute, then he masters himself.  \"<i>Well... I, uh, guess it was good t' see ya again...</i>\" he stammers.  \"<i>Hey, I'm sure you've got things to be doin' so I won't hold you up.</i>\"  As you attempt to protest, he chugs his drink and makes a show of slamming the can down, noisily and forcefully, on the bar.  Nodding at you, he pulls the cloak over his head and leaves the bar.  Apparently it was quite a shock to him.  You wonder if he'll avoid you from now on...");
 				flags[kFLAGS.ROGAR_DISABLED] = 1;
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else {
 				outputText("  " + SMultiCockDesc() + " gets a caress from him as he explores, arousing it to mild stiffness.  \"<i>[name],</i>\" he grunts.  \"<i>Ah hope ah'll be seein' more of ya.</i>\"  Ro'gar breaks the contact and tips back the remains of his drink while you ");
@@ -431,7 +439,7 @@ public function rogarThirdPhase():void {
 				flags[kFLAGS.ROGAR_PHASE] = 4;
 				flags[kFLAGS.ROGAR_WARNING] = 0;
 				dynStats("lus", 30, "scale", false);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 	}
@@ -448,7 +456,7 @@ public function rogarPhaseFour():void {
 		outputText(".  \"<i>Gee, ya look... different.  Been samplin' some of the local foods, huh?</i>\"  You agree cautiously, and he flags the bartender over and buys you a drink.  \"<i>I'm just bein' polite since we're pals,</i>\" the orc ventures.  \"<i>Ya kin pay me back another time.</i>\"  You nod, sip your drink, and converse reservedly with him for a while, then go on your way.");
 		//set Ro'roh Raggy = 1
 		flags[kFLAGS.ROGAR_WARNING] = 1;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	//(high fem or breasts >=B-cup and Ro'roh Raggy =1)
 	else if((player.biggestTitSize() >= 2) && flags[kFLAGS.ROGAR_WARNING] == 1) {
@@ -468,7 +476,7 @@ public function rogarPhaseFour():void {
 		//[(if F or U)
 		if(player.gender == 2 || player.gender == 0) {
 			outputText("  It reaches the center without interruption, and Ro'gar colors deeper.  \"<i>Uh... ferget it,</i>\" he mumbles.  \"<i>Didn't mean ta be indecent with you or anythin', miss.</i>\"  He nods to you and quickly departs before you can recover from the surprise.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		else {
 			outputText("  " + SMultiCockDesc() + " trembles under his strong touch, as he increases the pressure and looks into your eyes meaningfully.  ");
@@ -610,7 +618,7 @@ private function loseButtGinity():void {
 	player.sexReward("cum","Anal");
 	player.orgasm();
 	dynStats("sen", 2);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //((Scenario 2, [Give Anal]: Fuck Ro'gar))
@@ -636,7 +644,7 @@ private function fuckRogarsButtPussyBoyCuntManMoundSissySlitQueerQuim():void {
 	//[((If biggest cock is less than 4 inches))
 	if(player.longestCockLength() < 4) {
 		outputText("\"<i>Yer serious?</i>\" Ro'gar asks with a quirked eyebrow.  You blink as he suddenly gets up to stare you in the eyes.  \"<i>Not to be rude, [name], but I ain't gonna feel nothin'.</i>\"  You can't help but feel a little offended, saying something about motions of large bodies of water.  Ro'gar doesn't seem convinced as he buries his forehead in a palm.  \"<i>Listen, this ain't a really good time for this.  I'm already losin' my mojo.  You come back another time, okay?</i>\"  With that, you are ushered out as politely as possible.  You can't help but feel a little embarrassed as you walk the city streets like this is some sort of walk of shame.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		return;		//end if too small
 	}
 	//((else If smallest cock is over 18 inches))
@@ -683,7 +691,7 @@ private function fuckRogarsButtPussyBoyCuntManMoundSissySlitQueerQuim():void {
 	//<Lust sated>
 	player.orgasm();
 	dynStats("sen", -1);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //((Scenario 3, [Drink! (sorta)]: Fun with Bro Brew(Requires one bro brew per visit, uses it and turns player into a Bro)))
@@ -702,7 +710,7 @@ private function rogarIsDumb():void {
 
 	outputText("The playful mood broken, you hang out for a while and shoot the breeze, then head back.");
 	//end
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Fukkin' Grab It!]
@@ -785,7 +793,7 @@ private function takeDatBroBrewFromDaBigMeanOlOrc():void {
 	}
 	player.orgasm();
 	player.slimeFeed();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //((Scenario 4, [Frot]))
@@ -810,7 +818,7 @@ private function frotWithRogar():void {
 	//lose 100 lust, gain a little back, slimefeed?
 	player.orgasm();
 	dynStats("lus", 20, "scale", false);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //(([Get Tied Up], copy of Scenario 1a))
@@ -869,7 +877,7 @@ private function kinkyWithDaOrc():void {
 	player.orgasm();
 	dynStats("sen", 2);
 	player.slimeFeed();
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //(([Orc Rub Down], get some fun with oils))
@@ -905,7 +913,7 @@ private function sexyOrcPitsAreSexy():void {
         dynStats("sen", 2);
 	player.slimeFeed();
 	//end
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 //[Ignore pits]
 private function lickSomeMoreOrcButNoPits():void {
@@ -922,7 +930,7 @@ private function lickSomeMoreOrcButNoPits():void {
 	dynStats("sen", 2);
 	player.slimeFeed();
 	//end
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 }
 }

--- a/classes/classes/Scenes/Camp/CabinProgress.as
+++ b/classes/classes/Scenes/Camp/CabinProgress.as
@@ -1,4 +1,4 @@
-package classes.Scenes.Camp 
+package classes.Scenes.Camp
 {
 import classes.*;
 import classes.GlobalFlags.kACHIEVEMENTS;
@@ -13,7 +13,7 @@ import classes.Scenes.SceneLib;
 	public class CabinProgress extends BaseContent {
 		
 		public function CabinProgress() {
-			
+		
 		}
 		
 		public function initiateCabin():void {
@@ -21,12 +21,12 @@ import classes.Scenes.SceneLib;
 			//if (player.hasKeyItem("Nails") >= 0) player.removeKeyItem("Nails");
 			//Start cabin project!
 			if (flags[kFLAGS.CAMP_CABIN_PROGRESS] >= 10) flags[kFLAGS.CAMP_BUILT_CABIN] = 1;
-			if (flags[kFLAGS.CAMP_CABIN_PROGRESS] == 1) 
+			if (flags[kFLAGS.CAMP_CABIN_PROGRESS] == 1)
 			{
 				startWork();
 				return;
 			}
-			if (flags[kFLAGS.CAMP_BUILT_CABIN] == 1) 
+			if (flags[kFLAGS.CAMP_BUILT_CABIN] == 1)
 			{
 				SceneLib.dungeons.cabin.enterCabin();
 				return;
@@ -48,18 +48,18 @@ import classes.Scenes.SceneLib;
 				else if (flags[kFLAGS.CAMP_CABIN_PROGRESS] == 10) enterCabinFirstTime();
 			}
 			else
-			{	
+			{
 				outputText("You are too exhausted to work on your cabin!");
 				doNext(playerMenu);
 			}
-		}	
+		}
 		
 		//Error message
 		public function errorNotEnough():void {
-			outputText("\n\n<b>You do not have sufficient resources. You may buy more nails from the carpentry shop in Tel'Adre, get more wood from either the Forest or the Deepwoods and get more stones from some quarry or if you found someone to help you dig some from underground.</b>")		
+			outputText("\n\n<b>You do not have sufficient resources. You may buy more nails from the carpentry shop in Tel'Adre, get more wood from either the Forest or the Deepwoods and get more stones from some quarry or if you found someone to help you dig some from underground.</b>")
 		}
 		public function errorNotHave():void {
-			outputText("\n\n<b>You do not have the tools to build.</b>")		
+			outputText("\n\n<b>You do not have the tools to build.</b>")
 		}
 		
 		
@@ -75,7 +75,7 @@ import classes.Scenes.SceneLib;
 			outputText("You finally decide to begin your project: a cabin.  A comfortable cabin, come complete with a bed and nightstand along with some furniture. \n\nYou begin clearing away loose debris by picking up loose rocks and sticks and move them somewhere. It takes one hour and you feel a bit exhausted but you've finished creating a space.");
 			fatigue(50);
 			flags[kFLAGS.CAMP_CABIN_PROGRESS] = 3;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		//STAGE 3 - Think of materials. Obviously, wood.
@@ -83,8 +83,8 @@ import classes.Scenes.SceneLib;
 			outputText("Now that you have cleared an area for your cabin, you'll have to figure out how to get the resources you need. You look at the trees in the distance. Clearly, you'll need something to cut down trees. Maybe there's a shop somewhere?");
 			if (player.hasItem(weapons.L__AXE) || player.weaponName == "large axe") outputText("\n\nYour large axe will suffice for the daunting task of gathering materials.");
 			else if (player.hasKeyItem("Carpenter's Toolbox") >= 0) outputText("\n\nHappily, you have already bought it!");
-			else 
-			{	
+			else
+			{
 				outputText("\n\nYou realize something; you need an axe!");
 				if (camp.followerKiha())
 				{
@@ -92,7 +92,7 @@ import classes.Scenes.SceneLib;
 				}
 			}
 			flags[kFLAGS.CAMP_CABIN_PROGRESS] = 4;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function canGatherWoods():Boolean {
@@ -111,7 +111,7 @@ import classes.Scenes.SceneLib;
 			menu();
 			if (player.fatigue > player.maxFatigue() - 30) {
 				outputText("<b>You are too tired to consider cutting down the trees. Perhaps some rest will suffice?</b>");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			if (player.hasItem(weapons.L__AXE) || player.weaponName == "large axe") {
@@ -169,7 +169,7 @@ import classes.Scenes.SceneLib;
 			incrementWoodSupply(10 + Math.floor(player.str / 8));
 			awardAchievement("Getting Wood", kACHIEVEMENTS.GENERAL_GETTING_WOOD);
 			fatigue(50, USEFATG_PHYSICAL);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		//Cut down the tree yourself with large axe.
 		private function cutTreeTIMBER():void {
@@ -199,7 +199,7 @@ import classes.Scenes.SceneLib;
 			if (player.isInGoblinMech()) {
 				flags[kFLAGS.ACHIEVEMENT_PROGRESS_DEFORESTER] += (22 + Math.floor(player.str / 4));
 				incrementWoodSupply(22 + Math.floor(player.str / 4));
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else {
 				flags[kFLAGS.ACHIEVEMENT_PROGRESS_DEFORESTER] += (13 + Math.floor(player.str / 7));
@@ -228,7 +228,7 @@ import classes.Scenes.SceneLib;
 				if (model.time.hours <= 5 || model.time.hours >= 21) addButton(0, "Mine (N)", quarrySiteMine, true);
 				else addButton(0, "Mine (D)", quarrySiteMine).hint("Some ores might be available only at night.");
 			}
-			addButton(14, "Leave", camp.returnToCampUseOneHour);
+			addButton(14, "Leave", explorer.done);
 		}
 		private function quarrySitePickaxe():void {
 			outputText("\n\nYou pick up the old mining tool. This should prove useful when digging up gems, ore or stone from the landscape. Also inspecting leather bag it turns oput to be some lowest quality bag enchanted to store ores and other crafting materials in it. (It can store up to 5 pieces of 4 types of crafting materials)");
@@ -243,7 +243,7 @@ import classes.Scenes.SceneLib;
 		private function quarrySiteMine(nightExploration:Boolean = false):void {
 			if (player.fatigue > player.maxFatigue() - 50) {
 				outputText("\n\n<b>You are too tired to consider mining. Perhaps some rest will suffice?</b>");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			if (nightExploration) {
@@ -267,6 +267,7 @@ import classes.Scenes.SceneLib;
 		}
 		
 		private function findOre(nightExploration:Boolean = false):void {
+			explorer.stopExploring();
 			if (player.miningLevel > 0) {
 				if (rand(4) == 0) {
 					var itype:ItemType;
@@ -315,8 +316,8 @@ import classes.Scenes.SceneLib;
 			{
 				outputText("You are missing a toolbox. Maybe one of the shops sell these? \n\n");
 			}
-			doNext(camp.returnToCampUseOneHour); //- wadą tego etapu to brak menu lub menu za wcześnie?
-		}	
+			endEncounter(); //- wadą tego etapu to brak menu lub menu za wcześnie?
+		}
 		
 		//Get help from Kiha.
 		private function getHelpFromKiha():void {
@@ -334,7 +335,7 @@ import classes.Scenes.SceneLib;
 		
 		private function noThanks():void {
 			outputText("Deciding not to cut down the tree at the moment, you return to your camp. ");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function noThanks2():void {
 			outputText("Deciding not to work on your cabin right now, you return to the center of your camp.");
@@ -365,7 +366,7 @@ import classes.Scenes.SceneLib;
 		private function startCabinPart2():void {
 			outputText("You take out a paper, feather pen, and ink quill to draw some plans and diagrams. You spend one hour editing and perfecting your plans, reviewing and making some final changes to your plan before you fold the paper and put it away.");
 			flags[kFLAGS.CAMP_CABIN_PROGRESS] = 6;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		//STAGE 8 - Build cabin part 1.
@@ -454,7 +455,7 @@ import classes.Scenes.SceneLib;
 			outputText("You walk back to your cabin construction site and resume working. You take out the book and flip pages until you come across instructions on how to finish walls and roof. \n\n");
 			outputText("Segment by segment, you nail more wood on one side of the cabin. You move on to the next until the frame is covered. There is a hole where the window and door will be. You then climb up the ladder you have constructed from previous session. You then nail down the wood on roof frame. \n\n");
 			outputText("Several hours flew by as you've managed to complete the walls and roof. Finally, you apply paint on the roof and walls to ensure that it's waterproof and protected from the elements. \n\n");
-			outputText("<b>You have finished constructing the walls and roof!</b>\n\n");		
+			outputText("<b>You have finished constructing the walls and roof!</b>\n\n");
 			flags[kFLAGS.CAMP_CABIN_PROGRESS] = 8;
 			fatigue(100);
 			doNext(camp.returnToCampUseEightHours);
@@ -491,7 +492,7 @@ import classes.Scenes.SceneLib;
 			outputText("You walk back to your cabin construction site and resume working. You take out the book and flip pages until you come across instructions on how to construct a door.\n\n");
 			outputText("Following the instructions, you construct a wooden door that comes complete with a window. You frame the doorway and install the door into place.\n\n");
 			outputText("Next, you flip the book pages until you come across instructions on how to construct a window with functional shutters. You measure and cut the wood into the correct sizes before you nail it together into a frame. Next, you construct two shutters and install the shutters into window frame. Finally, you install the window into place.\n\n");
-			outputText("<b>You have finished installing the door and window!</b>\n\n");		
+			outputText("<b>You have finished installing the door and window!</b>\n\n");
 			flags[kFLAGS.CAMP_CABIN_PROGRESS] = 9;
 			fatigue(100);
 			doNext(camp.returnToCampUseFourHours);
@@ -529,8 +530,8 @@ import classes.Scenes.SceneLib;
 			outputText("Following the instructions, you lay some wood on the ground and measure the gap between each wood to be consistent.\n\n");
 			outputText("Next, you lay the wood and nail them in place. This takes time and effort but by the time you've finished putting the flooring into place, your cabin has wooden flooring ready to be polished. You spend the next few hours painting and polishing your floor.\n\n");
 			outputText("After spending time painting, you leave the floor to dry.\n\n");
-			outputText("<b>You have finished installing the flooring!</b>\n\n");		
-			outputText("<b>Congratulations! You have finished your cabin structure! You may want to construct some furniture though.</b>\n\n");		
+			outputText("<b>You have finished installing the flooring!</b>\n\n");
+			outputText("<b>Congratulations! You have finished your cabin structure! You may want to construct some furniture though.</b>\n\n");
 			flags[kFLAGS.CAMP_CABIN_PROGRESS] = 10;
 			flags[kFLAGS.CAMP_BUILT_CABIN] = 1;
 			fatigue(100);

--- a/classes/classes/Scenes/Camp/CabinProgress.as
+++ b/classes/classes/Scenes/Camp/CabinProgress.as
@@ -180,6 +180,7 @@ import classes.Scenes.SceneLib;
 			flags[kFLAGS.ACHIEVEMENT_PROGRESS_DEFORESTER] += (10 + Math.floor(player.str / 8));
 			incrementWoodSupply(10 + Math.floor(player.str / 8));
 			fatigue(50, USEFATG_PHYSICAL);
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 		}
 		//Cut down the tree yourself with Machined greatsword.
@@ -205,6 +206,7 @@ import classes.Scenes.SceneLib;
 				flags[kFLAGS.ACHIEVEMENT_PROGRESS_DEFORESTER] += (13 + Math.floor(player.str / 7));
 				incrementWoodSupply(13 + Math.floor(player.str / 7));
 				fatigue(50, USEFATG_PHYSICAL);
+				explorer.stopExploring();
 				doNext(camp.returnToCampUseTwoHours);
 			}
 		}
@@ -330,6 +332,7 @@ import classes.Scenes.SceneLib;
 			flags[kFLAGS.ACHIEVEMENT_PROGRESS_DEFORESTER] += (20 + Math.floor(player.str / 5));
 			incrementWoodSupply(20 + Math.floor(player.str / 5));
 			fatigue(50, USEFATG_PHYSICAL);
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 		}
 		

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -207,25 +207,46 @@ public class Combat extends BaseContent {
     }
 
     public function spellPerkUnlock():void {
-        if (flags[kFLAGS.SPELLS_CAST] >= 10 && !player.hasPerk(PerkLib.SpellcastingAffinity)) {
-            outputText("<b>You've become more comfortable with your spells, unlocking the Spellcasting Affinity perk and reducing mana cost of spells by 10%!</b>\n\n");
-            player.createPerk(PerkLib.SpellcastingAffinity, 10, 0, 0, 0);
+        var counter:Number = flags[kFLAGS.SPELLS_CAST];
+        var max:Number = 10;
+        if (counter >= 10) {
+            if (!player.hasPerk(PerkLib.SpellcastingAffinity)) {
+                outputText("<b>You've become more comfortable with your spells, unlocking the Spellcasting Affinity perk and reducing mana cost of spells by 10%!</b>\n\n");
+                player.createPerk(PerkLib.SpellcastingAffinity, 10, 0, 0, 0);
+            }
+            max = 30;
         }
-        if (flags[kFLAGS.SPELLS_CAST] >= 30 && player.perkv1(PerkLib.SpellcastingAffinity) < 20) {
-            outputText("<b>You've become more comfortable with your spells, further reducing your spell costs by an additional 10%!</b>\n\n");
-            player.setPerkValue(PerkLib.SpellcastingAffinity, 1, 20);
+        if (counter >= 30) {
+            if (player.perkv1(PerkLib.SpellcastingAffinity) < 20) {
+                outputText("<b>You've become more comfortable with your spells, further reducing your spell costs by an additional 10%!</b>\n\n");
+                player.setPerkValue(PerkLib.SpellcastingAffinity, 1, 20);
+            }
+            max = 70;
         }
-        if (flags[kFLAGS.SPELLS_CAST] >= 70 && player.perkv1(PerkLib.SpellcastingAffinity) < 30) {
-            outputText("<b>You've become more comfortable with your spells, further reducing your spell costs by an additional 10%!</b>\n\n");
-            player.setPerkValue(PerkLib.SpellcastingAffinity, 1, 30);
+        if (counter >= 70) {
+            if (player.perkv1(PerkLib.SpellcastingAffinity) < 30) {
+                outputText("<b>You've become more comfortable with your spells, further reducing your spell costs by an additional 10%!</b>\n\n");
+                player.setPerkValue(PerkLib.SpellcastingAffinity, 1, 30);
+            }
+            max = 150;
         }
-        if (flags[kFLAGS.SPELLS_CAST] >= 150 && player.perkv1(PerkLib.SpellcastingAffinity) < 40) {
-            outputText("<b>You've become more comfortable with your spells, further reducing your spell costs by an additional 10%!</b>\n\n");
-            player.setPerkValue(PerkLib.SpellcastingAffinity, 1, 40);
+        if (counter >= 150) {
+            if (player.perkv1(PerkLib.SpellcastingAffinity) < 40) {
+                outputText("<b>You've become more comfortable with your spells, further reducing your spell costs by an additional 10%!</b>\n\n");
+                player.setPerkValue(PerkLib.SpellcastingAffinity, 1, 40);
+            }
+            max = 310;
         }
-        if (flags[kFLAGS.SPELLS_CAST] >= 310 && player.perkv1(PerkLib.SpellcastingAffinity) < 50) {
-            outputText("<b>You've become more comfortable with your spells, further reducing your spell costs by an additional 10%!</b>\n\n");
-            player.setPerkValue(PerkLib.SpellcastingAffinity, 1, 50);
+        if (counter >= 310) {
+            if (player.perkv1(PerkLib.SpellcastingAffinity) < 50) {
+                outputText("<b>You've become more comfortable with your spells, further reducing your spell costs by an additional 10%!</b>\n\n");
+                player.setPerkValue(PerkLib.SpellcastingAffinity, 1, 50);
+            }
+            max = Infinity;
+        }
+        if (isFinite(max)) {
+            notificationView.popupProgressBar2("spellXP","spellXP",
+                    "Spellcasting XP", (counter-1)/max, counter/max);
         }
     }
 

--- a/classes/classes/Scenes/Dungeons/D3/D3.as
+++ b/classes/classes/Scenes/Dungeons/D3/D3.as
@@ -1,4 +1,4 @@
-package classes.Scenes.Dungeons.D3 
+package classes.Scenes.Dungeons.D3
 {
 import classes.BaseContent;
 import classes.EventParser;
@@ -29,7 +29,7 @@ import classes.room;
 		public var minotaurKing:MinotaurKingScenes = new MinotaurKingScenes();
 		public var lethice:LethiceScenes = new LethiceScenes();
 		
-		public function D3() 
+		public function D3()
 		{
 			configureRooms();
 		}
@@ -245,11 +245,12 @@ import classes.room;
 			outputText("\n\nDo you step inside, or wait until you’re better prepared?");
 			menu();
 			addButton(0, "Enter", enterD3);
-			addButton(1, "Leave", camp.returnToCampUseOneHour);
+			addButton(1, "Leave", explorer.done);
 		}
 		
 		public function enterD3():void
 		{
+			explorer.stopExploring();
 			SceneLib.dungeons.setDungeonButtons(); //Ensures the top buttons are visible.
 			menu(); //Clear bottom buttons
 			inRoomedDungeon = true;
@@ -399,7 +400,7 @@ import classes.room;
 		private function roomofmirrorsRoomFunc():Boolean
 		{
 			outputText("<b><u>Room of Mirrors</u></b>\n");
-			outputText("The metal door opens soundlessly onto a fairly large, unlit room, shabby and grey with disuse. It is cluttered with a great quantity of mirrors. Round hand mirrors are stacked on shelves, square wall mirrors are leant against walls, a large,"); 
+			outputText("The metal door opens soundlessly onto a fairly large, unlit room, shabby and grey with disuse. It is cluttered with a great quantity of mirrors. Round hand mirrors are stacked on shelves, square wall mirrors are leant against walls, a large,");
 			if (flags[kFLAGS.D3_MIRRORS_SHATTERED] == 1) outputText(" now shattered,");
 			outputText(" ornate standing mirror dominates the center of the room, and a number of broken, jagged specimens are stacked near the back. They reflect the dull trappings of this place back at you emptily. You guess as self-centred a race as the demons probably has quite a large use for these.");
 			
@@ -432,13 +433,13 @@ import classes.room;
                     if (flags[kFLAGS.BENOIT_AFFECTION] == 100) outputText("  This can only be the hall that " + SceneLib.bazaar.benoit.benoitMF("Benoit", "Benoite") + " once worked in.");
                     outputText("  You get the fright of your life when you think you see a number of depthless pools of grey revolve up to meet yours- but they don’t freeze you, you note as you reflexively turn away. The tinted glass must carry some sort of anti-petrifying charm, and further it must be reflective on the other side, because no one below seems to realize you’re standing there. Relaxing a bit, you continue to absorb the massive room. At the end furthest away from you two huge piles have been created- one of eggs, a massed assortment of every color and size imaginable, and one of pure junk, presumably everything the basilisks have found whilst scavenging and considered worth keeping. The detritus of a dozen collapsed civilizations must be down there, collected for the demons’ perusal by their scaly custodians. Directly below you, you can see archways like the one you just passed under, through which the basilisks ebb and flow.");
 					outputText("\n\nYour heartbeat quickens as you consider. There is a grid gantry running from where you are right around the room to the other side, where you can see a matching observation booth, presumably containing another exit. But it’s quite a distance, there are stairs leading down to the ground level, and outside the protective glass you would surely be spotted and apprehended");
-					if (player.canFly()) outputText(", even if you tried to fly it"); 
-					outputText(". Wouldn’t you? You can’t outrun the gaze of a thousand basilisks... could you?"); 
+					if (player.canFly()) outputText(", even if you tried to fly it");
+					outputText(". Wouldn’t you? You can’t outrun the gaze of a thousand basilisks... could you?");
 					if (player.hasKeyItem("Laybans") >= 0) outputText("  You take the Laybans out of your pouch and hold them up against the glass. It’s exactly as you hoped - they are made of the same material, and are almost certainly what the demons wear when they themselves interact with the basilisks. They would surely help you get across the hall, if you were crazy enough to try.");
 				}
 				else
 				{
-					outputText("Again you creep up to the tinted glass, again you take in the vast hall with the army of basilisks below hard at work, and again you stare out at the metal gantry, with the exit tantalizingly visible on the other side."); 
+					outputText("Again you creep up to the tinted glass, again you take in the vast hall with the army of basilisks below hard at work, and again you stare out at the metal gantry, with the exit tantalizingly visible on the other side.");
 					if (player.hasKeyItem("Laybans") < 0) outputText("  Are you going to try this?");
 					else outputText("  You take the Laybans out of your pocket, turning them around in your hands as you consider. Are you going to try this?");
 				}
@@ -446,7 +447,7 @@ import classes.room;
 				menu();
 				addButton(0, "Go!", jeanClaude.gogoFuckTheseBasilisks);
 				addButton(1, "Fall Back", fallbackFromMagpieHallS);
-					
+				
 				return true;
 			}
 			
@@ -516,7 +517,7 @@ import classes.room;
 			// Should actually be handled by the fallthrough of doNext(1) in the takeItem shit
 			
 			clearOutput();
-			outputText("You pluck out " + item.longName + " ");			
+			outputText("You pluck out " + item.longName + " ");
 			
 			flags[kFLAGS.D3_EGGS_AVAILABLE] += eggMask;
 			inventory.takeItem(item, playerMenu); //playerMenu is equivalent to doNext(1)
@@ -528,7 +529,7 @@ import classes.room;
 			
 			clearOutput();
 			item = weapons.DEMSCYT;
-			outputText("You pluck out " + item.longName + " ");			
+			outputText("You pluck out " + item.longName + " ");
 			flags[kFLAGS.D3_DEMONIC_SCYTHE] = 1;
 			inventory.takeItem(item, playerMenu);
 		}
@@ -613,7 +614,7 @@ import classes.room;
 		{
 			outputText("<b><u>South Courtyard</u></b>\n");
 			outputText("Lethice's courtyard is surprisingly well-groomed for a place that's supposedly home to neverending debauchery and depravity. The paths are laid with interconnecting sandstone bricks that reflect the sun to give the place a gentle, amber glow, and lush, green grass lines the sides along with well-trimmed hedges. You could almost mistake this place for a churchyard if it wasn't for the faint sound of moans on the wind. The courtyard paths lead away east and west, while the gateway out hangs open to the south.");
-			return false;			
+			return false;
 		}
 		
 		private function southwestcourtyardRoomFunc():Boolean

--- a/classes/classes/Scenes/Dungeons/DemonLab.as
+++ b/classes/classes/Scenes/Dungeons/DemonLab.as
@@ -4,10 +4,11 @@
  */
 package classes.Scenes.Dungeons {
 import classes.EventParser;
+import classes.GlobalFlags.kFLAGS;
+import classes.IMutations.IMutationsLib;
 import classes.PerkLib;
 import classes.Races;
 import classes.Saves;
-import classes.IMutations.IMutationsLib;
 import classes.Scenes.Dungeons.DemonLab.DemonDragonGroup;
 import classes.Scenes.Dungeons.DemonLab.Incels;
 import classes.Scenes.Dungeons.DemonLab.IncubusScientist;
@@ -19,7 +20,6 @@ import classes.Scenes.Dungeons.DemonLab.ScientistGunner;
 import classes.Scenes.NPCs.DivaScene;
 import classes.Scenes.NPCs.TyrantiaFollower;
 import classes.Scenes.SceneLib;
-import classes.GlobalFlags.kFLAGS;
 import classes.StatusEffects;
 import classes.internals.SaveableState;
 
@@ -129,7 +129,7 @@ public class DemonLab extends DungeonAbstractContent implements SaveableState {
 		outputText("\n\nDo you step inside, or wait until you’re better prepared?");
 		menu();
 		addButton(0, "Enter", EnteringDungeon);
-		addButton(1, "Leave", camp.returnToCampUseOneHour);
+		addButton(1, "Leave", explorer.done);
 	}
 
     //================================================================================
@@ -737,8 +737,8 @@ public class DemonLab extends DungeonAbstractContent implements SaveableState {
 		outputText("“<i>Your Majesty, is there anything in particular you wish to see?</i>” The second woman asks. This one is odd, even by demon standards. She has long, sharp bull horns, a horselike face and a red mane running down her body…A body covered in black and white striped scales. Her hair is red…and appears to be made from thin tendrils. Almost like the anemones from the lake. She turns her head towards the camera, and sticks her forked tongue out. Despite the horse-like shape of her face, she has snake-fangs, but the rest of her teeth are sharp. The back of her throat glows red, and she lets out a puff of smoke.\n\n");
 		outputText("Her breasts are C-cups, perky, and held in place by a milking machine repurposed as a bra. She wears a lab coat overtop, unbuttoned. Electricity visibly sparks from her body, and she levitates an inch or so off the ground. Her legs are thin, with a bone spike protruding from her knees, and her legs end in razor-sharp talons. She looks at the camera, and her pupils are…odd. They’re perfect ‘X’s, yellow, with a distinct glow.\n\n");
 		outputText("The Chimera has four arms, ending with clawed fingers. One holds an inkpot, and two hold a clipboard in front of her. She dips a single claw into the inkpot, jotting down notes with her remaining hand.\n\n");
-		outputText("“<i>No, Lucina. I want to know everything about the projects, and their progress.</i>” Lethice’s voice is firm, but very feminine, and she moves with an air of assured confidence. “<i>We’ve put a lot of effort into these labs of yours.</i>”\n\n"); 
-		outputText("“<i>Of course, my queen.</i>” As Lethice and her two retainers walk past, the quivering demon scientist in the back breaks formation, raising his voice.\n\n"); 
+		outputText("“<i>No, Lucina. I want to know everything about the projects, and their progress.</i>” Lethice’s voice is firm, but very feminine, and she moves with an air of assured confidence. “<i>We’ve put a lot of effort into these labs of yours.</i>”\n\n");
+		outputText("“<i>Of course, my queen.</i>” As Lethice and her two retainers walk past, the quivering demon scientist in the back breaks formation, raising his voice.\n\n");
 		outputText("“<i>Queen Lethice! Please, if you would?</i>” He takes two steps towards Lethice, but the massive minotaur turns, hefting his axe.\n\n");
 		outputText("“<i>You will speak to the queen when she requests your presence, and not a moment before.</i>” The chimeric woman says. Lethice ignores the disturbance, continuing on into the lab.\n\n");
 		outputText("“<i>Doctor Hemos, you will behave yourself.</i>” Another demon says, taking the doctor’s hand and pulling him back in line. “<i>Apologies, Doctor Lucina, for my…colleague's outburst.</i>” He shakes his head. “<i>He’s been working in his own lab for quite some time, and doesn’t know how to interact with others.</i>”\n\n");
@@ -1036,7 +1036,7 @@ public class DemonLab extends DungeonAbstractContent implements SaveableState {
             KihaFollower = false;
             DivaFollower = false;
             inDungeon = false;
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
         }
     }
 
@@ -1128,6 +1128,7 @@ public class DemonLab extends DungeonAbstractContent implements SaveableState {
         KihaFollower = false;
         DivaFollower = false;
         inDungeon = false;
+        explorer.stopExploring();
         doNext(camp.returnToCampUseTwoHours);
     }
 }

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth.as
@@ -108,6 +108,7 @@ public class EbonLabyrinth extends DungeonAbstractContent {
         outputText("You find the entrance to what appears to be a tunnel made of stone. This place looks man made as if carved by humanoid hands yet sports no decoration. Just empty linear corridors and corners dimly lit by magical torches. On a wall you find a sign reading ");
         outputText("-Woe to whom seeketh the black rose. Thy who enter beware, while riches you may find, death lurks in the Labyrinth's deepest reaches. It ever hungers.- how charming. The ruin of an old campfire is all that's left of the previous adventurers to come here.\n\n");
         outputText("<b>You found the Ebon Labyrinth.</b>\n\n");
+        explorer.stopExploring();
         doNext(enterDungeon);
     }
 

--- a/classes/classes/Scenes/Dungeons/Factory.as
+++ b/classes/classes/Scenes/Dungeons/Factory.as
@@ -47,7 +47,7 @@ use namespace CoC;
 			inDungeon = false;
 			clearOutput();
 			outputText("You slip out the door and disappear, heading back towards your camp, leaving the hellish factory behind.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function checkDoor1():void {

--- a/classes/classes/Scenes/NPCs/AlvinaFollower.as
+++ b/classes/classes/Scenes/NPCs/AlvinaFollower.as
@@ -175,7 +175,7 @@ public function alvinaSecondEncounter():void
 	flags[kFLAGS.ALVINA_FOLLOWER] = 9;
 	menu();
 	addButton(0, "Talk", alvinaSecondEncounterTalk);
-	addButton(4, "Leave", camp.returnToCampUseOneHour);
+	addButton(4, "Leave", explorer.done);
 }
 public function alvinaSecondEncounterTalk():void
 {
@@ -185,7 +185,7 @@ public function alvinaSecondEncounterTalk():void
 	menu();
 	addButton(0, "Her", alvinaSecondEncounterTalkHer, alvinaSecondEncounterTalk);
 	addButton(1, "Hobby", alvinaSecondEncounterTalkHobby, alvinaSecondEncounterTalk);
-	addButton(4, "Leave", camp.returnToCampUseOneHour);
+	addButton(4, "Leave", explorer.done);
 }
 public function alvinaSecondEncounterTalkHer(next:Function):void
 {
@@ -216,7 +216,7 @@ public function alvinaSecondBonusEncounter():void
 	outputText("\"<i>Is that so? Even then, what keeps you on Mareth still? Shouldn’t you have gone back to your homeland already? Perhaps it is something else that you seek. Regardless, if purging Mareth of the remaining corruption is your goal, you should go to the blight ridge. The area is dangerous and filled with demons, but surely the bane of Lethice should be able to get by without any issues?</i>\"\n\n");
 	outputText("She chuckles as a gust of wind throws dust at you, causing you to shield your eyes. The moment you look back at her, she is gone.\n\n");
 	flags[kFLAGS.ALVINA_FOLLOWER] = 10;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function alvinaThirdEncounter():void
@@ -232,7 +232,7 @@ public function alvinaThirdEncounterNo():void
 {
 	outputText("This is a very bad place, better not linger here. You decide to head back to camp.\n\n");
 	flags[kFLAGS.ALVINA_FOLLOWER] = 11;
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 public function alvinaThirdEncounterYes():void
 {
@@ -291,6 +291,7 @@ public function alvinaThirdEncounterYesSure():void
 	outputText("<b>Alvina has joined you as a follower.</b>\n\n");
 	flags[kFLAGS.ALVINA_FOLLOWER] = 13;
 	flags[kFLAGS.SIEGWEIRD_FOLLOWER] = 3;
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseOneHour);
 }
 public function alvinaThirdEncounterYesNever():void

--- a/classes/classes/Scenes/NPCs/CeraphFollowerScene.as
+++ b/classes/classes/Scenes/NPCs/CeraphFollowerScene.as
@@ -509,7 +509,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			outputText("Nodding, you give her ass a slap and send her off, noting Ceraph has freed her hands at some point and returned them to their normal position.  She hasn't done anything about the sexual filth coating her body, but knowing her, she probably doesn't want to.");
 			player.sexReward("vaginalFluids","Dick");
 			dynStats("sen", -2, "cor", .25);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //*Ceraph TongueFucks The PC (Zeddited)
@@ -560,7 +560,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			flags[kFLAGS.CERAPH_TIMES_LICKED]++;
 			player.sexReward("saliva", "Vaginal");
 			dynStats("sen", -2 ,"cor", .25);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //*Ceraph goes full tentacle and double penetrates herms (+ standard dick BJ if ceraph dick toggle is on) (Zeddited)
@@ -614,12 +614,12 @@ public class CeraphFollowerScene extends NPCAwareContent
 			if (!player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP - 32, 61); //Ceraph causes faster pregnancies
 			if (flags[kFLAGS.CERAPH_HIDING_DICK] == 0 && flags[kFLAGS.CERAPH_PUNISHED] == 0) {
 				outputText("You smirk and wonder if you should punish her for stuffing her cock down your throat.  Do you?");
-				simpleChoices("Punish", punishCeraphForSurpriseThroatFuck, "", null, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+				simpleChoices("Punish", punishCeraphForSurpriseThroatFuck, "", null, "", null, "", null, "Leave", explorer.done);
 			}
 			//ELSE:
 			else {
 				outputText("You nod graciously and begin to clean up, dismissing your personal demon... for now.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -631,7 +631,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			clearOutput();
 			outputText("You grab hold of Ceraph, bending the surprised demoness over a rock and laying into her ass.  She whimpers, but manages not to cry, even as you turn her purple butt into a black and blue canvas.  With each slap you deliver, you dictate that her cock is only allowed near your mouth at YOUR discretion, not a worthless slave's.  By the end, she's sniffling and nodding, murmuring, \"<i>Yes [Master],</i>\" over and over again.</i>\"\n\n");
 			outputText("You let the demon go with her pride bruised.  There's little doubt to be had - she'll never make that mistake again.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //Siamese Catgirl Twins - TDM (Zeddited, nya)
@@ -700,7 +700,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			//lust to 0, corruption +0.5
 			player.sexReward("no", "Dick");
 			//end scene
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 
@@ -768,7 +768,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 				player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP - 32, 61); //Ceraph causes faster pregnancies
 				trace("PC KNOCKED UP WITH CERAPH IMPS");
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //[Sober]
@@ -805,7 +805,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			outputText("Retrieving your [armor], when you turn around again, Urta is gone, the moment vanishing like a drop of water in an endless sea. \"<i>Thank you, [Master],</i>\" Ceraph's voice demurely whispers, gratitude floating on the wind.");
 			player.sexReward("vaginalFluids","Dick");
 			dynStats("sen", -2, "cor", 2);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //Corrupting the Innocent with optional gangbang -Luka (Zeddited) (with Shake N' Bake) (and Shambles helped)
@@ -942,7 +942,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			outputText("Chagrined, she unfurls her wings and flies off, the imps quickly wilting and following suit.");
 			//(disable repeat of scene)
 			flags[kFLAGS.CERAPH_RP_CORRUPT_DISABLED] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //[=No=]
@@ -952,7 +952,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			outputText("You tell her you have no interest in granting release to lowly imps.  If they want pleasure, then they should earn it themselves.\n\n");
 
 			outputText("\"<i>Sorry boys, " + player.mf("Master's", "Mistress") + " orders.</i>\"  She extends her wings and flies away, and the horny imps follow suit, still busy masturbating.  A 'pit-pat-pat' sound follows them, the noise of their pre-cum hitting the dry dirt from on high.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //[=Yes=]
@@ -971,7 +971,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 
 			outputText("Licking the cum off her body, she sashays towards you to give you a little peck on the cheek.  \"<i>Hmm, you're such a good [Master], I might have to leave Ceraph's harem and join yours instead.  See you around, hot stuff.</i>\"  She rounds up the tired imps and extends her wings, setting off alongside them.");
 			dynStats("lus", 5, "cor", 2);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //(not optimized in any way for centaur)
@@ -1093,7 +1093,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			//end (stat changes?)
 			player.sexReward("vaginalFluids","Dick");
 			dynStats("lib", 1, "sen", -5, "cor", 3);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //NOTES:
@@ -1207,7 +1207,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			player.sexReward("vaginalFluids","Dick");
 			dynStats("sen", -2, "cor", 2);
 			flags[kFLAGS.CERAPH_ROLEPLAY_AS_DOMINIKA_COUNT]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		/*Ceraph's Harem: Zetsuko
@@ -1304,7 +1304,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			outputText("\"<i>Zetsuko hopes to taste [Master] again sometime...</i>\"");
 			player.sexReward("vaginalFluids","Dick");
 			dynStats("lib", .25, "sen", -5, "cor", 2);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //▶[GetTongued] requires vagina
@@ -1359,7 +1359,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			outputText("\"<i>Zetsuko hopes to taste [Master] again sometime...</i>\"");
 			player.sexReward("saliva");
 			dynStats("lib", .25, "sen", -5, "cor", 2);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //▶[Banana?] silly mode
@@ -1386,7 +1386,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			outputText("\"<i>FUCK!</i>\"\n\n");
 
 			outputText("You'll take that as a yes.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function noZetsukoLoveToday():void
@@ -1469,7 +1469,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			dynStats("sen", -2, "cor", 5);
 			flags[kFLAGS.CERAPH_OWNED_DICKS]++;
 			player.removeCock(x, 1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function ceraphFollowerCuntTaking():void
@@ -1486,7 +1486,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			player.orgasm();
 			dynStats("sen", -2, "cor", 5);
 			flags[kFLAGS.CERAPH_OWNED_PUSSIES]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function ceraphFollowerTitTaking(rowNum:int = 0):void
@@ -1539,7 +1539,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			//(-1 fetish, +1 tit toy status)
 			dynStats("lus", 20, "cor", 5);
 			flags[kFLAGS.CERAPH_OWNED_TITS]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //NippleCunt Stuffing (Ceraph grows dick-nipples to plow your lusty twats!)
@@ -1581,7 +1581,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			outputText("\n\n\"<i>Delicious, my [Master],</i>\" the demoness coos as her wings unfurl, \"<i>Please, let's do this again.</i>\"  She leaps into the sky and flies off, no doubt to tend to her own pets.");
 			player.sexReward("cum","Vaginal");
 			dynStats("sen", 2, "cor", 1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //Portal Fuck (AKA Ceraph Hung Out With Cinnabar, Req's PC dick)
@@ -1623,7 +1623,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			dynStats("cor", 1);
 			awardAchievement("Now You're Fucking With Portals", kACHIEVEMENTS.GENERAL_FUCK_WITH_PORTALS, true, true);
 			flags[kFLAGS.TIMES_CERAPH_PORTAL_FUCKED]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		private function layEggsInSlaveCeraph():void
@@ -1672,7 +1672,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			outputText("\n\nHumming a happy tune to yourself as you walk around Ceraph's twitching form, you grab a handful of her hair and pull her up off the ground.  Her face is crusted with dirt and her sparkling, gem-like eyes stare senselessly at you.  You rub your ovipositor over her head, carefully wiping your mingled lubes off on her hair before retracting the organ back into its holding sleeve.  \"<i>That will be all,</i>\" you tell her, and she smiles dreamily at you.  You turn around to gather your things, and don't bother to look back.");
 			player.dumpEggs();
 			player.sexReward("Default","Default",true,false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 
@@ -1736,7 +1736,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			outputText("\n\nCeraph gets up with a shocked expression painted on her violet features.  \"<i>Didn't you have any fun?</i>\" she asks.  \"<i>We were just about to the good part!</i>\"");
 			outputText("\n\nYou tell her that it wasn't fun in the slightest, and you want out.");
 			outputText("\n\n\"<i>Well, okay then... [Master]...</i>\" she grumbles.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //[Either Once]
@@ -1870,7 +1870,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 			//Increase corruption, reset lust, increase sensitivity.
 			player.sexReward("cum","Anal");
 			dynStats("sen", 2, "cor", 1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //[Either Twice]
@@ -2078,7 +2078,7 @@ public class CeraphFollowerScene extends NPCAwareContent
 				outputText("\n\nYour collar is removed, and you look around realizing your owner is gone.  Your muscles are sore from the journey and you NEED to masturbate...  You aren't even sure why you did that.");
 			}
 			dynStats("sen", 4, "lus=", 100, "scale", false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 	}
 }

--- a/classes/classes/Scenes/NPCs/CeraphScene.as
+++ b/classes/classes/Scenes/NPCs/CeraphScene.as
@@ -192,7 +192,7 @@ public class CeraphScene extends NPCAwareContent
 				dynStats("lib", 3, "sen", 3, "cor", 1);
 				if (CoC.instance.inCombat)
 					cleanupAfterCombat();
-				else doNext(camp.returnToCampUseOneHour);
+				else endEncounter();
 			}
 		}
 
@@ -249,7 +249,7 @@ public class CeraphScene extends NPCAwareContent
 			dynStats("lib", 3, "sen", 3, "cor", 1);
 			if (!player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP - 32, 61); //Ceraph causes faster pregnancies
             if (CoC.instance.inCombat) cleanupAfterCombat();
-			else doNext(camp.returnToCampUseOneHour);
+			else endEncounter();
 		}
 
 //[OH SHIT SON YOU LOST GET EARS PIERCED]
@@ -381,7 +381,7 @@ public class CeraphScene extends NPCAwareContent
 			outputText("You tell Ceraph no, emphatically, over and over.  She gives you a smirk and says, \"<i>Whatever.  It's only a matter of time.  You'll join me soon, pet.</i>\"\n\n");
 
 			outputText("With that declaration she departs, leaving you confused and horny.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //[fight]
@@ -493,7 +493,7 @@ public class CeraphScene extends NPCAwareContent
 			player.earsPShort = "green gem-stone ear-studs";
 			player.earsPLong = "Green gem-stone ear-studs";
 			flags[kFLAGS.PC_FETISH] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //[PC 'BEAT OFF' Ceraph the first time...]
@@ -588,7 +588,7 @@ public class CeraphScene extends NPCAwareContent
 			outputText("\"<i>So, I take it you like it?  You'll never be able to raise a hand in anger again.  I guess if you want to win fights you'll have to tease your foes into submission with that luscious body.  I suppose that might be hard to do when you're getting off on exposing yourself and cumming from the thought of being tied down,</i>\" she laughs.\n\n");
 			outputText("You tremble with barely restrained lust as the demoness flounces away.  You'd pursue her, but between her ideas and exposing your crotch to the entire area, you need to cum more than anything in the world.  You scurry back to camp, too horny to think straight and your new piercing aching just enough to keep you from forgetting about it.");
 			flags[kFLAGS.PC_FETISH] = 3;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 
@@ -596,7 +596,7 @@ public class CeraphScene extends NPCAwareContent
 		public function encounterCeraph():void
 		{
 			//Just in case set up next button for 1 hr + camp
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 			//If havent met her
 			if (flags[kFLAGS.PC_MET_CERAPH] == 0) {
 				spriteSelect(SpriteDb.s_ceraph);
@@ -734,7 +734,7 @@ public class CeraphScene extends NPCAwareContent
 			dynStats("lus", 200, "scale", false);
             if (CoC.instance.inCombat)
                 cleanupAfterCombat();
-			else doNext(camp.returnToCampUseOneHour);
+			else endEncounter();
 		}
 
 //(REQ's – HUGE WANG, Exgartuan or Jojo corruption, and !centaur)
@@ -803,7 +803,7 @@ public class CeraphScene extends NPCAwareContent
                 outputText("</i>\"");
 				player.orgasm();
 				dynStats("lib", 3, "sen", 3, "cor", 1);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			outputText("  That's rarer than you know, so I'm feeling a little generous.  ");
@@ -898,7 +898,7 @@ public class CeraphScene extends NPCAwareContent
 			outputText("beat a hasty retreat from the trickster of fetishes.  Her masturbatory moans chase you down the mountainside back towards your camp, spiking the already-burning furnace of your lust.");
 			//(+10 lust + 10lust/piercing)
 			dynStats("lus", (10 + flags[kFLAGS.PC_FETISH] * 10), "scale", false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //[Trade]
@@ -949,7 +949,7 @@ public class CeraphScene extends NPCAwareContent
 			spriteSelect(SpriteDb.s_ceraph);
 			outputText("Ceraph smiles knowingly at your response.  \"<i>You'll find this to be quite sexy.  Just be careful putting it on.  If you don't fit it right it'll pinch,</i>\" the demoness instructs while tossing you a set of armor.\n\n");
 			//(Get trapped armor and go home)
-			inventory.takeItem(armors.SEDUCTA, camp.returnToCampUseOneHour);
+			inventory.takeItem(armors.SEDUCTA, explorer.done);
 		}
 
 //[Trade Bimbo Liquer]
@@ -964,7 +964,7 @@ public class CeraphScene extends NPCAwareContent
 			player.takePhysDamage(4);
 			flags[kFLAGS.PC_FETISH] = 0;
 			dynStats("lus", -20, "scale", false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //[Trade Genitals]
@@ -977,7 +977,7 @@ public class CeraphScene extends NPCAwareContent
 				outputText("A disembodied voice roars out, \"<i>FUCK NO!  You are NOT giving me to that crazy bitch!</i>\"  Exgartuan doesn't seem to want to run the risk of being taken by Ceraph, and he completely assumes control of your [legs] to make you flee with all due haste.  He taunts, \"<i>Rip off your own little dick, why doncha!  You'd look better with just a pussy anyhow ya dried out old sow!</i>\"\n\n");
 				outputText("Ceraph seems perturbed but doesn't bother to pursue you.");
 				dynStats("lus", -20, "scale", false);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 				return;
 			}
 			//Create array for choosing bits!
@@ -1070,7 +1070,7 @@ public class CeraphScene extends NPCAwareContent
 			clearOutput();
 			spriteSelect(SpriteDb.s_ceraph);
 			outputText("You let her know that you've changed your mind and take off before Ceraph can try to take your beloved body parts.  You hear her laugh and tease as you run, yelling, \"<i>What, can't handle the thought of an Omnibus touching your fun bits?  Poor baby!</i>\"\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //[Yes]
@@ -1176,7 +1176,7 @@ public class CeraphScene extends NPCAwareContent
 				flags[kFLAGS.CERAPH_OWNED_TITS]++;
 			}
 			//Fix any gender mixmatches
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 //NIGHTTIME
@@ -1445,7 +1445,7 @@ public class CeraphScene extends NPCAwareContent
 			player.sexReward("no", "Dick");
             if (CoC.instance.inCombat)
                 cleanupAfterCombat();
-			else doNext(camp.returnToCampUseOneHour);
+			else endEncounter();
 		}
 
 		public function rapeCerberusStyle():void {
@@ -1462,7 +1462,7 @@ public class CeraphScene extends NPCAwareContent
 			player.sexReward("vaginalFluids","Dick");
 			if (CoC.instance.inCombat)
 				cleanupAfterCombat();
-			else doNext(camp.returnToCampUseOneHour);
+			else endEncounter();
 		}
 	}
 }

--- a/classes/classes/Scenes/NPCs/DivaScene.as
+++ b/classes/classes/Scenes/NPCs/DivaScene.as
@@ -297,7 +297,7 @@ public class DivaScene extends XXCNPC {
                 cleanupAfterCombat();
             } else {
                 outputText("Diva regretfully breaks the embrace before going back to her coffin. Strangely, you don't feel tired from mating with her all night long.");
-                doNext(camp.returnToCampUseOneHour);
+                endEncounter();
             }
         }
     }
@@ -318,7 +318,7 @@ public class DivaScene extends XXCNPC {
             + "\n"
             + "This carry on for the whole night, the pair of you making love and feasting on numerous consecutive victims at the same time. It's only outside on the prowl that you notice how gracefully and efficiently she hunts at night, her technique both at lovemaking and hunting is simply flawless. Both of you head back to camp, highly satiated, as the sun begins to rise again. Diva bids you good day as she heads to her tent and coffin. As for yourself, you think your job is done when you walk at day, skip the sleep this time around. Not so surprisingly, your nightly vampiric meal offsets this issue, granting you the energy to go without rest today.\n");
         player.sexReward("cum");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     private function bloodyRose():void {
@@ -351,7 +351,7 @@ public class DivaScene extends XXCNPC {
         }
         function sharedEnd():void {
             outputText("ou start to doze off tired as Diva pulls you down in her coffin. You wake up in the morning, still in Diva's embrace. She's fast asleep but still wears a content smile.");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
         }
     }
 

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -321,7 +321,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         clearOutput();
         outputText("You can't decide what to do right now, so you leave the egg where it is and return to your camp.");
         //(You can restart this quest by randomly encountering this chamber again. It continues to reappear until you either Destroy or Take the egg.)
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //[=Destroy it=] (Z)
@@ -332,7 +332,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         outputText("\n\nWith nothing else in the cave, you prepare to leave, but find yourself stopped by a sudden thought.  The egg yolk, though raw, looks strangely appetizing...");
         flags[kFLAGS.EGG_BROKEN] = 1;
         //[Eat][Leave]
-        simpleChoices("Eat It", eatEmbersYolkLikeAnEvenBiggerDick, "", null, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+        simpleChoices("Eat It", eatEmbersYolkLikeAnEvenBiggerDick, "", null, "", null, "", null, "Leave", explorer.done);
     }
 
     //[=Eat=]
@@ -350,7 +350,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         //(also slimefeed!)
         dynStats("str", 5 + rand(5), "tou", 5 + rand(5), "int", 5 + rand(5), "cor", 20);
         player.slimeFeed();
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
 
@@ -393,7 +393,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
             outputText("\n\nYou look around over and over and over... but no matter how much you look you don't see anything at all that could even resemble some kind of magic rune, or activation button, or anything that could disable the ward.  You groan in frustration.");
             outputText("\n\nIt looks like you will have to leave the egg for now until you're better versed in magical methods... or strong enough to knock down a mountain!  You roll it back down the corridor into its shrine to prevent its being seen from the cave entrance.");
             //Same as taking the Leave option. Must find the egg again to take it.
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         }
         outputText("\n\n(<b>You have now begun the Mysterious Egg quest.  The Mysterious Egg is added to the <i>Items</i> at the Camp.</b>)");
@@ -401,7 +401,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         player.createKeyItem("Dragon Egg", 0, 0, 0, 0);
         flags[kFLAGS.TOOK_EMBER_EGG] = 1;
         flags[kFLAGS.EMBER_COR] = 50;
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
 
@@ -656,7 +656,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         clearOutput();
         if (player.gender == 0) {
             outputText("The light pulses decrease in speed as you disrobe and expose your bare crotch, leaving you disappointed after summoning your perversity to bring you this far.  You feel as if you've let it down somehow...  This is confusing!  You decide to go away and deal with this fickle egg another time.");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         }
         //Nothing changes. PC can go do something else, lose no time.
@@ -720,7 +720,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         flags[kFLAGS.EMBER_JACKED_ON] = 1;
         //INCREMENT EMBER FEEDINZ
         flags[kFLAGS.EMBER_EGG_FLUID_COUNT]++;
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //HATCH DAT BITCH
@@ -825,7 +825,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         outputText("\n\n<b>Before fully settling in your camp as if remembering something Ember pulls a shining shard from her inventory and hand it over to you as a gift. You acquired a Radiant shard!</b>");
         flags[kFLAGS.EMBER_HATCHED] = 1;
         player.removeKeyItem("Dragon Egg");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Appearance (shows Ember's appearance, always available)
@@ -964,23 +964,23 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         if (player.isPregnant() && hasCock()) { //Extra check might protect against inappropriate Ember complaints
             if (flags[kFLAGS.EMBER_OVI_BITCHED_YET] == 0 && (player.pregnancyType == PregnancyStore.PREGNANCY_OVIELIXIR_EGGS || player.pregnancy2Type == PregnancyStore.PREGNANCY_OVIELIXIR_EGGS)) {
                 emberBitchesAboutPCBeingFullOfEggs();
-                doNext(camp.returnToCampUseOneHour);
+                endEncounter();
                 return;
             }
             if ((player.pregnancyType == PregnancyStore.PREGNANCY_EMBER || player.pregnancy2Type == PregnancyStore.PREGNANCY_EMBER) && player.pregnancyType < 300 && flags[kFLAGS.EMBER_TALKS_TO_PC_ABOUT_PC_MOTHERING_DRAGONS] == 0) {
                 emberTalksToPCAboutPCDragoNPregnancy();
-                doNext(camp.returnToCampUseOneHour);
+                endEncounter();
                 return;
             }
             if (player.pregnancyIncubation < 200 && (player.pregnancyType != PregnancyStore.PREGNANCY_EMBER || player.pregnancy2Type != PregnancyStore.PREGNANCY_EMBER) && flags[kFLAGS.EMBER_BITCHES_ABOUT_PREGNANT_PC] == 0) {
                 manEmberBitchesAboutPCPregnancy();
-                doNext(camp.returnToCampUseOneHour);
+                endEncounter();
                 return;
             }
         }
         if (flags[kFLAGS.EMBER_PREGNANT_TALK] == 0 && pregnancy.event > 1) {
             emberIsPregnantFirstTimeTalkScene();
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
         }
         clearOutput();
         outputText("What will you talk about?");
@@ -1106,7 +1106,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         //(Low Affection)
         if (emberAffection() <= 25) {
             outputText("\n\n\"<i>You're a waste of time,</i>\" Ember says nonchalantly.  [ember Ey] walks past you and then flies off.");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         }
         //There's a points system here, that can range from 0 to 8, this is used to check Ember's final answer after " + emberMF("he","she") + "'s done examining the PC.
@@ -1425,7 +1425,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
             outputText("\n\nYou gently ask what [ember ey] means by \"<i>strange ideas</i>\".");
             outputText("\n\n\"<i>The ones you're getting!</i>\" Ember blurts out, before spinning on [ember eir] heels and leaving you alone. You watch [ember em] go and smile.");
         }
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     private function drinkDeeplyOfDagronBlud():void {
@@ -1443,7 +1443,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
             outputText("\n\nAs you break the kiss; Ember leans over, supporting [ember em]self on your shoulders.  \"<i>Ugh... I guess we overdid it... I feel woozy.</i>\"");
             outputText("\n\nYou quickly offer [ember em] a helping hand, inquiring if [ember ey] is all right.  Ember accepts your help, using your hand to balance [ember em]self.  \"<i>I-I'll be fine... just, no more sharing for the day...</i>\"");
         }
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //TF messages (Z)
@@ -1488,7 +1488,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
             outputText("\n\nEmber mumbles quietly, \"<i>Next time, fertilize it for me will you?</i>\"  You start at that; did she really just say it aloud?  But, knowing her temper, you decide against asking.  ");
             //git a dragon egg, small libido-based lust damage
             dynStats("lus", 10 + player.lib / 10, "scale", false);
-            inventory.takeItem(consumables.DRGNEGG, camp.returnToCampUseOneHour);
+            inventory.takeItem(consumables.DRGNEGG, explorer.done);
         }
         //(Medium Affection)
         else if (emberAffection() < 75) {
@@ -1542,7 +1542,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
             outputText("\n\nYou just smile and tell her you understand exactly what she meant.  One quick kiss and you head back to the camp proper, leaving one adorably flustered dragon behind you.  ");
             //git a dragon egg, small libido-based lust damage
             dynStats("lus", 10 + player.lib / 10, "scale", false);
-            inventory.takeItem(consumables.DRGNEGG, camp.returnToCampUseOneHour);
+            inventory.takeItem(consumables.DRGNEGG, explorer.done);
         }
     }
 
@@ -1554,7 +1554,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         if (flags[kFLAGS.EMBER_GENDER] == 3) outputText(".. it even drips with some kind of off-white fluid.");
         outputText("  \"<i>H-here's your egg.  Use it while it's fresh, okay?</i>\"  Her eyes glaze over a bit at the suggestion, and she giggles.  ");
         //git a dragon egg, no Ember affection change
-        inventory.takeItem(consumables.DRGNEGG, camp.returnToCampUseOneHour);
+        inventory.takeItem(consumables.DRGNEGG, explorer.done);
     }
 
     //[Watch]
@@ -1600,7 +1600,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         outputText("\n\nYes, you did, because she asked and she seemed to need your help, as you point out.  Ember doesn't bother coming up with something to say, she just unfurls her wings and jumps into the air with a gust of wind.");
         outputText("\n\nYou shake your head and sigh softly.  ");
         //git an egg, moderate lib-based lust damage, Ember affection up
-        inventory.takeItem(consumables.DRGNEGG, camp.returnToCampUseOneHour);
+        inventory.takeItem(consumables.DRGNEGG, explorer.done);
         emberAffection(5);
     }
 
@@ -1867,7 +1867,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         fatigue(-50);
         player.slimeFeed();
         HPChange(player.maxHP() * .33, false);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Sparring text outputs (Z) (FENCODED TO HERE)
@@ -1984,7 +1984,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         //(Low affection)
         if (emberAffection() <= 25) {
             outputText("\n\n\"<i>What!?  That is just gross!  Not to mention, it'd never fit!</i>\"  Ember doesn't bother waiting for your reply, shooing you out of [ember eir] den.");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         }
         //(Moderate affection)
@@ -2116,7 +2116,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         emberAffection(6);
         player.sexReward("cum", "Anal");
         dynStats("sen", 3);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //[Blow Ember] - your shipment of dragon dildoes has arrived
@@ -2218,7 +2218,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         player.sexReward("cum", "Lips");
         emberAffection(6);
         dynStats("lus", 10 + player.lib / 10, "scale", false);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Get Blown - put your dick in the knife drawer, it'll be fun! (Z, with reservation)
@@ -2230,7 +2230,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         //(Low Affection)
         if (emberAffection() <= 25) {
             outputText("\n\n\"<i>Ah.  And... what makes you think I would ever consider that?</i>\"  Ember huffs indignantly and walks away.");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         }
         //(Medium Affection)
@@ -2329,7 +2329,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         //lose lust, reset hours since cum
         player.sexReward("saliva");
         dynStats("sen", -1);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
 
@@ -2342,7 +2342,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         //(Low Affection)
         if (emberAffection() <= 25) {
             outputText("\n\n[ember Eir] eyes widen.  \"<i>Never!  N-E-V-E-R!  Not even over my dead body!</i>\" Ember exclaims.  The dragon unfurls [ember eir] wings and lifts off, beating the air furiously.");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         }
         //(Medium Affection)
@@ -2484,7 +2484,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         }
         player.sexReward("no");
         dynStats("sen", -2);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Eat Ember Out - b-baka! (Z)
@@ -2564,7 +2564,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         player.sexReward("vaginalFluids");
         emberAffection(6);
         dynStats("lus", 10 + player.lib / 10, "scale", false);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Get Eaten Out - actually halfway likeable
@@ -2576,7 +2576,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         if (emberAffection() <= 25) {
             outputText("\n\n\"<i>No way!  I have no idea what's been there!  Plus, that is just gross!</i>\"  Ember spins on [ember eir] heels and walks away.");
             //End scene
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         }
         //(Medium Affection)
@@ -2631,7 +2631,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         outputText("\n\nYou smile, hating to see [ember em] go, but so loving to watch [ember em] leave.  Shaking off your pleasurable fantasies, you manage to pull yourself back upright, redress yourself, and return to camp.");
         //minus some fukkin' lust, reset hours since cum
         player.sexReward("saliva");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Penetrate Her - seems not to accommodate centaurs, more's the pity (Z)
@@ -2645,7 +2645,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         //(Low Affection)
         if (emberAffection() <= 25) {
             outputText("\n\n\"<i>By you?  Ha!  Funny joke!</i>\"  Ember laughs forcibly as she walks away.");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         }
         //(Medium Affection)
@@ -2703,7 +2703,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
             if (player.cockTotal() == 1) outputText("that");
             else outputText("those");
             outputText(" and then come back!</i>\"  Ember turns on her heels and walks away, moodier than usual.");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         }
         //(else if PC has multiple fit cocks){
@@ -2789,7 +2789,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
             player.sexReward("vaginalFluids", "Dick");
             dynStats("sen", -2);
             emberAffection(-5);
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             flags[kFLAGS.EMBER_PUSSY_FUCK_COUNT]++;
             return;
         }
@@ -2847,6 +2847,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
 
         outputText("\n\nYour decency restored, you return to camp.");
         flags[kFLAGS.EMBER_PUSSY_FUCK_COUNT]++;
+        explorer.stopExploring();
         doNext(camp.returnToCampUseTwoHours);
     }
 
@@ -2862,7 +2863,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         //(Low Affection)
         if (emberAffection() <= 25) {
             outputText("\n\n\"<i>Ha!  I'm much more than you can handle!  Talk to me when you have something that can take even half of me.</i>\"  Ember mocks you, as [ember ey] walks away.");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         }
         //(Medium Affection)
@@ -2977,7 +2978,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
 
         outputText("\n\nEmber's eyes widen in terror.  \"<i>What!?  No!  Not again!</i>\" Ember screams, getting up and wasting no time in bolting away, setting into an unsteady flight as soon as [ember ey]'s gotten far enough.  You wait until [ember ey]'s gone, and then burst out laughing.  Totally worth it... even if you are, as the saying goes, going to be sleeping on the couch for a week as a result.");
         //slimefeed, preg check, reduce lust, reset hours since cum, drain massive libido
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
 
@@ -3949,7 +3950,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         if (player.cor < 50) outputText("thank her for being so understanding");
         else outputText("grunt an acknowledgement");
         outputText(" and then gather your things before heading off to wash yourself down.");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //[=Yes=]
@@ -4152,6 +4153,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         outputText("\n\nYou head off yourself, ready to resume the rest of your day.");
         //2 hours pass, PC's fatigue is healed some, Libido is reduced.
         fatigue(-20);
+        explorer.stopExploring();
         doNext(camp.returnToCampUseTwoHours);
     }
 

--- a/classes/classes/Scenes/NPCs/KihaFollower.as
+++ b/classes/classes/Scenes/NPCs/KihaFollower.as
@@ -2,13 +2,13 @@
 import classes.*;
 import classes.BodyParts.Tongue;
 import classes.GlobalFlags.kFLAGS;
-import classes.Scenes.Dungeons.DemonLab;
-import classes.Scenes.Monsters.Magnar;
-import classes.internals.SaveableState;
 import classes.Scenes.Areas.Forest.CorruptedGlade;
 import classes.Scenes.Areas.Swamp.SpiderMorphMob;
+import classes.Scenes.Dungeons.DemonLab;
+import classes.Scenes.Monsters.Magnar;
 import classes.Scenes.SceneLib;
 import classes.display.SpriteDb;
+import classes.internals.SaveableState;
 
 public class KihaFollower extends NPCAwareContent implements TimeAwareInterface, SaveableState {
     public static var DergKidnapped:int; //0 for not kidnapped, 1 for currently kidnapped, 2 for rescued, 3 if you've slain Magnar
@@ -425,7 +425,7 @@ public class KihaFollower extends NPCAwareContent implements TimeAwareInterface,
             outputText("[pg]To your surprise, Kiha slips an arm of her own around your waist, returning your affection for the first time.  You smile, and stroke her cheek, happy as the dragoness rests her head on your shoulder.");
             flags[kFLAGS.KIHA_TALK_STAGE]++;
             dynStats("cor", -1);
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             return;
         } else if (output) {
             //(Activated on Kiha proc'ing in the swamps; replaces combat encounter)
@@ -445,7 +445,7 @@ public class KihaFollower extends NPCAwareContent implements TimeAwareInterface,
         if (flags[kFLAGS.KIHA_TALK_STAGE] < 6) addButton(0, "Talk", talkToFriendlyKiha).hint("Talk to Kiha. She might not like it but you might make some progress.");
         addButton(1, "Spar", sparWithKiha).hint("Do some quick battle with Kiha!");
         addButton(2, "Hug", hugFriendWarmKiha).hint("Give the dragoness a hug.");
-        addButton(4, "Leave", camp.returnToCampUseOneHour);
+        addButton(4, "Leave", explorer.done);
     }
 
     //Spar with Friendly Kiha - Intro (Z)
@@ -512,7 +512,7 @@ public class KihaFollower extends NPCAwareContent implements TimeAwareInterface,
         outputText("[pg]The peaceful, companionable embrace only lasts for a few seconds before Kiha suddenly and violently pushes you away.  \"<i>What do you think you're doing, idiot!</i>\"  she shouts, and launches off into the air before you can respond.");
         outputText("[pg]You shake your head and head on back to camp.");
         kihaAffection(5);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //lose some corruption?
@@ -552,7 +552,7 @@ public class KihaFollower extends NPCAwareContent implements TimeAwareInterface,
         flags[kFLAGS.KIHA_TALK_STAGE]++;
         //lose some corruption
         dynStats("cor", -1);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Kiha x salamander Threesome - Introduction (Z)
@@ -584,7 +584,7 @@ public class KihaFollower extends NPCAwareContent implements TimeAwareInterface,
         flags[kFLAGS.KIHA_AND_HEL_WHOOPIE] = -1;
         outputText("While Kiha and the mysterious swordsman are distracted, you pick yourself up out of the mud and high-tail it out and head back to camp.  Over your shoulder, you hear the sounds of battle raging.");
         //to what penalty?
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Lie There
@@ -645,7 +645,7 @@ public class KihaFollower extends NPCAwareContent implements TimeAwareInterface,
         outputText("[pg]Your [armorName] squelches wetly all the way, full of your cum as it is.");
         if (!recalling) {
             player.sexReward("no", "Dick");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
         } else doNext(recallWakeUp);
     }
 
@@ -700,7 +700,7 @@ public class KihaFollower extends NPCAwareContent implements TimeAwareInterface,
         outputText("[pg]Laughing weakly, exhausted by your efforts at dominating the two fiery redheads, you pull out of Kiha's rectum, watching as cum gushers out of her stretched bum.  You give her a little pat on the thigh before untangling yourself from the dragoness.  You stop by to give Hel and Kiha both a quick kiss on the lips before grabbing your gear and staggering off to camp, leaving the girls to sort themselves out in the murky swamp.");
         if (!recalling) {
             player.sexReward("saliva", "Dick");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
         } else doNext(recallWakeUp);
     }
 
@@ -722,7 +722,7 @@ public class KihaFollower extends NPCAwareContent implements TimeAwareInterface,
         if (!recalling) { //only the first time!
             addButton(1, "Spar", sparWithKiha).hint("Do some quick battle with Kiha!");
             addButton(2, "Hug", hugFriendWarmKiha).hint("Give the dragoness a hug.");
-            addButton(4, "Leave", camp.returnToCampUseOneHour);
+            addButton(4, "Leave", explorer.done);
         }
         addButton(3, "LovinHug", lovinHugKiha).hint("Give the dragoness a hug and take things to a whole new level!");
     }
@@ -834,7 +834,7 @@ public class KihaFollower extends NPCAwareContent implements TimeAwareInterface,
         if (!recalling) {
             player.sexReward("vaginalFluids", "Dick");
             dynStats("sen", -2);
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
         } else doNext(recallWakeUp);
     }
 
@@ -856,7 +856,7 @@ public class KihaFollower extends NPCAwareContent implements TimeAwareInterface,
         if (!recalling) {
             player.sexReward("vaginalFluids", "Lips");
             dynStats("sen", -2);
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
         } else doNext(recallWakeUp);
     }
 
@@ -881,7 +881,7 @@ public class KihaFollower extends NPCAwareContent implements TimeAwareInterface,
         if (!recalling) {
             player.sexReward("vaginalFluids");
             dynStats("sen", -2);
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
         } else doNext(recallWakeUp);
     }
 
@@ -896,7 +896,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
 	addButton(4, "Spar", sparWithKiha).hint("Do some quick battle with Kiha!")
 		.disableIf(followerKiha() && flags[kFLAGS.CAMP_UPGRADES_SPARING_RING] < 2,
 			"You don't have a proper sparring ring for that.");
-	addButton(14, "Leave", followerKiha() ? camp.campLoversMenu : camp.returnToCampUseOneHour);
+	addButton(14, "Leave", followerKiha() ? camp.campLoversMenu : explorer.done);
 	if (followerKiha()) {
 		if (output) {
             if (flags[kFLAGS.LETHICE_DEFEATED] && !TalkedAfterLethice) {
@@ -988,7 +988,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
             if (!followerKiha()) outputText("you're back at Kiha's little islet, waving to the dragoness as she flies back home and you head to camp");
             else outputText("you're walking arm in arm again, heading home");
             outputText(".");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             kihaAffection(5);
         }
 
@@ -1042,7 +1042,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
             outputText(" idiot.  Don't just lie there,</i>\" she laughs.  Before you can move, through, Kiha leans up and presses her lips to yours, drawing you into a long, loving kiss.  Gently, her long, reptilian tongue presses against your lips, slithering in to entwine with your own tongue.  You lay together for a long while, cuddling and kissing and playing with each other.");
             outputText("[pg]Time seems meaningless in your draconic lover's embrace, yet eventually you know you must part - for the moment.  Giving her another long kiss, you pick yourself up from between Kiha's hefty bosom and, say your goodbyes.");
             outputText("[pg]Kiha gives you a wry smirk as you extricate yourself from your arms.  \"<i>I'll see you soon… Doofus.</i>\"");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
             kihaAffection(5);
         }
     }
@@ -1072,7 +1072,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("[pg]You roll your eyes and spend the next few minutes enjoying a delicious, quiet meal with your dragon lover.  When you've finished, you ruffle Kiha's hair, tell her to try and take better care of herself - or at least make herself a proper meal sometime - and head off back to camp.  You can almost hear her fuming behind you as you walk.");
         player.refillHunger(60);
         kihaAffection(-10);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
 
@@ -1114,7 +1114,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         } else if (player.hasCock())
             addButtonDisabled(2, "???", "Kiha doesn't seem to keen on the idea of vaginal sex right now.");
         if (allowBack) addButton(14, "Back", kihaScene.encounterKiha);
-        else addButton(14, "Leave", camp.returnToCampUseOneHour);
+        else addButton(14, "Leave", explorer.done);
     }
 
     //Savage Every Hole With A Bigass Horsecock
@@ -1379,7 +1379,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         flags[kFLAGS.KIHA_HORSECOCK_FUCKED]++;
         player.sexReward("vaginalFluids", "Dick");
         dynStats("sen", -1);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //flags[kFLAGS.KIHA_NEEDS_TO_REACH_TO_HORSECOCKING] = 1;
@@ -1462,7 +1462,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         if (amilyScene.amilyCorrupt()) outputText("  Amily begs, \"<i>May I help to service you next time, [master]?</i>\"");
         player.sexReward("no", "Dick");
         dynStats("sen", -1);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Girl Camp/Warm Sex
@@ -1492,7 +1492,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         player.sexReward("vaginalFluids", "Lips");
         player.sexReward("saliva", "Vaginal")
         dynStats("sen", -1);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Warm Kiha Sex - Anal (Needs a cock that fits her butt)
@@ -1558,7 +1558,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("[pg]You give Kiha a playful swat on the butt as you depart, laughing as the impact causes a trickle of your cum to leak out and down her thigh.  \"<i>Oh, you idiot!</i>\"  she growls as you run off back to your duties.");
         player.sexReward("Default", "Dick", true, false);
         flags[kFLAGS.TIMES_KIHA_ANALED]++;
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Warm/Follower Kiha Vagaginaginal
@@ -1592,7 +1592,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         kihaKnockUpAttempt();
         player.sexReward("vaginalFluids", "Dick");
         dynStats("sen", -1);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Kiha Takes an Incubus Draft (Requires [Pure?] Incubus Draft)
@@ -1627,7 +1627,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
             player.consumeItem(consumables.INCUBID);
             dynStats("cor", 2);
         }
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Kiha Tentacle Scene
@@ -1676,7 +1676,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         if (x1[3] > 0) player.sexReward("saliva", "Dick");
         if (x1[4] > 0) player.sexReward("no", "Dick");
         dynStats("lib", 1, "sen", -2);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Kiha Camp Move In Hint (Happens once and unlocks options)
@@ -1709,7 +1709,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         if (player.hasKeyItem("Radiant shard") >= 0) {
             player.addKeyValue("Radiant shard", 1, +1);
         } else player.createKeyItem("Radiant shard", 1, 0, 0, 0);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Possession 'n Boobies
@@ -1743,7 +1743,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         player.orgasm();
         dynStats("cor", 2);
         player.consumeItem(consumables.GROPLUS);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Kiha & Corrupt PCs -- Parting Ways
@@ -1777,7 +1777,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
     internal function leaveKihaAfterCorruptionBitch():void {
         clearOutput();
         outputText("You slump your shoulders, deciding not to risk confrontation.  As you step back from the dragoness, she lowers her axe, her head hanging sadly.  It seems this pains her as much as you, but… you return to camp. ");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //Kiha & Less-Corrupt PC -- Reunited
@@ -1794,7 +1794,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         if (!followerKiha()) kihaFriendlyGreeting(false);
         else {
             outputText("  You make your way back to camp, arm in arm.");
-            doNext(camp.returnToCampUseOneHour);
+            endEncounter();
         }
     }
 
@@ -1837,7 +1837,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         clearOutput();
         outputText("You break eye contact with the fierce dragoness and remain silent in the face of her challenge, unwilling to pursue the issue any further at the moment.  She snorts, dismissively, \"<i>If you don't fight for the things you want, people will just keep taking them from you.</i>\"  Kiha lewdly spreads her legs and runs her tail over her outer lips, teasing you as hard as she can.  She smirks as your eyes glue to her groin and turns away.");
         outputText("[pg]\"<i>Maybe once you grow some balls,</i>\" the dragoness taunts, giving you a wink.");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     //[Fight for position]
@@ -2037,7 +2037,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
     private function noRapePls():void {
         clearOutput();
         outputText("You break eye contact with the fierce dragoness and remain silent in the face of her challenge, unwilling to pursue the issue any further at the moment.  She snorts, dismissively.  \"<i>That's what I thought,</i>\" she sneers, narrowing her eyes in warning.  After a short pause, her fiery stare almost palpable on your cheek, she turns away once more- with an infuriating little toss of her head- and when you finally glance back at her again, you see that the corners of her mouth are turned up in a smirk.  You turn and walk away shamefully, unable to find the words to explain yourself or to defend your outburst.");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
 
@@ -2232,7 +2232,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         else outputText("\n\nKiha tells about how she plans to get into Lethice's stronghold and defeat Lethice once and for all.");
         outputText("\n\nThe " + (totalKihaChildren() == 1 ? "kid" : "kids") + " are happy to hear about the story. \"<i>Thank you for being with me and listening to my story, my Doofus,</i>\" Kiha says before giving you a peck on your cheek.");
         dynStats("cor", -2, "lus", -50, "scale", false);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     private function kihaTrainsHerKids():void {
@@ -2441,6 +2441,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("You walk back to camp together, reveling in each other’s company. You can feel her emotional reactions to everything, from her hand in yours (glee) to the cawing of some swamp birds (annoyance and hunger).\n\n");
         outputText("As you reach camp, Kiha puts a hand on each of your shoulders. \"<i>… One more thing.</i>\" She says. \"<i>The ring… It can tell you where I am… and the other way around.</i>\" She blushes, and you can hear her voice waver. \"<i>… Just in case.</i>\"\n\n");
         ProposalStatus = 3;
+        explorer.stopExploring();
         doNext(camp.returnToCampUseTwoHours);
     }
 
@@ -2449,6 +2450,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("Stunned into silence, you sit back down without another word. After a few seconds, Kiha whispers your name, and you look back at her. “W-well?” You tell Kiha that this is really sudden. You didn’t expect this… hell, you didn’t expect to find love here, let alone something like this. Kiha’s tail lies still behind her, and her eyes moisten. “So… that’s a no?” She’s almost whispering at this point, her dusky skin sallow and the color draining from her scales. \n\n"+
                     "You kneel down in front of Kiha, and you tell her that you’re sorry. You need some time to process all this. You tell the distraught dragoness that you love her, you do, but that you’re a bit overwhelmed. “O-oh… ” Kiha seems a little better at that, but she clearly was hoping to win you over tonight. You pick her up off the ground, giving your lover a hug. Kiha hugs back, but you can feel her tears on your back. “Well… Tell me when you make up your mind… I’ll be at camp if you need me.”");
         ProposalStatus = 4;
+        explorer.stopExploring();
         doNext(camp.returnToCampUseTwoHours);
     }
 
@@ -2457,7 +2459,8 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("Turning your head away from Kiha, you tell her that you can’t accept her proposal. \"<i>Wh-what?</i>\" Kiha’s dusky skin pales, and she falls to her knees. \"<i>But… </i>\" You tell her that you can’t go any further with her. You’re willing to keep things as they are right now, that you really care about her, but that you can’t be what she wants.\n\n");
         outputText("\"<i>… So I really am just another piece in your harem.</i>\" Kiha closes her eyes. \"<i>… Thank you for telling me earlier.</i>\" Her sarcasm is bitter, and you can all but see her walls going back up. You reach a hand out to Kiha, but the hot-headed dragoness lets loose a gout of flame. You jump back, and Kiha glares at you. \"<i>Just… leave me alone, [name]. Go back to camp.</i>\" You delay, and she roars her rage, spitting more flame at you. \"<i>GO!!!</i>\"\n\n");
         outputText("You head back to camp, her angered voice ringing in your ears.\n\n");
-        ProposalStatus = 6
+        ProposalStatus = 6;
+        explorer.stopExploring();
         doNext(camp.returnToCampUseTwoHours);
     }
 
@@ -2470,7 +2473,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("You tell her that her wings are a part of her, and that you like them… Just like the rest of her. She blushes even hotter, and you feel a bit of heat behind you as she exhales a bit of her fire breath. You continue playing with her wings, rubbing the thin bones, tickling the soft, leathery membranes. Kiha lets you, but the rapidly dampening patch against your thigh, coupled with the muffled exhales, let you know that your dragoness is enjoying this.\n\n");
         outputText("\"<i>Idiot.</i>\" Kiha’s voice is low, but tender. She slowly folds her wings, and you put your hands on her hips. (if playerheight<6ft) You look into her dark red eyes, and she puts a hand on your cheek. You jokingly remind Kiha that she chose to be here, with you. At this, she rolls her eyes, popping you on the thigh with her tail.\n\n");
         outputText("\"<i>Yeah… I did.</i>\" For a few minutes, the two of you stay like this, just… Together. Kiha eventually pushes your shoulders, signalling that the moment’s passed. \"<i>… I forgot what this was like.</i>\" Kiha says to you, not trying to hide her feelings for once. \"<i>Just… Holding someone.</i>\" She smiles slightly, shaking her head. \"<i>You give good hugs… My idiot.</i>\" She walks away, generous ass swaying and tail swishing, back into camp. She seems happier than before.\n\n");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     public function KihaLoveRecip():void {
@@ -2491,7 +2494,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("You tell Kiha that you came to Mareth to purify the land and help its people. You tell your dragoness that if it earns you the affection of a hot dragon lady like her, it’s hardly unwelcome… But you explain that a relationship can’t be your focus right now.\n\n");
         outputText("\"<i>Ah. Well, you’re hardly the only one who wants The Demons to pay, [name].</i>\" Kiha pulls away from you, turning her back. \"<i>… I’ll be around if you want me.</i>\" She flies away, and you feel a single droplet of water hit your shoulder. Clearly, Kiha wanted something more.\n\n");
         ProposalStatus = 4;
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     public function KihaWedding():void {
@@ -2700,7 +2703,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("You run in, making no attempt to be sneaky. As he turns, surprisingly swift for such a big being, you take your [weapon], slamming it as hard as you can into the giant’s face. He staggers back, and you lower your weapon for a rising blow. His armored wing lashes out, ready to intercept your attack, but you anticipated that. You aim your [weapon] at the base of his wing, and with a sickening *crack* it falls limp.\n\n");
         MagnarState = 1;
         startCombat(new Magnar);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     public function KihaRescueSneaky():void {
@@ -2708,7 +2711,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("You rush into the room as he turns back to Kiha, your wedding band sending pure fear coursing through your veins. As he pours a glass of the poisonous alcohol, you run as fast as you can, bearing down on the giant before he knows you’re there. You take your [weapon] and jam it into the brute’s left eye with all your strength. He roars in anger, dropping his glass, which shatters on the floor. Kiha sees you, her face lighting up and your wedding ring pouring relief, love and resolve into you.\n\n");
         MagnarState = 2;
         startCombat(new Magnar);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
 
@@ -2735,6 +2738,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("As you fall asleep, holding her close, you're almost overwhelmed by the warm, cozy feelings coursing through your mind. You chuckle gently, only one thought seems appropriate. You whisper it warmly in her ear, something you've always wanted to say to her face.\n\n");
         outputText("<i>God Damn it, Kiha… <i>.\n\n");
         DergKidnapped = 2;
+        explorer.stopExploring();
         doNext(camp.returnToCampUseEightHours)
     }
 
@@ -2846,6 +2850,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("You nod once, telling Kiha that she shouldn't need to hide her feelings… But that if she wants to keep this between you, that you're honored to be the only one to see her so vulnerable. She cough-laughs at that, resting her head on your shoulder again.\n\n");
         outputText("<i>Thank you… My idiot.</i>\n\n");
         outputText("The moment is over, but Kiha points at the rubble, mentioning a few buildings. Slowly, she tells you more about the town, and you listen intently, pride filling your chest. Eventually, Kiha sighs, giving you a slow, tender kiss. <i>\"Thank you… </i>\" Her voice is a bare whisper, low and tender. <i>\"My Idiot… </i> You ask her if she wants to go home, and Kiha's eyes shimmer. She lets loose a small burst of heat as she exhales, and nods. Hand in hand, you walk home in silence. While you see a few of Mareth's denizens, none seem willing to approach.\n\n");
+        explorer.stopExploring();
         doNext(camp.returnToCampUseEightHours);
     }
 
@@ -2886,7 +2891,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
     public function KihaTownHug():void {
         clearOutput();
         outputText("For a half-hour or so, you hold your fiery lover close. Slowly, steadily, she rests more and more of her weight on you, until you’re practically supporting her. You open your mouth to ask her if she’s alright, but a snore interrupts. With a small smile, you carry Kiha back to her part of the camp, putting her down to rest. She’s been pushing herself harder than usual, lately.\n\n");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     public function KihaTownSex():void {

--- a/classes/classes/Scenes/NPCs/LilyFollower.as
+++ b/classes/classes/Scenes/NPCs/LilyFollower.as
@@ -8,10 +8,10 @@ import classes.*;
 import classes.BodyParts.Tail;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.SceneLib;
-import classes.internals.SaveableState;
 import classes.display.SpriteDb;
-	
-	use namespace CoC;
+import classes.internals.SaveableState;
+
+use namespace CoC;
 	
 	public class LilyFollower extends NPCAwareContent implements SaveableState {
 		public static var LilyHairColor:String;
@@ -297,7 +297,7 @@ import classes.display.SpriteDb;
 			outputText("Tyrantia unbinds her little sister, who simply stares up at her, tongue out and eyes glazed over. <i>\"Good girl,\"</i> your giantess says simply, patting Lily’s head. The smaller Drider looks over at you, a blissed out look on her face.\n\n");
 			outputText("<i>\"[master], that…was…\"</i> Lily shakes, and you reach to her face, cupping her cheek in your palm. You tell your pet she did well, and Lily smiles, eyes closing as she flops the rest of the way to the ground.\n\n");
 			outputText("<i>\"We gotta do this again sometime,\"</i> your giantess says, and you’re inclined to agree. But for now, you redress, heading back to your part of camp.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		
@@ -351,7 +351,7 @@ import classes.display.SpriteDb;
 			outputText("\n\n<b>Before fully settling in your camp as if remembering something Lily pulls a shining shard from her inventory and hand it over to you as a gift. You acquired a Radiant shard!</b>");
 			LilyFollowerState = true;
 			DriderTown.LilyKidsPCPregnancy = 0;
-			cleanupAfterCombat(camp.returnToCampUseOneHour);
+			cleanupAfterCombat(explorer.done);
 		}
 		
 		public function LilySex():void {
@@ -496,7 +496,7 @@ import classes.display.SpriteDb;
 			outputText("You wake up in your bed, rather surprisingly. Weren’t you just on the floor? You turn your head, and see Lily asleep beside you, one arm dangled on your chest and a completely blissed-out smile on her face. You extract yourself from her arms, tucking your itsy bitsy spider into bed. You redress, somewhat tired, but satisfied and close your cabin door behind you. Your [cock] aches a little, but you decide it was well worth it.\n\n");
 			lilySubmissiveness(5);
 			lilyAffection(5);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function LilyBondageCabinDildo():void {
@@ -505,7 +505,7 @@ import classes.display.SpriteDb;
 			outputText("<i></i>\n\n");
 			outputText("<i></i>\n\n");
 			player.sexReward("vaginalFluids","Pussy");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function LilyBondageCabinFuck():void {
@@ -521,7 +521,7 @@ import classes.display.SpriteDb;
 			lilySubmissiveness(5);
 			lilyAffection(5);
 			player.sexReward("vaginalFluids","Dick");
-			inventory.takeItem(useables.T_SSILK, camp.returnToCampUseOneHour);
+			inventory.takeItem(useables.T_SSILK, explorer.done);
 		}
 		
 		public function LilyBondageCabinTease():void {
@@ -545,7 +545,7 @@ import classes.display.SpriteDb;
 			lilySubmissiveness(15);
 			lilyAffection(5);
 			player.sexReward("vaginalFluids");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function Lily3Somes():void {
@@ -581,7 +581,7 @@ import classes.display.SpriteDb;
 			clearOutput();
 			outputText("\n\n");
 			player.sexReward("vaginalFluids");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function SandwichSidonie():void {
@@ -604,7 +604,7 @@ import classes.display.SpriteDb;
 			outputText("\n\n");
 			player.sexReward("vaginalFluids", "Dick");
 			LilyAffectionMeter += 10;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function SidonieDom():void {
@@ -645,7 +645,7 @@ import classes.display.SpriteDb;
 			outputText("Lily gives you a wink as you leave. “Don’t keep me waiting, please?”\n\nn");
 			LilyAffectionMeter += 10;
 			player.sexReward("cum", "Vaginal");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function LilyExhibition():void {
@@ -699,7 +699,7 @@ import classes.display.SpriteDb;
 		public function LilyExhibitionEndLeave():void {
 			clearOutput();
 			outputText("You decide to leave Lily as she is for now. She protests, but you give her a grin, heading back out to camp.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function LilyExEtna():void {
 			clearOutput();
@@ -722,7 +722,7 @@ import classes.display.SpriteDb;
 			outputText("The irregular bucking motions finally tip you over, and you let out a growl, cumming into Electra’s well-fucked Raiju pussy. Electra hums, her furry tail finally losing a good chunk of its staticy fluff, and she wails, spraying you with femspunk as you pull out. Your spooge leaks from Electra, and she slides off Lily and onto the ground, bobbing her head happily back and forth. The chain isn’t long enough to reach the ground, and it slides out of Electra.\n\n");
 			outputText("Luna takes her fingers out of Lily’s pussy as you approach. You slide your [cock] across her chitinous leg, wiping your Raiju lover’s juices off.\n\n");
 			player.sexReward("vaginalFluids","Dick");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function LilyExIzma():void {
 			clearOutput();

--- a/classes/classes/Scenes/NPCs/SophieScene.as
+++ b/classes/classes/Scenes/NPCs/SophieScene.as
@@ -302,7 +302,7 @@ public function meetSophieRepeat():void {
 			outputText("Your climb manages to take you back into the harpy nests again.  Sophie flutters down next to you and warns, \"<i>Cutey, a " + player.mf("neuter","girl") + " like you doesn't belong up here.  The younger harpies don't really get the idea of conversation and see you as competition.</i>\"\n\n");
 
 			outputText("Do you see the wisdom of her words and climb back down the mountain, fight Sophie, or keep climbing?");
-			simpleChoices("Fight Sophie", FirstTimeSophieForceSex, "Keep Climbing", PCIgnoresSophieAndHarpyIsFought, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
+			simpleChoices("Fight Sophie", FirstTimeSophieForceSex, "Keep Climbing", PCIgnoresSophieAndHarpyIsFought, "", null, "", null, "Leave", explorer.done);
 		}
 		//(LACTATE)
 		else {
@@ -355,7 +355,7 @@ private function sophieLookingForDemons():void {
 	//Otherwise leave.
 	else {
 		outputText("  You gulp and nod, understanding quite clearly that the harpies don't care for demons in their nesting grounds.  Sophie smiles and turns about, fluffing purple-tinted tail-feathers at you in what is clearly a dismissal.");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 		return;
 	}
 	outputText("\"<i>Mmmm, have you gotten bored of the talk, ");
@@ -373,7 +373,7 @@ private function shootDownSophieSex():void {
 	sophieBimbo.sophieSprite();
 	clearOutput();
 	outputText("Sophie pouts for a moment, leaning forward to better display her cleavage. \"<i>Really?  Well if you change your mind, come back and visit me.</i>\"  She turns around and fluffs her tail-feathers at you in what is clearly a dismissal.  You climb down, careful to avoid any other nests as you head back to check on your camp and its portal.");
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 	if(player.lib > 25) dynStats("lib", -1);
 	if(player.lust > 50) dynStats("lus", -5, "scale", false);
 }
@@ -390,10 +390,10 @@ private function sophieMeetingChoseSex():void {
 		if(player.hasVagina()) {
 			outputText("  What do you do?");
 			//[Stay&Sex] [Leave]
-			simpleChoices("Force Sex", FirstTimeSophieForceSex, "Leave", camp.returnToCampUseOneHour, "", null, "", null, "", null);
+			simpleChoices("Force Sex", FirstTimeSophieForceSex, "Leave", explorer.done, "", null, "", null, "", null);
 			return;
 		}
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	//(Haz dick (male futa))
 	else {
@@ -440,7 +440,7 @@ private function sophieMeetingGotLost():void {
 		dynStats("lus", (10+player.lib/4), "scale", false);
 		if(player.inte < 50) dynStats("int", 1);
 		//[Go to camp if neither of the above]
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 
@@ -455,7 +455,7 @@ private function tellSophieYoureForagingForStuff():void {
 	//(+10 + libmod lust, +1 int up to 50 int))
 	dynStats("lus", (10+player.lib/4), "scale", false);
 	if(player.inte < 50) dynStats("int", 1);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Harpy Breastfeeding]
@@ -560,7 +560,7 @@ private function cramANippleInIt():void {
 	flags[kFLAGS.BREASTFEAD_SOPHIE_COUNTER]++;
     if (CoC.instance.inCombat)
         cleanupAfterCombat();
-	else doNext(camp.returnToCampUseOneHour);
+	else endEncounter();
 	//You've now been milked, reset the timer for that
 	if(player.hasStatusEffect(StatusEffects.Feeder)) {
 		player.addStatusValue(StatusEffects.Feeder,1,1);
@@ -716,6 +716,7 @@ private function postSophieSexSnuggle():void {
 	dynStats("lib", 1, "sen", 1);
 
 	//4 hours pass
+	explorer.stopExploring();
 	doNext(camp.returnToCampUseFourHours);
 }
 
@@ -726,7 +727,7 @@ private function postSexSophieSnuggleTurnedDown():void {
 	outputText("You turn down her offer and assure her that you'll be fine.  Sophie giggles while you try to get dressed, and you see her amber eyes watching you as try to climb back down the mountain with a stiffy.  She seems greatly amused by your predicament.");
 	//(+sensitivity, +libido
 	dynStats("lib", 1, "sen", 1);
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 //[Consentual Sex No Fito]

--- a/classes/classes/Scenes/NPCs/ZenjiScenes.as
+++ b/classes/classes/Scenes/NPCs/ZenjiScenes.as
@@ -142,7 +142,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You decide that it's not worth paying whatever he's demanding to venture into who knows where.\n\n");
 			outputText("\"<i>Eh? You’re just gonna leave me like dat? You don' want ta even try to fight me?</i>\" he chuckles, \"<i>Your loss.</i>\"\n\n");
 			outputText("You return back to your camp following the path that you made along your way.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function part1TrollEncounterFight():void {
@@ -293,7 +293,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				outputText("\"<i>Ahahah, you are a weak little one, try harda next time,</i>\" he says, dropping to the ground.\n\n");
 				outputText("Bested by his strength, you decide to return home.\n\n");
 				zenjiPerspectiveOnPlayer(-4);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else if (player.str < (145 + (player.newGamePlusMod() * 29))) {
 				outputText("You hold on with all your might, after a while you begin to grow tired and begin rocking back and forth to support yourself. You look over and you see the troll beginning to strain, it appears he's beginning to have trouble supporting himself as well.\n\n");
@@ -301,7 +301,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				outputText("\"<i>Heheh, you are a weak little one, you gotta do better dan dat next time,</i>\" he says, dropping to the ground.\n\n");
 				outputText("Bested by his strength, you decide to return home.\n\n");
 				zenjiPerspectiveOnPlayer(-4);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else {
 				outputText("You hold on with all your might, after a while your arms start to grow weary. You look over to the troll and notice him straining to keep his composure. After a moment he drops with an exasperated breath, and you drop down after him.\n\n");
@@ -325,7 +325,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				outputText("\"<i>Heheh, you are a weak little one, try harda next time,</i>\" he says dropping the rock onto the ground.\n\n");
 				outputText("Bested by his toughness, you decide to return home.\n\n");
 				zenjiPerspectiveOnPlayer(-4);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else if (player.tou < (140 + (player.newGamePlusMod() * 28))) {
 				outputText("After some time of holding the rock above your head, your arms begin to grow weary, the rock, despite not being too heavy, is beginning to put a burden on your arms as its weight begins to feel like it's increasing. You look over to the troll who seems to be showing signs of struggle holding the rock over his head.\n\n");
@@ -333,7 +333,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				outputText("\"<i>Heheh, you are a weak little one, you gotta do better dan dat next time,</i>\" he says dropping the rock onto the ground.\n\n");
 				outputText("Bested by his toughness, you decide to return home.\n\n");
 				zenjiPerspectiveOnPlayer(-4);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else {
 				outputText("After some time of holding the rock above your head, your arms begin to grow weary, the rock starting to put a burden on your arms. You look over to the troll who's struggling to support the rock with his arms.\n\n");
@@ -355,14 +355,14 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				outputText("\"<i>Heheh, you are a weak little one, try harda next time,</i>\" he says leaning back against the tree.\n\n");
 				outputText("Bested by his speed, you decide to return home.\n\n");
 				zenjiPerspectiveOnPlayer(-4);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else if (player.spe < (155 + (player.newGamePlusMod() * 31))) {
 				outputText("You sprint over to the tree as fast as you can, you stay close to the troll, but he's just faster than you are, it's close, but he beats you to the tree by a few seconds.\n\n");
 				outputText("\"<i>Heheh, you are a weak little one, you gotta do better dan dat next time,</i>\" he says leaning back against the tree.\n\n");
 				outputText("Bested by his speed, you decide to return home.\n\n");
 				zenjiPerspectiveOnPlayer(-4);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else {
 				outputText("You sprint over to the tree as fast as you can, you steadily succeed the troll, you're faster than he is and you beat him to the tree.\n\n");
@@ -384,14 +384,14 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				outputText("\"<i>Heheh, you are a weak little one, try harda next time,</i>\" he says, straightening his back.\n\n");
 				outputText("Bested by his intelligence, you decide to return home.\n\n");
 				zenjiPerspectiveOnPlayer(-4);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else if (player.inte < (125 + (player.newGamePlusMod() * 25))) {
 				outputText("He pauses for a moment and attempts to strike you with the branch, you deflect his oncoming attack, but you do not let your guard down, he's ready for you to strike, and you are not so keen on giving him an opening. You wait for his next strike, ready to deflect him, but he fakes you out and strikes you from the other side.\n\n");
 				outputText("\"<i>Heheh, you are a weak little one, you've gotta do better dan dat next time,</i>\" he says, straightening his back.\n\n");
 				outputText("Bested by his intelligence, you decide to return home.\n\n");
 				zenjiPerspectiveOnPlayer(-4);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else {
 				outputText("He pauses for a moment and attempts to strike you with the branch, you deflect his oncoming attack. He's quite predictable, read like an open book. He likes to strike and expose your weakness if you go for a counter attack, and his fake outs are easy to notice.\n\n");
@@ -416,7 +416,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				outputText("Sure enough, when the troll flips over the rock he's chosen there's far more insects than what was under yours.\n\n");
 				outputText("\"<i>Heheh, not the wisest little one, try harda next time,</i>\" he says.\n\n");
 				zenjiPerspectiveOnPlayer(-4);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else if (player.wis < (135 + (player.newGamePlusMod() * 27))) {
 				outputText("You inspect the rocks, remembering what he said about how the moss can be poisonous if dry, you feel around for the dampest rock, and when you think you've found the best one, you tell the troll that you're ready to compare results.\n\n");
@@ -424,7 +424,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				outputText("Sure enough, when the troll flips over the rock he's chosen there are noticeably some more bugs than what was under yours.\n\n");
 				outputText("\"<i>Heheh, not the wisest little one, you gotta do better dan dat next time,</i>\" he says.\n\n");
 				zenjiPerspectiveOnPlayer(-4);
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 			else {
 				outputText("You inspect the rocks, remembering what he said about how the moss can be poisonous if dry, you inspect the rocks carefully, making sure to peel the moss back to make sure it's damp all the way through. Once you've found the ideal rock, you tell the troll you're ready to compare results.\n\n");
@@ -505,7 +505,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("\"<i>Yeah, dat's right. Now, get outta here, I'm done wit dese games. Come back when you're better at dis!</i>\"\n\n");
 			outputText("Oh, maybe you will... It's almost endearing to watch his ego inflate.\n\n");
 			zenjiPerspectiveOnPlayer(-6);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function part1TrollEncounterSex():void {
@@ -536,7 +536,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			else if(event < 10) itype = useables.T_SSILK;
 			outputText("You spend some more time looking around the area and stumble upon " + itype.shortName + ".\n\n");
 			outputText("You decide to head back home afterwards as there doesn't appear to be anything else of interest right now.\n\n");
-			inventory.takeItem(itype, camp.returnToCampUseOneHour);
+			inventory.takeItem(itype, explorer.done);
 		}
 		
 		//PART 2
@@ -571,7 +571,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 		public function part2TrollEncounterFirstDecline():void {
 			flags[kFLAGS.ZENJI_PROGRESS] = -1;
 			outputText("\"<i>Ah, so be it den, I shall go somewhere else for a real challenge, all I see here are cowards.</i>\" Zenji leans back and climbs on top of a nearby tree, he quickly vanishes into the canopy where you can't see him anymore.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function part2TrollEncounterFirstFight():void {
@@ -619,7 +619,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 		public function part2TrollEncounterLeave():void {
 			outputText("You tell Zenji that you are not in the mood for sticking around with him at the moment.\n\n");
 			outputText("\"<i>Eh? Then whatcha here for? Go on den, no reason to stay if ya don' wanna be here.</i>\"\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function part2TrollEncounterTalk():void {
@@ -633,7 +633,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You decide to head back to your camp, but you’re halted by Zenji touching your shoulder.\n\n");
 			outputText("He quickly jumps back, his gaze slowly shying away from you, \"<i>Just… Be careful out dere…</i>\"\n\n");
 			zenjiPerspectiveOnPlayer(-3);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function part2TrollEncounterRepeatFight():void {
@@ -703,7 +703,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				player.fatigue += Math.round(player.maxFatigue() * 0.35);
 				zenjiPerspectiveOnPlayer(3);
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function part2TrollEncounterTrainToughness():void {
@@ -726,7 +726,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				player.fatigue += Math.round(player.maxFatigue() * 0.35);
 				zenjiPerspectiveOnPlayer(3);
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function part2TrollEncounterTrainSpeed():void {
@@ -751,7 +751,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				player.fatigue += Math.round(player.maxFatigue() * 0.35);
 				zenjiPerspectiveOnPlayer(3);
 			}
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		//ZENJI FOLLOWER
@@ -782,7 +782,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You tell Zenji that you don't want him to hang out around your camp.\n\n");
 			outputText("\"<i>Ah, dat is a shame, if ya don't want ta, I undastand, I still got all dis land to maself at least.</i>\"\n\n");
 			flags[kFLAGS.ZENJI_PROGRESS]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function followerZenjiOfferYes():void {
@@ -795,7 +795,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.createStatusEffect(StatusEffects.ZenjiTrainingsCounters1,0,0,0,0);
 			player.createStatusEffect(StatusEffects.ZenjiTrainingsCounters2,0,0,0,0);
 			flags[kFLAGS.ZENJI_PROGRESS] = 8;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function followerZenjiMainCampMenu():void {
@@ -860,7 +860,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText(player.modTone(player.maxToneCap(), 1));
 			player.fatigue += Math.round(player.maxFatigue() * 0.2);
 			followerZenjiMainCampMenuTrainingPerks();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function followerZenjiMainCampMenuTrainingToughness():void {
@@ -879,7 +879,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText(player.modTone(player.maxToneCap(), 1));
 			player.fatigue += Math.round(player.maxFatigue() * 0.2);
 			followerZenjiMainCampMenuTrainingPerks();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function followerZenjiMainCampMenuTrainingSpeed():void {
@@ -897,7 +897,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText(player.modThickness(0, 1));
 			player.fatigue += Math.round(player.maxFatigue() * 0.2);
 			followerZenjiMainCampMenuTrainingPerks();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function followerZenjiMainCampMenuTrainingIntelligence():void {
@@ -920,7 +920,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.trainStat("int",(4 - player.statusEffectv2(StatusEffects.ZenjiTrainingsCounters2)),player.trainStatCap("int",100));
 			player.fatigue += Math.round(player.maxFatigue() * 0.2);
 			followerZenjiMainCampMenuTrainingPerks();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function followerZenjiMainCampMenuTrainingWisdom():void {
@@ -942,7 +942,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.trainStat("wis",(4 - player.statusEffectv2(StatusEffects.ZenjiTrainingsCounters2)),player.trainStatCap("wis",100));
 			player.fatigue += Math.round(player.maxFatigue() * 0.2);
 			followerZenjiMainCampMenuTrainingPerks();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function followerZenjiMainCampMenuTrainingPerks():void {
@@ -1017,7 +1017,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji pauses for a moment, sighing softly.\n\n");
 			outputText("\"<i>But da's beside da point, I needed to do tings on ma own, live life on ma own without dem always watching over my every action. De bog was a nice place when I saw it, and dat area ya found me in was great for stretching and training wit people who wanted ta, like you when you came along. Eventually da people who I usually saw stopped coming, I don' know why, but I was starting ta get lonely, if there was one thing I missed about ma troll village, is all the people did care. Even if it was boring, der was still people everywhere. Den you came along, you fought with vigor, trained with passion, der was someting about ya, and I didn't want ta be alone out der anymore, so I wanted ta join you here in ya camp, I've even gotten ta meet some new friends, so dat's nice.</i>\"\n\n");
 			outputText("Zenji spends the rest of the hour talking about new experiences in the camp and other things about himself that he can recall.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function followerZenjiTalksTrolls():void {
@@ -1027,7 +1027,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("\"<i>Dere's many kinda trolls, tink of it like alraune, each one may be simila way back den, but now dey've split into different kinds, ya know? My troll village grew used to da jungle we lived in, plenty of shade and cold nights, ma fuzz is great at keeping warm and hiding in da trees of da jungle, da oda trolls never saw me coming haha!</i>\"\n\n");
 			outputText("He pauses for a moment, \"<i>But de other trolls in my village didn't like me too much, I caused trouble, I sought competition, when dey wanted peace and quiet, so I left. I didn't see many oda trolls out dere, but they’re probably not in de bog where I spent most’ve ma time.</i>\"\n\n");
 			outputText("Zenji spends the rest of the hour talking about trolls and other nuances about his kind from the other trolls.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function followerZenjiTalksYourself():void {
@@ -1039,7 +1039,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You ask what he thinks about you though.\n\n");
 			outputText("\"<i>Well, ya be a good friend here, good fighter, with vigor and strength. In de bog almost nobody could beat me in a fight, but you are something different, ya fight with unrivaled passion dat dey could neva compete with. Da's what I like about ya, ya don't give up, ya only fight harder.</i>\"\n\n");
 			outputText("You spend the rest of the hour talking about yourself and sharing old stories back in Ingnam with Zenji.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function followerZenjiSex():void {
@@ -1111,7 +1111,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 		public function loverZenjiOfferNo():void {
 			outputText("Zenji's eyes grow watery, \"<i>You are a brave soul, I tell ya dat.</i>\" He slowly moves closer to you and puts his hands on your shoulders. \"<i>Stay safe out dere, I will remain here if ya need me.</i>\"\n\n");
 			flags[kFLAGS.ZENJI_PROGRESS] = 10;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiOfferYes():void {
@@ -1128,7 +1128,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.createStatusEffect(StatusEffects.ZenjiPreparationsList,0,0,0,0);
 			player.createStatusEffect(StatusEffects.ZenjiZList,0,0,0,0);
 			flags[kFLAGS.ZENJI_PROGRESS] = 11;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiMainCampMenu2():void {
@@ -1243,7 +1243,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji spends the rest of the hour talking about new experiences in the camp and other things about himself that he can recall.\n\n");
 			if (player.statusEffectv1(StatusEffects.ZenjiPreparationsList) < 15) player.addStatusValue(StatusEffects.ZenjiPreparationsList, 1, 1);
 			ZenjiTalkCount++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiTalksTrolls():void {
@@ -1255,7 +1255,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji spends the rest of the hour talking about trolls and other nuances about his kind from the other trolls.\n\n");
 			if (player.statusEffectv1(StatusEffects.ZenjiPreparationsList) < 15) player.addStatusValue(StatusEffects.ZenjiPreparationsList, 1, 1);
 			ZenjiTalkCount++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiTalksYourself():void {
@@ -1269,7 +1269,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You spend the rest of the hour talking about yourself and sharing old stories back in Ingnam with Zenji.\n\n");
 			if (player.statusEffectv1(StatusEffects.ZenjiPreparationsList) < 15) player.addStatusValue(StatusEffects.ZenjiPreparationsList, 1, 1);
 			ZenjiTalkCount++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiTalksChildren():void {
@@ -1283,7 +1283,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("After nearly an hour of spending time with your children, you decide it’s best to continue with your day for now, but you’ll be sure that Zenji won't be a lonely father to the children.\n\n");
 			if (player.statusEffectv1(StatusEffects.ZenjiPreparationsList) < 15) player.addStatusValue(StatusEffects.ZenjiPreparationsList, 1, 1);
 			ZenjiTalkCount++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiShowoff():void {
@@ -1319,7 +1319,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You tell Zenji that you’d rather not take up on the offer.\n\n");
 			outputText("\"<i>Ah, well, I’ll always be here if ya need anything… </i>\" He replies.\n\n");
 			outputText("You decide to take your leave for the time being.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function loverZenjiShowoffYes():void {
 			outputText("The thought is interesting, but what does he mean exactly by \"front row seats\"?\n\n");
@@ -1396,7 +1396,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
 			outputText("You decide to let Zenji clean himself off, after all, he knows how to maintain himself like nobody else.\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function loverZenjiShowoffYesClean():void {
 			spriteSelect(SpriteDb.s_zenji);
@@ -1448,7 +1448,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				outputText("You smirk, dropping his loincloth just a few feet away from him. His naked body now on display for everyone to see, with his loincloth so close and yet just out of reach.");
 			}
 			outputText("\n\n");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiComfort():void {
@@ -1845,7 +1845,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("\"<i>Don' hesitate to ask me for a favor like dis, I will always have de time for you,</i>\" he states as he stands up, ready to continue the day.\n\n");
 			player.addStatusValue(StatusEffects.ZenjiZList, 3, 1);
 			player.sexReward("cum","Anal");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiTakeVaginal():void {
@@ -1887,7 +1887,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.sexReward("cum", "Vaginal");
 			if (player.hasUniquePregnancy()) player.impregnationRacialCheck();
 			else player.knockUp(PregnancyStore.PREGNANCY_ZENJI, PregnancyStore.INCUBATION_ZENJI);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiPitchAnal():void {
@@ -1925,7 +1925,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji blushes slightly… \"<i>Ah… tanks [name]...</i>\"\n\n");
 			player.addStatusValue(StatusEffects.ZenjiZList, 3, 1);
 			player.sexReward("no", "Dick");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiSexBlowHim():void {
@@ -1975,7 +1975,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.refillHunger(10 + ((player.statusEffectv2(StatusEffects.ZenjiModificationsList) + 1300) / 100));
 			player.sexReward("cum","Lips", false);
 			dynStats("lust", 25);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiSexCuddle():void {
@@ -2015,7 +2015,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			fatigue(-(Math.round(player.maxFatigue() * 0.15)));
 			dynStats("lust", 15);
 			dynStats("cor", -0.25);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiPregnantSex():void {
@@ -2069,7 +2069,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("\"<i>You will make a fine mother, dis I know. There's nobody I'd rather have to take care of our children dan you. You are everyting to me [name].</i>\"\n\n");
 			outputText("You spend some more time with your hunky troll lover before he cleans you off and helps you get ready to continue your day.\n\n");
 			player.sexReward("cum", "Vaginal");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiHotSpring():void {
@@ -2103,7 +2103,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji chuckles softly before sitting next to you, drying the two of you off with a towel. Once both of you are dried up Zenji pulls you in for a hug. \"<i>Dried off and ready ta continue da day!</i>\"\n\n");
 			outputText("You smile back at Zenji, with his support you feel like nothing can get in your way.\n\n");
 			fatigue(-(Math.round(player.maxFatigue() * 0.25)));
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function loverZenjiHotSpringRideAnal():void{
 			outputText("You look up at Zenji with a sly smirk.\n\n");
@@ -2139,7 +2139,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji looks down at his soaked loincloth, \"<i>Ugh… I did not tink dis through, I need ta get another piece of cloth.</i>\"\n\n");
 			player.addStatusValue(StatusEffects.ZenjiZList, 3, 1);
 			player.sexReward("cum","Anal");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function loverZenjiHotSpringRideVaginal():void{
 			outputText("You look up at Zenji with a sly smirk.\n\n");
@@ -2167,7 +2167,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.sexReward("cum", "Vaginal");
 			if (player.hasUniquePregnancy()) player.impregnationRacialCheck();
 			else player.knockUp(PregnancyStore.PREGNANCY_ZENJI, PregnancyStore.INCUBATION_ZENJI);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiSexGetFingered():void {
@@ -2188,7 +2188,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("\"<i>Now den… As much as I do like spending time wit ya, dere’s other tings I need ta attend to.</i>\" Zenji says, giving you a gentle kiss on the cheek before leaving.\n\n");
 			player.addStatusValue(StatusEffects.ZenjiZList, 3, 1);
 			player.sexReward("no", "Vaginal");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiSexGetHandjob():void {
@@ -2207,7 +2207,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("\"<i>Now den… As much as I do like spending time wit ya, dere’s other tings I need ta attend to.</i>\" Zenji says, giving you a gentle kiss on the cheek before leaving.\n\n");
 			player.addStatusValue(StatusEffects.ZenjiZList, 3, 1);
 			player.sexReward("no", "Dick");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiSexGetLicked():void {
@@ -2226,7 +2226,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji helps you up and redresses you. Soon enough you're ready to continue your day.\n\n");
 			player.addStatusValue(StatusEffects.ZenjiZList, 3, 1);
 			player.sexReward("no", "Vaginal");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiSexGetBlown():void {
@@ -2258,7 +2258,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You tell him you'll consider it. You give him a brief kiss before you gently break out of his embrace, ready to start your day again.\n\n");
 			player.addStatusValue(StatusEffects.ZenjiZList, 3, 1);
 			player.sexReward("no", "Dick");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiSexTease():void {
@@ -2318,7 +2318,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 		}
 		public function loverZenjiSexTeaseEnd():void {
 			player.addStatusValue(StatusEffects.ZenjiZList, 3, 1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function loverZenjiSexNevermind():void {
@@ -2664,7 +2664,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("He gives a soft chuckle, eying you before speaking up once more, \"<i>I love you, [name]... I'm happy ya let me do dis wit ya.</i>\"\n\n");
 			outputText("<b><i>Face Paint gives +10% magic resistance</i></b>\n\n");
 			player.addStatusValue(StatusEffects.ZenjiZList, 4, 2);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function loverZenjiHalloweenEventNo():void {
 			spriteSelect(SpriteDb.s_zenji);
@@ -2674,7 +2674,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("\"<i>I…</i>\" He shakes his head, \"<i>Dere is bravery, dere is ‘uperstition, but dis… I can’t protect ya from de dead when ya aren’t handled for it, but you said you’re a champion and… I… I will do anything for you, even if I disagree.</i>\"\n\n");
 			outputText("He packs up the bowls of paint and leaves you to get ready for the morning.\n\n");
 			player.addStatusValue(StatusEffects.ZenjiZList, 4, 1);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function loverZenjiHalloweenEventEnding():void {
 			spriteSelect(SpriteDb.s_zenji);
@@ -2718,7 +2718,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You spend some time relaxing with him before you’ve dried off, ready to continue your day.\n\n");
 			player.refillHunger(15);
 			player.addStatusValue(StatusEffects.ZenjiZList, 4, -2);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		public function loverZenjiHalloweenEventEndingDryOff():void {
 			spriteSelect(SpriteDb.s_zenji);
@@ -2728,7 +2728,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji pats himself down, rubbing some of the water off his fur, \"<i>Gonna be wet for some time now, water doesn’ come out easily from troll fur.</i>\" He gives you a longing glance, \"<i>But dat’s okay, I got you ta keep me company.</i>\" He lifts your chin to his and plants a soft kiss onto your lips.\n\n");
 			outputText("You spend some time relaxing with him before you’ve dried off, ready to continue your day.\n\n");
 			player.addStatusValue(StatusEffects.ZenjiZList, 4, -2);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		
 		public function birthScene():void {
@@ -2790,6 +2790,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			clearOutput();
 			outputText("\"<i>"+(Z2ndKid ? ""+Z2ndKid+"":""+Z1stKid+"")+"... I like dat name…'</i>\" he states with a smile.\n\n");
 			outputText("Zenji relaxes by your side as you drift off to sleep within his protection, exhausted from giving birth.");
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 		}
 		private function applyZenjikidName2():void {
@@ -2798,6 +2799,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			flags[kFLAGS.ZENJI_KIDS]++;
 			outputText("Zenji gives you a gentle stare as he gently caresses your child, \"<i>Actually, Ya know... I was thinkin’, and I thought I should name dem dis time.</i>\"\n\n");
 			outputText("He scoops up your baby once they detach from your breast. \"<i>What will daddy name you?</i>\" he croons, taking his child to his nest.\n\n");
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 		}
 		private function applyZenjikidName3():void {
@@ -2809,6 +2811,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You groan in pain as you spread your legs, ready to give birth, hoping for a healthy child.\n\n");
 			outputText("After an hour of pain and screaming, you successfully give birth to your child. She is doing just fine, taking her first breath as she cries.\n\n");
 			outputText("Maternal pride overwhelms you. You manage to collect yourself enough to bring your baby to your breast to comfort her. She latches on reflexively as you take a moment to rest.\n\n");
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 		}
 		
@@ -3677,6 +3680,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			if (!recalling) {
 				var timeShift:int = (24 - time.hours) + 8;
+				explorer.stopExploring();
 				doNext(createCallBackFunction(camp.returnToCamp, timeShift));
 			} else doNext(recallWakeUp);
 		}

--- a/classes/classes/Scenes/Places/Mindbreaker.as
+++ b/classes/classes/Scenes/Places/Mindbreaker.as
@@ -220,7 +220,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 			player.sexReward("no", "Vaginal");
 			player.sexReward("no", "Vaginal");
 			MindBreakerQuest = QUEST_STAGE_METMB;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function YesTentacleStage2():void {
@@ -283,7 +283,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 			player.sexReward("no", "Vaginal");
 			player.sexReward("no", "Vaginal");
 			player.sexReward("no", "Vaginal");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function YesTentacleStage3():void {
@@ -456,7 +456,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 			player.createPerk(PerkLib.PsionicEmpowerment,0,0,0,0);
 			player.removeAllRacialMutation();
 			MindBreakerQuest = QUEST_STAGE_ISMB;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function FuckNo():void {
@@ -467,7 +467,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 					"\n\nWith your mind made, you turn heel back to camp, never once looking back towards the ominous crevice. Once you’re relatively safe, a reassuring calm settles over you." +
 					" You’ve done the right thing in leaving that place behind, you’ve never felt so sure before." +
 					"\n\nYou’ve done the smart thing.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function NoIndecisive():void {
@@ -477,7 +477,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 					" You’ll just end up raped or worse: dead. Back to camp, you need to go back." +
 					" Return and train more. Come back when you’re actually ready, instead of getting ahead of yourself and thinking you were something of note. Inadequate. Inferior. Worthless." +
 					"\n\nTurn back. Grow. Develop. Return.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		///MINDBREAKER CAVE SECTION///
@@ -539,7 +539,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 			else if (MindBreakerConvert >= 10 && !MindbreakerPrisoner) addButtonDisabled(8,"Prisoner").hint("There is no prisoners in the cave for you to play with at the time.");
 			addButton(10, "More?", totalSubservience)
 				.hint("Ask if you can do even more for the Mindbreakers.");
-			addButton(14, "Leave", camp.returnToCampUseOneHour);
+			addButton(14, "Leave", explorer.done);
 		}
 
 		public function TalkAboutMB():void {
@@ -580,7 +580,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 					dynStats("lib", 10);
 				} else outputText("The two of you slowly disentangle from each other after briefly relishing the afterglow together.");
 				outputText("\n\nHighly satisfied after your lovemaking, you head back to camp.");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -613,7 +613,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 					+ "\n"
 					+ "Each thrust causes her to moan lewdly as her overstimulated pussy is unable to hold back any further. She completely shuts down as she faints from your efforts. Satisfied, you leave her to rest before returning to your camp.\n");
 				player.sexReward("vaginalFluids", "Dick");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 
 			function vagF():void {
@@ -627,7 +627,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 					+ "\n"
 					+ "After a few minutes the goblin faints, still impaled on the toy. You unplug her and a massive flood of pussy juice drenches the ground. Utterly satisfied, you leave her to rest and head back to camp.\n");
 				player.sexReward("vaginalFluids", "Vaginal");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -684,7 +684,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 			function sharedEnd():void {
 				outputText("\n\nHighly satisfied, you head back to camp.");
 				PlayerEggIsFertile = true;
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -733,7 +733,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 							"\n\n\"<i>Thank you, big sister. for showing me enlightenment. I know what I must do now. Seek, share, and spread!</i>\" She giggles as she heads to a corner to play with her other brethren." +
 							"\n\nSatisfied with the result, you head back to camp still smiling.");
 					player.sexReward("vaginalFluids","Vaginal");
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 				}
 
 				function dickF():void {
@@ -765,7 +765,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 							"\n\n\"<i>Thank you, big brother, for showing me enlightenment. I know what I must do now. Seek, share, and spread!</i>\"She giggles as she heads to a corner to play with her other brethren." +
 							"Satisfied, you head back to camp still smiling.");
 					player.sexReward("vaginalFluids","Dick");
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 				}
 			}
 			function convertMale():void { //Male Scene
@@ -804,7 +804,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 							"\n\n\"<i>Thank you, big sister, for showing me enlightenment. I know what I must do now. Seek, share, and spread!</i>\"He chuckles as she heads to a corner to play with his other brethren." +
 							"\n\nSatisfied, you head back to camp still smiling.");
 					player.sexReward("cum","Vaginal");
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 				}
 				function dickF():void {
 					outputText("He has been an excellent slut and it’s high time to reward his throbbing cock and complete submissiveness properly. " +
@@ -830,7 +830,7 @@ public class Mindbreaker extends BaseContent implements SaveableState{
 							"\n\n\"<i>Thank you, big brother, for showing me enlightenment. I know what I must do now. Seek, share, and spread!</i>\"He chuckles as she heads to a corner to play with his other brethren." +
 							"\n\nSatisfied, you head back to camp still smiling.");
 					player.sexReward("no", "Dick");
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
 				}
 			}
 			/*

--- a/classes/classes/Scenes/Places/TempleOfTheDivine.as
+++ b/classes/classes/Scenes/Places/TempleOfTheDivine.as
@@ -50,7 +50,7 @@ public class TempleOfTheDivine extends BaseContent {
 			}
 			outputText("\n\n\"<i>There haven't been many humans in Mareth, especially since the demons took over, so it’s likely that you are the first to make it here in a long time. If you seek salvation, I’m afraid the temple will not provide any, as the gods and their powers have long since left their altars. As for who I am, my name is Sapphire. I am the last guardian of this sacred ground, and the last line of defense against the fiends that desecrate this land.</i>\"");
 			outputText("\n\nHer name seems to be somewhat appropriate, her eyes glowing with a faint, azure hue. As you ponder these details, the gargoyle turns her back to you, taking flight towards one of the pillars in the room.\n\n\"<i>You are welcome to visit this place as often as you see fit. However, I will be watching you.</i>\"\n\n<b>You can now visit the Temple of the Divines!</b>");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function repeatvisitintro():void {
@@ -89,7 +89,7 @@ public class TempleOfTheDivine extends BaseContent {
 			else addButtonDisabled(6, "???", "Sapphire is a little lonely out there. Maybe you could make her a friend...?")
 			addButton(7, "Basement", templeBasement).hint("Visit the temple basement.");
 			if (flags[kFLAGS.FORGEFATHER_MOVED_TO_TEMPLE] == 1) addButton(8, "Workshop", SceneLib.forgefatherScene.workshopMainMenu);
-			addButton(14, "Leave", camp.returnToCampUseOneHour);
+			addButton(14, "Leave", explorer.done);
 		}
 
 		public function PlayerPrayAtTemple():void {
@@ -121,7 +121,7 @@ public class TempleOfTheDivine extends BaseContent {
 			}
 			else {
 				outputText("You attempt a prayer to a god of Mareth. Sadly, if this place ever housed the god’s divine power, its ruined state no longer can contain it. It seems you will get no benefit from praying here until you repair the altars, with the god simply unable to contact you while the building is in this sinful state.\n\n");
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -197,7 +197,7 @@ public class TempleOfTheDivine extends BaseContent {
 			purifyingPower += 10;
 			if (player.statusEffectv3(StatusEffects.TempleOfTheDivineTracker) == 2) purifyingPower += 5;
 			dynStats("cor", -purifyingPower);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function PlayerPrayAtTempleTaothAltar():void {
@@ -215,7 +215,7 @@ public class TempleOfTheDivine extends BaseContent {
 			if (player.HP < player.maxHP()) player.HP = player.maxHP();
 			dynStats("cor", -10);
 			statScreenRefresh();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function PlayerPrayAtTempleFenrirAltar():void {
@@ -232,7 +232,7 @@ public class TempleOfTheDivine extends BaseContent {
 			if (player.HP < player.maxHP()) player.HP = player.maxHP();
 			dynStats("cor", -10);
 			statScreenRefresh();
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function PlayerPrayAtTempleFeraAltar():void {
@@ -244,7 +244,7 @@ public class TempleOfTheDivine extends BaseContent {
 			player.buff("FerasBlessing").setStat("minlustx", 0.15).forHours(169).withText("Fera's Blessing");
 			if (player.HP < player.maxHP()) player.HP = player.maxHP();
 			dynStats("cor", 10);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
 		public function TempleAltarsRebuildMenu():void {
@@ -273,7 +273,7 @@ public class TempleOfTheDivine extends BaseContent {
 				clearOutput();
 				outputText("You take your time to look the place over. After a few moments, you conclude that, while restoring it back to its former glory isn't impossible, it will be a long and arduous task. To make it back into the temple it was in its glory days, you estimate that you will need to repair the altars, all of the stone statues including the one depicting Marae, and the benches, which should then make the temple fully functional again as a place of worship.");
 				flags[kFLAGS.TEMPLE_OF_THE_DIVINE_PROGRESS]++;
-				doNext(camp.returnToCampUseOneHour);
+				endEncounter();
 			}
 		}
 
@@ -309,6 +309,7 @@ public class TempleOfTheDivine extends BaseContent {
 			flags[kFLAGS.CAMP_CABIN_STONE_RESOURCES] -= 50;
 			flags[kFLAGS.TEMPLE_OF_THE_DIVINE_MARAE] = 1;
 			if (flags[kFLAGS.TEMPLE_OF_THE_DIVINE_PROGRESS] < 3) flags[kFLAGS.TEMPLE_OF_THE_DIVINE_PROGRESS]++;
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 
@@ -317,6 +318,7 @@ public class TempleOfTheDivine extends BaseContent {
 			outputText("You work for 8 hours, sculpting stone and repairing the altar of Taoth. By the time you're done you can feel divine power amass around it anew.");
 			flags[kFLAGS.CAMP_CABIN_STONE_RESOURCES] -= 50;
 			flags[kFLAGS.TEMPLE_OF_THE_DIVINE_TAOTH] = 1;
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 
@@ -325,6 +327,7 @@ public class TempleOfTheDivine extends BaseContent {
 			outputText("You work for 8 hours, sculpting stone and repairing the altar of Fenrir. By the time you're done you can feel a cold chilling aura amass around it. Was that really such a good idea?");
 			flags[kFLAGS.CAMP_CABIN_STONE_RESOURCES] -= 50;
 			flags[kFLAGS.TEMPLE_OF_THE_DIVINE_FENRIR] = 1;
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 
@@ -333,6 +336,7 @@ public class TempleOfTheDivine extends BaseContent {
 			outputText("You work for the entire day sculpting stone and repairing the altar of Fera. By the time you're done you can feel divine power albeit tainted amass around it anew.");
 			flags[kFLAGS.CAMP_CABIN_STONE_RESOURCES] -= 50;
 			flags[kFLAGS.TEMPLE_OF_THE_DIVINE_FERA] = 1;
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 
@@ -344,6 +348,7 @@ public class TempleOfTheDivine extends BaseContent {
             else outputText("Even though the altar is dysfunctional, the repaired statue looks like a nice addition to the temple.");
 			flags[kFLAGS.CAMP_CABIN_STONE_RESOURCES] -= 150;
 			flags[kFLAGS.TEMPLE_OF_THE_DIVINE_PROGRESS]++;
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 
@@ -352,6 +357,7 @@ public class TempleOfTheDivine extends BaseContent {
 			outputText("You work for the entire day sculpting stone. By the time you're done a set of well carved statue decorate the walls again.");
 			flags[kFLAGS.CAMP_CABIN_STONE_RESOURCES] -= 500;
 			flags[kFLAGS.TEMPLE_OF_THE_DIVINE_PROGRESS]++;
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 
@@ -363,6 +369,7 @@ public class TempleOfTheDivine extends BaseContent {
 			flags[kFLAGS.CAMP_CABIN_WOOD_RESOURCES] -= 50;
 			flags[kFLAGS.CAMP_CABIN_NAILS_RESOURCES] -= 10;
 			flags[kFLAGS.TEMPLE_OF_THE_DIVINE_PROGRESS]++;
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseEightHours);
 		}
 

--- a/classes/classes/Scenes/Soulforce.as
+++ b/classes/classes/Scenes/Soulforce.as
@@ -779,8 +779,6 @@ public class Soulforce extends BaseContent
 				.disableIf(!player.hasVagina(), "Req. to have a vagina.");
 		if (flags[kFLAGS.SOUL_SENSE_WORLD_TREE] >= 1)
 			addSSButton(btn++, "WorldTree", worldtreeScene.YggdrasilDiscovery, 100);
-		if (flags[kFLAGS.SOUL_SENSE_ANTHILL] >= 1 && !flags[kFLAGS.ANT_WAIFU])
-			addSSButton(btn++, "Ant Colony", SceneLib.desert.antsScene.antColonyChallenge, 200);
 		//button 11
 		addButton(13, "???", theUnknown).hint("Draw into your soulforce for soulsensing.");
 		addButton(14, "Back", accessSoulforceMenu);

--- a/classes/classes/Scenes/Soulforce.as
+++ b/classes/classes/Scenes/Soulforce.as
@@ -771,12 +771,6 @@ public class Soulforce extends BaseContent
 		outputText("\n\nAmount of soulforce used to locate them using soul sense depening of relative power of searched person or location.");
 		menu();
 		var btn:int = 0;
-		if (flags[kFLAGS.SOUL_SENSE_IZUMI] >= 3)
-			addSSButton(btn++, "Izumi", izumiScenes.encounter, 300);
-		if (flags[kFLAGS.SOUL_SENSE_MINOTAUR_SONS] >= 3)
-			addSSButton(btn++, "Mino Sons", minotaurSonsScene.meetMinotaurSons, soulforceForSons())
-				.disableIf(flags[kFLAGS.MINOTAUR_SONS_TRIBE_SIZE] < 3, "Req. to have 3+ minotaur sons.")
-				.disableIf(!player.hasVagina(), "Req. to have a vagina.");
 		if (flags[kFLAGS.SOUL_SENSE_WORLD_TREE] >= 1)
 			addSSButton(btn++, "WorldTree", worldtreeScene.YggdrasilDiscovery, 100);
 		//button 11

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -112,6 +112,22 @@ public class Utils extends Object
 			}
 			return x * y;
 		}
+		
+		/**
+		 * Solve the arithmetic progression.
+		 * For startValue=1, increment=1, return N such that 1 + 2 + 3 + ... + N = sum
+		 *
+		 * General form: return N such that
+		 *
+		 * `sum = startValue + (startValue + increment) + (startValue + 2*increment) + ...`
+		 * (N total items)
+		 */
+		public static function solveSum(sum:Number, startValue:Number = 1, increment:Number = 1):Number {
+			var a:Number = increment;
+			var b:Number = (2*startValue - increment);
+			var c:Number = -2*sum;
+			return (Math.sqrt(b*b - 4*a*c) - b)/(2*a);
+		}
 		public static function floor(value:Number,decimals:int=0):String {
 			if (decimals == 0) return ''+Math.floor(value);
 			var base:Number = ipow(10,decimals);

--- a/classes/coc/view/Block.as
+++ b/classes/coc/view/Block.as
@@ -71,7 +71,7 @@ public class Block extends Sprite {
 		// count autocols and convert fraction widths to pixels
 		for (i = 0; i < cols; i++) {
 			if (columns[i] < 0) {
-				autocols++;
+				autocols += -columns[i];
 				continue;
 			} else if (columns[i] <= 1) {
 				// fraction
@@ -83,7 +83,7 @@ public class Block extends Sprite {
 		if (autocols > 0) {
 			if (cellWidth <= 0) cellWidth = freespace/autocols;
 			for (i = 0; i < cols; i++) {
-				if (columns[i] < 0) columns[i] = cellWidth;
+				if (columns[i] < 0) columns[i] = cellWidth*(-columns[i]);
 			}
 		}
 		if (gap < 0) {

--- a/classes/coc/view/ButtonData.as
+++ b/classes/coc/view/ButtonData.as
@@ -23,6 +23,7 @@ public class ButtonData {
 	public var slotType:Function;
 	public var iconId:String = null;
 	public var iconQty:String = "";
+	public var cornerLabelText:String = "";
 	public function ButtonData(text:String, callback:Function =null, toolTipText:String ="", toolTipHeader:String ="") {
 		this.text = text;
 		this.callback = callback;
@@ -63,7 +64,10 @@ public class ButtonData {
 		this.iconId = iconId;
 		return this;
 	}
-	
+	public function cornerLabel(label:String):ButtonData {
+		this.cornerLabelText = label;
+		return this;
+	}
 	/**
 	 * Associate custom data with the button.
 	 */
@@ -104,7 +108,8 @@ public class ButtonData {
 			btn.show(text, callback, toolTipText, toolTipHeader)
 					.color(labelColor)
 					.disableIf(!enabled)
-					.icon(iconId, iconQty);
+					.icon(iconId, iconQty)
+					.cornerLabel(cornerLabelText);
 		}
 	}
 	/**

--- a/classes/coc/view/CoCButton.as
+++ b/classes/coc/view/CoCButton.as
@@ -79,6 +79,7 @@ public class CoCButton extends Block {
 				_key1label:TextField,
 				_key2label:TextField,
 				_iconQuantityLabel:TextField,
+				_cornerLabel:TextField,
 				_iconGraphic:BitmapDataSprite,
 				_backgroundGraphic:BitmapDataSprite,
 				_enabled:Boolean      = true,
@@ -160,6 +161,19 @@ public class CoCButton extends Block {
 		_iconQuantityLabel.filters = [UIUtils.outlineFilter(IconQuantityShadow)];
 		return _iconQuantityLabel;
 	}
+	private function cornerLabelElement():TextField {
+		if (_cornerLabel) return _cornerLabel;
+		_cornerLabel         = addElementAbove(UIUtils.newTextField({
+			x                : ICON_X,
+			width            : width - ICON_X * 2,
+			y                : ICON_Y,
+			height           : ICON_HEIGHT / 2,
+			textColor        : IconQuantityColor,
+			defaultTextFormat: IconQuantityFormat
+		}), _labelField) as TextField;
+		_cornerLabel.filters = [UIUtils.outlineFilter(IconQuantityShadow)];
+		return _cornerLabel;
+	}
 	private function key1labelElement():TextField {
 		if (_key1label) return _key1label;
 		_key1label         = addElementAbove(UIUtils.newTextField({
@@ -205,6 +219,9 @@ public class CoCButton extends Block {
 			if (_key1label) _key1label.width         = innerWidth - 12;
 			if (_key2label) _key2label.width         = innerWidth - 12;
 			iconId                   = iconId;
+		}
+		if (_cornerLabel) {
+			_cornerLabel.width = width - ICON_X * 2;
 		}
 		super.resize();
 	}
@@ -282,9 +299,24 @@ public class CoCButton extends Block {
 		return _iconQuantityLabel && _iconQuantityLabel.visible ? _iconQuantityLabel.text : "";
 	}
 	public function set iconQty(value:String):void {
-		iconQuantityElement();
-		_iconQuantityLabel.text    = value;
-		_iconQuantityLabel.visible = _iconGraphic && _iconGraphic.visible;
+		if (value && !_iconQuantityLabel) iconQuantityElement();
+		if (_iconQuantityLabel) {
+			_iconQuantityLabel.text    = value;
+			_iconQuantityLabel.visible = _iconGraphic && _iconGraphic.visible;
+		}
+	}
+	public function cornerLabel(value:String):CoCButton {
+		cornerLabelText = value;
+		return this;
+	}
+	public function get cornerLabelText():String {
+		return _cornerLabel ? _cornerLabel.text : "";
+	}
+	public function set cornerLabelText(value:String):void {
+		if (value && !_cornerLabel) cornerLabelElement();
+		if (_cornerLabel) {
+			_cornerLabel.text = value;
+		}
 	}
 	public function icon(iconId:String, iconQty:String=""):CoCButton {
 		this.iconId = iconId;
@@ -517,15 +549,16 @@ public class CoCButton extends Block {
 	
 	public function reset():CoCButton {
 		color(DEFAULT_COLOR);
-		visible       = false;
-		labelText     = "";
-		toolTipHeader = "";
-		toolTipText   = "";
-		alpha         = 1;
-		enabled       = false;
-		callback      = null;
-		iconId        = null;
-		iconQty       = "";
+		visible         = false;
+		labelText       = "";
+		toolTipHeader   = "";
+		toolTipText     = "";
+		alpha           = 1;
+		enabled         = false;
+		callback        = null;
+		iconId          = null;
+		iconQty         = "";
+		cornerLabelText = "";
 		return this;
 	}
 	/**

--- a/res/icons.xml
+++ b/res/icons.xml
@@ -440,6 +440,9 @@
         ==============-->
 
         <alias alias="TeaseXP" icon="I_Heart_Red"/>
+        <alias alias="herbXP" icon="I_Herb_Green"/>
+        <alias alias="mineXP" icon="I_BronzeB"/>
+        <alias alias="spellXP" icon="I_Book_Red"/>
         <!-- Mastery icons: 'CombatMastery' + player.combatMastery[i].combat -->
         <alias alias="CombatMastery" icon="I_GenericWeapon_Sword"/>
         <alias alias="CombatMasteryFeral" icon="CombatMastery"/>


### PR DESCRIPTION
* Lake holy item encounters are split
* Popups for spellcasting, mining, farming, herbalism XP
* Removed from old Soul Sense: anthill, Izumi, minomob
* Converted areas: Swamp, Bog, Hills, Caves, Mountain (L, M), High Mountain
* Rebalanced wisdom-based reveal.
* Perk menu categories show number of pickable perks
* Perk menu restyled
* Bugfixes

Code changes:
* Unique encounters can be grouped; only one of a group can appear
* Soul Sense can be configured per area, to reveal other encounters than just NPCs
* Buttons can have yellow label (like item quantity) in top right corner
