### PR TITLE
master-wip

### DIFF
--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -40,15 +40,20 @@ import coc.xxc.StoryContext;
 		{
 			EventParser.cheatTime(time, needNext);
 		}
-		protected function eachMinuteCount(time:Number, needNext:Boolean = false):void
+
+		/**
+		 * Advance time by `time` minutes. If overflows into next hour, delay this until next EngineCode.goNext call
+		 * @param time
+		 */
+		protected function advanceMinutes(time:Number):void
 		{
-			EventParser.eachMinuteCount(time, needNext);
+			EventParser.advanceMinutes(time);
 		}
 		protected static function get timeQ():Number
 		{
-			return CoC.instance.timeQ + (CoC.instance.timeQmin%60);
+			return CoC.instance.timeQ + Math.floor(CoC.instance.timeQmin/60);
 		}
-		
+
 		/**
 		 * Time advancement is planned
 		 */
@@ -59,7 +64,7 @@ import coc.xxc.StoryContext;
 		public static function get isNightTime():Boolean {
 			return (model.time.hours + timeQ <= 5 || model.time.hours + timeQ >= 22);
 		}
-		
+
 		/**
 		 * Examples:
 		 * - isTimeBetween(12, 16) - 12:00..15:59
@@ -81,7 +86,7 @@ import coc.xxc.StoryContext;
 		protected function get d3():D3 {
 			return SceneLib.d3;
 		}
-		
+
 		/**
 		 * Advance queued time and execute scheduled events. Then go to playerMenu (camp/Ingnam)
 		 * @param defNext Require [Next] button, otherwise can display the playerMenu right away
@@ -252,7 +257,7 @@ import coc.xxc.StoryContext;
 		protected static function mkLink(linkText:String, eventArgument:String):String {
 			return '<u><a href="event:'+encodeURI(eventArgument)+'">'+linkText+"</a></u>";
 		}
-		
+
 		protected static function outputText(output:String):void
 		{
 			EngineCore.outputText(output);
@@ -705,7 +710,7 @@ import coc.xxc.StoryContext;
 		protected function get vehicles():VehiclesLib{
 			return CoC.instance.vehicles;
 		}
-		
+
 		protected static function get questLib():QuestLib {
 			return CoC.instance.questLib;
 		}
@@ -732,7 +737,7 @@ import coc.xxc.StoryContext;
 		{
 			return CoC.instance.mainViewManager;
 		}
-		
+
 		protected static function get notificationView():NotificationView {
 			return CoC.instance.mainView.notificationView;
 		}
@@ -805,7 +810,7 @@ import coc.xxc.StoryContext;
 		protected function buttonIsVisible(index:int):Boolean {
 			return EngineCore.buttonIsVisible(index);
 		}
-		
+
 		protected static function get shiftKeyDown():Boolean {
 			return flags[kFLAGS.SHIFT_KEY_DOWN];
 		}
@@ -825,11 +830,14 @@ import coc.xxc.StoryContext;
 		protected static function get explorer():ExplorationEngine {
 			return SceneLib.explorationEngine;
 		}
-		/** [Next] to camp or exploartion map */
-		protected function endEncounter():void {
-			doNext(explorer.done);
+		/**
+		 * [Next] to camp or exploration map
+		 * @param timePassedMinutes Advance time, -1 for default value
+		 * */
+		protected function endEncounter(timePassedMinutes:int = -1):void {
+			doNext(curry(explorer.done,timePassedMinutes));
 		}
-		
+
 		protected function adjustedPlayerLevel():int {
 			return player.level + combat.playerLevelAdjustment();
 		}
@@ -879,7 +887,7 @@ import coc.xxc.StoryContext;
 			}
 			if (back != null) button(bi++).show("Back",back);
 		}
-		
+
 		/**
 		 * Display a 5xN button grid after the current text.
 		 * @param bd Button data, row-by-row.

--- a/classes/classes/EventParser.as
+++ b/classes/classes/EventParser.as
@@ -130,7 +130,8 @@ public class EventParser {
     private static function goNextWrapped(needNext:Boolean):Boolean {
         var player:Player = CoC.instance.player;
         //clearOutput();
-        if (timeAwareLargeLastEntry >= 0 && !DungeonAbstractContent.inDungeon) { //Finish calling timeChangeLarge before advancing the hour again
+        if (timeAwareLargeLastEntry >= 0 && (!DungeonAbstractContent.inDungeon && !SceneLib.explorationEngine.isActive)) {
+            //Finish calling timeChangeLarge before advancing the hour again
             for (; timeAwareLargeLastEntry < _timeAwareClassList.length; timeAwareLargeLastEntry++) {
                 var item:TimeAwareInterface = _timeAwareClassList[timeAwareLargeLastEntry];
                 var classname:String = getQualifiedClassName(item);
@@ -605,7 +606,11 @@ public class EventParser {
         }
         EngineCore.statScreenRefresh();
     }
-	public static function eachMinuteCount(time:Number, needNext:Boolean = false):void {
+    /**
+     * Advance time by `time` minutes. If overflows into next hour, delay this until next EngineCode.goNext call
+     * @param time
+     */
+	public static function advanceMinutes(time:Number):void {
         // Ex. minutes = 45, time = 20, overflow = 6
         var overflow:Number = (CoC.instance.model.time.minutes + time) - 59;
         if (overflow > 0) {

--- a/classes/classes/Items/Alchemy/AlchemyReagent.as
+++ b/classes/classes/Items/Alchemy/AlchemyReagent.as
@@ -1,38 +1,40 @@
 package classes.Items.Alchemy {
 public class AlchemyReagent {
     private static const Dicts:/*Object*/Array = [{},{},{},{},{}];
-    
+
     /**
      * AlchemyLib.CT_XXXX
      */
     public var type:int;
     public var intValue:int;
     public var stringValue:String;
-    
+
 	public function AlchemyReagent(type:int, intValue:int, stringValue:String) {
         this.type = type;
         this.intValue = intValue;
         this.stringValue = stringValue;
+        var n:String = name();
+        if (n.indexOf("ERROR") == 0) throw new Error("Invalid AlchemyReagent "+n);
 	}
-    
+
     public function name():String {
         switch (type) {
             case AlchemyLib.RT_SUBSTANCE:
-                return AlchemyLib.Substances[intValue].name+" substance";
+                return (AlchemyLib.Substances[intValue] || {name: "ERROR " + intValue})["name"]+" substance";
             case AlchemyLib.RT_ESSENCE:
-                return AlchemyLib.Essences[intValue].name+" essence";
+                return (AlchemyLib.Essences[intValue] || {name: "ERROR " + intValue})["name"]+" essence";
             case AlchemyLib.RT_RESIDUE:
-                return AlchemyLib.Residues[intValue].name+" residue";
+                return (AlchemyLib.Residues[intValue] || {name: "ERROR " + intValue})["name"]+" residue";
             case AlchemyLib.RT_PIGMENT:
                 return stringValue+" pigment";
         }
         return "ERROR "+type+"/"+intValue+"/"+stringValue;
     }
-    
+
     public function key():* {
         return (type == AlchemyLib.RT_PIGMENT) ? stringValue : intValue;
     }
-    
+
     private static function getAC(key:*, type:int, intValue:int, stringValue:String):AlchemyReagent {
         var dict:Object= Dicts[type];
         if(key in dict) return dict[key] as AlchemyReagent;

--- a/classes/classes/Items/Consumable.as
+++ b/classes/classes/Items/Consumable.as
@@ -33,11 +33,11 @@ import classes.internals.Utils;
 			EngineCore.doNext.apply(null, [func].concat(args));
 		}
 		protected function rand(n:Number):int { return Utils.rand(n); }
-		
+
 		override public function get category():String {
 			return CATEGORY_CONSUMABLE;
 		}
-		
+
 		public function Consumable(id:String, shortName:String = null, longName:String = null, value:Number = 0, description:String = null) {
 			super(id, shortName, longName, value, description);
 		}
@@ -64,7 +64,7 @@ import classes.internals.Utils;
 		protected function dynStats(... args):void {
 			game.player.dynStats.apply(game.player, args);
 		}
-		
+
 		// Random drop table: [weight:number, essence:int][];
 		public var essences: /*Number[]*/Array = null;
 		// Random drop table: [weight:number, essence:int][];
@@ -73,7 +73,7 @@ import classes.internals.Utils;
 		public var residues: /*Number[]*/Array = null;
 		// Random drop table: [weight:number, pigment:String][];
 		public var pigments: /*Array*/Array = null;
-		
+
 		public function getRefineReagents(type:int):/*AlchemyReagent*/Array {
 			var result:/*AlchemyReagent*/Array = [];
 			var source:/*Array*/Array;
@@ -96,7 +96,7 @@ import classes.internals.Utils;
 					getRefineReagents(AlchemyLib.RT_SUBSTANCE)
 			)
 		}
-		
+
 		public function get isRefinable():Boolean {
 			return essences || substances || residues || pigments;
 		}
@@ -114,16 +114,26 @@ import classes.internals.Utils;
 				residues:/*Number[]*/Array = null,
 				pigments:Array = null
 		):Consumable {
+			var i:int;
 			if (substances && substances.length > 0) {
 				if (!this.substances) this.substances = [];
+				for each (i in substances) {
+					if (!AlchemyLib.Substances[i]) throw new Error("Ingredient "+id+" has invalid refineableInto substance "+i);
+				}
 				pushAll(this.substances, substances);
 			}
 			if (essences && essences.length > 0) {
 				if (!this.essences) this.essences = [];
+				for each (i in essences) {
+					if (!AlchemyLib.Essences[i]) throw new Error("Ingredient "+id+" has invalid refineableInto essence "+i);
+				}
 				pushAll(this.essences, essences);
 			}
 			if (residues && residues.length > 0) {
 				if (!this.residues) this.residues = [];
+				for each (i in residues) {
+					if (!AlchemyLib.Residues[i]) throw new Error("Ingredient "+id+" has invalid refineableInto residue "+i);
+				}
 				pushAll(this.residues, residues);
 			}
 			if (pigments && pigments.length > 0) {
@@ -145,7 +155,7 @@ import classes.internals.Utils;
 					}
 				}
 				// merge duplicates
-				for (var i:int = 0; i < this.pigments.length; i++) {
+				for (i=0; i < this.pigments.length; i++) {
 					for (var j:int = this.pigments.length-1; j > i; j--) {
 						if (this.pigments[i][1] == this.pigments[j][1]) {
 							this.pigments[i][0] += this.pigments[j][0];

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -1669,8 +1669,9 @@ import flash.utils.getQualifiedClassName;
 			error += super.validate();
 			error += Utils.validateNonNegativeNumberFields(this, "Monster.validate", ["lustVuln"]);
 			for each (var ability:* in abilities) {
+				if (!ability.call) continue;
 				if ('condition' in ability && !(ability.condition is Function)) {
-					error += "Ability is not a Function. ";
+					error += "Ability condition is not a Function. ";
 				}
 			}
 			return error;

--- a/classes/classes/Scenes/API/ExplorationEngine.as
+++ b/classes/classes/Scenes/API/ExplorationEngine.as
@@ -214,6 +214,8 @@ public class ExplorationEngine extends BaseContent {
 			} else {
 				timePassedMinutes = ExplorationEntry.EncounterKinds[currentEntry.kind].time;
 			}
+		}
+		if (timePassedMinutes > 0) {
 			advanceMinutes(timePassedMinutes);
 		}
 		markEncounterDone();

--- a/classes/classes/Scenes/API/ExplorationEngine.as
+++ b/classes/classes/Scenes/API/ExplorationEngine.as
@@ -1,6 +1,7 @@
 package classes.Scenes.API {
 import classes.BaseContent;
 import classes.CoC;
+import classes.EngineCore;
 import classes.PerkLib;
 import classes.Scenes.SceneLib;
 import classes.internals.Utils;
@@ -24,7 +25,7 @@ public class ExplorationEngine extends BaseContent {
 	private static const LINE_DISABLED:String = "#888888";
 	private static const LINE_COLOR:String = "#884444";
 	private static const LINE_NEXT:String  = "#0080ff";
-	
+
 	private function filterUnique(e:SimpleEncounter):Boolean {
 		if (e.unique) {
 			var group:String = e.unique as String;
@@ -54,12 +55,12 @@ public class ExplorationEngine extends BaseContent {
 		return soulSenseCheck(e) && filterUnique(e);
 	}
 	private const filters:/*Function*/Array = [filterForStart, filterForMid, filterForEnd];
-	
+
 	public function ExplorationEngine() {
 		const SIZE:Number = ExplorationEntry.RADIUS * 2;
 		const XGAP:Number = (MainView.TEXTZONE_W) / (MAXDEPTH + 1) - SIZE;
 		const YGAP:Number = SIZE * 1.5;
-		
+
 		startPos       = new ExplorationEntry(-1, -1, XGAP / 2, YGAP + (NROADS - 1) * (SIZE + YGAP) / 2);
 		startPos.label = "Start";
 		var y:Number   = YGAP;
@@ -76,7 +77,7 @@ public class ExplorationEngine extends BaseContent {
 		initialized = true; // for clear() to work
 		clear();
 	}
-	
+
 	/**
 	 * This properties can be set after prepareArea() and before doExplore()
 	 */
@@ -124,7 +125,7 @@ public class ExplorationEngine extends BaseContent {
 	public var areaTags:Object       = {};
 	public var branchChance:Number   = 0;
 	public var crossingAllowed:Boolean = false;
-	
+
 	private var maxDepth:int         = MAXDEPTH;
 	private var source:GroupEncounter               = new GroupEncounter("UNUSED", []);
 	private var playerEntry:ExplorationEntry        = null;
@@ -140,7 +141,7 @@ public class ExplorationEngine extends BaseContent {
 	private var finished:Boolean                    = false;
 	private var startPos:ExplorationEntry;
 	private var nextNodes:/*ExplorationEntry*/Array = [];
-	
+
 	/**
 	 * Switch to clear, uninitialized state.
 	 */
@@ -182,7 +183,9 @@ public class ExplorationEngine extends BaseContent {
 	/**
 	 * Switch to "finished" state where data is still kept but exploration cannot proceed.
 	 *
-	 * This function can be called in encounters that finish exploration early (e.g. combat loss)
+	 * This function can be called in encounters that finish exploration early (e.g. combat loss).
+	 *
+	 * This function does not display any menus!
 	 */
 	public function stopExploring():void {
 		trace("explorer.stopExploring");
@@ -196,12 +199,22 @@ public class ExplorationEngine extends BaseContent {
 	 * This function can be used as a callback when finishing the encounter.
 	 *
 	 * If there is no encounter, return to camp using 1 hour.
+	 *
+	 * @param timePassedMinutes Advance time, -1 for default value
 	 */
-	public function done():void {
+	public function done(timePassedMinutes:int = -1):void {
 		trace("explorer.done");
 		if (!initialized) {
 			defaultReturn();
 			return;
+		}
+		if (timePassedMinutes < 0) {
+			if (currentEntry == null) {
+				timePassedMinutes = 0;
+			} else {
+				timePassedMinutes = ExplorationEntry.EncounterKinds[currentEntry.kind].time;
+			}
+			advanceMinutes(timePassedMinutes);
 		}
 		markEncounterDone();
 		if (finished) onEnd.callback();
@@ -223,7 +236,10 @@ public class ExplorationEngine extends BaseContent {
 			trace("explorer.doExplore(ended)")
 			stopExploring();
 			onEnd.callback();
-		} else */{
+		} else */if (timeQueued) {
+			trace("explorer.doExplore(timeQueued)");
+			goNext(false);
+		} else {
 			trace("explorer.doExplore(normal)")
 			validate();
 			showUI();
@@ -256,14 +272,14 @@ public class ExplorationEngine extends BaseContent {
 			}
 		}
 	}
-	
+
 	private function defaultReturn():void {
 		camp.returnToCampUseOneHour();
 	}
 	private function get maxRevealLevel():int {
 		return canRevealFull ? ExplorationEntry.REVEAL_FULL : ExplorationEntry.REVEAL_KIND;
 	}
-	
+
 	/**
 	 * Current entry that is being executed - after player starts the encounter and before stopExploring()/markEncounterDone()/done()
 	 */
@@ -273,6 +289,10 @@ public class ExplorationEngine extends BaseContent {
 	public function get inEncounter():Boolean {
 		return !!currentEntry;
 	}
+
+	/**
+	 * True if exploration engine is currently active - whether on a map or inside an encounter.
+	 */
 	public function get isActive():Boolean {
 		return initialized && !finished;
 	}
@@ -294,7 +314,7 @@ public class ExplorationEngine extends BaseContent {
 		}
 		return 0;
 	}
-	
+
 	public function findByName(name:String):ExplorationEntry {
 		for (var i:int = 0; i < N; i++) {
 			if (!flatList[i].isDisabled && flatList[i].encounterName == name) return flatList[i];
@@ -407,7 +427,7 @@ public class ExplorationEngine extends BaseContent {
 			if (nextNodes.indexOf(entry) >= 0) execEntry(entry);
 		}
 	}
-	
+
 	private function execEntry(entry:ExplorationEntry):void {
 		trace("explorer.execEntry", entry.encounterName);
 		clearOutput();
@@ -437,14 +457,14 @@ public class ExplorationEngine extends BaseContent {
 	private function createMap():Sprite {
 		var map:Sprite = new Sprite();
 		var g:Graphics = map.graphics;
-		
+
 		if (roadIndex < 0) {
 			startPos.isPlayerHere = true;
 			playerEntry           = startPos;
 		}
 		startPos.redraw();
 		map.addChild(startPos.sprite);
-		
+
 		for (var i:int = 0; i < NROADS; i++) {
 			for (var j:int = 0; j < MAXDEPTH; j++) {
 				var node:ExplorationEntry = roads[i][j];
@@ -491,20 +511,32 @@ public class ExplorationEngine extends BaseContent {
 				}
 			}
 		}
-		
+
 		return map;
 	}
 	private function showUI(message:String = ""):void {
 		var i:int;
-		for (i = 0; i < N; i++) {
-			// If there is an encounter with chance ALWAYS, stop the exploration and execute it immediately
+		var e:Encounter = null;
+		// If there is an encounter with chance ALWAYS, stop the exploration and execute it immediately
+		for (i = 0; e == null && i < N; i++) {
 			if (flatList[i].encounter && !flatList[i].isDisabled && flatList[i].encounter.encounterChance() == Encounters.ALWAYS) {
-				stopExploring();
-				flatList[i].encounter.execEncounter();
-				return;
+				e = flatList[i].encounter;
 			}
 		}
-		
+		// Check to pool for same
+		for (i = 0; e == null && i < source.components.length; i++) {
+			if (source.components[i].encounterChance() >= Encounters.ALWAYS) {
+				e = source.components[i];
+			}
+		}
+		if (e != null) {
+			stopExploring();
+			if (onEncounter != null) {
+				onEncounter(e);
+			}
+			e.execEncounter();
+		}
+
 		// Buttons
 		// [Forward/Path 1] [Path 2] [Path 3] [Path 4] [Path 5]
 		// [   SoulSense  ] [      ] [      ] [      ] [      ]
@@ -563,26 +595,27 @@ public class ExplorationEngine extends BaseContent {
 				button(12).disable("You're too aroused to explore!");
 			}
 		}
-		
+
 		if (debug) {
 			button(14).show("Menu", cheatMenu);
 		} else {
 			if (leave && !finished && !isAtEnd) leave.applyTo(button(14));
 		}
 		if (onMenu != null) onMenu();
+		mainViewManager.updateCharviewIfNeeded();
 	}
 	public function cheatMenu():void {
 		function cheatReveal(level:int):void {
 			revealAll(level);
 			showUI();
 		}
-		
+
 		function cheatReroll():void {
 			for (var i:int = 0; i < N; i++) flatList[i].isPlayerHere = false;
 			generateAll();
 			showUI();
 		}
-		
+
 		statScreenRefresh();
 		menu();
 		button(0).show("Reveal(0)", curry(cheatReveal, 0))
@@ -595,11 +628,11 @@ public class ExplorationEngine extends BaseContent {
 								.hint("Recreate the map")
 		button(4).show("Camp", camp.returnToCampUseOneHour)
 				 .hint("Return to camp");
-		
+
 		if (leave && !finished && !isAtEnd) leave.applyTo(button(13));
 		button(14).show("Back", showUI).icon("Back");
 	}
-	
+
 	/**
 	 *
 	 * @param entry
@@ -697,13 +730,13 @@ public class ExplorationEngine extends BaseContent {
 			}
 		}
 	}
-	
+
 	public function skillBasedReveal(areaLevel:Number, timesExplored:Number):void {
 		var n:Number = 0;
-		
+
 		// +1 reveal per 100 area explorations
 		n += timesExplored / 100;
-		
+
 		// Wisdom-based reveal:
 		// * first reveal costs 10 wisdom, scaled with NG+ and area level
 		// * each following reveal costs 5% more wis
@@ -711,7 +744,7 @@ public class ExplorationEngine extends BaseContent {
 		wisFactor *= 1 + 4 * (areaLevel - 1) / 99; // x1 on area level 1, x4 on area level 100
 		wisFactor *= (1 + 0.2 * CoC.instance.newGamePlusMod()); // +20% per NG level
 		n += solveSum(player.wis, wisFactor, wisFactor*0.05);
-		
+
 		// +1 reveal per Eyes of the Hunter rank
 		if (player.hasPerk(PerkLib.EyesOfTheHunterNovice)) n += 1;
 		if (player.hasPerk(PerkLib.EyesOfTheHunterAdept)) n += 1;
@@ -720,7 +753,7 @@ public class ExplorationEngine extends BaseContent {
 		if (player.hasPerk(PerkLib.EyesOfTheHunterGrandMaster)) n += 1;
 		if (player.hasPerk(PerkLib.EyesOfTheHunterEx)) n += 1;
 		if (player.hasPerk(PerkLib.EyesOfTheHunterSu)) n += 1;
-		
+
 		revealMultiple(n);
 	}
 	public function soulSenseCost():Number {
@@ -732,7 +765,7 @@ public class ExplorationEngine extends BaseContent {
 	public function doSoulSense():void {
 		player.soulforce -= soulSenseCost();
 		statScreenRefresh();
-		
+
 		var candidates:/*ExplorationEntry*/Array = [];
 		var message:String = "";
 		for (var i:int = 0; i < N; i++) {
@@ -764,10 +797,10 @@ public class ExplorationEngine extends BaseContent {
 				message = "You've found something!";
 			}
 		}
-		
+
 		showUI(message);
 	}
-	
+
 	/**
 	 * Add an encounter at the end of the road
 	 * @param encounter

--- a/classes/classes/Scenes/API/ExplorationEntry.as
+++ b/classes/classes/Scenes/API/ExplorationEntry.as
@@ -30,19 +30,19 @@ public class ExplorationEntry {
 	private static const BORDER_PLAYER:String  = "#ffaa00";
 	private static const COLOR_DISABLED:String = "#666666";
 	private static const COLOR_DEFAULT:String  = "#aaaaaa";
-	private static const EncounterKinds:Object = {
-		"walk"    : {label: "Walk", color: "#eeeeee"},
-		"item"    : {label: "Item", color: "#00ff00"},
-		"treasure": {label: "Treasure", color: "#80ff00"},
-		"npc"     : {label: "NPC", color: "#ff80ff"},
-		"place"   : {label: "Place", color: "#88aaff"},
-		"special" : {label: "Special", color: "#ff00ff"},
-		"event"   : {label: "Event", color: "#eeee00"},
-		"monster" : {label: "Monster", color: "#aa0000"},
-		"boss"    : {label: "Boss", color: "#ff0000"},
-		"trap"    : {label: "Trap", color: "#ff8000"}
+	public static const EncounterKinds:Object = {
+		"walk"    : {label: "Walk", color: "#eeeeee", time: 30},
+		"item"    : {label: "Item", color: "#00ff00", time: 10},
+		"treasure": {label: "Treasure", color: "#80ff00", time: 15},
+		"npc"     : {label: "NPC", color: "#ff80ff", time: 30},
+		"place"   : {label: "Place", color: "#88aaff", time: 30},
+		"special" : {label: "Special", color: "#ff00ff", time: 30},
+		"event"   : {label: "Event", color: "#eeee00", time: 15},
+		"monster" : {label: "Monster", color: "#aa0000", time: 15},
+		"boss"    : {label: "Boss", color: "#ff0000", time: 30},
+		"trap"    : {label: "Trap", color: "#ff8000", time: 15}
 	}
-	
+
 	public var encounter:SimpleEncounter;
 	public var kind:String;
 	public var color:String;
@@ -64,7 +64,7 @@ public class ExplorationEntry {
 	public var roadIndex:int;
 	public var roadPos:int;
 	public var nextNodes:/*ExplorationEntry*/Array = [];
-	
+
 	public function get isFullyRevealed():Boolean { return revealLevel == REVEAL_FULL }
 	public function get encounterName():String { return encounter ? encounter.encounterName() : "(null)"}
 	public function ExplorationEntry(
@@ -80,7 +80,7 @@ public class ExplorationEntry {
 		createUI();
 		setEmpty();
 	}
-	
+
 	private function createUI():void {
 		sprite = new Sprite();
 		tfLabel         = UIUtils.newTextField({
@@ -91,7 +91,7 @@ public class ExplorationEntry {
 		});
 //		tfLabel.filters       = [UIUtils.outlineFilter(LABEL_OUTLINE)];
 		sprite.addChild(tfLabel);
-		
+
 		sprite.mouseChildren = false;
 		sprite.addEventListener(MouseEvent.CLICK, onClick);
 		sprite.addEventListener(MouseEvent.ROLL_OVER, onHover);
@@ -101,20 +101,20 @@ public class ExplorationEntry {
 	}
 	public function redraw():void {
 		var g:Graphics = sprite.graphics;
-		
+
 		var borderColor:uint = Color.convertColor32(
 				isPlayerHere ? BORDER_PLAYER
 						: isDisabled ? BORDER_CLEARED
 								: isNext ? BORDER_NEXT
 										: isCleared ? BORDER_CLEARED : BORDER_UNKNOWN
 		);
-		
+
 		g.clear();
 		g.lineStyle(BORDER_WIDTH, borderColor);
 		g.beginFill(Color.convertColor32(isPlayerHere ? COLOR_DISABLED : color));
 		g.drawCircle(RADIUS, RADIUS, RADIUS);
 		g.endFill();
-		
+
 		var mainTextFormat:TextFormat = CoC.instance.mainView.mainText.defaultTextFormat;
 		tfLabel.defaultTextFormat = UIUtils.convertTextFormat({
 			font : mainTextFormat.font,
@@ -123,10 +123,10 @@ public class ExplorationEntry {
 			align: 'center'
 		});
 		tfLabel.text = label;
-		
+
 		sprite.buttonMode = isNext;
 	}
-	
+
 	private function onClick(event:MouseEvent):void {
 		if (encounter && !isDisabled) SceneLib.explorationEngine.entryClick(this);
 	}
@@ -137,7 +137,7 @@ public class ExplorationEntry {
 	private function onDim(event:MouseEvent):void {
 		CoC.instance.mainView.toolTipView.hide();
 	}
-	
+
 	public function setEmpty():void {
 		encounter     = null;
 		kind          = null;
@@ -159,7 +159,7 @@ public class ExplorationEntry {
 	public function link(e:ExplorationEntry):void {
 		nextNodes.push(e);
 	}
-	
+
 	public function setupForEncounter(e:SimpleEncounter):void {
 		encounter  = e;
 		kind       = e.getKind();
@@ -206,7 +206,7 @@ public class ExplorationEntry {
 			revealFull();
 		}
 	}
-	
+
 	public function revealFull():void {
 		revealKind();
 		revealLevel   = REVEAL_FULL;
@@ -214,7 +214,7 @@ public class ExplorationEntry {
 		tooltipHeader = encounter.getTooltipHeader();
 		tooltipText   = encounter.getTooltipHint();
 	}
-	
+
 	public function markCleared():void {
 		revealFull();
 		color         = COLOR_DISABLED;

--- a/classes/classes/Scenes/Areas/Ashlands.as
+++ b/classes/classes/Scenes/Areas/Ashlands.as
@@ -110,7 +110,7 @@ public class Ashlands extends BaseContent
 			call: SceneLib.exploration.demonLabProjectEncounters
 		});
 	}
-	
+
 	public const areaLevel:int = 35;
 	public function isDiscovered():Boolean {
 		return SceneLib.exploration.counters.ashlands > 0;
@@ -121,7 +121,7 @@ public class Ashlands extends BaseContent
 	public function timesExplored():int {
 		return SceneLib.exploration.counters.ashlands;
 	}
-	
+
 	public function exploreAshlands():void {
 		explorer.prepareArea(ashlandsEncounter);
 		explorer.setTags("ashlands");
@@ -139,8 +139,7 @@ public class Ashlands extends BaseContent
 		clearOutput();
 		outputText("You walk for some time, roaming the ashlands. As you progress, you can feel the air getting warm. It gets hotter as you progress until you finally stumble across a blackened landscape. You reward yourself with a sight of the endless series of a volcanic landscape. Crags dot the landscape.\n\n");
 		outputText("<b>You've discovered the Volcanic Crag!</b>");
-		explorer.stopExploring();
-		doNext(camp.returnToCampUseTwoHours);
+		explorer.done(120);
 	}
 
 	private function findNothing():void {
@@ -209,20 +208,19 @@ public class Ashlands extends BaseContent
 		}
 	}
 	private function findGem():void {
-		explorer.stopExploring();
 		if (player.miningLevel > 4) {
 			if (rand(4) == 0) {
-				inventory.takeItem(useables.RBYGEM, camp.returnToCampUseTwoHours);
+				inventory.takeItem(useables.RBYGEM, curry(explorer.done,120));
 				player.mineXP(player.MiningMulti() * 2);
 			}
 			else {
 				outputText("After attempt to mine Rubies you ended with unusable piece.");
-				doNext(camp.returnToCampUseTwoHours);
+				endEncounter(120);
 			}
 		}
 		else {
 			outputText(" Your mining skill is too low to find any Rubies.");
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 		}
 	}
 }

--- a/classes/classes/Scenes/Areas/Beach.as
+++ b/classes/classes/Scenes/Areas/Beach.as
@@ -21,7 +21,7 @@ import classes.Scenes.SceneLib;
 //import classes.Scenes.NPCs.CaiLin;
 
 	use namespace CoC;
-	
+
 	public class Beach extends BaseContent
 	{
 		public var ceaniScene:CeaniScene = new CeaniScene();
@@ -29,7 +29,7 @@ import classes.Scenes.SceneLib;
 		public var demonsPack:DemonPackBeachScene = new DemonPackBeachScene();
 		public var pinchoushop:PinchousWaterwearAndTools = new PinchousWaterwearAndTools();
 		public var gooGirlScene:GooGirlScene = new GooGirlScene();
-		
+
 		public const areaLevel:int = 25;
 		public function isDiscovered():Boolean {
 			return SceneLib.exploration.counters.beach > 0;
@@ -49,7 +49,7 @@ import classes.Scenes.SceneLib;
 			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 		}
-		
+
 		public function Beach()
 		{
 			onGameInit(init);
@@ -235,7 +235,7 @@ import classes.Scenes.SceneLib;
 			explorer.skillBasedReveal(areaLevel, timesExplored());
 			explorer.doExplore();
 		}
-	
+
 		public function beachChance():Number {
 			var temp:Number = 0.2;
 			temp *= player.npcChanceToEncounter();
@@ -271,7 +271,7 @@ import classes.Scenes.SceneLib;
 			endEncounter();
 		}
 
-		
+
 		public function partsofHarpoonGun():void {
 			clearOutput();
 			outputText("As you explore the beach you run into what appears to be the half buried remains of some old contraption. Wait this might just be what that gun vendor was talking about! You proceed to dig up the items releasing this to indeed be the remains of a broken firearm.\n\n");
@@ -280,7 +280,7 @@ import classes.Scenes.SceneLib;
 			player.createKeyItem("Harpoon gun", 0, 0, 0, 0);
 			endEncounter();
 		}
-		
+
 		public function findBeachSite():void {
 			clearOutput();
             outputText("You stumble across a vein of Sandstone, this looks like suitable material for your gargoyle form.\n");
@@ -310,20 +310,19 @@ import classes.Scenes.SceneLib;
 		}
 
 		private function findGem():void {
-			explorer.stopExploring();
 			if (player.miningLevel > 4) {
 				if (rand(4) == 0) {
-					inventory.takeItem(useables.EMDGEM, camp.returnToCampUseTwoHours);
+					inventory.takeItem(useables.EMDGEM, curry(explorer.done,120));
 					player.mineXP(player.MiningMulti() * 2);
 				}
 				else {
 					outputText("After attempt to mine Emeralds you ended with unusable piece.");
-					doNext(camp.returnToCampUseTwoHours);
+					endEncounter(120);
 				}
 			}
 			else {
 				outputText(" Your mining skill is too low to find any Emeralds.");
-				doNext(camp.returnToCampUseTwoHours);
+				endEncounter(120);
 			}
 		}
 	}

--- a/classes/classes/Scenes/Areas/Caves.as
+++ b/classes/classes/Scenes/Areas/Caves.as
@@ -16,14 +16,14 @@ import classes.Scenes.NPCs.Forgefather;
 import classes.Scenes.SceneLib;
 
 use namespace CoC;
-	
+
 	public class Caves extends BaseContent
 	{
 		public var darkelfScene:DarkElfScene = new DarkElfScene();
 		public var cavewyrmScene:CaveWyrmScene = new CaveWyrmScene();
 		public var displacerbeastScene:DisplacerBeastScene = new DisplacerBeastScene();
 		public var darkslimeScene:DarkSlimeScene = new DarkSlimeScene();
-		
+
 		public function Caves() {
 			onGameInit(init);
 		}
@@ -164,7 +164,7 @@ use namespace CoC;
 				call: curry(SceneLib.exploration.demonLabProjectEncounters, 1)
 			})
 		}
-		
+
 		public const areaLevel:int = 30;
 		public function isDiscovered():Boolean {
 			return SceneLib.exploration.counters.caves > 0;
@@ -183,8 +183,8 @@ use namespace CoC;
 			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 		}
-		
-		
+
+
 		public function exploreCaves():void {
 			explorer.prepareArea(cavesEncounter);
 			explorer.setTags("caves");
@@ -296,20 +296,19 @@ use namespace CoC;
 		}
 
 		private function findGem():void {
-			explorer.stopExploring();
 			if (player.miningLevel > 4) {
 				if (rand(4) == 0) {
-					inventory.takeItem(useables.AMEGEM, camp.returnToCampUseTwoHours);
+					inventory.takeItem(useables.AMEGEM, curry(explorer.done,120));
 					player.mineXP(player.MiningMulti() * 2);
 				}
 				else {
 					outputText("After attempt to mine Amethysts you ended with unusable piece.");
-					doNext(camp.returnToCampUseTwoHours);
+					endEncounter(120);
 				}
 			}
 			else {
 				outputText(" Your mining skill is too low to find any Amethysts.");
-				doNext(camp.returnToCampUseTwoHours);
+				endEncounter(120);
 			}
 		}
 

--- a/classes/classes/Scenes/Areas/DefiledRavine.as
+++ b/classes/classes/Scenes/Areas/DefiledRavine.as
@@ -22,7 +22,7 @@ use namespace CoC;
 	{
 		public var demonScene:DemonScene = new DemonScene();
 		public var demonSoldierScene:DemonSoldierScene = new DemonSoldierScene();
-		
+
 		public const areaLevel:int = 36;
 		public function isDiscovered():Boolean {
 			return SceneLib.exploration.counters.defiledRavine > 0;
@@ -33,7 +33,7 @@ use namespace CoC;
 		public function timesExplored():int {
 			return SceneLib.exploration.counters.defiledRavine;
 		}
-		
+
 		public function DefiledRavine() {
 			onGameInit(init);
 		}
@@ -123,7 +123,7 @@ use namespace CoC;
 				call: SceneLib.exploration.demonLabProjectEncounters
 			});
 		}
-		
+
 		public function exploreDefiledRavine():void {
 			explorer.prepareArea(defiledRavineEncounter);
 			explorer.setTags("defiledRavine");
@@ -194,20 +194,19 @@ use namespace CoC;
 		}
 
 		private function findGem():void {
-			explorer.stopExploring();
 			if (player.miningLevel > 4) {
 				if (rand(4) == 0) {
-					inventory.takeItem(useables.TPAZGEM, camp.returnToCampUseTwoHours);
+					inventory.takeItem(useables.TPAZGEM, curry(explorer.done,120));
 					player.mineXP(player.MiningMulti() * 2);
 				}
 				else {
 					outputText("After attempt to mine Topaz you ended with unusable piece.");
-					doNext(camp.returnToCampUseTwoHours);
+					endEncounter(120);
 				}
 			}
 			else {
 				outputText(" Your mining skill is too low to find any Topaz.");
-				doNext(camp.returnToCampUseTwoHours);
+				endEncounter(120);
 			}
 		}
 

--- a/classes/classes/Scenes/Areas/Desert/GorgonScene.as
+++ b/classes/classes/Scenes/Areas/Desert/GorgonScene.as
@@ -5,7 +5,7 @@ import classes.BodyParts.Face;
 
 public class GorgonScene extends BaseContent
 	{
-		
+
 		public function GorgonScene()
 		{
 		}
@@ -65,7 +65,7 @@ public function gorgonEncounter():void {
 				//[player has three or more dicks]
 				if(player.cockTotal() >= 3) outputText("She takes one in each hand, stroking them slowly and making sure to pay attention to the tip. Every so often she switches to a different dick to make sure that each and every one of your throbbing cocks has some love given to them. ");
 				outputText("A hiss of pleasure escapes your lips as the gorgon strokes your [cocks], her talented fingers bringing you further into a state of arousal. She stops her caress and brings her hand to a scaly covering at her crotch, spreading it wide to reveal her soft pussy.\n\n");
-				
+
 				//[player has one dick]
 				if(player.cockTotal() == 1) outputText("She carefully lines it up with your member and starts to tease the tip before gently inserting the first few inches. ");
 				//[player has two dicks]
@@ -78,7 +78,7 @@ public function gorgonEncounter():void {
 				if(player.cumQ() > 250) outputText("You quickly fill her with your seed to the point where she overflows, leaving her pussy dripping with semen afterwards.");
 				//[JIZZ, JIZZ EVERYWHERE]
 				else if(player.cumQ() > 1000) outputText("Her stomach quickly swells from the sheer volume of seed pumped into her. The sperm that her womb is unable to hold starts to gush out from her stuffed cunt.");
-				
+
 				outputText("\n\nThe two of you lay there for a moment, basking in the warm glow of orgasm. Eventually the gorgon slowly unwraps her tail from your own and gives you a kiss on the forehead. \"<i>I look forward to our next encounter,</i>\" she whispers softly into your ear before slithering off into the desert.  You watch as she leaves and wave her a kiss goodbye before she disappears from your sight.\n\n");
 			}
 			player.sexReward("Default","Default",true,false);
@@ -105,8 +105,7 @@ public function gorgonEncounter():void {
 			player.cuntChange(30,true,false,true);
 			player.sexReward("Default","Default",true,false);
 			outputText("You think it would be a very good idea to come to the desert more often.");
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseFourHours);
+			endEncounter(120);
 			return;
 		}
 		//Genderleast
@@ -146,6 +145,6 @@ public function gorgonEncounter():void {
 	startCombat(new Gorgon());
 }
 
-	
+
 	}
 }

--- a/classes/classes/Scenes/Areas/GlacialRift/WendigoScene.as
+++ b/classes/classes/Scenes/Areas/GlacialRift/WendigoScene.as
@@ -33,16 +33,14 @@ package classes.Scenes.Areas.GlacialRift
 				outputText("\"<i>Yu amazed [name], [name] found this kid in the blizzard and brought her all the way here? Most never come back home. Come with Yu child, Yu will make you some warm food and once storm is over we look for parent.</i>\"\n\n");
 				outputText("Thankful, Yu gives you a few gems for your trouble. Guess being nice pays off sometimes?\n\n");
 				player.gems += 10 + rand(10);
-				explorer.stopExploring();
-				doNext(camp.returnToCampUseTwoHours);
+				endEncounter(120);
 			}
 			else {
 				if (player.isRace(Races.WENDIGO, 1, false)) {
 					outputText("You walk steadily toward the lost girl to offer her support. Then you realise it's just another wendigo.\n\n");
 					outputText("\"<i>So hungry… kin please, do you have food… anything... I’m starving.</i>\"\n\n");
 					outputText("You don’t and truth be told even if you did you wouldn’t share it with her because if you did have food you would have eaten it already. Wendigos are the reason you are in this sorry state in the first place. Frustrated by your reply the wendigo turns back heels and wails as she resumes looking for food, which reminds you that you also need to look for lunch. You head back to camp still starving.\n\n");
-					explorer.stopExploring();
-					doNext(camp.returnToCampUseTwoHours);
+					endEncounter(120);
 				}
 				else {
 					outputText("You walk steadily toward the lost girl to offer her support.\n\n");

--- a/classes/classes/Scenes/Areas/Mountain/WormsScene.as
+++ b/classes/classes/Scenes/Areas/Mountain/WormsScene.as
@@ -2,7 +2,7 @@
 //const CAME_WORMS_AFTER_COMBAT:int = 788;
 /*
  LICENSE
- 
+
 This license grants Fenoxo, creator of this game usage of the works of
 Dxasmodeus in this product. Dxasmodeus grants Fenoxo and the coders assigned by him to this project permission to alter the text to conform with current and new game functions, only. Dxasmodeus retains exclusive rights to alter or change the core contents of the events and no other developer may alter, change or use the events without permission from dxasmodeus. Fenoxo agrees to include Dxasmodeus' name in the credits with indications to the specific contribution made to the licensor. This license must appear
 either at the beginning or the end of the primary file in the source code and cannot be deleted by a third party. This license is also retroactive to include all versions of the game code including events created by dxasmodeus.
@@ -33,11 +33,11 @@ import classes.display.SpriteDb;
 
 public class WormsScene extends BaseContent
 	{
-		
+
 		public function WormsScene()
 		{
 		}
-		
+
 		public function wormEncounter():void {
 			spriteSelect(SpriteDb.s_dickworms);
 			clearOutput();
@@ -91,7 +91,7 @@ public class WormsScene extends BaseContent
 			player.createStatusEffect(StatusEffects.WormsOff, 0, 0, 0, 0);
 			endEncounter();
 		}
-		
+
 		private function wormsConfront():void {
 			spriteSelect(SpriteDb.s_dickworms);
 			clearOutput();
@@ -165,11 +165,10 @@ public class WormsScene extends BaseContent
 					}
 				}
 			}
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
-			
+			endEncounter(120);
+
 		}
-		
+
 		public function playerInfest():void {
 			spriteSelect(SpriteDb.s_dickworms);
 			//Keep logic sane if this attack brings victory
@@ -180,7 +179,7 @@ public class WormsScene extends BaseContent
 				enemyAI();
 				return;
 			}
-			
+
 			//(if PC uses Infest)
 			if(monster.short == "Izma") {
 				fatigue(40, USEFATG_PHYSICAL);
@@ -248,7 +247,7 @@ public class WormsScene extends BaseContent
 			outputText(" open and vulnerable to the piles of spunk-hungry parasites, and as you look on in shock, you see four of them slide into your worm-packed tunnel");
 			if(player.cockTotal() > 1) outputText("s");
 			outputText(", one after another!  No!  You reach for your [cock biggest] to somehow try and stop the infestation, but it's a futile gesture.  The worm pile on your [legs] is as big as the rest of you.  Worse still, you doubt you can pull out the ones that have already crawled inside.");
-			
+
 			outputText("\n\nGrabbing hold of [oneCock] with both hands, you pinch your fingers around ");
 			if(player.cocks[player.biggestCockIndex()].cockThickness >= 6) outputText("as tight around the girth as you can");
 			else outputText("tightly around your girth");
@@ -270,17 +269,17 @@ public class WormsScene extends BaseContent
 				outputText(" filled to the brim with moist wigglers.");
 			}
 			outputText("  You can feel narrow, tapered heads pushing at where you've pressed your urethra closed, and they try to force their way under again and again while more of their brethren pile in behind.  You stay resolute in your efforts to prevent the coming infection, pinching so hard it's painful and crying out as a result.  The pressure on your [cock biggest] wars with the way your body is reacting to the other sensations assaulting it.  Your [cock biggest] spasms powerfully when a big, fat worm perches on your [cockHead biggest], slithering all around it, leaving behind a trail of slimy gunk and sending accompanying tingles of delight through your rigid pole.");
-			
+
 			outputText("\n\nThe surge of blood into your erection shifts your grip just enough that one - no, two worms slip through.  Oh nooo!  They wriggle deeper inside you, little tails lashing at the side of your sensitive, innermost flesh, massaging your concentration away with each motion they make.  Your grip fails completely, and the torrent of parasites flows unimpeded past your pleasure-weakened digits.  They move through your urethra, getting deeper by the second.  At the same time, the big, heavy worm, arguably the king of this little colony, pushes its thick, white head into your piss-hole.  Your flagging resolve shatters as you're stretched wide by the insectile invasion, utterly penetrated.   The littler worms have already started to move into your prostate, and once there, they start to convulse, each slapping its head and tail against the sensitive organ again and again.");
-			
+
 			outputText("\n\nMoaning, you look on as the distended bulge makes its way down your [cock biggest], thrashing slightly when it disappears into your crotch, the sensations far stronger once it passes beyond your sight.  This is it... you're definitely infested now.  The worms are inside of you, and they're going to make you cum.  Lying back while your [hips] fruitlessly twitch upward, you let your eyes close and give in to the knowledge that soon, you'll be another horny worm-factory, roaming around and spraying them out at every opportunity.  That big, slithering blob joins the rest in your prostate, stretching it dangerously, and it starts to shake, thumping at the sides of your innermost organ.");
-			
+
 			outputText("\n\nThe painful pressure and erotic horror rise with the onslaught of spasming ecstasy in your reproductive organs, peaking when that huge intruder nestles itself completely inside you, squeezing your organ until you're wailing and bucking your hips, slapping [eachCock] on your belly while you cum.  The torrent of cum that you loose is unexpectedly voluminous, splattering off your [chest] and chin, dripping onto the ground in gooey streams.  Reacting quickly, the rest of the colony smushes over your spurting boner");
 			if(player.cockTotal() > 1) outputText("s");
 			outputText(" to absorb the sensual nutrition.  Some of them even slop off the sides after the dripping whiteness, to get to it before it absorbs into the brittle, wasted earth.  You cum and cum, almost without end, yet each thick jet is slurped into the writhing mass immediately, leaving behind just the parasitic, clear slime.");
-			
+
 			outputText("\n\nThe big one bathes in your jism, moving faster and faster to spur you to release even more.  Glittering spunk drains out of your tip mixed with a few white creatures until [eachCock] is twitching against you, convulsing with pleasure but unable to leak a single drop.  Only after you've given everything does the internal prostate massage subside, the uncomfortable weight settling into a steady throb.  They feel so good, and a hot wave of contentment slowly rolls through you.  Maternal pride wells up unbidden - these things are a part of you now, and keeping them fed feels so good.");
-			
+
 			outputText("\n\nYou relax in the afterglow, pondering just how you'll handle living with the constant desire, barely noticing the colony slinking off, freshly lubricated by your sexual fluids.  You drink into a lusty slumber, absently fingering [oneCock].");
 			outputText("\n\n<b>You are infested, again!</b>");
 			//Reinfest
@@ -296,7 +295,7 @@ public class WormsScene extends BaseContent
 			}
 			doNext(playerMenu);
 		}
-		
+
 	}
 
 }

--- a/classes/classes/Scenes/Areas/Swamp.as
+++ b/classes/classes/Scenes/Areas/Swamp.as
@@ -22,7 +22,7 @@ use namespace CoC;
 		public var femaleSpiderMorphScene:FemaleSpiderMorphScene = new FemaleSpiderMorphScene();
 		public var maleSpiderMorphScene:MaleSpiderMorphScene = new MaleSpiderMorphScene();
 		public var rogar:Rogar = new Rogar();
-		
+
 		public const areaLevel:int = 13;
 		public function isDiscovered():Boolean {
 			return SceneLib.exploration.counters.swamp > 0;
@@ -39,11 +39,10 @@ use namespace CoC;
 			outputText("All things considered, you decide you wouldn't mind a change of scenery.  Gathering up your belongings, you begin a journey into the wasteland.  The journey begins in high spirits, and you whistle a little traveling tune to pass the time.  After an hour of wandering, however, your wanderlust begins to whittle away.  Another half-hour ticks by.  Fed up with the fruitless exploration, you're nearly about to head back to camp when a faint light flits across your vision.  Startled, you whirl about to take in three luminous will-o'-the-wisps, swirling around each other whimsically.  As you watch, the three ghostly lights begin to move off, and though the thought of a trap crosses your mind, you decide to follow.\n\n");
 			outputText("Before long, you start to detect traces of change in the environment.  The most immediate difference is the increasingly sweltering heat.  A few minutes pass, then the will-o'-the-wisps plunge into the boundaries of a dark, murky, stagnant swamp; after a steadying breath you follow them into the bog.  Once within, however, the gaseous balls float off in different directions, causing you to lose track of them.  You sigh resignedly and retrace your steps, satisfied with your discovery.  Further exploration can wait.  For now, your camp is waiting.\n\n");
 			outputText("<b>You've discovered the Swamp!</b>");
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 		}
-		
-		
+
+
 		public function Swamp() {
 			onGameInit(init);
 		}

--- a/classes/classes/Scenes/Areas/Swamp/Rogar.as
+++ b/classes/classes/Scenes/Areas/Swamp/Rogar.as
@@ -119,8 +119,7 @@ public function encounterRogarSwamp():void {
 			//set Ro'gar phase = 2
 			flags[kFLAGS.ROGAR_PHASE] = 2;
 			dynStats("lus", 30, "scale", false);
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 			return;
 		}
 		//((high femininity or breasts >=B-cup, libido less than 50))
@@ -133,8 +132,7 @@ public function encounterRogarSwamp():void {
 			outputText("  You just grin and shake your head at his politeness.  \"<i>It's been too long since I got ta talk with any decent folk.</i>\" Ro'gar says, grinning.  Soon you both have empty mugs.  You can't help but sway where you sit from the alcohol, stronger than anything you've had before.  Ro'gar gives a hearty laugh at you, clearly enjoying your inebriated state.  \"<i>You don't look the heavy drinkin' type.</i>\" Ro'gar smirks, as you sway.  Frowning, you assure him that you can handle it, all the while punctuating your sentences with small hiccups which cause both of you to break out in laughter.  \"<i>Ya know, I've been in this swamp here for so long.  I'm getting' the itch ta go out inta the world and find greener grass, if'n ya know what I'm sayin'.  Listenin' to yer stories about yer travels ain't helpin' none, either.</i>\"  His tone of voice is distant, almost sounding disappointed with himself.  He gets to his feet with a grunt as he rises.  \"<i>Yer lookin' like yer needin' some shut eye.</i>\"  He helps you to your feet; you manage to get your balance somehow and walk to the door.  \"<i>Y'alright?</i>\" he asks, looking you over.  Through a dumb grin you manage to assure him that you're fine.  \"<i>Well allll-right.</i>\"  Ro'gar nods at you as you turn to leave.  \"<i>Ya take care now.</i>\"  He watches you walk off with concern in his eyes, but you make it back to camp just fine.\n\n");
 			//set Ro'gar phase = 2
 			flags[kFLAGS.ROGAR_PHASE] = 2;
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 			return;
 		}
 		//((androgynous or masculine and breasts <= A-cup, libido less than 50))
@@ -280,8 +278,7 @@ private function waitForChunkyOrcLoe():void {
 		outputText("<b>You can now find Ro'gar's hut when wandering the swamp occasionally!</b>");
 		//pass 2 hours, set Ro'gar phase flag = 1
 		flags[kFLAGS.ROGAR_PHASE] = 1;
-		explorer.stopExploring();
-		doNext(camp.returnToCampUseTwoHours);
+		endEncounter(120);
 	}
 }
 
@@ -297,8 +294,7 @@ private function ewwwRogarIsGay():void {
 	outputText("Declining in a clipped manner, you get to your feet and make for the door, doing your best to ignore Ro'gar's disappointed face.  He calls out to you, but it only falls on deaf ears as you shut the door quickly behind you, your legs powering through the swamp as you run with all the speed you can muster.  Only once you get back to camp do you realize you've lost the crude map... either in Ro'gar's hut or in the trackless swamp.");
 	//<set Crying Game = 1>
 	flags[kFLAGS.ROGAR_DISABLED] = 1;
-	explorer.stopExploring();
-	doNext(camp.returnToCampUseTwoHours);
+	endEncounter(120);
 }
 
 //((No thanks bro))
@@ -309,8 +305,7 @@ private function noSlowBroIDontWantPokeSex():void {
 	//<Continue without sex, set Dirt Mc Girt flag = 1 and Ro'gar phase = 2>
 	flags[kFLAGS.ROGAR_DIRT] = 1;
 	flags[kFLAGS.ROGAR_PHASE] = 2;
-	explorer.stopExploring();
-	doNext(camp.returnToCampUseTwoHours);
+	endEncounter(120);
 }
 
 //((Ok))
@@ -347,8 +342,7 @@ private function okayBroLetsHaveAGayCarwash():void {
 	flags[kFLAGS.ROGAR_DIRT] = 2;
 	flags[kFLAGS.ROGAR_PHASE] = 2;
 	if(player.inte < 30) {
-		explorer.stopExploring();
-		doNext(camp.returnToCampUseTwoHours);
+		endEncounter(120);
 	}
 	//lose 3 hours instead of 1 if int<30
 	else endEncounter();

--- a/classes/classes/Scenes/Areas/Tundra.as
+++ b/classes/classes/Scenes/Areas/Tundra.as
@@ -20,7 +20,7 @@ use namespace CoC;
 	{
 		public var valkyrieScene:ValkyrieScene = new ValkyrieScene();
 		public var alrauneScene:AlrauneScene = new AlrauneScene();
-		
+
 		public const areaLevel:int = 35;
 		public function isDiscovered():Boolean {
 			return SceneLib.exploration.counters.tundra > 0;
@@ -31,7 +31,7 @@ use namespace CoC;
 		public function timesExplored():int {
 			return SceneLib.exploration.counters.tundra;
 		}
-		
+
 		public function Tundra()
 		{
 			onGameInit(init);
@@ -119,7 +119,7 @@ use namespace CoC;
 				call: SceneLib.exploration.demonLabProjectEncounters
 			});
 		}
-		
+
 		public function exploreTundra():void {
 			explorer.prepareArea(tundraEncounter);
 			explorer.setTags("tundra");
@@ -131,7 +131,7 @@ use namespace CoC;
 			explorer.skillBasedReveal(areaLevel, timesExplored());
 			explorer.doExplore();
 		}
-		
+
 		public function nothingEncounter():void {
 			clearOutput();
 			outputText("You spend one hour exploring tundra but you don't manage to find anything interesting.");
@@ -142,7 +142,7 @@ use namespace CoC;
 			dynStats("tou", .5);
 			endEncounter();
 		}
-		
+
 		public function alabasterEncounter():void {
 			clearOutput();
 			outputText("You stumble across a vein of Alabaster, this looks like suitable material for your gargoyle form.\n");
@@ -151,13 +151,13 @@ use namespace CoC;
 			addButton(0, "Yes", tundraSiteMine);
 			addButton(1, "No", explorer.done);
 		}
-		
+
 		public function golemEncounters():void {
 			clearOutput();
 			outputText("As you take a stroll, from nearby trees emerge huge golem. Looks like you have encountered 'true ice golem'! You ready your [weapon] for a fight!");
 			startCombat(new GolemTrueIce());
 		}
-		
+
 		public function snowLilyEncounter():void {
 			clearOutput();
 			if (player.hasKeyItem("Dangerous Plants") >= 0 && player.inte / 2 > rand(50)) {
@@ -169,21 +169,21 @@ use namespace CoC;
 				alrauneScene.alrauneGlacialRift();
 			}
 		}
-		
+
 		public function frostGiantEncounter():void {
 			clearOutput();
 			outputText("You wander the chilling landscape of the Tundra. As you cross the peak of a rather large, lightly forested hill, you come face to gigantic face with a Young Frost Giant! He belches fiercely at you and you tumble back down the hill. He mostly steps over it as you come to your senses. You quickly draw your [weapon] and withdraw from the hill to prepare for battle.\n\n");
 			startCombat(new YoungFrostGiant());
 		}
-		
+
 		public function valkyrieEncounter():void {
 			clearOutput();
 			outputText("Making your way across the tundra, you’re surprised to see the thick gray clouds part overhead.  You see a beautiful woman descend from on high, her snow-white wings flapping powerfully behind her back.  Armed with a long spear and shield, and clad in a bronze cuirass and a winged helm, she looks every bit the part of a mighty warrior.\n\n");
 			outputText("She touches down gently a few feet before you, her shield and spear raised.  \"<i>You seem a worthy sort to test my skills against, wanderer.  Prepare yourself!</i>\" she shouts, bearing down on you.  She doesn’t look like she’s going to back down -- you ready your [weapon] for a fight!");
 			startCombat(new Valkyrie());
 		}
-		
-		
+
+
 		private function tundraSiteMine():void {
 			if (Forgefather.materialsExplained != 1) endEncounter();
 			else {
@@ -200,8 +200,6 @@ use namespace CoC;
 				SceneLib.forgefatherScene.incrementAlabasterSupply(minedStones);
 				player.mineXP(player.MiningMulti());
 				findGem();
-				explorer.stopExploring();
-				doNext(camp.returnToCampUseTwoHours);
 			}
 		}
 
@@ -211,20 +209,19 @@ use namespace CoC;
 		}
 
 		private function findGem():void {
-			explorer.stopExploring();
 			if (player.miningLevel > 4) {
 				if (rand(4) == 0) {
-					inventory.takeItem(useables.SAPPGEM, camp.returnToCampUseTwoHours);
+					inventory.takeItem(useables.SAPPGEM, curry(explorer.done,120));
 					player.mineXP(player.MiningMulti() * 2);
 				}
 				else {
 					outputText("After attempt to mine Sapphires you ended with unusable piece.");
-					doNext(camp.returnToCampUseTwoHours);
+					endEncounter(120);
 				}
 			}
 			else {
 				outputText(" Your mining skill is too low to find any Sapphires.");
-				doNext(camp.returnToCampUseTwoHours);
+				endEncounter(120);
 			}
 		}
 	}

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -137,7 +137,7 @@ public class Camp extends NPCAwareContent{
 	public var IsSleeping: Boolean = false;
 	public var CanDream: Boolean = false;
 	public var IsWaitingResting: Boolean = false;
-	
+
 	/**
 	 * @return 0: normal lust, 1: over lust, 2: over lust, can't do anything
 	 */
@@ -159,7 +159,7 @@ public class Camp extends NPCAwareContent{
 		}
 		return 0;
 	}
-	
+
 	public function doCamp():void { //Only called by playerMenu
 		//Force autosave on HARDCORE MODE! And level-up.
 
@@ -2275,7 +2275,7 @@ public class Camp extends NPCAwareContent{
 		flags[kFLAGS.CAMP_CABIN_MECHANISM_RESOURCES] += 1;
 		doNext(campMiscActions);
 	}
-	
+
 	public function menuForCombiningAndSeperating():void {
 		clearOutput();
 		outputText("You can combine two single weapons into one dual weapon or separate dual weapons into two single weapons. <b>(WARNING: ENCHANTED ITEMS WOULD IRREVERSABLE LOOSE ENCHANTMENTS DURING COMBINING!!!)</b>");
@@ -2317,7 +2317,7 @@ public class Camp extends NPCAwareContent{
 		}
 		submenu(bd, menuForCombiningAndSeperating,0,false);
 	}
-	
+
 	public function menuCombining(weapon1: *, weapon2: *):void {
 		clearOutput();
 		outputText("Combining.\n\n");
@@ -2334,7 +2334,7 @@ public class Camp extends NPCAwareContent{
 		outputText("\n\n");
 		inventory.takeItem(weapon2, menuForCombiningAndSeperating);
 	}
-	
+
 	public function mainPagePocketWatch(page:int = 1):void {
 		clearOutput();
 		outputText("Which perks would you like to combine using the watch?");
@@ -2751,7 +2751,7 @@ public class Camp extends NPCAwareContent{
 			doNext(VisitFishery);
 		}
 	}
-	
+
 	public function FisheryDailyProduction():Number {
 		var fishproduction:Number = 0;
 		if (flags[kFLAGS.FOLLOWER_AT_FISHERY_1] != "") {
@@ -3332,12 +3332,12 @@ public class Camp extends NPCAwareContent{
 
 	private function useGryphonStatuette():void {
 		CoC.instance.mutations.skybornSeed(1, player);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 		doNext(playerMenu);
 	}
 	private function usePeacockStatuette():void {
 		CoC.instance.mutations.skybornSeed(2, player);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 		doNext(playerMenu);
 	}
 
@@ -3384,7 +3384,7 @@ public class Camp extends NPCAwareContent{
 		bonus += 0.5*(hours*(hours-1)/2); // 0 + 0.5 + 1 + 1.5 + ...
 		return bonus;
 	}
-	
+
 	public function rest():void {
 		campQ = true;
 		IsWaitingResting = true;

--- a/classes/classes/Scenes/Camp/CabinProgress.as
+++ b/classes/classes/Scenes/Camp/CabinProgress.as
@@ -11,11 +11,11 @@ import classes.Scenes.SceneLib;
 	 * @author Kitteh6660
 	 */
 	public class CabinProgress extends BaseContent {
-		
+
 		public function CabinProgress() {
-		
+
 		}
-		
+
 		public function initiateCabin():void {
 			clearOutput();
 			//if (player.hasKeyItem("Nails") >= 0) player.removeKeyItem("Nails");
@@ -53,7 +53,7 @@ import classes.Scenes.SceneLib;
 				doNext(playerMenu);
 			}
 		}
-		
+
 		//Error message
 		public function errorNotEnough():void {
 			outputText("\n\n<b>You do not have sufficient resources. You may buy more nails from the carpentry shop in Tel'Adre, get more wood from either the Forest or the Deepwoods and get more stones from some quarry or if you found someone to help you dig some from underground.</b>")
@@ -61,15 +61,15 @@ import classes.Scenes.SceneLib;
 		public function errorNotHave():void {
 			outputText("\n\n<b>You do not have the tools to build.</b>")
 		}
-		
-		
+
+
 		//STAGE 1 - A wild idea appears!
 		public function startWork():void {
 			outputText("You wander around your camp for a good few moments when suddenly, something crosses your mind. Yes, that's it! A cabin! Just what you would need to live comfortably instead of your tent. You wander for a good while until you find a suitable location to build your cabin. You memorize the location.");
 			flags[kFLAGS.CAMP_CABIN_PROGRESS] = 2;
 			doNext(camp.returnToCampUseTwoHours);
 		}
-		
+
 		//STAGE 2 - Survey and clear area for cabin site.
 		private function startLayout():void {
 			outputText("You finally decide to begin your project: a cabin.  A comfortable cabin, come complete with a bed and nightstand along with some furniture. \n\nYou begin clearing away loose debris by picking up loose rocks and sticks and move them somewhere. It takes one hour and you feel a bit exhausted but you've finished creating a space.");
@@ -77,7 +77,7 @@ import classes.Scenes.SceneLib;
 			flags[kFLAGS.CAMP_CABIN_PROGRESS] = 3;
 			endEncounter();
 		}
-		
+
 		//STAGE 3 - Think of materials. Obviously, wood.
 		private function startThinkingOfMaterials():void {
 			outputText("Now that you have cleared an area for your cabin, you'll have to figure out how to get the resources you need. You look at the trees in the distance. Clearly, you'll need something to cut down trees. Maybe there's a shop somewhere?");
@@ -180,8 +180,7 @@ import classes.Scenes.SceneLib;
 			flags[kFLAGS.ACHIEVEMENT_PROGRESS_DEFORESTER] += (10 + Math.floor(player.str / 8));
 			incrementWoodSupply(10 + Math.floor(player.str / 8));
 			fatigue(gatherWoodsORquarrySiteMineCost(), USEFATG_PHYSICAL);
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 		}
 		//Cut down the tree yourself with Machined greatsword.
 		private function cutTreeMechTIMBER():void {
@@ -206,11 +205,10 @@ import classes.Scenes.SceneLib;
 				flags[kFLAGS.ACHIEVEMENT_PROGRESS_DEFORESTER] += (13 + Math.floor(player.str / 7));
 				incrementWoodSupply(13 + Math.floor(player.str / 7));
 				fatigue(gatherWoodsORquarrySiteMineCost(), USEFATG_PHYSICAL);
-				explorer.stopExploring();
-				doNext(camp.returnToCampUseTwoHours);
+				endEncounter(120);
 			}
 		}
-		
+
 		public function quarrySite():void {
 			clearOutput();
 			if (player.hasStatusEffect(StatusEffects.ResourceNode1) && player.statusEffectv2(StatusEffects.ResourceNode1) >= 5) outputText("You return to the mountain area where you found before a very good mineral formation.");
@@ -275,9 +273,8 @@ import classes.Scenes.SceneLib;
 			}
 			findOre(nightExploration);
 		}
-		
+
 		private function findOre(nightExploration:Boolean = false):void {
-			explorer.stopExploring();
 			if (player.miningLevel > 0) {
 				if (rand(4) == 0) {
 					var itype:ItemType;
@@ -301,16 +298,16 @@ import classes.Scenes.SceneLib;
 						default:
 							outputText("Something bugged! Please report this bug to Ormael/Aimozg.");
 					}
-					inventory.takeItem(itype, camp.returnToCampUseTwoHours);
+					inventory.takeItem(itype, curry(explorer.done,120));
 				}
 				else {
 					outputText(" After attempt to mine ore vein you ended with unusable piece.");
-					doNext(camp.returnToCampUseTwoHours);
+					endEncounter(120);
 				}
 			}
 			else {
 				outputText(" Your mining skill is too low to find any ore.");
-				doNext(camp.returnToCampUseTwoHours);
+				endEncounter(120);
 			}
 		}
 
@@ -328,7 +325,7 @@ import classes.Scenes.SceneLib;
 			}
 			endEncounter(); //- wadą tego etapu to brak menu lub menu za wcześnie?
 		}
-		
+
 		//Get help from Kiha.
 		private function getHelpFromKiha():void {
             clearOutput();
@@ -340,10 +337,9 @@ import classes.Scenes.SceneLib;
 			flags[kFLAGS.ACHIEVEMENT_PROGRESS_DEFORESTER] += (20 + Math.floor(player.str / 5));
 			incrementWoodSupply(20 + Math.floor(player.str / 5));
 			fatigue(gatherWoodsORquarrySiteMineCost(), USEFATG_PHYSICAL);
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 		}
-		
+
 		private function noThanks():void {
 			outputText("Deciding not to cut down the tree at the moment, you return to your camp. ");
 			endEncounter();
@@ -352,7 +348,7 @@ import classes.Scenes.SceneLib;
 			outputText("Deciding not to work on your cabin right now, you return to the center of your camp.");
 			doNext(playerMenu);
 		}
-		
+
 		public function incrementWoodSupply(amount:int):void {
 			outputText("<b>(+" + amount + " wood"+(amount>1?"s":"")+"!");
 			flags[kFLAGS.CAMP_CABIN_WOOD_RESOURCES] += amount;
@@ -362,7 +358,7 @@ import classes.Scenes.SceneLib;
 			}
 			outputText(")</b>");
 		}
-		
+
 		public function incrementStoneSupply(amount:int):void {
 			outputText("<b>(+" + amount + " stone"+(amount>1?"s":"")+"!");
 			flags[kFLAGS.CAMP_CABIN_STONE_RESOURCES] += amount;
@@ -372,7 +368,7 @@ import classes.Scenes.SceneLib;
 			}
 			outputText(")</b>");
 		}
-		
+
 		//STAGE 6 - Work on cabin part 2. Planning your cabin.
 		private function startCabinPart2():void {
 			outputText("You take out a paper, feather pen, and ink quill to draw some plans and diagrams. You spend one hour editing and perfecting your plans, reviewing and making some final changes to your plan before you fold the paper and put it away.");
@@ -410,7 +406,7 @@ import classes.Scenes.SceneLib;
 				doNext(playerMenu);
 			}
 		}
-		
+
 		private function doCabinWork1():void {
 			clearOutput();
 			flags[kFLAGS.CAMP_CABIN_NAILS_RESOURCES] -= 100;
@@ -434,7 +430,7 @@ import classes.Scenes.SceneLib;
 			fatigue(gatherWoodsORquarrySiteMineCost()*2);
 			doNext(camp.returnToCampUseEightHours);
 		}
-		
+
 		//Stage 9 - Build cabin part 2.
 		private function buildCabinPart2():void {
 			clearOutput();
@@ -471,7 +467,7 @@ import classes.Scenes.SceneLib;
 			fatigue(gatherWoodsORquarrySiteMineCost()*2);
 			doNext(camp.returnToCampUseEightHours);
 		}
-		
+
 		//Stage 10 - Build cabin part 3 - Install door and window.
 		private function buildCabinPart3():void {
 			clearOutput();
@@ -508,7 +504,7 @@ import classes.Scenes.SceneLib;
 			fatigue(gatherWoodsORquarrySiteMineCost()*2);
 			doNext(camp.returnToCampUseFourHours);
 		}
-		
+
 		//Stage 11 - Build cabin part 4 - Install flooring.
 		private function buildCabinPart4():void {
 			clearOutput();

--- a/classes/classes/Scenes/Camp/CampMakeWinions.as
+++ b/classes/classes/Scenes/Camp/CampMakeWinions.as
@@ -2,7 +2,7 @@
  * ...
  * @author Ormael / Liadri
  */
-package classes.Scenes.Camp 
+package classes.Scenes.Camp
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
@@ -10,15 +10,15 @@ import classes.Scenes.SceneLib;
 
 public class CampMakeWinions extends BaseContent
 	{
-		public function CampMakeWinions() 
+		public function CampMakeWinions()
 		{}
-		
+
 		//-----------
 		//
 		//  GOLEMS
 		//
 		//-----------
-		
+
 		public function maxTemporalGolemsBagSize():Number {
 			var maxTemporalGolemsBagSizeCounter:Number = 0;
 			if (player.hasPerk(PerkLib.JobGolemancer)) maxTemporalGolemsBagSizeCounter += 15;
@@ -201,7 +201,7 @@ public class CampMakeWinions extends BaseContent
 			else addButtonDisabled(13, "Upgrades", "Req. 'Golems, Animations and You' manual.");
 			addButton(14, "Back", camp.campWinionsArmySim);
 		}
-		
+
 		public function makeTemporalStoneGolem():void {
 			clearOutput();
 			if (player.mana < temporalGolemMakingCost()) {
@@ -227,8 +227,8 @@ public class CampMakeWinions extends BaseContent
 			if (flags[kFLAGS.TEMPORAL_GOLEMS_BAG] < 1) flags[kFLAGS.TEMPORAL_GOLEMS_BAG] = 1;
 			else flags[kFLAGS.TEMPORAL_GOLEMS_BAG]++;
 			doNext(accessMakeWinionsMainMenu);
-			if (player.hasPerk(PerkLib.TemporalGolemsRestructuration)) eachMinuteCount(5);
-			else eachMinuteCount(10);
+			if (player.hasPerk(PerkLib.TemporalGolemsRestructuration)) advanceMinutes(5);
+			else advanceMinutes(10);
 		}
 		public function makeTemporalStoneGolems():void {
 			clearOutput();
@@ -254,8 +254,8 @@ public class CampMakeWinions extends BaseContent
 			outputText("You draw five seals in the ground, each with a ring of stones, golem core in the middle and another line of smaller stones. With the groundwork done, you stand back and begin to chant, mana flowing from your hands into the seals. The stones glow, the smaller rings coating the five cores as they rise from the ground. One by one, the stones cover the cores, forming five rough bumanoid shapes. The golems stand, the seals vanishing from the earth. You order the newly created golems to come to you, storing them in your golem bag.");
 			flags[kFLAGS.TEMPORAL_GOLEMS_BAG] += 5;
 			doNext(accessMakeWinionsMainMenu);
-			if (player.hasPerk(PerkLib.TemporalGolemsRestructurationEx)) eachMinuteCount(15);
-			else eachMinuteCount(20);
+			if (player.hasPerk(PerkLib.TemporalGolemsRestructurationEx)) advanceMinutes(15);
+			else advanceMinutes(20);
 		}
 		public function makeTemporalStoneGolemsMore():void {
 			clearOutput();
@@ -281,7 +281,7 @@ public class CampMakeWinions extends BaseContent
 			outputText("You draw a complex seal on the ground with 20 node points, complete with golem core and a pile of stones. Once done, you stand back and begin to seep your mana into the seal. Each pile becomes a 6 feet tall golem. Finishing the work on your creations, you store them in your 'golem bag'.");
 			flags[kFLAGS.TEMPORAL_GOLEMS_BAG] += 20;
 			doNext(accessMakeWinionsMainMenu);
-			eachMinuteCount(40);
+			advanceMinutes(40);
 		}
 		public function makePermanentStoneGolem():void {
 			clearOutput();
@@ -320,7 +320,7 @@ public class CampMakeWinions extends BaseContent
 			if (flags[kFLAGS.PERMANENT_GOLEMS_BAG] < 1) flags[kFLAGS.PERMANENT_GOLEMS_BAG] = 1;
 			else flags[kFLAGS.PERMANENT_GOLEMS_BAG]++;
 			doNext(accessMakeWinionsMainMenu);
-			eachMinuteCount(20);
+			advanceMinutes(20);
 		}
 		public function makePermanentImprovedStoneGolem():void {
 			clearOutput();
@@ -366,7 +366,7 @@ public class CampMakeWinions extends BaseContent
 			if (flags[kFLAGS.IMPROVED_PERMANENT_GOLEMS_BAG] < 1) flags[kFLAGS.IMPROVED_PERMANENT_GOLEMS_BAG] = 1;
 			else flags[kFLAGS.IMPROVED_PERMANENT_GOLEMS_BAG]++;
 			doNext(accessMakeWinionsMainMenu);
-			eachMinuteCount(40);
+			advanceMinutes(40);
 		}
 		public function makePermanentSteelGolem():void {
 			clearOutput();
@@ -418,7 +418,7 @@ public class CampMakeWinions extends BaseContent
 			if (flags[kFLAGS.PERMANENT_STEEL_GOLEMS_BAG] < 1) flags[kFLAGS.PERMANENT_STEEL_GOLEMS_BAG] = 1;
 			else flags[kFLAGS.PERMANENT_STEEL_GOLEMS_BAG]++;
 			doNext(accessMakeWinionsMainMenu);
-			eachMinuteCount(20);
+			advanceMinutes(20);
 		}
 		public function makePermanentImprovedSteelGolem():void {
 			clearOutput();
@@ -470,7 +470,7 @@ public class CampMakeWinions extends BaseContent
 			if (flags[kFLAGS.IMPROVED_PERMANENT_STEEL_GOLEMS_BAG] < 1) flags[kFLAGS.IMPROVED_PERMANENT_STEEL_GOLEMS_BAG] = 1;
 			else flags[kFLAGS.IMPROVED_PERMANENT_STEEL_GOLEMS_BAG]++;
 			doNext(accessMakeWinionsMainMenu);
-			eachMinuteCount(40);
+			advanceMinutes(40);
 		}
 
 		public function putInGolemCoreIntoGolemBag():void {
@@ -486,7 +486,7 @@ public class CampMakeWinions extends BaseContent
 			flags[kFLAGS.REUSABLE_GOLEM_CORES_BAG]--;
 			inventory.takeItem(useables.GOLCORE, accessMakeWinionsMainMenu);
 		}
-		
+
 		public function upgradesForPermanentGolems():void {
 			clearOutput();
 			var element:String = "Inactive (not yet upgraded)";
@@ -547,7 +547,7 @@ public class CampMakeWinions extends BaseContent
 			outputText("Focusing on the instructions, you take each permanent golem out of your bag and start engraving new mana pathways. It's slow work, but you know that a 2nd attack is worth the time. Each attack will drain more mana from you, but you deem the cost worth it.\n");
 			player.addStatusValue(StatusEffects.GolemUpgrades1, 1, 1);
 			doNext(upgradesForPermanentGolemsMultiAttacks);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		public function upgradesForPermanentGolemsMultiAttacksRank2():void {
 			clearOutput();
@@ -564,7 +564,7 @@ public class CampMakeWinions extends BaseContent
 			outputText("Focusing on the instructions, you take each permanent golem out of your bag and start engraving new mana pathways. It's slow work, but you know that a 3rd attack is worth the time. Each attack will drain more mana from you, but you deem the cost worth it.\n");
 			player.addStatusValue(StatusEffects.GolemUpgrades1, 1, 1);
 			doNext(upgradesForPermanentGolemsMultiAttacks);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		public function upgradesForPermanentGolemsImprovedManaCircuit():void {
 			menu();
@@ -616,7 +616,7 @@ public class CampMakeWinions extends BaseContent
 			outputText("Focusing on the instructions, you take out each permanent golem out of your bag. You sit down beside each golem, removing the old mana circuits. Once that's done, you engrave new, more efficient pathways. Once you're done, these new and improved golems will not only be more effective in combat, but also be much easier on your mana reserves.\n");
 			player.addStatusValue(StatusEffects.GolemUpgrades1, 2, 1);
 			doNext(upgradesForPermanentGolemsImprovedManaCircuit);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function upgradesForPermanentGolemsImprovedManaCircuits():void {
 			clearOutput();
@@ -633,7 +633,7 @@ public class CampMakeWinions extends BaseContent
 			outputText("Focusing on the instructions, you take out each permanent golem out of your bag. You sit down beside each golem, removing the old mana circuits. Once that's done, you engrave new, more efficient pathways. Once you're done, these new and improved golems will not only be more effective in combat, but also be much easier on your mana reserves.\\n");
 			player.addStatusValue(StatusEffects.GolemUpgrades1, 2, 1);
 			doNext(upgradesForPermanentGolemsImprovedManaCircuit);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		public function upgradesForPermanentGolemsElementalWeaponry():void {
 			clearOutput();
@@ -652,25 +652,25 @@ public class CampMakeWinions extends BaseContent
 			if (player.hasStatusEffect(StatusEffects.GolemUpgrades1)) player.addStatusValue(StatusEffects.GolemUpgrades1, 3, 1);
 			else player.createStatusEffect(StatusEffects.GolemUpgrades1, 0, 0, 1, 0);
 			doNext(upgradesForPermanentGolems);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		public function upgradesForPermanentGolemsPoisonedWeaponry():void {
 			clearOutput();
-			
+
 		}/*
 		public function upgradesForPermanentGolems():void {
 			clearOutput();
-			
+
 		}
 		public function upgradesForPermanentGolems():void {
 			clearOutput();
-			
+
 		}
 		public function upgradesForPermanentGolems():void {
 			clearOutput();
-			
+
 		}*/
-		
+
 		public function postFightGolemOptions1():void {
 			clearOutput();
 			outputText("What you gonna do now?\n\n");
@@ -767,13 +767,13 @@ public class CampMakeWinions extends BaseContent
 				inventory.takeItem(useables.GOLCORE, cleanupAfterCombat);
 			}
 		}
-		
+
 		//--------------
 		//
 		//  ELEMENTALS
 		//
 		//--------------
-		
+
 		private var elecost:Number = 0;
 		private var elecostr:Boolean = false;
 		private function maxSizeOfElementalsArmy():Number {
@@ -822,7 +822,7 @@ public class CampMakeWinions extends BaseContent
 			if (player.statusEffectv2(StatusEffects.SummonedElementals) > 0) currentSizeOfElementalsArmyCounter += player.statusEffectv2(StatusEffects.SummonedElementals) * 2;
 			return currentSizeOfElementalsArmyCounter;
 		}
-		
+
 		public function accessSummonElementalsMainMenu():void {
 			clearOutput();
 			outputText("Which one elemental would you like to summon or promote to higher rank?\n\n");
@@ -1386,7 +1386,7 @@ public class CampMakeWinions extends BaseContent
 				(player.hasPerk(PerkLib.ElementalConjurerDedication) && player.perkv1(PerkLib.ElementalConjurerDedication) < 2) ||
 				(player.hasPerk(PerkLib.ElementalConjurerSacrifice) && player.perkv1(PerkLib.ElementalConjurerSacrifice) < 2);
 		}
-		
+
 		private function elementaLvlUp():void {
 			var elementalTypes:Array = [];
 			var contractRankI:int = 0;
@@ -1934,7 +1934,7 @@ public class CampMakeWinions extends BaseContent
 			if (player.hasStatusEffect(StatusEffects.SummonedElementals)) player.addStatusValue(StatusEffects.SummonedElementals, 1, 1);
 			else player.createStatusEffect(StatusEffects.SummonedElementals, 1, 0, 0, 0);
 			doNext(accessSummonElementalsMainMenu);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function summonElementalAirEpic():void {
 			clearOutput();
@@ -2012,9 +2012,9 @@ public class CampMakeWinions extends BaseContent
 			if (player.hasStatusEffect(StatusEffects.SummonedElementals)) player.addStatusValue(StatusEffects.SummonedElementals, 2, 1);
 			else player.createStatusEffect(StatusEffects.SummonedElementals, 0, 1, 0, 0);
 			doNext(accessSummonElementalsMainMenu);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
-		
+
 		private function rankUpElementalAir():void {
 			clearOutput();
 			elecost += ((rankUpElementalElementalEnergyCost() * player.statusEffectv2(StatusEffects.SummonedElementalsAir)) / 4);
@@ -2038,7 +2038,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalEarth():void {
 			clearOutput();
@@ -2063,7 +2063,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalFire():void {
 			clearOutput();
@@ -2088,7 +2088,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalWater():void {
 			clearOutput();
@@ -2113,7 +2113,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalIce():void {
 			clearOutput();
@@ -2138,7 +2138,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalLightning():void {
 			clearOutput();
@@ -2163,7 +2163,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalDarkness():void {
 			clearOutput();
@@ -2188,7 +2188,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalWood():void {
 			clearOutput();
@@ -2213,7 +2213,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalMetal():void {
 			clearOutput();
@@ -2238,7 +2238,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalEther():void {
 			clearOutput();
@@ -2263,7 +2263,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalPoison():void {
 			clearOutput();
@@ -2288,7 +2288,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalPurity():void {
 			clearOutput();
@@ -2313,7 +2313,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalCorruption():void {
 			clearOutput();
@@ -2338,7 +2338,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			else failToRankUpElemental(elecost, elecostr);
 			doNext(elementaLvlUp);
-			eachMinuteCount(30);
+			advanceMinutes(30);
 		}
 		private function rankUpElementalManaCost():Number {
 			var rankUpElementalManaCost:Number = 100;
@@ -2406,7 +2406,7 @@ public class CampMakeWinions extends BaseContent
 				HPChange(-(Math.round(player.HP * failToRankUpHPCost())), true);
 			}
 			doNext(elementaLvlUpEpic);
-			eachMinuteCount(45);
+			advanceMinutes(45);
 		}
 		private function rankUpElementalEarthEpic():void {
 			clearOutput();
@@ -2437,7 +2437,7 @@ public class CampMakeWinions extends BaseContent
 				HPChange(-(Math.round(player.HP * failToRankUpHPCost())), true);
 			}
 			doNext(elementaLvlUpEpic);
-			eachMinuteCount(45);
+			advanceMinutes(45);
 		}
 		private function rankUpElementalFireEpic():void {
 			clearOutput();
@@ -2469,7 +2469,7 @@ public class CampMakeWinions extends BaseContent
 				HPChange(-(Math.round(player.HP * failToRankUpHPCost())), true);
 			}
 			doNext(elementaLvlUpEpic);
-			eachMinuteCount(45);
+			advanceMinutes(45);
 		}
 		private function rankUpElementalWaterEpic():void {
 			clearOutput();
@@ -2499,15 +2499,15 @@ public class CampMakeWinions extends BaseContent
 				HPChange(-(Math.round(player.HP * failToRankUpHPCost())), true);
 			}
 			doNext(elementaLvlUpEpic);
-			eachMinuteCount(45);
+			advanceMinutes(45);
 		}
-		
+
 		//-------------
 		//
 		//  SKELETONS
 		//
 		//-------------
-		
+
 		public function maxDemonBonesStored():Number {
 			var maxDemonBonesStoredCounter:Number = 100;
 			if (player.hasPerk(PerkLib.BoneSoul)) maxDemonBonesStoredCounter += 100;
@@ -2550,7 +2550,7 @@ public class CampMakeWinions extends BaseContent
 			if (player.hasStatusEffect(StatusEffects.BonusEffectsNecroSet)) maxSkeletonMagesCounter += player.statusEffectv1(StatusEffects.BonusEffectsNecroSet);
 			return maxSkeletonMagesCounter;
 		}
-		
+
 		public function accessMakeSkeletonWinionsMainMenu():void {
 			clearOutput();
 			outputText("What skeleton would you like to make?\n\n");
@@ -2575,7 +2575,7 @@ public class CampMakeWinions extends BaseContent
 					addButtonDisabled(1, "???", "Req. Greater harvest perk to unlock this option.");
 					addButtonDisabled(2, "???", "Req. Greater harvest perk to unlock this option.");
 				}
-				
+
 			}
 			else {
 				addButtonDisabled(0, "C.Skeleton(W)", "You lack required amont of demon bones (20+) and/or soulforce (5000+) to create skeleton warrior.");
@@ -2590,7 +2590,7 @@ public class CampMakeWinions extends BaseContent
 			}
 			addButton(14, "Back", camp.campWinionsArmySim);
 		}
-		
+
 		public function createSkeletonWarrior():void {
 			clearOutput();
 			if (player.perkv2(PerkLib.PrestigeJobNecromancer) == maxSkeletonWarriors()) {
@@ -2604,7 +2604,7 @@ public class CampMakeWinions extends BaseContent
 			outputText("You draw a seal in the ground around the pile of bone that will soon be your servant. Once done you stand back and begin to seep your soulforce inside of the pile aligning joints together into a large 10 feet tall shape. Finishing the link on your creation you begin to feel its every movement on your fingertips. Satisfied you admire your brand new Skeleton Warrior, ready to fight things and do anything your finger will request.");
 			player.addPerkValue(PerkLib.PrestigeJobNecromancer, 2, 1);
 			doNext(accessMakeSkeletonWinionsMainMenu);
-			eachMinuteCount(10);
+			advanceMinutes(10);
 		}
 		public function createSkeletonArcher():void {
 			clearOutput();
@@ -2619,7 +2619,7 @@ public class CampMakeWinions extends BaseContent
 			outputText("You draw a seal in the ground around the pile of bone that will soon be your servant. Once done you stand back and begin to seep your soulforce inside of the pile aligning joints together into a large 10 feet tall shape. Finishing the link on your creation you begin to feel its every movement on your fingertips. Satisfied you admire your brand new Skeleton Archer, ready to fight things and do anything your finger will request.");
 			player.addPerkValue(PerkLib.GreaterHarvest, 1, 1);
 			doNext(accessMakeSkeletonWinionsMainMenu);
-			eachMinuteCount(10);
+			advanceMinutes(10);
 		}
 		public function createSkeletonMage():void {
 			clearOutput();
@@ -2634,7 +2634,7 @@ public class CampMakeWinions extends BaseContent
 			outputText("You draw a seal in the ground around the pile of bone that will soon be your servant. Once done you stand back and begin to seep your soulforce inside of the pile aligning joints together into a large 10 feet tall shape. Finishing the link on your creation you begin to feel its every movement on your fingertips. Satisfied you admire your brand new Skeleton Mage, ready to fight things and do anything your finger will request.");
 			player.addPerkValue(PerkLib.GreaterHarvest, 2, 1);
 			doNext(accessMakeSkeletonWinionsMainMenu);
-			eachMinuteCount(10);
+			advanceMinutes(10);
 		}
 	}
 }

--- a/classes/classes/Scenes/Camp/CampScenes.as
+++ b/classes/classes/Scenes/Camp/CampScenes.as
@@ -652,7 +652,7 @@ public function PCGoblinDaughtersBuilingWorkshopSpareParts():void {
 	flags[kFLAGS.CAMP_CABIN_ENERGY_CORE_RESOURCES] += player.statusEffectv4(StatusEffects.PCDaughtersWorkshopSpareParts);
 	player.removeStatusEffect(StatusEffects.PCDaughtersWorkshopSpareParts);
 	doNext(playerMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 
 }

--- a/classes/classes/Scenes/Crafting.as
+++ b/classes/classes/Scenes/Crafting.as
@@ -36,7 +36,7 @@ public class Crafting extends BaseContent implements SaveableState
 			successChance: 75,
 			value        : 25000
 		});
-		
+
 		public static const FURNACE_LEVELS:/*EnumValue*/Array = [];
 		public static const FURNACE_LEVEL_NONE:int            = EnumValue.add(FURNACE_LEVELS, 0, "NONE", {
 			name         : "no pill furnace",
@@ -62,9 +62,9 @@ public class Crafting extends BaseContent implements SaveableState
 			stoneLimit   : 8,
 			value        : 25000
 		});
-		
+
 		// State
-		
+
 		public static var BagSlot01:Number;
 		public static var BagSlot01Cap:Number;//Cooper Ore
 		public static var BagSlot02:Number;
@@ -145,7 +145,7 @@ public class Crafting extends BaseContent implements SaveableState
 		public static var BagSlot39Cap:Number;
 		public static var BagSlot40:Number;
 		public static var BagSlot40Cap:Number;
-		
+
 		public static var alembicLevel:int = 0;
 		// Catalyst currently in the alembic, or null
 		public static var alembicCatalyst:AlembicCatalyst = null;
@@ -154,7 +154,7 @@ public class Crafting extends BaseContent implements SaveableState
 		public static var xmcLuck:int = 0;
 		// Amount of 'stinky goo' produced when refining ingredients
 		public static var gooProduced:int = 0;
-		
+
 		// Map of substanceId -> count
 		public static var substanceStock:Object = {};
 		// Map of essenceId -> count
@@ -163,7 +163,7 @@ public class Crafting extends BaseContent implements SaveableState
 		public static var residueStock:Object = {};
 		// Map of pigment color -> count
 		public static var pigmentStock:Object = {};
-		
+
 		// Map of itemId -> reagentType -> set of reagent id
 		// ex. { FoxJewl: { RT_ESSENCE: { AE_FOX: true } } }
 		// It is saved in a compressed form
@@ -258,7 +258,7 @@ public class Crafting extends BaseContent implements SaveableState
 			BagSlot39Cap = 0;
 			BagSlot40 = 0;
 			BagSlot40Cap = 0;
-			
+
 			alembicLevel = 0;
 			alembicCatalyst = null;
 			furnaceLevel = 0;
@@ -357,7 +357,7 @@ public class Crafting extends BaseContent implements SaveableState
 				"BagSlot39Cap": BagSlot39Cap,
 				"BagSlot40": BagSlot40,
 				"BagSlot40Cap": BagSlot40Cap,
-				
+
 				"xmcLuck": xmcLuck,
 				"gooProduced": gooProduced,
 				"alembicLevel": alembicLevel,
@@ -454,7 +454,7 @@ public class Crafting extends BaseContent implements SaveableState
 				BagSlot39Cap = o["BagSlot39Cap"];
 				BagSlot40 = o["BagSlot40"];
 				BagSlot40Cap = o["BagSlot40Cap"];
-				
+
 				xmcLuck = intOr(o["xmcLuck"], 0);
 				gooProduced = intOr(o["gooProduced"], 0);
 				alembicLevel = intOr(o["alembicLevel"], 0);
@@ -464,6 +464,16 @@ public class Crafting extends BaseContent implements SaveableState
 				essenceStock = objectOr(o["essenceStock"], {});
 				residueStock = objectOr(o["residueStock"], {});
 				pigmentStock = objectOr(o["pigmentStock"], {});
+				// Delete invalid elements
+				for each (var k:String in keys(substanceStock)) {
+					if (!AlchemyLib.Substances[k]) delete substanceStock[k];
+				}
+				for each (k in keys(essenceStock)) {
+					if (!AlchemyLib.Essences[k]) delete essenceStock[k];
+				}
+				for each (k in keys(residueStock)) {
+					if (!AlchemyLib.Residues[k]) delete residueStock[k];
+				}
 				uncompressTfPillKnowledge(o["tfPillKnowledge"]);
 				uncompressIngredientKnowledge(o["ingredientKnowledge"]);
 			} else {
@@ -471,20 +481,20 @@ public class Crafting extends BaseContent implements SaveableState
 				resetState();
 			}
 		}
-		
+
 		public function isLuckyXianxiaMC():Boolean {
 			return xmcLuck < 10 && flags[kFLAGS.GAME_DIFFICULTY] == 4;
 		}
 		public function useXianxiaMCLuck():void {
 			xmcLuck++;
 		}
-		
+
 		/*
 		public static const TYPE_ALCHEMY:int = 0;
 		public static const TYPE_COOKING:int = 1;
 		public static const TYPE_SMITHING:int = 2;
 		public static const TYPE_TAILORING:int = 3;
-		
+
 		private var item1:ItemType = null;
 		private var item1Quantity:int = 0;
 		private var item2:ItemType = null;
@@ -495,15 +505,15 @@ public class Crafting extends BaseContent implements SaveableState
 		private var item4Quantity:int = 0;
 		private var itemResult:ItemType = null;
 		*/
-		
+
 		public const alchemyExtraction:AlchemyExtraction = new AlchemyExtraction();
 		public const mutagenPillCrafting:MutagenPillCrafting = new MutagenPillCrafting();
 		public const statPillCrafting:StatPillCrafting = new StatPillCrafting();
-		
+
 		public function Crafting() {
 			Saves.registerSaveableState(this);
 		}
-		
+
 public function accessCraftingMaterialsBag():void {
 	clearOutput();
 	outputText("Would you like to put some crafting materials into the bag, and if so, with ones?\n\n");
@@ -546,7 +556,7 @@ public function accessCraftingMaterialsBag():void {
 		else addButtonDisabled(7, "IronOre", "You don't have any iron ore to store.");
 	}
 	else addButtonDisabled(7, "IronOre", "You can't store more iron ore in your bag.");
-	
+
 	if (BagSlot04 > 0) addButton(8, "IronOre", craftingMaterialsIronOre1Down);
 	else addButtonDisabled(8, "IronOre", "You don't have any iron ore in your bag.");
 	//Ebon Ingot
@@ -555,7 +565,7 @@ public function accessCraftingMaterialsBag():void {
 		else addButtonDisabled(10, "EbonIngot", "You don't have any ebon ingot to store.");
 	}
 	else addButtonDisabled(10, "EbonIngot", "You can't store more ebon ingots in your bag.");
-	
+
 	if (BagSlot06 > 0) addButton(11, "EbonIngot", craftingMaterialsEbonIngot1Down);
 	else addButtonDisabled(11, "EbonIngot", "You don't have any ebon ingot in your bag.");
 	//Moonstone
@@ -564,7 +574,7 @@ public function accessCraftingMaterialsBag():void {
 		else addButtonDisabled(12, "Moonstone", "You don't have any moonstone to store.");
 	}
 	else addButtonDisabled(12, "Moonstone", "You can't store more moonstones in your bag.");
-	
+
 	if (BagSlot07 > 0) addButton(13, "Moonstone", craftingMaterialsMoonstone1Down);
 	else addButtonDisabled(13, "Moonstone", "You don't have any moonstone in your bag.");
 	addButton(14, "Back", craftingMain);
@@ -635,20 +645,20 @@ private function craftingMaterialsMoonstone1Down():void {
 			outputText("What would you like to craft?");
 			menu();
 			if (type == TYPE_ALCHEMY) {
-			
+
 			}
 			else if (type == TYPE_COOKING) {
-			
+
 			}
 			else if (type == TYPE_SMITHING) {
-			
+
 			}
 			else if (type == TYPE_TAILORING) {
-			
+
 			}
 			addButton(14, "Back", campActions);
 		}
-		
+
 		private function createCraftingRecipe(item:*, recipe:Array):void {
 			var button:int = 0;
 			var temp:int = 0;
@@ -663,7 +673,7 @@ private function craftingMaterialsMoonstone1Down():void {
 			}
 			addButton(button, item.shortName, displayCraftingRequirement, item, recipe);
 		}
-		
+
 		private function meetsItemRequirement(id:int):Boolean {
 			if (id == 1) {
 				if (item1 == null) return true;
@@ -683,7 +693,7 @@ private function craftingMaterialsMoonstone1Down():void {
 			}
 			return false;
 		}
-		
+
 		private function displayCraftingRequirement(item:ItemType, recipe:Array):void {
 			//Item #1
 			if (recipe[0] != undefined) item1 = recipe[0];
@@ -737,7 +747,7 @@ private function craftingMaterialsMoonstone1Down():void {
 				doNext(accessCraftingMenu);
 			}
 		}
-		
+
 		private function craftItem():void {
 			clearOutput();
 			if (item1 != null) player.destroyItems(item1, item1Quantity);
@@ -839,10 +849,10 @@ private function craftingMaterialsMoonstone1Down():void {
 			}
 			return false;
 		}
-		
+
 		public function craftingMain():void {
 			clearOutput();
-			
+
 			if (alembicLevel > 0) {
 				outputText("You can use your "+alchemyExtraction.alembicName()+" to extract alchemical reagents from consumable items.\n");
 			}
@@ -850,9 +860,9 @@ private function craftingMaterialsMoonstone1Down():void {
 				outputText("With "+mutagenPillCrafting.furnaceName()+" you can refine alchemical reagents into pills.\n");
 			}
 			outputText("If you have pigments and foundations, you can mix them into hair dyes and eye drops.\n")
-			
+
 			outputText("\nWhat will you do?");
-			
+
 			menu();
 			// [Extract ] [Mut.Pill] [StatPill] [Dyes    ] [Stock   ]
 			// [        ] [        ] [        ] [        ] [        ]
@@ -880,10 +890,10 @@ private function craftingMaterialsMoonstone1Down():void {
 			}
 			button(14).show("Back", camp.campActions).icon("Back");
 		}
-		
+
 		public function checkStock(withMenu:Boolean=false):void {
 			clearOutput();
-			
+
 			function printAlchemyReagentStock(type:int):void {
 				var a:Array;
 				// Array of [AlchemyReagent, quantity:int, name:String]
@@ -915,7 +925,7 @@ private function craftingMaterialsMoonstone1Down():void {
 				button(14).show("Back",craftingMain).icon("Back");
 			}
 		}
-		
+
 		private function craftingCheats():void {
 			clearOutput();
 			outputText("You have:");
@@ -942,7 +952,7 @@ private function craftingMaterialsMoonstone1Down():void {
 				for (i = 1; i < AlchemyLib.Residues.length; i++) {
 					if (AlchemyLib.Residues[i]) addResidue(i, 10);
 				}
-				
+
 				craftingMain();
 				checkStock();
 			}
@@ -996,16 +1006,17 @@ private function craftingMaterialsMoonstone1Down():void {
 					  .hint("Spawn items like alembic catalysts.");
 			button(14).show("Back", craftingMain);
 		}
-		
+
 		//=========//
 		// ALCHEMY //
 		//=========//
-		
-		
+
+
 		public function maxReagentCount():int {
 			return 100
 		}
 		public function addSubstance(id:int, change:int =+1):int {
+			if (!AlchemyLib.Substances[id]) throw new Error("Invalid alchemical substance "+id);
 			var count:int = substanceStock[id];
 			count = boundInt(0, count + change, maxReagentCount());
 			if (count > 0) substanceStock[id] = count;
@@ -1013,6 +1024,7 @@ private function craftingMaterialsMoonstone1Down():void {
 			return count;
 		}
 		public function addEssence(id:int, change:int=+1):int {
+			if (!AlchemyLib.Essences[id]) throw new Error("Invalid alchemical essence "+id);
 			var count:int = essenceStock[id];
 			count = boundInt(0, count + change, maxReagentCount());
 			if (count > 0) essenceStock[id] = count;
@@ -1020,6 +1032,7 @@ private function craftingMaterialsMoonstone1Down():void {
 			return count;
 		}
 		public function addResidue(id:int, change:int=+1):int {
+			if (!AlchemyLib.Residues[id]) throw new Error("Invalid alchemical residue "+id);
 			var count:int = residueStock[id];
 			count = boundInt(0, count + change, maxReagentCount());
 			if (count > 0) residueStock[id] = count;
@@ -1079,7 +1092,7 @@ private function craftingMaterialsMoonstone1Down():void {
 			}
 			return result;
 		}
-		
+
 		//================================//
 		// ALCHEMY - KNOWLEDGE MANAGEMENT //
 		//================================//
@@ -1169,7 +1182,7 @@ private function craftingMaterialsMoonstone1Down():void {
 				tfPillKnowledge[tf] = true;
 			}
 		}
-		
+
 		public function isTfPillKnown(substance:int, essence:int):Boolean {
 			return !!tfPillKnowledge["TF_"+substance+"_"+essence];
 		}
@@ -1228,14 +1241,14 @@ private function craftingMaterialsMoonstone1Down():void {
 				}
 				outputText("</ul>");
 			}
-			
+
 			menu();
 			button(14).show("Back", backFn).icon("Back");
 		}
 		//======================//
 		// ALCHEMY - DYE MIXING //
 		//======================//
-		
+
 		private var selectedPigment:String = "";
 		private function selectPigment(pigment:String):void {
 			if (selectedPigment) {
@@ -1247,7 +1260,7 @@ private function craftingMaterialsMoonstone1Down():void {
 		}
 		public function dyeCraftingMenu():void {
 			clearOutput();
-			
+
 			// if we're returning from crafting and used last pigment
 			if (int(pigmentStock[selectedPigment]) <= 0) selectedPigment = "";
 			var dyeFnd:int = player.itemCount(useables.DYE_FOUNDATION);
@@ -1259,14 +1272,14 @@ private function craftingMaterialsMoonstone1Down():void {
 			outputText("\n<b>Dye foundations</b>: "+dyeFnd);
 			outputText("\n<b>Skin oil foundations</b>: "+oilFnd);
 			outputText("\n<b>Eyedrop foundations</b>: "+dropFnd);
-			
+
 			if (keys(pigmentStock).length == 0) {
 				outputText("\n\n<b>You don't have any pigments. Pigments can be extracted from consumables.</b> ");
 			}
 			if (dyeFnd == 0 && oilFnd == 0 && dropFnd == 0) {
 				outputText("\n\n<b>You have no foundations. Buy some from hair dye vendor.</b>")
 			}
-			
+
 			menu();
 			button(0).show("Pigment", curry(selectReagent, AlchemyLib.RT_PIGMENT, selectPigment, dyeCraftingMenu, selectedPigment))
 					 .hint("Select a pigment to use")
@@ -1286,7 +1299,7 @@ private function craftingMaterialsMoonstone1Down():void {
 					 .icon("I_EyeDye")
 					 .disableIf(dropFnd == 0, "++\n<b>You need an eyedrop foundation!</b>")
 					 .disableIf(!selectedPigment, "Select a pigment");
-			
+
 			button(14).show("Back",function():void {
 				if (selectedPigment) {
 					addPigment(selectedPigment);

--- a/classes/classes/Scenes/Crafting/MutagenPillCrafting.as
+++ b/classes/classes/Scenes/Crafting/MutagenPillCrafting.as
@@ -11,22 +11,22 @@ public class MutagenPillCrafting extends AbstractPillCraftingContent {
 	public function get furnaceLevel():int {
 		return Crafting.furnaceLevel;
 	}
-	
+
 	public function MutagenPillCrafting() {
 	}
-	
+
 	// Runtime state variables - not saved, must be cleared when you leave the scene
 	private var furnaceSubstance:int = AlchemyLib.AE_NONE;
 	private var furnaceEssence:int   = AlchemyLib.AS_NONE;
-	
+
 	public override function craftingMenu():void {
 		clearOutput();
-		
+
 		outputText("<b>Tool quality</b>: " + furnaceName());
 		outputText("\n<b>Substance</b>: " + (furnaceSubstance ? AlchemyLib.Substances[furnaceSubstance].name : "<i>none</i>"));
 		outputText("\n<b>Essence</b>: " + (furnaceEssence ? AlchemyLib.Essences[furnaceEssence].name : "<i>none</i>"));
 		printStonesInFurnace();
-		
+
 		outputText("\n<b>Skill</b>: " + player.alchemySkillLevel);
 		outputText("\n<b>Result</b>: ");
 		if (debug || crafting.isTfPillKnown(furnaceSubstance, furnaceEssence)) {
@@ -40,7 +40,7 @@ public class MutagenPillCrafting extends AbstractPillCraftingContent {
 			outputText("???")
 		}
 		printRefinementChances();
-		
+
 		// [ Refine!] [Substanc] [Essence ] [        ] [        ]
 		// [Add SS  ] [Take SS ] [        ] [        ] [        ]
 		// [        ] [        ] [        ] [ Clean  ] [ Back   ]
@@ -67,13 +67,13 @@ public class MutagenPillCrafting extends AbstractPillCraftingContent {
 		craftingMenu();
 	}
 	private function selectEssence(i:int):void {
-		if (furnaceEssence) crafting.addSubstance(furnaceEssence);
+		if (furnaceEssence) crafting.addEssence(furnaceEssence);
 		furnaceEssence = i;
 		craftingMenu();
 	}
 	private function doRefinePill():void {
 		clearOutput();
-		
+
 		outputText("The soulforce-powered furnace roars and dissolves the ingredients into tiny particles. They circle in complicated orbits, intertwine and recombine in seemingly chaotic ways until forming a turbulent cloud. ");
 		if (furnaceStones > 0) {
 			outputText("The " + (furnaceStones > 1 ? "spirit stones" : "spirit stone") + " crumble and release the soulforce, fueling the process and empowering the mixture. ");
@@ -144,6 +144,6 @@ public class MutagenPillCrafting extends AbstractPillCraftingContent {
 		}
 		super.cleanTheFurnace();
 	}
-	
+
 }
 }

--- a/classes/classes/Scenes/Dungeons/AnzuPalace/AnzuScene.as
+++ b/classes/classes/Scenes/Dungeons/AnzuPalace/AnzuScene.as
@@ -18,7 +18,7 @@ use namespace CoC;
 	{
 		public function AnzuScene()
 		{}
-		
+
 		public function anzuAffection(amount:int = 0):int {
 			flags[kFLAGS.ANZU_AFFECTION] += amount;
 			if (flags[kFLAGS.ANZU_AFFECTION] < 0) flags[kFLAGS.ANZU_AFFECTION] = 0;
@@ -32,8 +32,8 @@ use namespace CoC;
 		public function anzuSexCounter():int {
 			return flags[kFLAGS.ANZU_ANAL_CATCH_COUNTER] + flags[kFLAGS.ANZU_VAGINAL_CATCH_COUNTER] + flags[kFLAGS.ANZU_BLOWN_YOU_COUNTER] + flags[kFLAGS.ANZU_SUCKED_OFF_COUNTER] + flags[kFLAGS.ANZU_ANAL_PITCH_COUNTER] + flags[kFLAGS.ANZU_FED_COUNTER];
 		}
-		
-		
+
+
 		//INTRO
 		public function initialPalaceEncounter():void {
 			clearOutput();
@@ -46,7 +46,7 @@ use namespace CoC;
 			addButton(0, "Approach", apporachInitialPalace);
 			addButton(1, "Leave", leaveInitialPalace);
 		}
-		
+
 		private function apporachInitialPalace():void {
 			clearOutput();
 			outputText("What could go wrong? You’re the Champion of Ingnam after all. If you’ve survived minotaurs, demons, giants and everything else that Mareth has to offer, whatever lives in that building shouldn’t be a problem if it decides to attack you. ");
@@ -115,15 +115,15 @@ use namespace CoC;
 			}
 			outputText("\n\n<b>Anzu's Palace is now accessible from Dungeons submenu under Places menu.</b>");
 			flags[kFLAGS.ANZU_PALACE_UNLOCKED] = 1;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		private function leaveInitialPalace():void {
 			clearOutput();
 			outputText("Well, if this place looks dangerous enough to keep giants away, then it probably means whatever lives here is something that you want to avoid. Since it doesn’t look like an area inhabited by demons, it's none of your business.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		public function anzuTransition():void {
 			if (anzuRelationshipLevel() == 1) {
 				outputText("Coming back to the avian’s home, you wander around the insides for a while without finding Anzu. When you’re almost leaving, you hear a noise in the upper floor. On the third floor, you quickly recognize the sound of the beating of wings. You go upstairs until reaching the roof. There, you finally spot Anzu, who is flying over the building. When he sees you there, he waves to you. After drawing a few circles in the air, he lands next to you.");
@@ -225,16 +225,16 @@ use namespace CoC;
 			outputText("\n\n\"<i>It’s okay. The champion thing and all that, right?</i>\" He answers \"<i>Well, by now, you should have memorized where this place is so you can visit me anytime you want. I really enjoy when you’re here. And please, over all things, [name], keep yourself safe.</i>\"");
 			outputText("\n\nWaving goodbye to the avian, you return to you camp.");
 			dynStats("lus", 40, "scale", false);
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function anzuRelatLvl3Dont():void {
 			clearOutput();
 			outputText("Excusing yourself, you ask him if he needs to attend something, you’ll give him the time.");
 			outputText("\n\n\"<i>Oh, thanks…</i>\" he says, quickly catching your idea. \"<i>Suddenly, I feel as if my bladder is full. I need to use the bathroom as soon as I can.</i>\"");
 			outputText("\n\nHurrying to the mentioned room, the avian leaves you alone in the living room, enjoying the warmness of the fireplace. After a few seconds, the obvious sound of someone jerking off is heard across the hall. Judging from the size of Anzu’s...attributes, he’ll have much to clean up after he finishes.");
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		private function anzuRelatLvl4Sex():void {
 			clearOutput();
 			outputText("You answer him that you love him back too. The avian lowers himself until both of you meet eye to eye. His arms surround you, and soon you’re in the warmness of his embrace. Soon, the force of his grip becomes so strong it threatens to leave you without air.");
@@ -260,9 +260,9 @@ use namespace CoC;
 			outputText("\n\nYou say your goodbyes to Anzu, and return to the camp, leaving your avian friend to his own thoughts.");
 			flags[kFLAGS.ANZU_AFFECTION] = 50;
 			flags[kFLAGS.ANZU_RELATIONSHIP_LEVEL] = 3;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		//MENU & INTERACTIONS
 		public function anzuMenus():void {
 			clearOutput();
@@ -281,7 +281,7 @@ use namespace CoC;
 			}
 			addButton(14, "Back", playerMenu);
 		}
-		
+
 		//Appearance
 		private function anzuAppearance():void {
 			clearOutput();
@@ -294,7 +294,7 @@ use namespace CoC;
 			outputText("\n\nFor clothing, he usually wears a white shirt and dark brown pants, and over them he has a luxurious purple robe, decorated in gold and amethyst.");
 			doNext(anzuMenus);
 		}
-		
+
 		//Talk
 		private function anzuTalkMenu():void {
 			clearOutput();
@@ -307,7 +307,7 @@ use namespace CoC;
 			addButton(4, "Marae & Lethice", anzuTalkMaraeAndLethice).hint("Ask Anzu what he thinks about Marae and Lethice.");
 			addButton(14, "Back", anzuMenus);
 		}
-		
+
 		private function anzuTalkPast():void {
 			clearOutput();
 			//outputText(images.showImage("anzu-talk-past"));
@@ -474,7 +474,7 @@ use namespace CoC;
 			flags[kFLAGS.ANZU_TALKED_GODS] = 1;
 			doNext(playerMenu);
 		}
-		
+
 		//Sex
 		private function anzuSexMenu(showText:Boolean = true):void {
 			if (showText) {
@@ -514,7 +514,7 @@ use namespace CoC;
 			else addButtonDisabled(5, "Feed Him", "This option is only available if you have lactating breasts.");
 			addButton(14, "Back", anzuMenus);
 		}
-		
+
 		private function catchAnalPart1():void {
 			clearOutput();
 			//outputText(images.showImage("anzu-sex-anal-catch"));
@@ -546,7 +546,7 @@ use namespace CoC;
 			}
 			doNext(catchAnalPart2);
 		}
-		
+
 		private function catchAnalPart2():void {
 			clearOutput();
 			var wasVirgin:Boolean = player.ass.analLooseness < 1;
@@ -622,9 +622,9 @@ use namespace CoC;
 			player.slimeFeed();
 			anzuAffection(5);
 			flags[kFLAGS.ANZU_ANAL_CATCH_COUNTER]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		private function catchVaginal():void {
 			clearOutput();
 			//outputText(images.showImage("anzu-sex-vaginal-catch"));
@@ -672,9 +672,9 @@ use namespace CoC;
 			player.slimeFeed();
 			anzuAffection(5);
 			flags[kFLAGS.ANZU_VAGINAL_CATCH_COUNTER]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		private function getBlown():void {
 			clearOutput();
 			//outputText(images.showImage("anzu-sex-give-blowjob"));
@@ -711,9 +711,9 @@ use namespace CoC;
 			player.orgasm();
 			anzuAffection(5);
 			flags[kFLAGS.ANZU_BLOWN_YOU_COUNTER]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		private function suckOffDeitysCock():void {
 			clearOutput();
 			//outputText(images.showImage("anzu-sex-receive-blowjob"));
@@ -767,9 +767,9 @@ use namespace CoC;
 			dynStats("lus", 30, "scale", false);
 			anzuAffection(5);
 			flags[kFLAGS.ANZU_SUCKED_OFF_COUNTER]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		private function fuckGodlyBirdButt():void {
 			clearOutput();
 			//outputText(images.showImage("anzu-sex-analpitch"));
@@ -809,9 +809,9 @@ use namespace CoC;
 			outputText("\n\nTired, you fall asleep over him, using his body as a huge pillow. He covers you with his wings, while both of you take a nap.");
 			player.orgasm();
 			flags[kFLAGS.ANZU_ANAL_PITCH_COUNTER]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		private function feedAnzu():void {
 			clearOutput();
 			//outputText(images.showImage("anzu-sex-feeding"));
@@ -870,9 +870,9 @@ use namespace CoC;
 			dynStats("lus", 20, "sen", -1);
 			player.milked();
 			flags[kFLAGS.ANZU_FED_COUNTER]++;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		//Dinner
 		public function dinnerWithAnzu():void {
 			clearOutput();
@@ -928,9 +928,9 @@ use namespace CoC;
 				}
 				doYesNo(eatFoodWithAnzu, dontEatFoodWithAnzu);
 			}
-			
+
 		}
-		
+
 		private function eatFoodWithAnzu():void {
 			clearOutput();
 			//Determine amount to refill hunger
@@ -989,7 +989,7 @@ use namespace CoC;
 				flags[kFLAGS.ANZU_TIMES_DINED_DINNER]++;
 			}
 			inDungeon = false;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function dontEatFoodWithAnzu():void {
 			clearOutput();
@@ -1010,10 +1010,10 @@ use namespace CoC;
 				outputText("\n\nLeaving Anzu with the cake, you wave off him and return to your camp.");
 			}
 			inDungeon = false;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 
-		
+
 		//------------
 		// BATHING (2PM)
 		//------------
@@ -1033,7 +1033,7 @@ use namespace CoC;
 			outputText("\n\nSeems like the bird want to take his bath with you, but knowing him, you’ll probably end a bit sticky throughout your bath. What do you say?");
 			doYesNo(anzuBathTimeAccept, anzuBathTimeDecline);
 		}
-		
+
 		private function anzuBathTimeAccept():void {
 			clearOutput();
 			outputText("Well, a warm bath sounds nice at this time of the day, and Anzu seems to be enjoying it, so, why not? " + player.clothedOrNaked("Leaving your " + player.armorDescript() + "aside, on a nearby table, y", "Y") + "ou get in the pool, not without making sure that Anzu gets a good view of your naked body when entering on it. When you return the look, you manage to see his avian manhood under the water, hanging limp and lazy between his legs. Even in its unaroused state, it remains quite impressive. Under it, a pair of huge, feather-covered, nuts lie, moving slightly with the water.");
@@ -1055,7 +1055,7 @@ use namespace CoC;
 			addButton(0, "Sexy times", anzuBathTimeSex);
 			addButton(1, "Just relax", anzuBathTimeRelax);
 		}
-		
+
 		private function anzuBathTimeSex():void {
 			clearOutput();
 			//outputText(images.showImage("anzu-bathtime-sex"));
@@ -1069,7 +1069,7 @@ use namespace CoC;
 			player.fatigue -= 30;
 			anzuSexMenu(false);
 		}
-		
+
 		private function anzuBathTimeRelax():void {
 			clearOutput();
 			//outputText(images.showImage("anzu-bathtime-relax"));
@@ -1085,15 +1085,15 @@ use namespace CoC;
 			dynStats("lus", 20, "scale", false);
 			player.fatigue -= 30;
 			inDungeon = false;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
 		private function anzuBathTimeDecline():void {
 			clearOutput();
 			outputText("Not in the mood of getting your " + player.skin.desc + " wet (and sticky) at this time of day, you thank him for his offer but explain that you’re not exactly in the mood to get wet. Bidding him farewell, you leave him to his own matters and return to your camp.");
 			inDungeon = false;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		//------------
 		// SLEEPING (8PM)
 		//------------
@@ -1109,15 +1109,15 @@ use namespace CoC;
 			outputText("\n\nWell, the truth is that your camp isn’t the major target of the demon forces, and since your arrival there hasn’t been anything interesting around it besides the random imp or goblin. Maybe you should consider Anzu’s offer and spend a relaxed night in love and luxury instead of a night on the wastelands. What do you say?");
 			doYesNo(acceptSleepingWithAnzu, declineSleepingWithAnzu);
 		}
-		
+
 		private function declineSleepingWithAnzu():void {
 			clearOutput();
 			outputText("Tired as you are, a task is a task. You answer the avian that sadly, you have to keep guard tonight on the portal, so it will be on another time. Though a bit disappointed, the avian quickly cheers up and nuzzles your neck playfully, then he hugs you again and helps you to stand up. Gathering your things, you make it to the door, not without getting another playful nibble as you leave.");
 			outputText("\n\n\"<i>Be careful on your way to the camp, little friend</i>\" he says from the door while waving you. Waving him back you cross the Rift and return to your camp.");
 			inDungeon = false;
-			doNext(camp.returnToCampUseOneHour);
+			endEncounter();
 		}
-		
+
 		private function acceptSleepingWithAnzu():void {
 			clearOutput();
 			//outputText(images.showImage("anzu-bed-mid"));
@@ -1145,7 +1145,7 @@ use namespace CoC;
 			outputText("\n\nSoon enough, you mind slips away, carried by many days of fatigue, as you fall asleep on bed, with your feathered companion at your side...");
 			doNext(sleepingWithAnzuPart2);
 		}
-		
+
 		private function sleepingWithAnzuPart2():void {
 			clearOutput();
 			outputText("<b>At some moment, near midnight…</b>");
@@ -1156,7 +1156,7 @@ use namespace CoC;
 			outputText("\n\nDo you attempt to get some midnight 'snack' or just go back to sleep?");
 			doYesNo(sleepingWithAnzuBlowjob, sleepingWithAnzuNoBJ);
 		}
-	
+
 		private function sleepingWithAnzuBlowjob():void {
 			clearOutput();
 			//outputText(images.showImage("anzu-bed-blowjob"));
@@ -1183,13 +1183,13 @@ use namespace CoC;
 			dynStats("lus", 20, "scale", false);
 			doNext(wakeUpWithAnzuGoodMorningBirdie);
 		}
-		
+
 		private function sleepingWithAnzuNoBJ():void {
 			clearOutput();
 			outputText("You shake your head and close your eyes. It takes quite a while but eventually, you succeed in catching your sleep again and make your way back to the dreamland.");
 			doNext(wakeUpWithAnzuGoodMorningBirdie);
 		}
-		
+
 		private function wakeUpWithAnzuGoodMorningBirdie():void {
 			clearOutput();
 			camp.cheatSleepUntilMorning();
@@ -1200,7 +1200,7 @@ use namespace CoC;
 			inDungeon = false;
 			doNext(playerMenu);
 		}
-		
+
 	}
 
 }

--- a/classes/classes/Scenes/Dungeons/DeepCave/ValaScene.as
+++ b/classes/classes/Scenes/Dungeons/DeepCave/ValaScene.as
@@ -136,7 +136,7 @@ public class ValaScene extends BaseContent implements SaveableState
                     doNext(playerMenu);
                 }
                 else doNext(recallWakeUp);
-                
+
             }
             function vagF_2():void {
 			    clearOutput();
@@ -145,7 +145,7 @@ public class ValaScene extends BaseContent implements SaveableState
 				outputText("It's a hopeless race, however, as she quickly zeros in on your g-spot, curling her tongue to coil thickly inside of you. You grab her head by its purple hair and crush it into your crotch, crushing her nose on your " + clitDescript() + ", momentarily forgetting about the fairy's pussy as she tongue-rapes yours. When you cum, your body tenses and you hold your breath as your " + hipDescript() + " threaten to draw the small girl's whole head into your " + vaginaDescript(0) + ". You hear a slurping and realize she's drinking your girl cum. The thought is enough to remind you about the fairy slit at eye-level just as she climaxes from the taste of your body. She squirts wildly into your face, small jets of hot, sticky liquid spraying into your mouth, over your cheeks, and into your eyes.\n\n");
 
 				outputText("You blink, and give the little brat a bump on the back of the head for her sneaky facial. She flutters right-side up again and when you see her face, your heart leaps in your chest. Your orgasm has washed her visage clean and you realize she's breathtaking. The soft curves of her heart-shaped face, the timeless alabaster of her flawless skin, and most surprisingly, the glimmers in her almond-shaped, pink eyes. She kisses you, softly this time, almost affectionately. Perhaps your exchange unlocked the memory of sweeter days with her fairy sisters? Your heart sinks when you realize she'll never be able to recapture those lost days in her state and you resolve to make sure she finds her way out of this place once you've defeated its dark master. You return her kiss and redress as she finally gets some long-delayed, restful sleep.");
-                
+
                 if (!recalling) {
                     player.sexReward("vaginalFluids", "Lips");
                     player.sexReward("saliva", "Vaginal");
@@ -415,7 +415,7 @@ public class ValaScene extends BaseContent implements SaveableState
 			}
 			else {
 				outputText("\n\nSome time passes...");
-				eachMinuteCount(30);
+				advanceMinutes(30);
 				doNext(SceneLib.dungeons.deepcave.fightValaVictory);
 			}
 		}
@@ -712,7 +712,7 @@ public class ValaScene extends BaseContent implements SaveableState
 					player.tallness++;
 					if(player.cor > 40) dynStats("cor", -.3);
 				}
-				eachMinuteCount(30);
+				advanceMinutes(30);
 				doNext(SceneLib.telAdre.barTelAdre);
 			}
 			function vagF_2():void {
@@ -736,7 +736,7 @@ public class ValaScene extends BaseContent implements SaveableState
 					//[Player grows 1", lust drops to 0, corruption drops by 2]
 					if(player.cor > 40) dynStats("cor", -.5);
 				}
-				eachMinuteCount(30);
+				advanceMinutes(30);
 				doNext(SceneLib.telAdre.barTelAdre);
 			}
 		}
@@ -891,7 +891,7 @@ public class ValaScene extends BaseContent implements SaveableState
 			outputText("\n\n");
 
 			outputText("\"<i>You see?</i>\" Vala asks, holding the organic device aloft with a mischievous smile. \"<i>They don't last forever, but while they do, these little toys give us a very intimate connection to loved ones. This way, I can go all week with a reminder of you inside me.</i>\" She gives you a kiss on the lips and the fairies give you a tiny chorus of applause for the entertaining show. It's good that her little friends aren't around more often, you pant to yourself, or you'd be a drooling vegetable in no time.\n\n");
-			eachMinuteCount(30);
+			advanceMinutes(30);
 			player.sexReward("saliva", "Dick");
 			doNext(camp.returnToCampUseOneHour);
 		}
@@ -910,7 +910,7 @@ public class ValaScene extends BaseContent implements SaveableState
 			outputText("When you finally calm down enough to swallow your spittle, wipe the slick sweat from your face and body, and release the fairy girl from the death-grip between your " + hipDescript() + ", you try to ask what happened to the petals inside your body. The fae girl gives your " + clitDescript() + " a little kiss and places her lips on your pussy. She puffs her cheeks and whispers a string of strange words into your quivering cunt. All at once, the soft petals inside you meld into one warm, hard shape, perfectly mirroring your pussy, labia to cervix. Very carefully, Vala draws the verdant shaft from your body and produces the most intricately ridged, molded dildo that you've ever seen. It's a soft pink color, matching your engorged genitals, and even gently pulses with your every heartbeat.\n\n");
 
 			outputText("\"<i>You see?</i>\" Vala asks, holding the organic device aloft with a mischievous smile. \"<i>They don't last forever, but while they do, these little toys give us a very intimate connection to loved ones. This way, I can go about all week with a reminder of you inside me.</i>\" She gives you a kiss on the lips and the fairies give you a tiny chorus of applause for the entertaining show. It's good that her little friends aren't around more often, you gasp to yourself, or you'd be a drooling vegetable in no time.");
-			eachMinuteCount(30);
+			advanceMinutes(30);
 			player.sexReward("saliva", "Vaginal");
 			doNext(camp.returnToCampUseOneHour);
 		}

--- a/classes/classes/Scenes/Dungeons/DungeonEngine.as
+++ b/classes/classes/Scenes/Dungeons/DungeonEngine.as
@@ -1,4 +1,4 @@
-package classes.Scenes.Dungeons 
+package classes.Scenes.Dungeons
 {
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.SceneLib;
@@ -21,11 +21,11 @@ public class DungeonEngine extends DungeonAbstractContent {
     public var ebonlabyrinth:EbonLabyrinth = new EbonLabyrinth;
     public var beehive:BeeHive = new BeeHive;
     public var demonLab:DemonLab = new DemonLab();
-    
+
     public var map:DungeonMaps = new DungeonMaps;
-    
+
     public function DungeonEngine() {}
-    
+
     public function getRoomFunc(dungeonLoc:int):Function {
         switch(dungeonLoc) {
             //Cabin
@@ -262,7 +262,7 @@ public class DungeonEngine extends DungeonAbstractContent {
     public function checkRoom():void {
         getRoomFunc(dungeonLoc)(); //no null-checking - error will be already thrown
     }
-    
+
     public function checkFactoryClear():Boolean {
         return (flags[kFLAGS.FACTORY_SHUTDOWN] > 0 && flags[kFLAGS.FACTORY_SUCCUBUS_DEFEATED] > 0 && flags[kFLAGS.FACTORY_OMNIBUS_DEFEATED] > 0 && (flags[kFLAGS.FACTORY_INCUBUS_DEFEATED] > 0 || flags[kFLAGS.FACTORY_INCUBUS_BRIBED] > 0));
     }
@@ -326,8 +326,8 @@ public class DungeonEngine extends DungeonAbstractContent {
         return flags[kFLAGS.EBON_LABYRINTH_RECORD] >= nextAwardEL();
         //return (flags[kFLAGS.EBON_LABYRINTH] > 1);//exploracja 50 pokoi bez porażki
     }
-    
-    
+
+
     public function canFindDeepCave():Boolean {
         return flags[kFLAGS.DISCOVERED_DUNGEON_2_ZETAZ] == 0
                 && flags[kFLAGS.FACTORY_SHUTDOWN] > 0;
@@ -335,17 +335,17 @@ public class DungeonEngine extends DungeonAbstractContent {
     public function canFindDenOfDesire():Boolean {
         return flags[kFLAGS.GAR_NAME] != 0;
     }
-    
+
     public function navigateToRoom(room:Function = null):void {
-        eachMinuteCount(5);
+        advanceMinutes(5);
         room();
     }
     public function navigateToRoomRD(room:Function = null):void {
         if (player.hasStatusEffect(StatusEffects.ThereCouldBeOnlyOne)) player.removeStatusEffect(StatusEffects.ThereCouldBeOnlyOne);
-        eachMinuteCount(5);
+        advanceMinutes(5);
         room();
     }
-    
+
     /**
      * Set the top buttons for use while in dungeons.
      */
@@ -356,7 +356,7 @@ public class DungeonEngine extends DungeonAbstractContent {
         mainView.hideMenuButton( MainView.MENU_DATA );
         SceneLib.camp.setLevelButton(true);
     }
-    
+
     /**
      * Set the buttons for use in dungeons. The parameters can be used to connect to rooms.
      * @param	northFunction
@@ -400,13 +400,13 @@ public class DungeonEngine extends DungeonAbstractContent {
     */
 
     //Old button function here. The function itself was moved into EL, but can be brought back for new dungeons.
-	
+
 	//IT"S FOR NEW DUNGEON SIMILAR TO BOTH EL AND RD SO PLEASE NOT KEEP TRYING TO DELETE THAT CODE -.-
     /*
     public function navigateToRoomEL(room:Function = null):void {
         if (player.hasStatusEffect(StatusEffects.ThereCouldBeOnlyOne)) player.removeStatusEffect(StatusEffects.ThereCouldBeOnlyOne);
         player.addStatusValue(StatusEffects.EbonLabyrinthB, 1, 1);
-        eachMinuteCount(15);
+        advanceTimeNoEvents(15);
         room();
     }
     public function setDungeonButtonsEL(northFunction:Function = null, southFunction:Function = null, westFunction:Function = null, eastFunction:Function = null, upFunction:Function = null, downFunction:Function = null):void {

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth.as
@@ -80,7 +80,7 @@ public class EbonLabyrinth extends DungeonAbstractContent {
     public var bossTracker:int  = 0;
     //containts the references... right?
     private var bossPool:Array;
-    
+
     public function EbonLabyrinth() {
         //init boss arrays.
         bossPool = [];
@@ -162,7 +162,7 @@ public class EbonLabyrinth extends DungeonAbstractContent {
         outputText("<b>Are you sure about that?</b>");
         doYesNo(exitDungeon, playerMenu);
     }
-		
+
     //Player menu. Doesn't start any encounters.
     //Can print stuff is called with 'true' and new direction.
     public function roomStatic(move:Boolean = false, newDir:int = DIR_DOWN):void {
@@ -198,14 +198,14 @@ public class EbonLabyrinth extends DungeonAbstractContent {
         //unique buttons
         if (fountainRoom) addButton(10, "Fountain", encountersUpgradeFountain, true);
     }
-	
+
     //Navigation function. Increments the counter and checks the encounters.
     public function navigateToRoomEL(newDir:int):void {
         //clear room-specific
         fountainRoom = false;
         //move
         ++room;
-        eachMinuteCount(15);
+        advanceMinutes(15);
         //modify enemy level
         if (newDir == DIR_DOWN)
             ++depth;
@@ -263,7 +263,7 @@ public class EbonLabyrinth extends DungeonAbstractContent {
     public function doSleepEL():void {
         clearOutput();
         if (rand(2) == 0) {
-            eachMinuteCount(15);
+            advanceMinutes(15);
             outputText("You ready your bedroll and go to sleep, keen on continuing your exploration tomorrow. Sadly as you prepare to lay down, a creature from the labyrinth stumbles upon your makeshift camp and you are forced to defend yourself.\n");
             enemySelector(false);
             return;
@@ -334,7 +334,7 @@ public class EbonLabyrinth extends DungeonAbstractContent {
         addButton(0, "Dip Item", CelessScene.itemImproveMenu, 1, fountainCorrupt);
         addButton(4, "Back", playerMenu);
     }
-	
+
     private function encountersFountainOfPurity():void {
         player.addStatusValue(StatusEffects.RathazulAprilFool, 3, 1);
         clearOutput();
@@ -383,13 +383,13 @@ public class EbonLabyrinth extends DungeonAbstractContent {
         var choices:Array = [displacerEL, darkSlimeEL, succubusEL, incubusEL, amogusEL, tentabeastEL, minotaurEL, mindbreakerEL];
         choices[rand(choices.length)](print);
     }
-    
+
     //==================================================================================================
     //Random enemy attacks (one-liners, not worth moving into classes)
     //==================================================================================================
-    
+
     private function displacerEL(print:Boolean = true):void {
-        
+
         if (print) {
             clearOutput();
             outputText("You turn around the corner and come face to face with a greyish six armed catgirl. She would be terrifying already even without the two tentacles on her back that writhe in excitation. Readying for battle is the best you can do as the beast woman charges you with a gleam of hunger in her feral eyes.");
@@ -469,7 +469,7 @@ public class EbonLabyrinth extends DungeonAbstractContent {
     //==================================================================================================
     //Shit
     //==================================================================================================
-	
+
     //rework this to SceneLib, please
     public function defeatedByStrayDemon():void {
         clearOutput();//succubus, incibus or omnibus

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/HellfireSnailScene.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/HellfireSnailScene.as
@@ -30,7 +30,7 @@ public class HellfireSnailScene extends BaseContent {
         if (flags[kFLAGS.HELLFIRE_SNAIL_ENC] < 1) flags[kFLAGS.HELLFIRE_SNAIL_ENC] = 1;
         startCombat(new HellfireSnail(), true);
     }
-    
+
     public function defeatedBy():void {
         clearOutput();
         outputText("The snail girl catches you before you even hit the floor, a wide gooey smile on her face.\n\n");
@@ -47,7 +47,7 @@ public class HellfireSnailScene extends BaseContent {
             EventParser.gameOver();
         }
     }
-    
+
     public function defeat():void {
         clearOutput();
         outputText("You beat up the snail girl so hard her shell end upside down! She desperately tries to get back on her belly but is stuck swinging from side to side, you get the opportunity to run past her.\n\n");
@@ -57,7 +57,7 @@ public class HellfireSnailScene extends BaseContent {
     }
 
     public function hellfireSnailSex():void {
-        eachMinuteCount(15);
+        advanceMinutes(15);
         outputText("The snail giggles at your pleasant attention and begin to grind her lubricated pussy against "+(player.hasCock() ? "your burning cock" : "yours")+" in earnest. Blazing goop and other fluids begins to mingle as the two of you make it out the other residents of the labyrinth either oblivious or too scared to interfere with your smoldering mating session. ");
         outputText("This might also be because both of you spray fire and lava everywhere as part of mating and despite you both being immune to each other the unlooker likely wouldn't. The mating is deliberately slow, gentle and calculated with no single movement wasted as unlike most of Mareth denizen your current partner likes it nice and slow taking her time to make everything count.\n\n");
         outputText("You reach your peak and erupt in orgasm, your partner following short mere seconds after");

--- a/classes/classes/Scenes/Holidays.as
+++ b/classes/classes/Scenes/Holidays.as
@@ -848,8 +848,7 @@ public class Holidays extends BaseContent {
         function noThanksTurkeyGal():void {
             clearOutput();
             outputText("You reluctantly push her away.  You've no need to ram your dick down some new monstrosity's gullet.  The girl forlornly gobbles one last time, then prances off into the fading evening light, globular ass jiggling.");
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
 
         //Baste Her -McGirt, reluctantly
@@ -924,8 +923,7 @@ public class Holidays extends BaseContent {
                 player.createPerk(PerkLib.PilgrimsBounty, 0, 0, 0, 0);
                 outputText("\n\n(<b>Perk Gained: Pilgrim's Bounty - Lower lust values no longer reduce the size of your orgasm.</b>)");
             }
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
 
         //Let her Approach:
@@ -1003,8 +1001,7 @@ public class Holidays extends BaseContent {
             //HP set to full, fatigue to 0?
             fatigue(-100);
             HPChange(3000, false);
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
 
         //Turkey Girl II: Return of the Cockgobbler (Cockwielders)
@@ -1153,8 +1150,7 @@ public class Holidays extends BaseContent {
                 + "\n\n\"<i>Gobble,</i>\" you agree, wrapping the giddy turkey up in your arms and planting one last kiss on her big ol' boob.  She stares sedately at you with big, blue eyes, a cute little smile on her lips as you withdraw from her, wiping the last of your spunk on her feathery thigh.  Running your hand through the turkey-girl’s hair, you whisper what a good little cockgobbler she is.  However, you soon find that the poor thing’s passed out, your rut finally over with.  Still, she's left you with a nice soft tit-pillow to lay your head down upon as you pick up the lunch you’d been preparing to eat before the eager slut arrived."
                 + "\n\n\"<i>That’ll do, turkey,</i>\" you say, patting her jiggling tit and scraping some of the excess gravy out of your lunch.  \"<i>That’ll do.</i>\"");
             player.orgasm();
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
     }
 
@@ -1352,8 +1348,7 @@ public class Holidays extends BaseContent {
             outputText("\n\nYou sigh");
             if (changed) outputText(", feeling your body expand as you waddle out back towards camp with belly full of sweet syrup");
             outputText(". For only one gem, that was a pretty good time...");
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
     }
 
@@ -1439,8 +1434,7 @@ public class Holidays extends BaseContent {
             //With no other things to do, you go back to camp to rest.
             //{Small Lust Increase, return to camp, go to sleep}
             player.dynStats("lus", 10, "scale", false);
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
 
         //([Scylla])
@@ -1496,8 +1490,7 @@ public class Holidays extends BaseContent {
                 outputText("\n\n(<b>You have gained the Pure and Loving perk!</b>");
                 player.createPerk(PerkLib.PureAndLoving, 0, 0, 0, 0);
             }
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
 
         //[Make out]
@@ -1547,8 +1540,7 @@ public class Holidays extends BaseContent {
                 outputText("\n\n(<b>You have gained the Sensual Lover perk!</b>)");
                 player.createPerk(PerkLib.SensualLover, 0, 0, 0, 0);
             }
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
 
         //[Feed Her!]
@@ -1562,8 +1554,7 @@ public class Holidays extends BaseContent {
                 outputText("\n\n(<b>You have gained the One Track Mind perk.</b>");
                 player.createPerk(PerkLib.OneTrackMind, 0, 0, 0, 0);
             }
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
 
 
@@ -1632,8 +1623,7 @@ public class Holidays extends BaseContent {
 
             player.orgasm();
             player.dynStats("sen", -3);
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
 
         //{PLEASURE HER}
@@ -1661,8 +1651,7 @@ public class Holidays extends BaseContent {
             }
 
             player.dynStats("lus", 80, "scale", false);
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
 
         //([Pastie])
@@ -1681,8 +1670,7 @@ public class Holidays extends BaseContent {
                 if (player.hasVagina()) addButton(3, "Pussy", pastieValentineIntro, "vag");
             } else {
                 outputText("\n\nYou tell Pastie that, regrettably, you only have what she sees.  She nods and says, \"<i>Too bad.  I think I'll better get going, then.  It's been somewhat fun, and I finally get a chance to go to sleep sober and wake up without a hangover.\"</i>");
-                explorer.stopExploring();
-                doNext(SceneLib.camp.returnToCampUseTwoHours);
+                endEncounter(120);
             }
         }
 
@@ -1784,8 +1772,7 @@ public class Holidays extends BaseContent {
             }
             player.orgasm();
             player.dynStats("sen", -2);
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
 
         //[RubDick]
@@ -1817,8 +1804,7 @@ public class Holidays extends BaseContent {
             }
             player.orgasm();
             player.dynStats("sen", -2);
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
 
         //[Pussy Dive]
@@ -1849,8 +1835,7 @@ public class Holidays extends BaseContent {
 
             player.orgasm();
             player.dynStats("sen", -2);
-            explorer.stopExploring();
-            doNext(SceneLib.camp.returnToCampUseTwoHours);
+            endEncounter(120);
         }
     }
 

--- a/classes/classes/Scenes/Masturbation.as
+++ b/classes/classes/Scenes/Masturbation.as
@@ -932,7 +932,7 @@ public class Masturbation extends BaseContent {
 				}
 			}
 			if (inDungeon && DungeonAbstractContent.dungeonLoc != DungeonAbstractContent.DUNGEON_CABIN && player.companionsInPCParty()) {
-				eachMinuteCount(60);
+				advanceMinutes(60);
 				doNext(playerMenu);
 			}
 			else endEncounter();
@@ -1791,7 +1791,7 @@ public class Masturbation extends BaseContent {
 				if (player.cocks.length > 1) {
 					outputText("The sensations prove too much for you, and you feel the tightness building in your loins.  ");
                     var multiTypedIndex:int;
-					
+
 					if ((multiTypedIndex = player.findCockWithType(CockTypesEnum.HORSE)) >= 0) { //Primary Horse
 						outputText("You feel a pulsing in your sheath, slowly working its way up your " + player.cockDescript(multiTypedIndex) + "s.  Pre-cum pours from your " + player.cockDescript(multiTypedIndex) + "s, slicking the wobbly equine shafts as they get ready to blow.  ");
 					}
@@ -2766,7 +2766,7 @@ public class Masturbation extends BaseContent {
             eggDickNormal();
         }
 
-		
+
 			//Bee Eggs in Huge Cock + Exgartuan: Finished (Slywyn)(edited)
 			public function eggExgartuan():void {
                 clearOutput();

--- a/classes/classes/Scenes/NPCs/AlvinaFollower.as
+++ b/classes/classes/Scenes/NPCs/AlvinaFollower.as
@@ -343,6 +343,7 @@ public function alvinaThirdEncounterYesNeverWon():void
 		outputText("“<i>Checkmates uh… I guess that's just what I deserve for all the things I've done... tsk some justice this world has. Mother... Dad... I'm coming home at last.\"</i>\n\n");
 		outputText("Her shape starts to bloat with light as the immense powers she used to control overwhelms her. Alvina seems to silently accept death before exploding in a conflagration of arcane magic turning to ashes.\n\n");
 		outputText("You turn your eyes away, nauseated at the scene… This is what happens to those who play with forbidden powers, quite a fitting end. You prepare to leave the cave feeling like you have rid Mareth of a powerful villain but before you do you grab the shattered remains of Alvina phylactery with you. Someone is bound to know what to do with this.\n\n");
+		explorer.stopExploring();
 		alvinaDies(camp.returnToCampUseSixHours);
 	}
 }
@@ -369,6 +370,7 @@ public function alvinaThirdEncounterYesNeverLost():void
 		outputText("And you guess she's right, and she always was. As such you take the decision not to disappoint her again.");
 		player.removeStatusEffect(StatusEffects.DevilPurificationScar);
 		player.dynStats("cor", 100);
+		explorer.stopExploring();
 		doNext(camp.returnToCampUseEightHours);
 	}
 	outputText("You wake up, somewhat horny, in the middle of the blight ridge.\n\n");
@@ -389,6 +391,7 @@ public function alvinaThirdEncounterYesNeverLostNightmare():void
 public function alvinaThirdEncounterPutHerOutOfHerMisery():void
 {
 	outputText("With one decisive strike you stomp on Alvina's chest causing the pendant at her neck to crack and break into so many shards of purple crystals. Alvina's body, as if unable to sustain further damage, simply explodes into a shower of ashes and embers. You prepare to leave the cave feeling like you have rid Mareth of a powerful villain but before you do you grab the shattered remains of Alvina phylactery with you. Someone is bound to know what to do with this.");
+	explorer.stopExploring();
 	alvinaDies(camp.returnToCampUseSixHours);
 }
 public function alvinaThirdEncounterTakeHer():void
@@ -502,7 +505,7 @@ public function alvinaThirdEncounterTakeHer():void
 		player.destroyItems(consumables.F_TEAR, 1);
 		GaveAlvinaFafnirTear = true;
 		GiftCooldown = 7;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	public function alvinaGiveFlower(flower:Consumable):void {
 		spriteSelect(SpriteDb.s_archmage_alvina_shadowmantle2Concealed_16bit);
@@ -555,7 +558,7 @@ public function alvinaThirdEncounterTakeHer():void
 		player.destroyItems(consumables.CHOCBOX, 1);
 		GaveAlvinaChocolate = true;
 		GiftCooldown = 1;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	public function alvinaGiveWandBack():void {
 		outputText("You ask how it went with the magical tool, and she hands the wand to you fully repaired.\n\n");
@@ -586,6 +589,7 @@ public function alvinaThirdEncounterTakeHer():void
 		outputText("Alvina laughs then declares \"<i>Ah told you so! Yes everything is fleeting and will likely be gone one day so why are you fighting so hard for them my poor [name] you should just give up on your quest and try to live for yourself not something as hopeless as this because even if you win your reward will be to just die one day. The demons may just have the right side of this conflict.</i>\"\n\n");
 		outputText("She excuses herself then heads back down the building bidding you good night.");
 		DateFailed = true;
+		explorer.stopExploring();
 		doNext(camp.returnToCampUseFourHours);
 	}
 	public function alvinaDatePrecious():void {
@@ -606,6 +610,7 @@ public function alvinaThirdEncounterTakeHer():void
 		outputText("Alvina laughs then declares \"<i>Ah told you so! Yes feelings are pointless and only good at hindering your good judgment! Who needs those anyway.</i>\"\n\n");
 		outputText("She excuses herself then heads back down the building bidding you good night.");
 		DateFailed = true;
+		explorer.stopExploring();
 		doNext(camp.returnToCampUseFourHours);
 	}
 	public function alvinaDatePreciousNo():void {
@@ -616,6 +621,7 @@ public function alvinaThirdEncounterTakeHer():void
 		outputText("\"<i>It is late, I have to get going. [name] you better live up to those ideals of yours because… because I will not forgive you if you don't not after such a big moving speech!</i>\"\n\n");
 		outputText("She jumps down slowing her fall with a spell before heading down the street. Before she goes though, you spot the glimpse of pain in her expression. Did something you said wounded her? Guess you should head back to camp yourself.\n\n");
 		FirstDateSuccess = true;
+		explorer.stopExploring();
 		doNext(camp.returnToCampUseFourHours);
 	}
 
@@ -639,7 +645,7 @@ public function alvinaThirdEncounterTakeHer():void
 		outputText("She excuses herself then heads back down the building bidding you good night. Despite this you got the feeling deep down that perhaps this isn't what Alvina truly wanted to hear.\n\n");
 
 		DateFailed = true;
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	public function alvinaSecondDateLove():void {
 		spriteSelect(SpriteDb.s_archmage_alvina_shadowmantle2Concealed_16bit);
@@ -753,6 +759,7 @@ public function alvinaThirdEncounterTakeHer():void
 		outputText("\"<i>What are you even apologizing for? I only regret that you didn't appear in this world sooner and catched me before I slipped.</i>\"\n\n");
 		outputText("Alvina suddenly takes the initiative and kisses you for the first and last time before her body completely vanishes. The proof of a love found and then just as swiftly lost. The only thing remaining of the fallen archmage is her broken phylactery, a reminder that Alvina Shadowmantle the witch from which the demon calamity began once upon a time did live on Mareth.\n\n");
 		outputText("With a heavy heart you pick up the broken pendant if only as a memento. She deserved better than this.\n\n");
+		explorer.stopExploring();
 		alvinaDies(camp.returnToCampUseSixHours);
 	}
 	public function alvinaMakeLovePure():void {
@@ -903,7 +910,7 @@ public function alvinaMainCampMenuDiary():void
 		outputText("what has made  me human in the first place. Bah, who need theses anyway, morality is just a tether in the way of progress and true advancement can only be achieved by discarding it. Did I ever even have a moral code in the first place? Well I guess I somewhat did but I have chosen to ignore it, otherwise I wouldn't have gotten this far.</i>\n\n");
 		outputText("The journal continues and Alvina is nowhere in sight, you are anxious to see what's inside the diary beyond these page. Do you resume reading and throw caution out the window?\n\n");
 		flags[kFLAGS.ALVINA_DIARY] = 5;
-		eachMinuteCount(30);
+		advanceMinutes(30);
 		menu();
 		addButton(1, "No", alvinaMainCampMenuDiaryNo);
 		addButton(3, "Yes", alvinaMainCampMenuDiaryYes);
@@ -928,7 +935,7 @@ public function alvinaMainCampMenuDiary():void
 		outputText("Alvina almost catches you this time but you manage to act like you didn't open her diary or read it. This is starting to become dangerous. Maybe you should stop your reading now? You head back to camp.\n\n");
 		flags[kFLAGS.ALVINA_DIARY] = 4;
 		doNext(camp.campFollowers);
-		eachMinuteCount(20);
+		advanceMinutes(20);
 	}
 	else if (flags[kFLAGS.ALVINA_DIARY] == 2) {
 		outputText("While Alvina is busy out of view you open her diary and keep on reading.\n\n");
@@ -954,7 +961,7 @@ public function alvinaMainCampMenuDiary():void
 		outputText("You decide to close the book before Alvina catches you reading it. This is getting creepier the more you know about her. Thankfully she didn’t notice and so you head back to camp.\n\n");
 		flags[kFLAGS.ALVINA_DIARY] = 3;
 		doNext(camp.campFollowers);
-		eachMinuteCount(20);
+		advanceMinutes(20);
 	}
 	else if (flags[kFLAGS.ALVINA_DIARY] == 1) {
 		outputText("While Alvina is busy out of view you open her diary and keep on reading.\n\n");
@@ -968,7 +975,7 @@ public function alvinaMainCampMenuDiary():void
 		outputText("You decide to close the book before Alvina catches you reading it. This is getting creepier the more you learn about her. Thankfully she didn’t notice, so you head back to camp.\n\n");
 		flags[kFLAGS.ALVINA_DIARY] = 2;
 		doNext(camp.campFollowers);
-		eachMinuteCount(10);
+		advanceMinutes(10);
 	}
 	else {
 		outputText("As you look in Alvina’s things you notice a small book that was left on a table. Curious you take it with you while she is busy and proceed to read it.\n\n");
@@ -983,7 +990,7 @@ public function alvinaMainCampMenuDiary():void
 		outputText("You decide to close the book before Alvina catches you reading it. Thankfully she didn’t notice and so you head back to camp.\n\n");
 		flags[kFLAGS.ALVINA_DIARY] = 1;
 		doNext(camp.campFollowers);
-		eachMinuteCount(10);
+		advanceMinutes(10);
 	}
 }
 public function alvinaMainCampMenuDiaryNo():void
@@ -1012,7 +1019,7 @@ public function alvinaMainCampMenuDiaryYes():void
 		outputText("She picks up her journal and packs it up back in her bag.\n\n");
 		flags[kFLAGS.ALVINA_DIARY] = 6;
 		doNext(camp.campFollowers);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	}
 	else {
 		outputText("\"<i>You know what they say about curiosity [name]?</i>\"\n\n");
@@ -1048,7 +1055,7 @@ public function alvinaMainCampMenuConfession():void
 		outputText("Fact is, the black rose is the facet of a long-lost deity related to death by natural causes and aging. I want to acquire it to study its properties. Bring me the rose and I will offer you a place in my bed.</i>\"\n\n");
 		flags[kFLAGS.ALVINA_FOLLOWER] = 17;
 		doNext(camp.campFollowers);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	}
 }
 
@@ -1090,7 +1097,7 @@ public function alvinaMainCampSexMenu2():void
 		outputText("It's barely been an hour and Alvina has already become quite bored. She shakes her head negatively and removes herself from you.\n\n");
 		outputText("\"<i>You lack both originality and talent even for a demon. Just where’s your libido?! I’m quite disappointed, so nah, I don’t think you're worth my while on this field. Now if you would excuse me I have my stuff to pack up.</i>\"\n\n");
 		doNext(camp.campFollowers);
-		eachMinuteCount(45);
+		advanceMinutes(45);
 	}
 }
 
@@ -1299,7 +1306,7 @@ public function alvinaAfterSex():void
 		outputText("<b>Alvina is now your lover.</b>\n\n");
 		flags[kFLAGS.ALVINA_FOLLOWER] = 20;
 	}
-	doNext(camp.returnToCampUseOneHour);
+	endEncounter();
 }
 
 public function alvinaHenchmanOption():void {
@@ -1327,7 +1334,7 @@ public function alvinaHenchmanOption():void {
 		addButtonDisabled(6, "Team (2)", "Req. Intermediate Leadership.");
 	}
 	addButton(14, "Back", alvinaMainCampMenu);
-	
+
 }
 public function alvinaHenchmanOption2(slot:Number = 1):void
 {
@@ -1385,7 +1392,7 @@ public function alvinaCampStudy():void
 			}
 		}
 		doNext(camp.campFollowers);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	} else {
 		outputText("Strangely, despite being a demon, Alvina makes for a great teacher. She corrects your posture when you miss a movement and helps you learn faster than you would by just reading books.\n\n");
 		outputText("\"<i>Still daydreaming in the middle of my lectures [name]?</i>\"\n\n");
@@ -1414,6 +1421,7 @@ public function alvinaCampStudy():void
 			player.trainStat("lib",10,player.trainStatCap("lib",100))
 			flags[kFLAGS.ALVINA_FOLLOWER] = 14;
 		}
+		explorer.stopExploring();
 		doNext(camp.returnToCampUseSixHours);
 	}
 }
@@ -1431,7 +1439,7 @@ public function alvinaCampAdvancedStudy():void
 		player.addStatusValue(StatusEffects.AlvinaTraining2, 1, 1);
 		inventory.takeItem(consumables.POL_MID, camp.campFollowers);
 		AlvinaGaveScroll = true;
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	}
 	else if (player.statusEffectv1(StatusEffects.AlvinaTraining2) == 2 && player.hasItem(useables.AMETIST, 1) && player.hasItem(consumables.L_DRAFT, 5) && player.hasItem(useables.SOULGEM, 5) && (player.hasKeyItem("Marae's Lethicite") >= 0 && player.keyItemvX("Marae's Lethicite", 1) > 0 || player.hasKeyItem("Stone Statue Lethicite") >= 0)) {
 		player.destroyItems(useables.AMETIST, 1);
@@ -1461,6 +1469,7 @@ public function alvinaCampAdvancedStudy():void
 		player.addStatusValue(StatusEffects.AlvinaTraining2, 1, 1);
 		player.createPerk(PerkLib.Phylactery, 0, 0, 0, 0);
 		if (player.cor < 100) player.cor = 100;
+		explorer.stopExploring();
 		doNext(camp.returnToCampUseSixHours);
 	}
 	else if (player.statusEffectv1(StatusEffects.AlvinaTraining2) == 1) {
@@ -1491,7 +1500,7 @@ public function alvinaCampAdvancedStudy():void
 		}
 		else outputText("\"<i>You are still way too pure for us to proceed further. Corrupt your body with some demonic transformatives and we will continue.</i>\"\n\n");
 		doNext(camp.campFollowers);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	}
 	else if (player.hasStatusEffect(StatusEffects.AlvinaTraining2)) {
 		outputText("You ask your teacher if there is nothing else she can teach you.\n\n");
@@ -1509,7 +1518,7 @@ public function alvinaCampAdvancedStudy():void
 			outputText("\"<i>While there is one last thing I could teach you in the dark arts, I'm afraid you are still too pure for this knowledge. Come back when your soul is fully stained.</i>\"\n\n");
 		}
 		doNext(camp.campFollowers);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	}
 	else {
 		if (player.cor >= 50) {
@@ -1517,13 +1526,14 @@ public function alvinaCampAdvancedStudy():void
 			outputText("\"<i>Your soul is plenty corrupted enough to understand this theory. Regardless, sending your lust at an opponent is one thing, but what of the opponent's own lust? To arouse an opponent with a spell is nice, but it works even better if you mess with the enemy's mind, using his own desires against him. I taught you about controlling your desire, now you need to learn about controlling the desires of others.</i>\"\n\n");
 			outputText("She goes on for several hours, but eventually, you learn how to inspire even more lust with your spells. Smiling maliciously at the idea of trying this out.\n\n");
 			player.createStatusEffect(StatusEffects.AlvinaTraining2, 0, 0, 0, 0);
+			explorer.stopExploring();
 			doNext(camp.returnToCampUseSixHours);
 		}
 		else {
 			outputText("You ask your mentor for more advanced applications of black magic but she replies in the negative.\n\n");
 			outputText("\"<i>While I could attempt to teach you many things, there is little you could learn without darkening your soul further. Advanced black magic is for the corrupt. Without the proper mindset, there is no way you could even comprehend it. Go get fucked by a few imps or take some transformatives and we will talk about this again.</i>\"\n\n");
 			doNext(camp.campFollowers);
-			eachMinuteCount(5);
+			advanceMinutes(5);
 		}
 	}
 }
@@ -1652,7 +1662,7 @@ private function marriageSexMale(sleep:Boolean = false):void {
 		if (sleep) {
 
 			doNext(camp.sleepWrapper, 2.0);
-		} else doNext(camp.returnToCampUseOneHour);
+		} else endEncounter();
 	} else doNext(recallWakeUp);
 }
 
@@ -1677,7 +1687,7 @@ private function marriageSexFemale(sleep:Boolean = false):void {
 	if (!recalling) {
 		player.sexReward("cum", "Vaginal");
 		sexBuffs();
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	} else doNext(recallWakeUp);
 }
 
@@ -1788,7 +1798,7 @@ public function postMarriageSleep():void {
 			AlvinaInfernalOilCooldown = 1;
 			player.consumeItem(consumables.INFWINE);
 			AlvinaInfernalOilAsked = true;
-			eachMinuteCount(15);
+			advanceMinutes(15);
 			doNext(playerMenu);
 			return;
 		}
@@ -1798,7 +1808,7 @@ public function postMarriageSleep():void {
 		outputText("\"<i>Don't abuse it… wouldn't want to get side effects or something... not that id know them. If anything I'm just telling you what my sister used to say all the time about medicine and its that too much of a good thing is a bad thing.</i>\"\n\n");
 		AlvinaInfernalOilCooldown = 0;
 		AlvinaInfernalOilAsked = false;
-		eachMinuteCount(15);
+		advanceMinutes(15);
 		inventory.takeItem(consumables.SAGEMED, playerMenu);	//Sage Medicine	//Azazel TF from
 	}
 
@@ -1888,7 +1898,7 @@ public function postMarriageSleep():void {
 		outputText("\"<i>Well that's a good thing [name] seeing as I haven't reached my peak yet.</i>\" She kisses you before promising softly. \"<i>Don't you worry I will keep stuffing you until you can't go on.\"\n\n");
 		outputText("Alvina's movement do not stop, indeed allowing you to reach and feel peaks you've never reached before. Alvina's technique is so good you can't think about anything but her dick in your vagina right now as your brain slowly turns to mush. Eventually though, even Alvina reaches her limit as she unloads rope after rope of cum, painting your thirsty vagina white.\n\n");
 		alvinaPureSexFertilityComment();
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 	private function alvinaPureSexFertilityComment():void
 	{
@@ -1901,7 +1911,7 @@ public function postMarriageSleep():void {
 		spriteSelect(SpriteDb.s_archmage_alvina_shadowmantle2Concealed_16bit);
 		clearOutput();
 		outputText("Pending scene text");
-		doNext(camp.returnToCampUseOneHour);
+		endEncounter();
 	}
 }
 

--- a/classes/classes/Scenes/NPCs/ArianScene.as
+++ b/classes/classes/Scenes/NPCs/ArianScene.as
@@ -108,7 +108,7 @@ Corruption Path (Arian's body is drastically altered, but [Arian eir] personalit
 			}
 			return false;
 		}
-	
+
 		public function timeChangeLarge():Boolean {
 			return false;
 		}
@@ -175,10 +175,10 @@ public function arianChest():String {
 	var buffer:String = "";
 	//Men get no cool descriptions!
 	if(flags[kFLAGS.ARIAN_BREASTS] == 0) return "chest";
-	
+
 	//Tits ahoy!
 	if(rand(2) == 0) buffer += arianChestAdjective() + " ";
-	
+
 	//Name 'dose titays
 	var temp:int = rand(10);
 	if(temp <= 2) buffer += "tits";
@@ -197,7 +197,7 @@ public function meetArian():void {
 	spriteSelect(SpriteDb.s_arian);
 	outputText("As you wander Tel'Adre's streets, you pass by one of the many dark alleys that litter the half-empty city; you hear the sound of hacking, rasping coughs.  Following your ears, you see a hooded figure wrapped in a form-concealing cloak slumped against the wall, bent over and coughing loudly, wheezing for breath.  They really don't sound very well at all... on the other hand, it could be a setup for muggers or something.  Maybe you shouldn't try playing the good samaritan here...");
 	//[Help] [Don't Help]
-	
+
 	menu();
 	addButton(0,"Help",helpArianWhenYouMeetHim);
 	addButton(1,"Don't Help",dontHelpArianWhenYouMeetHim);
@@ -226,31 +226,31 @@ private function helpArianWhenYouMeetHim():void {
 
 	flags[kFLAGS.ARIAN_PARK] = 1;
 	flags[kFLAGS.ARIAN_COCK_SIZE] = 1;
-	
+
 	outputText("You approach the hooded figure with caution, asking if they're all right; it feels a little silly to say that, but you can't think of much else to say.");
-	
+
 	outputText("\n\n\"<i>Just... help me up,</i>\" a masculine voice asks, between coughs.");
-	
+
 	outputText("\n\nYou lean down and offer the stranger your shoulder, letting them place their arm across your neck before you stand upright, helping pull them to their feet.  Once the hooded figure is standing, the hood slides off [arian eir] head, to reveal a reptilian muzzle that could only belong to some sort of lizard.  His scales are white, almost absurdly so, and he takes deep breaths, trying to calm down his coughing fit.");
 	camp.codex.unlockEntry(kFLAGS.CODEX_ENTRY_LIZANS);
 	outputText("\n\nOnce it seems like he's calmed down, he looks at you and you gaze at his auburn slitted eyes.  \"<i>Thank you very much.</i>\"  He politely nods at you.  \"<i>Would you mind helping me one more time though?  I'm trying to avoid some people and I'd really appreciate it if you could help me go to a park nearby.</i>\"");
-	
+
 	outputText("\n\nYou ask him if he's in some kind of trouble first.  \"<i>No, of course not.  My aides are just a tad overprotective, that's all,</i>\" he insists, coughing a bit.");
 
 	outputText("\n\nYou consider your options, then decide it can't hurt to take him, conveying your decision to the sickly lizard-man.");
-	
+
 	outputText("\n\nIt doesn't take long before you arrive at what looks like a small abandoned park; the grass has grown wild in some patches, while in others it is dry and withered.  The lizan points at a nearby bench and you help him sit.  With a sigh the lizan slumps back and closes his eyes with a smile.");
-	
+
 	outputText("\n\n\"<i>Thank you very much for helping me get here.  If I had to stay in bed even for a second longer, I swear I would have gone mad.</i>\"");
-	
+
 	outputText("\n\nStay in bed?  You noticed the coughing; has he caught some kind of sickness?");
-	
+
 	outputText("\n\n\"<i>Err, not really.  I'm just going through some health problems right now...</i>\" He trails off.  You wonder if maybe it has something to do with the whiteness of his scales - they look so abnormally pale - but leave the matter.  Instead, you ask who he is and why he was in that alley where you found him.");
-	
+
 	outputText("\n\nThe lizan gasps and covers his mouth, startled.  \"<i>Oh, forgive me.  How rude, I should have introduced myself before.</i>\"  He clears his throat and starts, \"<i>My name is Arian, and as you can see, I'm a lizan.  I just wanted to go out for a little while, but my aides are intent on keeping me in bed; they say I'm not well enough to be going out... but I say if anyone knows my body, that would be me!  And if I feel like going out, then so the gods help me, I will!</i>\"  He finishes forcefully, before realizing he's rambling.  \"<i>Oh, forgive me... this really isn't your problem, sorry for troubling you,</i>\" he says, letting his head hang.");
 
 	outputText("\n\nYou tell him it's all right.  It sounds like he's been cooped up by his aides for a long time.  \"<i>Yes, sometimes I just feel like getting a bit of fresh air, so I just come to this park.</i>\"  He smiles to himself.  \"<i>I shouldn't keep you though.  Thank you for your help... err?</i>\"  You tell the lizan your name.  \"<i>I will be fine now, so I'll be seeing you.</i>\"  He smiles at you in a friendly way.");
-	
+
 	outputText("\n\nYou decide to leave him for the moment, and head back to the camp.");
 	//(Park added to TA's Menu.  It will later be replaced by Arian's house.)
 	outputText("\n\n(<b>The park has been added to Tel'Adre's menu.</b>)");
@@ -267,84 +267,84 @@ public function visitThePark():void {
 	spriteSelect(SpriteDb.s_arian);
 	outputText(images.showImage("arian-park"));
 	outputText("As you enter the ragged remnants of the park, you spot the sickly lizan, Arian, sitting at his usual bench, and greet him.  \"<i>Oh, hello there [name].  Good to see you.</i>\"  He waves lazily.");
-	
+
 	//Visit 1
 	if (flags[kFLAGS.ARIAN_PARK] == 1) {
 		outputText("\n\nFeeling ");
 		if(player.cor < 50) outputText("curious");
 		else outputText("bored");
 		outputText(", you decide to ask him what his story is.");
-		
+
 		outputText("\n\nHe gives you an apologetic smile.  \"<i>I guess I should start at the beginning; it's a bit of a long story though, so why don't you take a seat?</i>\"  He motions for you to sit beside him.");
-		
+
 		outputText("\n\nYou do as he says.");
-		
+
 		outputText("\n\n\"<i>I'm actually a mage; I've been training in the magical arts ever since I was a kid.  If you're wondering about my strange white scales, I have them because I was born with something called albinism, some kind of hereditary disease... I'm not really sure, but that's beside the point.  I spent most of my youth inside, stuck at home, studying the white arts.  People always said I had a way with magic, some even called me a genius.  Some genius, huh?  I can't even walk a few blocks without help.</i>\"  He finishes with a cough, as if for emphasis.");
-		
+
 		outputText("\n\nYou ask if he's really a mage - you thought all the mages in Tel'Adre were kept away from the general populace, projecting the spells that keep the city safe from the demons.");
-		
+
 		outputText("\n\n\"<i>Oh, yes, I really am a mage.  But I don't belong to the covenant that protects this town... You see, I'm not fit for the job.  And besides that, with my magic... it would kill me....</i>\"");
-		
+
 		outputText("\n\nHow is that so?");
 		//(PC has at least 1 Black or White Magic spell:)
 		if (player.hasSpells()) {
 			outputText("  You thought spellcasting merely took fatigue and the proper mindset, not life force, and you express that sentiment to the lizan.");
 		}
-		
+
 		outputText("\n\n\"<i>Ah...  Now we're getting to why I'm in such a miserable state.  You see I've found a new way to use white magic; one that results in far more powerful spells;  problem is it is very unhealthy for the caster.</i>\"  [arian Ey] smiles at you weakly.  \"<i>In order to achieve a state of complete concentration, I stop all my bodily functions.  My heart stops beating, I stop breathing, I dedicate all of my being to the spell I wish to cast.  This is very dangerous, but thanks to this I am able to achieve a degree of concentration that no other mage can.</i>\"  He gauges your reaction.  \"<i>So what would you say?  Impressive?  Reckless?  Stupid?</i>\"");
 		outputText("\n\nYou admit that's an impressive feat to pull off... but, can't he just cast magic the usual way?  Wouldn't that be better for him, if his technique is so much more draining and physically challenging than the conventional style?");
-		
+
 		outputText("\n\n\"<i>Yes, you are correct my friend.  And while I do use my magic in the traditional fashion now, that simply was not an option.</i>\"  He coughs.  \"<i>But that is a story for another time, I think I've held you enough for now.</i>\"  He closes his eyes and leans back.");
-		
+
 		outputText("\n\nYou excuse yourself and head back to camp.");
 	}
 	//Visit 2
 	else if (flags[kFLAGS.ARIAN_PARK] == 2) {
 		outputText("\n\nAfter you make yourself comfortable, you suggest that he continue his story.  He looks at you in surprise at first, but he smiles shortly afterwards.  \"<i>Very well, where was I?</i>\"  He rubs his chin in thought.  \"<i>Ah, yes.</i>\"");
-		
+
 		outputText("\n\nHe clears his throat.  \"<i>I had to use my power to help my friends.  You see, our academy had been overrun by demons and I tried to fight them.  But... of course I was not strong enough to defeat all of them or save everyone.  All I could do was protect my pupils and myself.</i>\"  He coughs, but smiles all the same.");
-		
+
 		outputText("\n\nSo, he's not originally from Tel'Adre?  You suggest he should go into details, tell you about his academy.");
-		
+
 		outputText("\n\nArian smiles.  \"<i>Very well.  The academy was a place of study, where mages of all kinds gathered.  It was renowned for its extensive library and for being one of the best academies to learn about white magic.  It was pretty far from this city, but since the demons attacked I wouldn't expect it to still be standing.  Things got pretty ugly before my pupils and I made our escape.</i>\"");
-		
+
 		outputText("\n\nYou indicate you understand and he should go on.");
-		
+
 		outputText("\n\n\"<i>The demons caught us by surprise... they covered the academy in their corrupt black magic, and turned some of the best and most powerful mages into mindless fucktoys.  If I hadn't been to one of the warded practice rooms I would have been taken too.</i>\"  He coughs.  \"<i>There were so many of them... my pupils were in their room, and by the time I fought my way over they were on the verge of being taken by a pair of incubi.  They were affected by the initial wave of black magic, but thankfully my white magic was enough to set them free.</i>\"");
-		
+
 		outputText("\n\nYou show that you're still paying attention and he continues.");
-		
+
 		outputText("\n\n\"<i>After saving them, I quickly realized that there was no way we could fight the demons off, so we ran as far and as fast as we could.  By the time we made it far enough that I could relax I had already used too much of my magic; and as a result... well... you're looking at it.</i>\"  He coughs for emphasis.");
-		
+
 		outputText("\n\nYou tell him that you've heard enough for this time, so it's probably best if he saves his strength and calls it quits there.  \"<i>Very well.  I'll be seeing you then, [name].</i>\"  He waves you off.");
 	}
 	//Visit 3
 	else if (flags[kFLAGS.ARIAN_PARK] == 3) {
 		outputText("\n\nYou bring up the last conversation you had with Arian and ask him whatever happened to his apprentices.");
-		
+
 		outputText("\n\nHe smiles.  \"<i>You see... my apprentices are actually my aides now.  They swore to live their lives in my service as my aides.</i>\"  So, he's been avoiding his apprentices?");
-		
+
 		outputText("\n\n\"<i>They are worried about me all the time.  Maybe too worried... and it's not like I don't appreciate their concern, but sometimes I feel smothered.  Make no mistake, I love them like family, but I like to get out sometimes too.</i>\"  You give a nod in response, figuring it's what he wants to see.");
 		outputText("\n\n\"<i>Anyway, there is not much more to my story.  We made our escape and wandered about the desert, until we found Tel'Adre.  They were nice enough to take us in and so here we are.</i>\"  He motions to the area surrounding the two of you.");
-		
+
 		outputText("\n\n\"<i>So, [name]?</i>\"  You look at him in response.  \"<i>Can I interest you in a magical demonstration?</i>\"  You answer in the positive.");
-		
+
 		outputText("\n\nHe holds his hands apart from each other, palm facing palm.  \"<i>Here's what you can normally do with White Magic.</i>\"  He closes his eyes and focus.  You watch as arcs of electrical energy, like a tiny current of lightning, sparkles and crackles from one hand to the next.  You comment that's quite a sight");
 		if(player.cor > 66) outputText(", whilst privately thinking to yourself how useless that looks - no wonder they can't fight the demons if this is the best they're capable of");
 		outputText(".");
-		
+
 		outputText("\n\n\"<i>Now let me show you what I can do with my technique.</i>\"  He closes his eyes once more and focuses.  His white scales begin glowing as his power increases and you gasp as energy virtually explodes from hand to hand, a cascade of lightning coruscating between his hands with enough fury to consume anything that falls between them.  He stops when he racks and begins coughing.  Now, that is more impressive, you have to admit to yourself.");
-		
+
 		outputText("\n\n\"<i>I guess I might have overdone it.</i>\"  He smiles at you goofily, then coughs in what is obviously meant to cover his embarrassment.  \"<i>Thanks for keeping me company, I enjoy our chats a lot, [name].  You've been a great friend for me.</i>\"  You accept the compliment and tell him that it was nothing");
 		if(player.cor >= 66) outputText(", keeping your real reasons for bothering with him to yourself");
 		outputText(".");
-		
+
 		outputText("\n\n\"<i>Could I bother you one more time though?</i>\" Arian asks shyly.  \"<i>Would you mind helping me home?  My aides are probably pestering the guard to come and find me right about now, and I feel like I got my share of fresh air for the moment.</i>\"");
-		
+
 		outputText("\n\nYou decide that it wouldn't be too much trouble, and tell Arian that you'll give him a hand to get home.");
-		
+
 		outputText("\n\nArian leads you to the doorsteps of his house, and unhooking his arm from around your shoulder he takes your hands in [arian eir] own and smiles at you.  \"<i>Thank you for the help, and for listening to my story.</i>\"  Then looking into you eyes expectantly, he asks, \"<i>Listen [name].  I would love it if you could visit me once in a while.  It can be very lonely here and although my aides are always by my side there are things I simply can't talk about with them.  So... could you find time to visit a sickly mage?</i>\"");
-		
+
 		outputText("\n\nYou assure him you'll think about it; it's time he went inside and had some rest.  \"<i>Thank you, I'll be seeing you then.</i>\"  He releases your hand and slowly walks inside, barely getting the door open before two pairs of arms grab him and drag him in, closing the door behind him.  You shrug it off and head back towards camp; that diversion was nice, but you have other things to do.");
 		//Player returns to (Tel'Adre / camp).
 		//Arian's House replaces Park in Tel'Adre menu.
@@ -421,7 +421,7 @@ public function visitAriansHouse(back:Boolean = false):void {
 				}
 				else outputText("pussy");
 				outputText(".  For a long moment, [arian ey] just stares back at you; if lizans could blush, you're certain [arian ey]'d be red as a beet.  \"<i>[name]! I was- I was just....  Oh, this is embarrassing,</i>\" [arian ey] mutters, looking at [arian eir] feet.");
-				
+
 				outputText("\n\nYou flash the flustered lizan a knowing smile, telling [arian em] not to worry; there is nothing you haven't seen before under [arian eir] robes.  Arian shivers in a way that just speaks volumes about [arian eir] embarrassment.  You ask if, perhaps, [arian ey] would like you to step outside while [arian ey] makes [arian emself] decent?  Not that you mind the sight....");
 				outputText("\n\n\"<i>P-please.</i>\" Arian stammers, still unable to meet your gaze.  You gently tap [arian em] on the nose and move outside.  A short while later you hear [arian em] yell, \"<i>C-come in!</i>\"");
 				outputText("\n\nYou can't wipe the smirk off your face, as you return and see that Arian is, indeed, decent and there doesn't seem to be any trace of the mess [arian ey]'d made earlier.  You walk up to the still flustered lizan and tell [arian em] that if [arian ey]'s feeling edgy, you'd be happy to help [arian em] deal with it.");
@@ -438,17 +438,17 @@ public function visitAriansHouse(back:Boolean = false):void {
 		if(flags[kFLAGS.ARIAN_PARK] == 4) {
 			flags[kFLAGS.ARIAN_PARK]++;
 			outputText("Deciding to visit the sickly, Lizan mage, Arian, you promptly start walking.  The house is fairly large, at least two stories tall, but it looks pretty ordinary; there's nothing about it to make it really stand out from the other buildings in the neighborhood.  It's only the small brass plate on the door that says \"<i>Arian, Magus</i>\" that provides any clue that a wizard lives here.  There is a knocker on the front door, solid brass, carved in the shape of a leering grotesque, and you take hold of the handle and loudly bang it against the door to announce your presence.");
-			
+
 			outputText("\n\n\"<i>One minute!</i>\"  You hear a feminine voice yell from inside.  After hearing the clicking of a latch the door slowly opens to reveal what looks like a tan-furred female ferret looking at you with bespectacled brown eyes; she is not very tall, and her body is clad in loose comfortable robes that hide her curves well.  She adjusts her glasses and asks, \"<i>How may I help you, " + player.mf("sir","ma'am") + "?</i>\"");
-			
+
 			outputText("\n\nYou explain you're an acquaintance of Arian the wizard, and you came to see him.  With a smile the ferret steps aside.  \"<i>Please come in.</i>\"  You promptly step inside, getting your first look at Arian's home.  The exterior and the interior match quite well; it looks very normal in here.  Aside from a few nice vases and potted flowers, nothing else stands out.");
-			
+
 			outputText("\n\nThe ferret girl slowly closes the door behind you, closing the latch before she dusts her robes and turns to you.  \"<i>I'm afraid we haven't been properly introduced just yet, " + player.mf("sir","ma'am") + ".  My name is Laika and I'm one of master Arian's aides.</i>\"  She curtsies with a smile and adds, \"<i>Pleased to meet you... umm....</i>\"  You smile and tell her your name.  She closes her eyes and nods.  \"<i>Ah, yes, [name]....</i>\"  Suddenly she opens her eyes wide open.  \"<i>Wait a moment... [name]!?</i>\"  She advances on you, threatening you with a wooden spoon.  \"<i>You! You're the one who helped master Arian get away!</i>\"  She yells with a frown, poking your [chest] with her spoon.");
-			
+
 			outputText("\n\nYou ask if that's really such a big deal; all he wanted was to go and sit in a park.  Laika points an accusing finger at you and is about to say something when a masculine voice interrupts her.  \"<i>Sis! What's the problem?</i>\" Slowly, another tan-furred ferret emerges from the hallway nearby, clad in robes much like his sister's.  If Laika were to remove her spectacles, they would look like identical twins.");
-			
+
 			outputText("\n\n\"<i>Boon, this is the....</i>\"  Boon raises his hands, stopping Laika mid-sentence.  \"<i>Yes, sister.  Half the neighborhood knows by now.</i>\"  He walks up to his sister and slowly pushes her back towards the kitchen.  \"<i>Let me handle this, sis.  Just finish doing the dishes and cool your head down, I've already finished with my chores, so I can attend to our visitor.</i>\"");
-			
+
 			outputText("\n\nLaika glares at both you and her brother, but complies.  Sighing, Boon turns to you.  \"<i>Hello, [name].  I'm Boon, Laika's brother and master Arian's apprentice.  You'll have to forgive my sister, she's rather... passionate... when it comes to our master, but she does have a point.  What if master Arian had collapsed?  Or needed his medicine?</i>\"");
 
 			outputText("\n\nBefore you can protest he stops you.  \"<i>You know what, it doesn't matter.  He would've found a way to run off whether you were there or not.  So, thanks for keeping him company.</i>\"  You accept the thanks with your usual grace, then ");
@@ -456,34 +456,34 @@ public function visitAriansHouse(back:Boolean = false):void {
 			else if(player.cor < 66) outputText("casually");
 			else outputText("indifferently");
 			outputText(" ask why he's thanking you.");
-			
+
 			outputText("\n\nBoon smiles and motions for you to follow, leading you upstairs.  \"<i>You see... master Arian didn't always enjoy taking long walks... I don't really know what has made  him suddenly take a liking for long walks around the city, but his condition does not allow him to do so, and he's just too stubborn to admit it.  So we kinda have to reel him in, or he will end up passing out in one of the rough parts of the city.</i>\"  Boon explains, turning on a hallway.  \"<i>Still, master looked really happy when he came back.  I'm glad he wound up meeting someone nice like you, instead of a mugger or a thief.</i>\"  Boon smiles at you.");
-			
+
 			outputText("\n\nHe stops at a wooden door and turns the knob.  \"<i>Of course!</i>\"  Once he does open the door, you're treated to a surprising sight.  Boon slaps his forehead with an open palm and groans.  Arian is standing on his bed, halfway out of the window, a surprised look plastered on his white face.");
-			
+
 			outputText("\n\n\"<i>Master Arian... I'm going to close this door and pretend I didn't just catch you trying to run away again.  I hope that when I open this door again I'll see you back in bed, or I'll sic Laika on you.</i>\"  At the mention of Laika, Arian shudders.  You just stand behind Boon, looking at the scene play out. Boon closes the door and waits a few moments before opening the door once again and motioning you in.  \"<i>Master Arian, you have a visitor.</i>\"");
-			
+
 			outputText("\n\nYou head inside at the ferret's gesture, wondering if Arian has stayed or not.  To your pleasant surprise, he is seated inside his bed, tucked somewhat sulkily under the covers.  You tell him that you wanted to come and visit, apologizing if you're interrupting something important.");
-			
+
 			outputText("\n\nArian smiles at you.  \"<i>Not at all.  Boon, you may leave us for now.</i>\"  Boon bows and leaves, closing the door behind him.  Arian sighs, removing his covers to sit up properly on the bed and motioning towards a nearby chair.  \"<i>Just make yourself at home; I'm really glad you came to see me.  I was wondering if I'd ever get to see you again.</i>\"");
-			
+
 			outputText("\n\nYou tell him that you couldn't resist coming to see him, even as you ");
 			if(!player.isTaur()) outputText("pull up a chair");
 			else outputText("seat your tauric body on the floor");
 			outputText(".  You rack your brains for polite conversation, and finally ask how he's been since you saw him last.");
-			
+
 			outputText("\n\n\"<i>Well, I had to take some extra medicine after that little stunt at the park.  But that aside, I've been well.</i>\"  Arian smiles.  \"<i>What about you, my friend?  How have you been?  Have you done anything interesting between now and our last meeting?  I don't get to go out much, so I'd love to hear about whatever you can tell me about the world outside.</i>\"  Arian awaits your reply expectantly.");
-			
+
 			outputText("\n\nYou rack your brains; what can you tell him? Finally, you shrug and start talking about your travels in the wilderness beyond Tel'Adre.  Seeing how much exploration excites him, you take particular care to detail the many different places you've seen, how hard it is to know what you'll find with the strange \"<i>shifting</i>\" that the demons seem to have caused across the land, and all the many sex-mad monsters you've encountered in your travels.");
-			
+
 			outputText("\n\nArian listens attentively, like a child being told a story.  When you're done Arian smiles at you.  \"<i>Wow, you must be really busy.  And you still found time to be with a sickly mage.  Thank you so much for coming; it really means a lot to me.</i>\"  Arian takes your hand between his.  Despite yourself, you feel a swell of pride at the attention he's showing you; you squeeze his hand gently and promise him that you'll make sure and come back again if he's always going to be this attentive a listener.  It's nice to hear people are interested in your stories.");
-			
+
 			outputText("\n\nYou two continue to chatter for a while longer, but eventually you feel you must leave.  Arian looks visibly disappointed, but smiles at you all the same.  \"<i>Okay, I hope to see you soon, [name].</i>\"  Clearing his throat, Arians yells, \"<i>Boon!</i>\"  Mere moments later Boon opens the door.  \"<i>Yes, master Arian?</i>\"");
-			
+
 			outputText("\n\n\"<i>Boon, would you please escort [name] out?</i>\"  Boon nods and smiles.  \"<i>Of course, master.  Please come with me, [name].</i>\"  You say one last farewell to the smiling lizan and start on your way out of the house.  Once at the doorsteps, Boon stops you.  \"<i>Hey, [name].  You're an adventurer right?</i>\"");
-			
+
 			outputText("\n\nYou confirm that you are, yes.  Boon takes your hand in his and bows.  \"<i>Please! If you find a potion or herb or any other kind of medicine that could help, bring it for our master!  We've looked all over Tel'Adre but have been unable to find anything effective.  So please!  If you find something, bring it to us!</i>\"");
-			
+
 			outputText("\n\nYou promise to keep an eye out.  You then head back out to check up on your camp.");
 			//PC returns to Tel'Adre menu screen
 			//PC begins Arian romance quest
@@ -565,7 +565,7 @@ public function visitAriansHouse(back:Boolean = false):void {
 					else outputText("\n\nYou simply sit beside [arian eir] bed.");
 					outputText("\n\nArian smiles at you and asks, \"<i>So... what do you want to do today?</i>\"");
 				}
-				
+
 			}
 			//30-49 health:
 			else if(flags[kFLAGS.ARIAN_HEALTH] < 50) {
@@ -673,9 +673,9 @@ private function peepOnArian():void {
 	outputText("Curious, you decide to take a little peek through the lock; you press yourself against it as best you can, looking through into the bedroom beyond.  True to what your ears heard, the sickly albino's health has improved enough for him to focus on more... carnal matters.  Naked from the waist down, he sits on the edge of his bed, groinal slit disgorging a single, average-sized phallus.  Maybe 6 inches long, it's a bright purple-red color, covered in strange lumps");
 	if(player.lizardCocks() > 0) outputText(" just like yours");
 	outputText(", though this isn't stopping him from enthusiastically stroking himself off.");
-	
+
 	outputText("\n\n\"<i>Curse my illness... curse my dreams... oh, [name]... if only you knew....</i>\"  Arian pants and moans, the distinct sound of fapping quite audible from where you are.  He whimpers softly and bites his lip, clearly nearing the brink.  \"<i>Ah! The things you do to me... the things I wish you would do to me... ah....</i>\"  He groans to himself.");
-	
+
 	outputText("\n\nYou ponder this curious development.  So, the reptile has developed a crush on you?  He thinks you're attractive?  Well, now... should you give him the chance to finish himself off, or should you head in now - either to tell him off, or offer him something a bit better than his hand to play with?");
 	dynStats("int", 1);
 	//[Barge In - Leads on to \"<i>Barge In</i>\" scene from first choice] [Leave]
@@ -789,14 +789,14 @@ private function youDontMindBeingGayForArian():void {
 	outputText("\n\nArian hides his face once more inside his covers and says in a whisper, \"<i>Yes....</i>\"");
 	outputText("\n\nWell, we'll have to fix that then.  You pull the covers off his face.  Slipping off his bed, you begin stripping off your [armor].  Arian shyly does the same, stripping out of his robes until he is laying in his bed, completely naked.\n\n");
 	//(Proceed Give Anal)
-	
+
 	// Redirecting the scene if the players cock is too big for the anal scene... not ideal, but its a QWIKFIX™
 	menu();
 	if (player.cockThatFits(arianCapacity) == -1)
 		addButton(0, "Next", getBlownByArian);
 	else
 		addButton(0, "Next", giveArianAnal);
-	
+
 }
 //[=Like Girls=]
 private function youLikeGirlsNotSickLizardDudes():void {
@@ -833,45 +833,45 @@ private function arianStoryDialogue1():void {
 	//PC has met Marae:
 	if(flags[kFLAGS.MET_MARAE] >= 1) outputText("Marae herself told you they showed up about, what, 20-30 years ago?");
 	else outputText("you'd guess a long while ago given the general mess they seem to have made of the world.");
-	
+
 	outputText("\n\nArian nods.  \"<i>Good guess....  And how old do I look?</i>\"");
-	
+
 	outputText("\n\nYou look the reptilian wizard up and down, contemplating. Then you profess you aren't really familiar with people covered in scales, but you'd guess somewhere in [arian eir] mid-20s?");
 	outputText("\n\nArian nods and smiles.  \"<i>I'm actually 23 years old....  So I can't tell you much about how this whole trouble started, I was only a child back then... and my parents made sure to keep me sheltered from all that as well....</i>\"  Arian stares in the distance.  \"<i>Sheltered, I guess that word defines me pretty well.  I've been sheltered from the world for the most of my life.</i>\"");
 	outputText("\n\nYou ask why; what has made [arian eir] parents shelter him from the world outside?");
-	
+
 	outputText("\n\nArian looks back at you.  \"<i>Well, the world was a mess, so they thought it would be best if I just stayed in the academy; they told me stories of young lizans walking outside who were dragged away by demons to take part in terrible rituals.  They weren't entirely wrong I guess, but that was a really cruel thing to say to a child.  Although, they were just looking after me, in the end, and as curious as I am....  Well, let's not dwell on that.</i>\"  Arian clears [arian eir] throat.  \"<i>So, I've been at the academy for as long as I can remember.  I told you about how I used to live buried in books right?</i>\"");
-	
+
 	outputText("\n\nYou nod your head and admit that [arian ey] did indeed tell you that.");
 	outputText("\n\n\"<i>Well, what I didn't tell you is that books used to be the only thing I cared about as well.</i>\"");
 	outputText("\n\nYou comment that it does seem kind of odd that a self-professed bookworm would be so desperate to get out and stretch [arian eir] legs, now that [arian ey] mentions it.  Arian laughs at that.  \"<i>Yes, quite a change wouldn't you say?</i>\"  Then, with a sigh, [arian ey] says, \"<i>It's ironic actually.  Since I couldn't go outside, all I had were the books; and the books had become my world: I read them, loved them, lived in them, and mastered them. With the time I spent reading, it was quite an easy path towards wizardhood.  As soon as I was of age, I joined the academy formally, and during my testing I was shown to have skills greater than or on par with my testers. In the end, they didn't see a need to instruct me, so they declared me a master of the art and assigned to me my pupils: Laika and Boon.</i>\"");
 	outputText("\n\nDid [arian ey] enjoy having students of [arian eir] own to teach?");
 	outputText("\n\nArian's eyes light up in recollection.  \"<i>Enjoy it?  I loved it!  These two... they became much more than mere pupils; they were my friends.  I can even say they're part of my family.  Having grown up alone, ignored by my elders, who were too busy with their next research project to pay any attention to me, and with nothing but books to keep me entertained.  Can you imagine how many friends I had?</i>\"");
 	outputText("\n\nYou must confess that the situation [arian ey]'s describing sounds quite lonely.");
-	
+
 	outputText("\n\n\"<i>So you can imagine how thrilled I was to get not one, but two people who would have to pay attention to every single instruction I gave them.</i>\"  Arian looks down, a slight tinge of regret on [arian eir] face.  \"<i>I was pretty mean at first.  I wound up taking my frustrations out on them, but thankfully they found it in their hearts to forgive me.  We've been very close ever since.</i>\"  Arian smiles.");
 	outputText("\n\nYou tell [arian eir] that it's good to hear they got to know each other properly; is that why Arian gave particular attention to ensuring they escaped when [arian eir] academy was attacked?");
 	outputText("\n\nArian shakes [arian eir] head.  \"<i>Not exactly.  It was my intention to defeat all of the invading demons; I was arrogant and it has costed me greatly.  I only managed to save Boon and Laika because they were the closest to me when the wave of dark magic hit us.  I used much of my power and concentration to resist the wave's effects... it was brutal.</i>\"");
-	
+
 	outputText("\n\nDoes that have something to do why [arian ey]'s so frail now - the stress of shielding [arian em]self and [arian eir] apprentices from the demons' black magic?");
-	
+
 	outputText("\n\n\"<i>Yes, actually. I'm not going to get into any specifics right now, but my method of casting spells causes damage to the caster's body, which is why I'm in such a miserable state.</i>\"  Arian sighs.  \"<i>Now I can't even go for a walk....</i>\"");
 	outputText("\n\nYou reach out a hand and pat [arian em] on the shoulder; you don't really think it'll make [arian em] feel any better, but it's what they always used to do when people got like this back in your village.  As you pat [arian eir] shoulder, you realize [arian ey] still hasn't told you what has made  [arian em] change [arian eir] attitude so much.  Even as you continue giving [arian em] comforting touches, you ask why it bothers [arian em] being bedridden now if [arian ey] was an antisocial stay-at-home bookworm before.");
 	outputText("\n\n\"<i>Oh, yes.  I got sidetracked, sorry.</i>\" Arian grins at you and says, \"<i>I escaped the academy.</i>\"  You scratch the back of your neck; this isn't much of an explanation.  Noticing the confusion in your face, Arian explains, \"<i>The academy didn't have any windows.  Something about preserving our privacy and ensuring no external elements would interrupt our studies.  It doesn't matter now.  So, before escaping the academy with Boon and Laika in tow, I hadn't even gazed at the sky.</i>\"");
-	
+
 	outputText("\n\nYou blink in surprise; [arian ey]'d never even seen the sky?  How could they keep anyone so constrained?  What - did [arian ey] hatch indoors and was never allowed outside?");
 	outputText("\n\nArian sighs.  \"<i>Well, I did tell you my parents kept me inside the academy at all times.</i>\"  [arian Ey] sighs once again.  \"<i>I never knew the world was so big, or so beautiful.  I'd been missing out.  I want to go out and see more.  All the good and the bad.</i>\"  Arian looks down.  \"<i>But the truth is I can't, not like this.</i>\"  [arian Ey] sighs in exasperation.");
-	
+
 	outputText("\n\nYou try to cheer the depressed lizan up, exhorting that [arian ey] needs to be optimistic about things; after all, amongst all the crazy potions and tonics, surely there's something that can make a drinker healthier and stronger?");
 	outputText("\n\nArian sighs.  \"<i>I have tried so many already.  Boon and Laika have been all over Tel'Adre trying to find something to help me get better, but nothing seems to work....</i>\"");
 	outputText("\n\nYou press the subject and ask [arian em] if [arian ey] really doesn't know or hasn't heard about anything that could help at all.");
-	
+
 	outputText("\n\nArian furrows [arian eir] brows in deep thought.  \"<i>I think... I heard there might be something after all.  Something... vitality... I don't recall its name right now.  It's some kind of tonic or tea that is supposed to help you get tougher and stronger.</i>\"");
 	outputText("\n\nAll right, it's settled then.  You tell Arian you're going to help [arian em] out, but [arian ey] must promise to behave and stay in bed; if [arian ey] keeps going out like when you first met [arian em] [arian ey]'s never going to get better.");
 	outputText("\n\nArian sighs.  \"<i>I know I shouldn't go out, but sometimes I feel like I'm going insane if I stay cooped up in here.  I've spent so much time inside at the academy, and besides that, you have no obligation to help me at all.  I couldn't trouble you by sending you to look after some kind of medicine I don't even know where to find.</i>\"");
 	outputText("\n\nYou tell [arian em] that you understand how that must make [arian em] feel. Still, running around all the time clearly isn't doing [arian em] any good. Furthermore, it's no trouble at all; you want to help. Hmm... what if you promise to drop in now and then - share some of your stories about life in the wasteland, let [arian em] live vicariously through your actions?  Will that encourage [arian em] to stay in bed and avoid overexerting [arian em]self?");
 	outputText("\n\nArian smiles at your offer.  \"<i>Well, that would certainly help.  I enjoy your company; there's something about you that.  Well... I guess you help me relax, and hearing about the world is not so bad either.  But I really wanted to see it.</i>\"");
-	
+
 	outputText("\n\nAnd see it [arian ey] will, but only if [arian ey] listens to you and gives [arian em]self a real chance to recover!  You insist that [arian ey] start relaxing; it's probably the tension as well as the punishment [arian ey] puts [arian em]self through in the name of boredom that's keeping [arian eir] from making any major recovery.");
 	outputText("\n\n\"<i>Maybe you're right.  All right then, I'll trust you [name].  I've been stuck inside the academy for many years... I guess I can hold out for a few weeks longer, as long as you come visit me.</i>\"  [arian Ey] extends [arian eir] hand.  \"<i>Deal?</i>\"");
 
@@ -945,9 +945,9 @@ private function arianDialogue3():void {
 private function yesArianShouldMagicTeach():void {
 	clearOutput();
 	outputText("You tell [arian em] that sounds fascinating.  You'd love to learn how to cast spells the way [arian ey] can, and you're grateful [arian ey] wants to take you on as an apprentice.  Especially when [arian ey]'s already so busy with the ones [arian ey] already has.  Arian rubs the back of [arian eir] neck.  \"<i>Sorry, [name].  But I can't actually teach you how to cast spells the same way I do....  That would take years to teach, not to mention it's very dangerous; I mean, look at what it's done to me....</i>\"  [arian Ey] smiles at you.  \"<i>But I could still teach you about magic in general - how to cast more spells, how to make them more powerful, the principles behind every spell....  Basically, theory that might help you in the pursuit of magical studies.  I spent my whole childhood buried in books, so I'm sure I could help you out somehow.</i>\"");
-	
+
 	outputText("\n\nYou smirk and point out that's basically what you meant, but you're definitely still interested either way.  Arian nods happily.  \"<i>Okay, then, where to start....</i>\"");
-	
+
 	//(Go to Talk about Magic)
 	menu();
 	addButton(0,"Next",arianMagicLessons);
@@ -958,7 +958,7 @@ private function noArianShouldntMagicTeach():void {
 	clearOutput();
 	outputText("You think it over for a moment, and then tell Arian that while you are flattered by the offer and willing to consider it, you can't say that you want to study magic right this moment.  You'd like to discuss it at some other time, please.");
 	outputText("\n\nArian nods happily.  \"<i>Certainly, I'd be happy to be of some help to you.  So... is there something you'd like to do today?</i>\"");
-	
+
 	//(display options)
 	arianHomeMenu();
 }
@@ -969,31 +969,31 @@ private function arianImbue():void {
 	clearOutput();
 	arianHealth(1);
 	outputText("Before you can say anything, Arian gasps, \"<i>Oh, [name].  I have a surprise for you.</i>\"  Arian says with a smile.");
-	
+
 	outputText("\n\nA surprise?  What is it?");
 	outputText("\n\nArian opens a drawer in [arian eir] work desk and removes a small package, neatly wrapped and adorned with a small ribbon.  \"<i>For you.</i>\"  Arian says, handing over the gift.");
-	
+
 	outputText("\n\nYou reach out and gently take it from [arian em], carefully opening the package.  A part of you briefly wonders if it might be an engagement ring, then dismisses the thought - surely not, not even here in Tel'Adre.  Once the package is open, you gaze upon a silver necklace: the design is intricate and exotic - very beautiful.  Held by its unusual chain lies a small silver plate with a rune adorning the center, although you don't recognize the rune.");
 	outputText("\n\nArian smiles at you.  \"<i>Do you like it?  I made it myself.</i>\"");
-	
+
 	outputText("\n\nYou study the fascinating piece, and tell [arian em] the honest truth: it's beautiful.  You never would have expected [arian em] to be such a crafts[arian man].  Arian blushes at your flattery.  \"<i>Thanks, I'm glad you like it.  But let me explain - that is not a common necklace; it's actually a magical talisman.  I wanted to give you something that would be useful in your adventures,</i>\" Arian explains.");
-	
+
 	outputText("\n\nYou smile at [arian em], and promptly hang the necklace around your neck, telling [arian em] it's as thoughtful as it is attractive.  Arian blushes.  \"<i>There is just a... well, a tiny problem.</i>\"");
-	
+
 	outputText("\n\nYou freeze nervously.  Problem...?  You wonder if putting it on was such a good idea now.  Arian nods.  \"<i>I haven't actually imbued the talisman with any spell, since I don't have any ingredients to do so.  Sorry, [name].</i>\"  Arian looks down disappointed.");
-	
+
 	outputText("\n\nYou heave a sigh of relief; is that all?  Well, what if you just bring [arian em] some ingredients next time you drop in, hmm?  Would that help [arian em] put the finishing touches on it?");
-	
+
 	outputText("\n\nArian smiles and nods.  \"<i>Of course.  But I should warn you that the talisman can only hold one spell, although once it's been imbued with a spell you may use it to your heart's content... I mean... as long as you don't get too tired doing so....  I have a list of spells and things that I need to complete a spell; all you have to do is bring the ingredients and tell me which spell you want.</i>\"");
-	
+
 	outputText("\n\nYou thank Arian; such a gift is bound to be useful in your travels.");
-	
+
 	outputText("\n\nArian bites [arian eir] lower lips.  \"<i>So... is there anything you'd like to do?  Maybe....</i>\" Arian blushes.  \"<i>You could thank me properly... for the gift.</i>\" [arian Ey] eyes you up and down, resting [arian eir] gaze on the floor as [arian ey] fidgets.");
-	
+
 	outputText("\n\nOh-hooo....  Your smoldering eyes burn holes in the nervously embarrassed lizan, and you give [arian em] your sexiest glare as you ask whatever [arian ey] means by \"<i>thanking [arian em] properly</i>\"...?  You reach out and stroke the side of [arian eir] face to emphasize your words, watching [arian em] shudder anticipatorily at your touch.");
-	
+
 	outputText("\n\nArian swallows audibly.  \"<i>I... I... I want you!</i>\" Arian blurts out, averting your gaze in embarrassment, fidgeting even more in what you've come to recognize as a sign [arian ey] is aroused.");
-	
+
 	outputText("\n\nDo you have sex with Arian?");
 	player.createKeyItem("Arian's Talisman",0,0,0,0);
 	//ArianSDialogue++;
@@ -1017,9 +1017,9 @@ private function noPlotSexNauArian():void {
 	clearOutput();
 	outputText("You apologize to the lizan, telling [arian em] that you aren't in the mood right now....");
 	outputText("\n\nArian looks a bit disappointed, but doesn't press the issue.  \"<i>Oh... Okay then, but... maybe, next time?</i>\" [arian ey] asks hopefully, smiling nervously despite [arian eir] embarrassment....");
-	
+
 	outputText("\n\n Maybe next time, you agree. Arian grins at you.  \"<i>Okay, then.  Is there something else you'd like to do?</i>\"");
-	
+
 	//(Display Options)
 	arianHomeMenu();
 }
@@ -1032,11 +1032,11 @@ private function arianPlot4():void {
 	outputText("Before you can say anything, Arian says, \"<i>Oh, I have good news, [name]!</i>\"");
 	outputText("\n\nGood news?  What is it?");
 	outputText("\n\n\"<i>I'm feeling well enough that I think I can channel my magic through you and help you if you feel you're getting overwhelmed by this world's corruption.  But due to the intensity of the treatment, I don't think I'd be able to do it more than once per day....</i>\"");
-	
+
 	outputText("\n\nYou tell [arian em] that, even if it's only once every 24 hours, that could be a very useful trick, and thank [arian em] for being willing to make such a sacrifice on your behalf.");
-	
+
 	outputText("\n\nArian smiles brightly at you.  \"<i>No problem.  I'd do anything for you.</i>\"  [arian Ey] gazes into your eyes in silence... perhaps a bit too long....  You clear your throat and Arian seems to snap out of [arian eir] trance.  \"<i>Oh!  Umm... is there something you want to do?</i>\"  [arian Ey] fidgets.");
-	
+
 	//(Display Options)
 	//ArianSDialogue++;
 	flags[kFLAGS.ARIAN_S_DIALOGUE]++;
@@ -1048,19 +1048,19 @@ private function arianPlot5():void {
 	clearOutput();
 	arianHealth(1);
 	outputText("Before you can say anything, Arian stops you.  \"<i>I've been meaning to ask you something, [name].  I've been feeling a lot better lately; in fact, I may be even better than I was before.</i>\"  Arian blushes.");
-	
+
 	outputText("\n\n\"<i>I wanted to ask you if we could... well... live together?</i>\"  Arian bites [arian eir] lower lip.");
 
 	outputText("\n\nYou explain to Arian about the portal, and your mission as the champion - how due to your duties, you cannot just move here and live with [arian em].");
-	
+
 	outputText("\n\nArian quickly adds, \"<i>Oh... no....  You wouldn't be moving here.  I would be the one moving in with you....");
 	if(camp.companionsCount() > 1) outputText("  There are other people living with you already, so what's one more?  Right?");
 	outputText("</i>\"");
-	
+
 	outputText("\n\nYou ponder [arian eir] request...  On one hand, having someone who understands magic would be of great help for your quest, and you've come to enjoy Arian's company, but what about Boon and Laika?");
-	
+
 	outputText("\n\n\"<i>I've spoken with them already and I believe they are ready to pursue their magical studies on their own.  They've been caring for me for a long time; I think it's time they lived their lives for themselves.  Besides, we won't be separated for good; I'll come and visit every once in a while.</i>\"  Arian smiles hopefully at you.");
-	
+
 	outputText("\n\nWell... when [arian ey] puts it that way... what should you do?");
 	//ArianSDialogue++;
 	flags[kFLAGS.ARIAN_S_DIALOGUE]++;
@@ -1074,7 +1074,7 @@ private function arianPlot5():void {
 private function acceptArianMovingIntoCamp():void {
 	clearOutput();
 	outputText("You tell Arian you'd be delighted to have [arian em] move in with you.  Arian's face lights up like a kid's who's been given a bucket of candy.  \"<i>Really!?  Great!  I'll pack my stuff and we can go right away!</i>\"");
-	
+
 	//(Skip to ‘Invite to Camp')
 	menu();
 	addButton(0,"Next",inviteArianToCamp);
@@ -1084,7 +1084,7 @@ private function acceptArianMovingIntoCamp():void {
 private function denyAriansMoveIn():void {
 	clearOutput();
 	outputText("You tell Arian you'd like some time to think about it.  Arian looks disappointed at first, but smiles at you all the same.  \"<i>I understand... no pressure....  So, what are we going to do today?</i>\"");
-	
+
 	//(Display Options)
 	arianHomeMenu();
 }
@@ -1107,7 +1107,7 @@ private function TyrantiaEggQuestArian():void {
 	clearOutput();
 	outputText("You ask your wizard-lizard about Purifying the unborn. You explain Tyrantia’s situation, and why she struggles so much with it. [arian Ey] gives you an odd look, and shakes [arian eir] head.\n\n");
 	outputText("\"<i>I’m afraid not. I’m sorry, but my anti-corruption magic can harm, and someone with less constitution could even be injured by it. What you’re thinking simply isn’t possible. Not in the way you’re thinking. My spell would be quite destructive to such a vulnerable little one.</i>\" Arian puts a hand on your shoulder. \"<i>I wish I could help you, I really do.</i>\" Arian seems genuinely sad about your situation. You thank Arian for [arian eir] time, leaving.");
-	eachMinuteCount(15);
+	advanceMinutes(15);
 	doNext(talkToArianChoices);
 }
 
@@ -1136,23 +1136,23 @@ private function arianMagicLessons():void {
 	clearOutput();
 	arianHealth(1);
 	outputText("You ask Arian if [arian ey] wouldn't mind giving you some magic lessons.");
-	
+
 	//(if ArianMLesson >= 4)
 	if(flags[kFLAGS.ARIAN_LESSONS] >= 4) {
 		outputText("\n\nArian raises [arian eir] hand, stopping you in your tracks.  \"<i>I appreciate your enthusiasm, [name].  But first you must rest and let the lessons of the day sink in.  I promise I'll teach you more tomorrow.</i>\"  Arian smiles at you.");
-		
+
 		outputText("\n\nMaybe [arian ey]'s right... you tell [arian em] you'll ask [arian em] to teach you more tomorrow and excuse yourself.");
 		doNext(camp.returnToCampUseOneHour);
 		return;
 	}
 	outputText("\n\nArian nods.  \"<i>Of course!  Now where do I begin....</i>\"");
-	
+
 	//(if PC int < 25) //Basics!
 	if(player.inte < 25) {
 		outputText("\n\nYou let Arian know you're actually pretty new to magic in general, so maybe [arian ey] could teach you a few basics?  Arian nods.  \"<i>Very well...</i>\"  Arian clears [arian eir] throat.");
 		outputText("\n\n\"<i>The basis of all magic is mental strength, or more appropriately, your willpower - the desire, the wish, the passion to make something that is not... be.  Which is the reason mages study so hard to begin with.</i>\"");
 		outputText("\n\nYou pay attention to Arian's every word, making mental notes of the more important lessons....");
-		
+
 		outputText("\n\n\"<i>And that is all; any questions?</i>\"  Arian patiently awaits your reply.  You sigh, tired after a long lesson on the fundamentals of magic and spellcasting.  You tell [arian em] that you don't have any questions for now... but you'd like to repeat the lesson some other time.");
 		outputText("\n\nArian smiles at you.  \"<i>Of course, [name].  If you have any doubts or would like me to repeat, all you have to do is ask.  I'll make sure to always have time for you.</i>\"");
 		outputText("\n\nYou thank the lizan for the lesson and ");
@@ -1236,7 +1236,7 @@ private function arianSexingTalk():void {
 	clearOutput();
 	arianHealth(1);
 	outputText("You smirk knowingly at [arian em] and ask how [arian ey] feels about sex now that [arian ey]'s had [arian eir] first time?");
-	
+
 	outputText("\n\nArian bites [arian eir] lower lip in embarrassment.  \"<i>I... umm... can't we talk about something else?</i>\"  You shake your head and tell [arian em] there's nothing to be ashamed of.  The two of you have already shared intimacy after all; and you'd like to know [arian eir] kinks and wishes as well.");
 	outputText("\n\nArian blushes, and takes a deep breath.  \"<i>Okay....</i>\"");
 	//Block about penis. Should only show up if Arian has a cock at all.
@@ -1246,7 +1246,7 @@ private function arianSexingTalk():void {
 			outputText("\n\n\"<i>I've always resented my lack of a second dick,</i>\" Arian admits.");
 			outputText("\n\nReally?");
 			outputText("\n\n\"<i>Well, lizans like me usually have two, and I only have one....  I've always thought I was freakish and usually avoided any kind of sexual contact, not that it was hard to avoid it, since I usually had my muzzle buried in a book.  Maybe I wasn't as social because of that... or... I don't know.  The point is, I never hoped to find someone who'd... you know....</i>\"  Arian fidgets, smiling nervously at you.");
-			
+
 			outputText("\n\nYou smile right back at [arian em].  You happen to find Arian is adorable, especially when [arian ey] gets all shy like that.  But if [arian eir] lack of a matching dick is such a big problem, maybe you could find something in your journey to help [arian em] remedy that.  Would [arian ey] like that?");
 			outputText("\n\n\"<i>Oh... I suppose there might be something that can do that.  Although I suppose it doesn't matter that much now.  Unless you'd like me to get a second one?</i>\"");
 			outputText("\n\nYou ponder the idea, but decide that Arian is fine just the way [arian ey] is; maybe someday though...");
@@ -1324,7 +1324,7 @@ private function arianSexingTalk():void {
 		outputText("\n\n[arian ey] blushes and averts [arian eir] eyes.  \"<i>I can't stop thinking about when you use my ass... it feels really good... and if I had to say if there's anything I like... then it's that.... I hope it feels good for you, too.</i>\"  Arian smiles at you, nervously.");
 		outputText("\n\nThat's... quite forward of [arian em]... you didn't expect an admission like that.  But you like it; [arian eir] ass certainly feels good, and you're glad it is pleasurable and that Arian likes it so much.");
 		outputText("\n\nArian takes a glance at your crotch.");
-		
+
 		//if PC has no cock)
 		if(!player.hasCock()) {
 			outputText("\n\nBut [arian ey] sighs in disappointment when [arian ey] sees no bulge.  \"<i>Maybe... you could grow your dick back and... never mind....</i>\"  Arian averts [arian eir] eyes.");
@@ -1381,15 +1381,15 @@ private function inviteArianToCamp():void {
 	}
 	else outputText("woman");
 	outputText(".");
-	
+
 	outputText("\n\n\"<i>Great! I'll pack up and we can go right away!</i>\" Arian announces happily.");
 
 	//(Story Dialogue Links here.)
 	outputText("\n\nArian opens a small closet and brings out a pair of small bags.  One of them is tightly closed and seems close to bursting, the other looks completely empty.  [arian Ey] takes a few neatly folded spare sets of clothes and gently packs them inside [arian eir] bag, then turns and walks to [arian eir] work desk where [arian ey] picks up a few more trinkets and bags them all.");
-	
+
 	outputText("\n\nHaving done that, Arian grabs both bags in [arian eir] hands and happily announces, \"<i>All done!</i>\"");
 	outputText("\n\nYou look at the bags skeptically and ask what kind of joke the lizan is trying to pull over you.");
-	
+
 	outputText("\n\nArian looks at you in confusion.  \"<i>Joke?  What do you mean by joke?</i>\"");
 
 	outputText("\n\n[arian Ey] can't seriously expect you to believe that's all [arian ey] intends on taking.");
@@ -1399,16 +1399,16 @@ private function inviteArianToCamp():void {
 	outputText("\n\nArian drops [arian eir] bags and opens [arian eir] arms, inviting the twins into a hug, which they happily accept.");
 	outputText("\n\n\"<i>I'm happy for you, " + arianMF("master","mistress") + ", I really am,</i>\" Boon says.");
 	outputText("\n\n\"<i>Make sure you're taking care of yourself, " + arianMF("master","mistress") + ".  Don't forget to bathe regularly and eat well... and contact us once in a while... and visit on the holidays,</i>\" Laika says, sniffing.");
-	
+
 	outputText("\n\nArian smiles at [arian eir] pupils.  \"<i>I'm not your " + arianMF("master","mistress") + " anymore.  From now on you're full-fledged mages.  Remember all that you learned, and I'm sure you'll be okay.</i>\"");
 	outputText("\n\nBoon is the first to break the hug, followed shortly by Laika.  The twins then turn to you.");
-	
+
 	outputText("\n\n\"<i>Please, [name], take good care of the " + arianMF("mas","mis") + "... err... Arian.  [arian Ey] might be a handful sometimes, but [arian ey]'s a really good person,</i>\" Boon says with a bow.");
-	
+
 	outputText("\n\n\"<i>If " + arianMF("master","mistress") + "... I mean... if Arian gives you any trouble call us and we'll come running to give [arian em] a good scolding,</i>\" Laika says with a bow.");
 	outputText("\n\n\"<i>Please don't sic Laika on me!</i>\" Arian pleads.");
 	outputText("\n\nYou smile and laugh softly at the three; they really are just like family, aren't they? You promise that you'll take good care of their teacher and that you'll call them if [arian ey] needs them to spank [arian em].");
-	
+
 	outputText("\n\n\"<i>Come on, I'm not that bad, am I?</i>\" Arian protests.  Boon and Laika look at each other, then look at you, wearing expressions identical to your own.  Finally you all nod in unison.  Arian sighs....");
 	outputText("\n\nHaving said your farewells, you begin the long trek back home... bringing with you a new ally (and lover) in tow.");
 	menu();
@@ -1432,13 +1432,13 @@ private function takeYerLizardHomePartII():void {
 	outputText("\n\n\"<i>In case you have forgotten, [name], I happen to be a master mage,</i>\" Arian says with a proud smile.");
 	outputText("\n\nYou look at the surprise tent and shake your head.  Truly, you hadn't forgotten... but you didn't know magic could be used for something as mundane as this.  [arian Ey] really surprised you this time.");
 	outputText("\n\nArian slowly walks towards the entrance and holds the tarp for you.  \"<i>Care to take a peek inside?</i>\"  You nod and follow the lizan into the tent.");
-	
+
 	outputText("\n\nAs you walk inside you can't help but gasp in amazement... clearly you have underestimated the lizan.  The inside of the tent is pretty big comparing to the outside, and you see all the tools and facilities one would need to live in the wilderness with relative comfort.");
-	
+
 	outputText("\n\nIn one corner you see what looks like a small kitchen of sorts, complete with a wide assortment of utensils.  In the opposite corner you see a work desk much like the one Arian had set up in [arian eir] house.  Sitting in the middle of the room is a comfy-looking couch with a small table in front of it.  Further inside you see a comfortable looking bed with a few bookshelves and a small wardrobe sitting nearby.  A soft rug covers the floor of the tent and looking up you see what looks like a small magic lamp, lighting up the whole tent so you can clearly see how comfortable Arian is going to be compared to you");
 	if(camp.followersCount() > 1) outputText(" and your other companions");
 	outputText(".");
-	
+
 	outputText("\n\n\"<i>So what do you think?  Cozy?</i>\" Arian asks.");
 	outputText("\n\nYou tell [arian em] it looks very cozy indeed. ");
 	if (flags[kFLAGS.CAMP_CABIN_FURNITURE_BED] <= 0) outputText("In fact, you jest, you just might bring your sleeping roll in here and sleep with the lizan instead of in your own " + (CoC.instance.flags[kFLAGS.CAMP_BUILT_CABIN] == 1 ? "cabin" : "tent") + "Arian averts [arian eir] eyes and then smiles at you nervously.  \"<i>T-there's no need for you to bring your sleeping bag... </i>");
@@ -1446,9 +1446,9 @@ private function takeYerLizardHomePartII():void {
 	outputText("<i>If you want to stay in here I'd be happy to share my bed with you.</i>\" ");
 	outputText("\n\nYou tell the lizan it was just a jest... still, you drawl, you'll keep that in mind. ");
 	outputText("Maybe you will drop by some night.");
-	
+
 	outputText("\n\n[arian Ey] nods.  \"<i>You're always welcome here whenever you want.</i>\"");
-	
+
 	outputText("\n\nYou politely excuse yourself, saying you should let the lizan make [arian emself] comfortable in [arian eir] new home, and step back outside.");
 	//flag arian as follower
 	flags[kFLAGS.ARIAN_FOLLOWER] = 1;
@@ -1526,12 +1526,12 @@ private function giveArianAnal():void {
 		outputText(images.showImage("arianfemale-home-giveArianAnal"));
 	else
 		outputText(images.showImage("arianmale-home-giveArianAnal"));
-	
+
 	// This breaks the capacity-restriction, but it's a quickfix to make the scene stop crashing in lieu of writing new
 	// content to work around the player not being able to call this scene from earlier interactions with Arian.
 	if (x == -1)
 		x = player.smallestCockIndex();
-		
+
 	outputText("You tell Arian that, if [arian ey]'s willing, you'd like to take [arian em] from behind.");
 	//AnalXP < 33
 	//Tight, sensitive enough to orgasm. (It hurts... but feels good)
@@ -1559,27 +1559,27 @@ private function giveArianAnal():void {
 			else outputText("reptilian prick");
 		}
 		outputText(".  Oh, someone's excited about this.  Why, you almost half-expected [arian eir] ass to start drooling like a pussy, [arian ey]'s obviously that turned on by the idea of you fucking [arian eir] ass.  You emphasize your point by gently worming one probing finger into the virgin-like tightness of [arian eir] anus.  Wow, [arian ey]'s so tight....");
-		
+
 		outputText("\n\n\"<i>Ow!  B-be gentle... please,</i>\" Arian protests, but despite that you feel [arian em] gently pushing against your intruding digit.  You tell [arian em] that you'll try, but [arian ey] is making this hard on you; [arian ey]'s so eager for you to start fucking [arian eir] ass, isn't [arian ey]?  It's hard to control yourself when [arian ey]'s just begging for it.  You gently grind your [cock] under the base of [arian eir] tail, in between [arian eir] girly asscheeks, to emphasize your point.");
-		
+
 		outputText("\n\n\"<i>I... yes....  I-I want it, too.  It's going to hurt, but I want it.... I-I want you to do it,</i>\" Arian admits, burying [arian eir] face in the covers in an attempt to hide [arian eir] shameless admission.  [arian Ey] braces [arian em]self, holding [arian eir] pillow tightly in [arian eir] clawed hands and bracing [arian em]self for the next step.");
-		
+
 		outputText("\n\nYou begin jerking yourself off, using slow, careful strokes to bring precum dribbling from your cock, smearing it across your shaft in an effort to lube it for your lizan lover.  Finally deciding you've made yourself slick enough, unable to resist making your move, you take hold of [arian eir] butt for support and begin pushing your " + cockDescript(x) + " against [arian eir] virginal back door.  Arian lets out a girly yelp and [arian eir] sphincter suddenly clenches up, halting your entry.  You ask what's wrong.");
 		outputText("\n\n\"<i>N-nothing... you just surprised me... that's all.</i>\"  Even though [arian ey]'s not admitting it, you can tell that Arian is very tense.  You lean over the nervous lizan and envelop [arian em] in a soft hug, telling [arian em] it's okay; you're not going to hurt [arian em], you're going to make [arian em] feel very good, but first [arian ey] needs to relax or this will be painful when it shouldn't be.");
-		
+
 		outputText("\n\nArian sighs and relaxes, loosening [arian eir] sphincter enough to allow an easier penetration.  You don't risk delaying any more and promptly, but carefully, slide yourself into [arian em] before [arian ey] can tense up again.  Damn, but [arian ey]'s so tight back here!  You have to push hard to make any progress, and it takes a lot of care to ensure you don't hurt the lizan in your press to penetrate [arian eir] bowels.  \"<i>Ah!  It's in!</i>\"  Arian shudders, struggling to remain relaxed while you plow into [arian eir] depths.  Finally, after a few more careful thrusts, you feel yourself bottom out in your shuddering lizan lover.");
-		
+
 		outputText("\n\nArian trembles and moans in pained pleasure as [arian ey] finally feels your [hips] resting flush against [arian eir] backside.  [arian Ey] pants in obvious pleasure as [arian eir] watertight little rosebud adjusts to your girth and length.  \"<i>H-how does it feel?  G-good?</i>\"");
-		
+
 		outputText("\n\nYou tell [arian em] that it feels wonderful; [arian ey]'s so tight and firm back here... to be honest, [arian ey]'s almost too tight; you can feel [arian eir] heartbeat with every involuntary contraction of [arian eir] anal walls, squeezing your cock like it's trying to wring it off and swallow it.  Arian chuckles.  \"<i>I'm not going to lie, [name].  It hurts, but it also feels good.  I think... maybe you should start moving?</i>\"");
-		
+
 		outputText("\n\nOh, and suddenly [arian ey]'s an expert on this, hmm?  You agree [arian ey] has a point.  You start to withdraw yourself from [arian em], fighting against the squeezing walls and intense suction all the way, then painstakingly pushing yourself back in, worming your way in inch by inch until you have plunged yourself all the way into [arian eir] depths, only to start again.  Arian moans and groans with each movement.  \"<i>It's starting to feel good now... really good.  Don't stop.</i>\"");
-		
+
 		outputText("\n\nTime fades away as you continue to squeeze your shaft in and out of Arian's tight, delicious little ass.  Soon - all too soon - the unmistakable feeling of orgasm starts boiling up from " + (player.balls == 0 ? "the base of your cock" : "the bottom of your balls") + "");
 		outputText(" and you warn Arian that you're going to cum inside [arian em] if you keep going.  [arian Ey] drools in pained pleasure, for a moment you wonder if [arian ey] even heard you.  \"<i>Cum.  Cum inside me.  I want it... all of it! Ah!</i>\"");
-		
+
 		outputText("\n\nYou groan and cry out as you promptly fulfill [arian eir] request.");
-		
+
 		//(Low Cum Amount)
 		if(player.cumQ() < 250) {
 			outputText("\n\nEven though your load might pale in comparison to other creatures native to Mareth, you have no doubt that you're more than enough to fill Arian's tight ass flush with cum.  You unload inside [arian em] with short, controlled thrusts.");
@@ -1596,13 +1596,13 @@ private function giveArianAnal():void {
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) outputText("spewing forth large gobs of cum of [arian eir] own " + (flags[kFLAGS.ARIAN_VAGINA] > 0 ? "and " : ""));
 		if(flags[kFLAGS.ARIAN_VAGINA] > 0) outputText("wetting both your and [arian eir] legs with a healthy serving of lizan pussy juice");
 		outputText(".  You shudder and gasp until, utterly spent, you can't resist sinking down atop Arian and bearing [arian em] into the comforting embrace of the bed.  You lay there, recovering your strength from your most delightful exertions, wriggling to give the lizan a proper snuggling while you lay there.");
-		
+
 		outputText("\n\nArian pants tiredly.  \"<i>[name], was I any good?</i>\" [arian ey] asks hopefully.");
-		
+
 		outputText("\n\nYou tell [arian em] that [arian ey] was wonderful, though you can't resist a wry smirk and a note that [arian ey] was wonderful for an amateur.  With a little practice though, well....");
-		
+
 		outputText("\n\nArian turns [arian eir] head to look at you with a tired, but happy smile.  \"<i>I'm glad you liked it.  It hurt, and I'll probably be sore later.... But it was worth it.  I liked it....</i>\"  Then [arian ey] laughs.  \"<i>If all I need is some practice, I'm hoping you will help me with that?</i>\"");
-		
+
 		outputText("\n\nYou laugh and reply that you'll consider it, but right now you're quite sated, thank you.  \"<i>Great....</i>\"  Arian's maw opens into a huge, lazy yawn.  \"<i>I think I'll take a nap now....</i>\"");
 		outputText("\n\nYou pat the lizan playfully on the head and tell [arian em] to get some rest.  You watch as [arian ey] settles down to sleep off the excitement of your sex, then carefully redress yourself and leave [arian em] to rest.");
 		//PC returns to camp menu
@@ -1613,7 +1613,7 @@ private function giveArianAnal():void {
 		outputText("\n\n[arian Ey] fidgets, smiling at you nervously.  \"<i>Okay, but don't be too rough.  I might have gotten a bit used to it, but you're still capable of giving me quite a stretch.</i>\"  Arian rolls onto [arian eir] hands and knees, tail waving excitedly as you catch a glimpse of [arian eir] stretched hole.  [arian Ey] looks back at you, shooting you [arian eir] best seductive look and wiggling [arian eir] hips side to side.");
 		outputText("\n\nYou smile at [arian em] and gently stroke [arian eir] swaying tail.  [arian Ey] sighs and lays down on the bed, reaching behind with [arian eir] hands to spread [arian eir] buttcheeks apart for you; [arian eir] tail strokes your side lovingly.  You reach your hands down and gently bat Arian's away, then begin to caress [arian eir] luxurious ass, even as you tell [arian em] that [arian ey]'s got a very sexy rear and you're going to enjoy fucking [arian eir] back passage oh so very much.");
 		outputText("\n\nArian raises [arian eir] behind, giving you better access, then looks at you with a glimmer in [arian eir] eyes.  \"<i>I'm going to enjoy this, too.</i>\"");
-		
+
 		outputText("\n\nYou slick your fingers up with some saliva, noisily smacking your tongue around the digits to make it as lewd as possible, and then gently start to probe at Arian's black pucker, seeking entry in an effort to gauge how stretched [arian ey] is.  Your digits slide in easily enough, meeting only a token resistance as you slowly invade [arian eir] bowels.\n\n\"<i>Ah... this feels good....</i>\"\n\nYou raise an eyebrow, though you know [arian ey] can't really see you from this position, and ask if [arian ey]'s really getting to be such a buttslut that even this feels good?");
 		outputText("\n\nArian turns as much as [arian ey] can to look at you.  \"<i>Lizan females have assholes that are as sensitive as vaginas to accommodate their mate's dual penises.</i>\"  [arian Ey] stops [arian eir] explanation momentarily to moan in pleasure as you begin stroking [arian eir] insides.");
 		//(if ArianVagina < 1)
@@ -1649,22 +1649,22 @@ private function giveArianAnal():void {
 		outputText(" greet");
 		if((flags[kFLAGS.ARIAN_VAGINA] == 0 && flags[kFLAGS.ARIAN_DOUBLE_COCK] == 0) || (flags[kFLAGS.ARIAN_VAGINA] == 1 && flags[kFLAGS.ARIAN_COCK_SIZE] == 0)) outputText("s");
 		outputText(" your touch.  What a little slut [arian ey] is turning into; [arian ey]'s already raring to go, and even knowing it's going to be [arian eir] ass that's getting fucked, too!");
-		
+
 		outputText("\n\nArian pants and moans.  \"<i>[name], please. Stop teasing me.  I want you.</i>\"  [arian Ey] looks back at you with eyes full of desire.  [arian Ey] humps against your intruding fingers in [arian eir] ass in obvious excitement.");
-		
+
 		outputText("\n\nWell, if [arian ey]'s that eager to get started....  You deliver a playful slap on [arian eir] ass, which ripples delightfully at the impact and sends a crack echoing through the lizan's ");
 		if(arianFollower()) outputText("tent");
 		else outputText("bedchamber");
 		outputText(".  You sink your fingers into the smoothly scaled skin of [arian eir] butt, and promptly thrust your " + cockDescript(x) + " into [arian eir] back passage; not with the gentleness you showed Arian as an anal virgin, but not with brutal force, either.  The practice the lizan's had with pleasuring your cock with [arian eir] ass is obvious - you slide in as if it's been lubed, with what little resistance it poses quickly giving way under the insistent pressure of your thrusts.  It's not as painfully tight as it was, the looseness letting you move more freely without fear of hurting your lover, but at the same time it grips you like a well-trained pussy, holding you deliciously tight and eagerly sucking you into its depths.");
-		
+
 		outputText("\n\nArian moans lewdly at your intrusion.  \"<i>Ah, I can feel you inside me.  I love this feeling... so full....  Do you like my ass, [name]?  Does it feel good when you use me like this?</i>\"");
-		
+
 		outputText("\n\nYes, you hiss, yes it feels good... does [arian ey] really enjoy this so much?  You never stop your thrusts, relentlessly pounding into [arian eir] greedy little ");
 		if(flags[kFLAGS.ARIAN_VAGINA] < 1) outputText("boypussy");
 		else outputText("nether-pussy");
 		outputText(".  \"<i>Yesssss.... Oh, sometimes it hurts a bit, but the feeling, the pleasure, the pain.... It's heavenly.</i>\"");
 		outputText("\n\nSmiling wryly, you lean over Arian's back and whisper into [arian eir] ear, that if [arian ey] likes this so much... you'll just have to fuck [arian em] more.  Having said that, you quicken your pace, drawing a pleasured, shuddering moan from your lizan lover.  \"<i>Ah!  [name]!  If you keep this up you're going to make me - Ah!</i>\"  Make [arian em] what now?  \"<i>C-cuuuuum~</i>\"");
-		
+
 		outputText("\n\nArian's ass tightens around your " + cockDescript(x) + " as [arian eir] ");
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
 			if(flags[kFLAGS.ARIAN_DOUBLE_COCK] == 0) outputText("cock spews its load");
@@ -1674,12 +1674,12 @@ private function giveArianAnal():void {
 		}
 		if(flags[kFLAGS.ARIAN_VAGINA] > 0) outputText("contracting pussy paints your lower body with lizan femcum");
 		outputText(". Arian is only capable of moaning and shuddering as [arian eir] powerful orgasm rocks the poor lizan to [arian eir] core.  The extra tightness of [arian eir] contracting butthole increases the friction on your " + cockDescript(x) + ", pushing you ever closer to the climax.");
-		
+
 		outputText("\n\nSeeing no point in holding back yourself, you cry out as you give yourself over to the feeling of climax, orgasm ripping its way through you from the ");
 		if(player.balls == 0) outputText("base of your spine");
 		else outputText("depths of your balls");
 		outputText(".  Arian, completely blissed out, lays limply on [arian eir] bed, [arian eir] butt held up by your gripping hands.  With a final deep thrust you finally go over the edge.");
-		
+
 		//(Low Cum Amount)
 		if(player.cumQ() < 250) outputText("\n\nYou pump [arian eir] insides with as much cum as you can muster, filling [arian em] with your liquid love while the lizan gasps, moans, and grips you tightly with [arian eir] distended sphincter.  You are quickly spent though, and after a couple more tugs, you feel the lizan's contracting rosebud relax to let you pull out of [arian eir] depths.");
 		//(Medium Cum Amount)
@@ -1688,11 +1688,11 @@ private function giveArianAnal():void {
 		else {
 			outputText("\n\nYou bury yourself as deep as you can into the lizan's behind and brace yourself, holding onto [arian eir] hips as the first of many jets of cum finally escapes your throbbing " + cockDescript(x) + ".  You can feel the groaning lizan shudder with each blast that you pump into [arian eir] inviting interior; each of your sticky ropes of cum filling [arian em] up until [arian eir] belly looks as big as a beach ball.  Arian's contracted sphincter tries its best to hold your prodigious load in, but it can't hope to contain it all; soon white jism explodes from around the seal of your cock.  Trails of your pleasure run down the lizan's legs to soak the bedsheets along with the lizan's own fluids.  One final jet pushes Arian off your shaft, and you gaze at the messy results of your recent activities.");
 		}
-		
+
 		outputText("\n\nFor a moment you admire your handiwork, but all too soon the exhaustion of your recent tryst catches up to you and you collapse atop the lizan, almost as blissed out as [arian ey] is....");
-		
+
 		outputText("\n\n\"<i>That... that was the best, [name].  I never hoped that sex could feel this good,</i>\" Arian remarks between pants. [arian Ey] rolls around, looking at you with a smiling face, then yawns widely, displaying [arian eir] sharp teeth to you. \"<i>So sleepy... could use a nap now....</i>\"");
-		
+
 		outputText("\n\nYou smile and pet the lizan's head, telling [arian em] that you wish you could understand how a talking lizard could be just so adorable.  You watch [arian em] as [arian ey] drifts off to sleep, then quietly slide from [arian eir] bed, get dressed and leave the ");
 		if(!arianFollower()) outputText("room");
 		else outputText("tent");
@@ -1702,21 +1702,21 @@ private function giveArianAnal():void {
 	//Very Loose, sensitive enough to make Arian cum just from insertion. (Feels better than anything else. Yep, Arian really becomes a buttslut at this point)
 	else {
 		outputText("\n\n[arian Ey] fidgets and moans as [arian ey] eagerly rolls onto [arian eir] hands and knees, lifting [arian eir] tail out of the way and spreading [arian eir] cheeks to give you a glimpse of [arian eir] throbbing, loose, puckered hole.  Arian pants and looks back at you in excitement.  \"<i>I'm all ready for you, [name].  Just go ahead and fill me up.</i>\"  [arian Ey] grins at you.  It's clear to see that Arian likes the idea of being taken, but there really is no need to rush... you'd rather savor this, plus teasing your eager lizan lover is always a bonus.");
-		
+
 		outputText("\n\nYou smirk fiercely and ask teasingly if this is really the proud, independent mage Arian lying before you with [arian eir] tail in the air and [arian eir] ass up, a buttslut yearning and anxious to be fucked like an animal.  Arian looks back at you, pleadingly.  \"<i>Aww, come on, don't tease me.  Can't you see how much I need this?</i>\"");
-		
+
 		outputText("\n\nHow much does [arian ey] need it, you ask?  Enough to beg for it, like the little buttslut [arian ey] is, hmm?  If [arian ey] can convince you [arian ey] wants it enough, you'll give it to [arian em], you tell [arian em].  Arian's tail encircles your waist, and pulls you towards [arian eir] quivering rosebud.  \"<i>Come on... fill me up.  I'm so hot it feels like I'm on fire!  Fill me up, please?</i>\"");
-		
+
 		outputText("\n\nWhat a naughty, naughty little buttslut [arian ey] is, you croon, and deliver a playful slap to [arian eir] ass, before squeezing the luscious round buttock, fingers creeping into [arian eir] crevice to probe at [arian eir] back passage.  To your surprise, the slight pressure you're exerting makes [arian eir] orifice ripple and flex; [arian ey]'s trained [arian eir] ass so well [arian ey] can even try to deliberately grab you with it and suck you in.");
-		
+
 		outputText("\n\nArian moans and bucks against your fingers, eager to get more of you inside.  \"<i>Ah... yessss... more...</i>\"  [arian Ey] groans.  Looking under [arian em], you can see that [arian eir] ");
 		if(flags[kFLAGS.ARIAN_VAGINA] > 0) outputText("wet gash is positively leaking lizan juices");
 		if(flags[kFLAGS.ARIAN_VAGINA] > 0 && flags[kFLAGS.ARIAN_COCK_SIZE] > 0) outputText(" and [arian eir] ");
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) outputText("erect cock is already leaking pre like a sieve");
 		outputText(".  You can hardly believe how far Arian has come; you ask [arian em] if it really feels that good?  \"<i>More than you can... ah... imagine, now fill me up!</i>\" [arian ey] demands with a sense of urgency.");
-		
+
 		outputText("\n\nSeeing no reason to delay any longer, and figuring [arian ey] must be well-trained enough now that you don't need to be gentle, you promptly extract your fingers from the lizan's greedy ass and then slam your shaft home in one fierce thrust, asking if this is what [arian ey] wanted.");
-		
+
 		outputText("\n\nArian gasps and opens [arian eir] maw in a silent scream.  [arian Eir] ass contracts, milking you; ");
 		if(flags[kFLAGS.ARIAN_VAGINA] > 0) {
 			outputText("[arian eir] pussy clenches, spilling a flood of juices; ");
@@ -1724,9 +1724,9 @@ private function giveArianAnal():void {
 		}
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) outputText("his cock throbs and shoots rope after rope of cum onto the bedsheets");
 		outputText(". Overwhelmed by your sudden intrusion, Arian collapses forward, burying [arian eir] face on [arian eir] pillow and dragging you on top of [arian em].  \"<i>Ah... [name], you feel so good.  It's amazing.  I never thought buttsex could ever feel this good.</i>\"");
-		
+
 		outputText("\n\nYou almost blink in surprise; you were just throwing the term buttslut around as a joke, you didn't think Arian was really like that.  Still, there are far more important matters - like digging your way into the depths of [arian eir] greedy little ass with your " + cockDescript(x) + "!  You squeeze the lizan's scaly butt and begin to rut [arian em] like an animal, thrusting your way in and out of [arian eir] back passage with all the eagerness you can muster.");
-		
+
 		outputText("\n\n[arian Ey] screams in pleasure, muffled by [arian eir] pillow.  [arian Eir] ass strives to pull you in as far as you can go, contracting, milking, gripping; even though Arian's just climaxed, you can see [arian eir] ");
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
 			if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("cocks are");
@@ -1736,15 +1736,15 @@ private function giveArianAnal():void {
 		}
 		if(flags[kFLAGS.ARIAN_VAGINA] > 0) outputText("pussy squirting juices against your [legs] with each shuddering impact of your [hips]");
 		outputText(". \"<i>Ah! Yes! More, give me more! Harder! Faster!</i>\" Arian pleads, before biting on [arian eir] pillow in pleasure.");
-		
+
 		outputText("\n\nYou see no reason not to give it to [arian em] how [arian ey] wants, and keep thrusting - it's surprisingly difficult to pull out, though, as the lizan's hungry nethers keep trying to stubbornly hold you in.  Greedily [arian eir] inner walls ripple and flex, caressing and squeezing in an effort to milk you into giving up your precious seed.");
-		
+
 		outputText("\n\nYou can feel the pressure on [arian eir] sphincter increasing and guess Arian must be close to another orgasm; you're not very far yourself, and if [arian ey] keeps squeezing and massaging your " + cockDescript(x) + " like this, you feel you'll blow any moment now.  Before you finally reach the inevitable abyss of your orgasm, you decide to lean over [arian em], hugging [arian eir] midriff just so you can pound [arian em] harder.  It's surprising that Arian only seems to be feeling pleasure, others would be screaming in pain with how rough you're being, yet [arian ey] bucks back against you with all [arian eir] might, trying to get you deeper.  You ask [arian em] if [arian ey]'s really okay, if it doesn't hurt [arian em] even a bit?");
-		
+
 		outputText("\n\n\"<i>No! Ah, yes!  Cum inside me, [name]!  I need your seed inside my naughty ass.  I need to feel you filling me up, using me like the buttslut I am!  I want to cum with you!</i>\"  You lift a brow, of all the people you know, Arian is the last one you'd expect to hear this from... what would [arian eir] apprentices say if they heard their " + arianMF("master","mistress") + " begging to be used like that?  \"<i>Ah... I don't care, just fill me up with your hot, slimy spunk!</i>\"  It would seem the lizan mage is too far gone to give you a straight answer.  You'll have to talk to [arian em] after this.");
-		
+
 		outputText("\n\nWith that in mind, you give yourself over to the pleasures of your reptilian lover and [arian eir] naughty little ass, allowing the building orgasm to finally reach its climax and boil from your body in a gush of salty spooge.");
-		
+
 		//(Low Cum amount)
 		if(player.cumQ() < 250) {
 			outputText("\n\nYou spill your load, deep into Arian's bowels, [arian eir] ass working overtime to ensure not even a single drop of seed is left in you.  \"<i>Ah!  I can feel it!  Yes!</i>\"  [arian Ey] screams, in ecstasy.  Gob after gob of cum travels down your urethra and into Arian's blooming rosebud, you almost feel bad when you run dry and are unable to give [arian em] anymore; even as [arian eir] ass continues to impatiently milk you. \"<i>...Aww. No more?</i>\" [arian ey] jokes.");
@@ -1763,29 +1763,29 @@ private function giveArianAnal():void {
 		}
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) outputText("  [arian Eir] throbbing cock flexes and shoots one last rope of lizan-cum against your belly.");
 		outputText("  [arian Eir] ass grips you forcefully, forming a vacuum and finally loosens.  \"<i>That... that wash da best,</i>\"  Arian slurs, before finally collapsing on [arian eir] bed.");
-		
+
 		outputText("\n\nYou find yourself collapsing on top of the collapsed lizan, heaving to regain your breath after such a vigorous fuck.  Finally, you regain sufficient energy to pull yourself free of the absent-minded sucking of [arian eir] ass, which wetly slurps shut afterwards to hold your seed inside.  \"<i>I feel so empty when you're not inside,</i>\" Arian utters tiredly.");
-		
+
 		//(ArianAssChat == 0)
 		if(flags[kFLAGS.ARIAN_ASS_CHAT] == 0) {
 			outputText("\n\nYou shake your head slowly in disbelief, telling [arian em] [arian ey]'s really let [arian emself] go.  Arian averts [arian eir] gaze in embarrassment.  \"<i>I... sorry.  It's just that it feels so good, and I can't... sorry.</i>\"  [arian Ey] looks away, moving [arian eir] tail into [arian eir] hands. You sigh softly and stroke [arian eir] scaly face, telling him it's not a bad thing that [arian ey] enjoys [arian em]self, it's just you're surprised at how \"<i>into it</i>\" [arian ey] gets.  [arian Ey] doesn't need to debase [arian em]self for you, this is supposed to be good for both of you.");
-			
+
 			outputText("\n\n\"<i>I... I'm not really trying to debase myself.  I guess I lose a bit of control when it comes to anal, because it really feels that good for me.  You're not mad at for being like that... for liking being fucked from behind.  Are you?</i>\"");
-			
+
 			outputText("\n\nYou tell [arian em] you certainly aren't; you were just making sure that [arian ey] was really enjoying [arian em]mself, that [arian ey]'s not under the conception [arian ey] has to act that way for you to do this to [arian em].  Arian breaths a sigh of relief.  \"<i>No, I... sorry if my being like that offends you.  I thought you enjoyed it too, since you were teasing me, but maybe I should change?</i>\"");
-			
+
 			outputText("\n\nYou shake your head; [arian ey] is who [arian ey] is, and you're quite comfortable with it.  If you really didn't enjoy playing with [arian em] like that, well, you'd stop sexing [arian eir] ass, wouldn't you?  Arian bites [arian eir] lower lip and smiles nervously at you. \"<i>So, you like my ass?</i>\"");
-			
+
 			outputText("\n\nYes.  Yes you do, you declare.  \"<i>Good, because I like you in my ass, so I don't have to change?</i>\"");
-			
+
 			outputText("\n\nYou still have to confess it was a shock that someone as respectable as Arian is would get so enthusiastically into anal - and on the receiving end, no less - but you don't want [arian em] to change just for your sake.");
-			
+
 			outputText("\n\n\"<i>This is all new to me.  I'd never been with anyone before you came, so there is no problem if I act like... well, like that?  Because I could change if it really bothers you...</i>\"");
-			
+
 			outputText("\n\nNo, there's nothing about [arian eir] behavior you want to change... besides, you think [arian ey]'s kind of sexy when [arian ey] gets like that.  At that Arian perks up.  \"<i>Really?</i>\"  Yes, really, you reply. [arian Ey] smiles happily at you.  \"<i>So... do you want to go again?</i>\"");
-			
+
 			outputText("\n\nYou chuckle. Not right this moment, no, you tell [arian em]; the two of you just had a pretty intense session, you need a few moments to recover; besides that you have other matters that need your attention.  Arian looks down in disappointment, pouting.  Now, now, there's no need for that, you can always have some fun another time.  \"<i>All right then... see you later?</i>\"  You nod.  \"<i>Ok... I'll be waiting.</i>\"");
-			
+
 			outputText("\n\nYou promptly gather your clothes and quietly make your way ");
 			if(!arianFollower()) outputText("back to Tel'Adre's streets, and from there back to camp.");
 			else outputText("out of [arian eir] tent.");
@@ -1793,9 +1793,9 @@ private function giveArianAnal():void {
 		}
 		else {
 			outputText("\n\nYou pat Arian gently on [arian eir] ass and comment playfully that [arian ey] is such an unabashed buttslut, isn't [arian ey]?  Still, did [arian ey] get enough cock up [arian eir] ass for a while?");
-			
+
 			outputText("\n\nArian smiles wryly at you.  \"<i>I guess I've got enough to hold me for a while now, but I could always use another dose.</i>\"");
-			
+
 			outputText("\n\nWell, this greedy little lizard of yours will have to wait until you're ready.  But if [arian ey]'s good, maybe you'll come back later, you tell [arian em], playfully tapping [arian em] on the snout for emphasis.  \"<i>Okay, I'll be waiting.</i>\"  [arian Ey] grins happily.");
 			outputText("\n\nSmiling back at [arian em], you gather your clothes and quietly make your way ");
 			if(!arianFollower()) outputText("back to Tel'Adre's streets, and from there back to camp.");
@@ -1818,41 +1818,41 @@ private function getBlownByArian():void {
 	else
 		outputText(images.showImage("arianmale-home-getbj"));
 	outputText("You trail your hand down your belly, pondering what to do.  Arian doesn't seem to notice, instead staring with anticipation at your erection.  You idly swing your hips from side to side, and notice with amusement that the lizan seems to follow it.  Building on that train of thought, you ask if [arian ey] would be willing to suck you off.");
-	
+
 	//(if ArianHasBlown == 0)
 	if(flags[kFLAGS.ARIAN_HAS_BLOWN] == 0) {
 		outputText("\n\nThe lizan averts [arian eir] eyes, snapping out of [arian eir] reverie.");
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] == 3) outputText("  You notice Arian's exposed shaft slowly hardening at your invitation.");
 		outputText("  \"<i>I... Can I really?</i>\"");
-		
+
 		outputText("\n\nYou smile and note [arian ey] almost sounds eager to do that, though you admonish [arian em] to be careful; it's a sensitive body part and, while you don't doubt [arian eir] affections, that doesn't make [arian eir] teeth any less sharp.");
-		
+
 		outputText("\n\nArian nods eagerly.  \"<i>I promise I will be careful.  I wouldn't dream of hurting you, [name].</i>\"  You nod in return, and tell the lizan that you'll trust [arian em], settling on [arian eir] bed and giving [arian em] full access to what's between your [legs].");
 	}
 	else {
 		outputText("\n\nThe lizan smiles at you and licks [arian eir] lips.  \"<i>I would love to!</i>\" [arian ey] replies eagerly.  You smile and remind [arian em] to be careful with [arian eir] teeth.");
-		
+
 		outputText("\n\nArian acknowledges your concern by nodding emphatically.  \"<i>Sure, I would never hurt you, [name].</i>\"");
-		
+
 		outputText("\n\nSatisfied with [arian eir] reply, tell [arian em] you'll trust [arian em] and settle on [arian eir] bed and giving [arian em] full access to what's between your legs.");
 	}
-	
+
 	outputText("\n\nArian rolls on top of you and reaches for your [cock biggest], caressing it almost reverently.  Looking at [arian eir] face, you see [arian em] eyeing your cock up and down, sizing it up.  [arian Ey] looks at you and smiles; then without breaking eye contact [arian ey] extends [arian eir] tongue to lick at your [cockHead biggest] and slowly take your cock in, careful to purse [arian eir] lips so [arian eir] teeth won't hurt you.");
-	
+
 	outputText("\n\nYou shudder in pleasure at the sensation; the interior of [arian eir] mouth is warmer than you expected, but smooth in texture and silky soft.  Something long and wet wriggles around your [cock biggest]; for a heartbeat, you'd almost think it's a slimy snake, but then logic hits and you realize it's Arian's long, prehensile tongue, which [arian ey] is using to coil around and entangle your intruding shaft.");
-	
+
 	outputText("\n\nWith one powerful slurp, [arian ey] coaxes a small jet of pre out of your [cock biggest], which Arian is only too happy to drink down, moaning at the first taste of your seed; this in turn sends wonderful vibrations along your length, coaxing even more pre into [arian eir] hungry maw.");
-	
+
 	//(If ArianHasBlown == 0)
 	if(flags[kFLAGS.ARIAN_HAS_BLOWN] == 0) {
 		outputText("\n\nAs you gasp in pleasure, you cannot help but wonder when did Arian get so skillful with [arian eir] mouth; you thought [arian ey] said [arian ey] was a virgin before you came along.");
 		outputText("\n\nYou ask if Arian's sure [arian ey] was a virgin until [arian ey] met you.");
 		outputText("\n\nArian lets go of your cock, kissing its [cockHead biggest] before replying, \"<i>Yes, I'm sure... but I practiced a lot on myself...</i>\"");
-	
+
 		outputText("\n\nOn [arian em]self?!  You blurt out; just how flexible is [arian ey]?!");
-		
+
 		outputText("\n\nArian smiles nervously and bites [arian eir] lower lip.  \"<i>I'm a mage, remember?  There's a lot of things you can do with magic, but this isn't about me, [name].  It's about you... so let me show you what I learned.</i>\" [arian Ey] plants a kiss on your [cockHead biggest] before slowly wrapping around it with [arian eir] tongue and sucking you right back into [arian eir] cock-hungry maw.");
-		
+
 		outputText("\n\nYou moan, agreeing that, yes, this is far more important.");
 	}
 	else {
@@ -1860,33 +1860,33 @@ private function getBlownByArian():void {
 		outputText("\n\n[arian Ey] lets go of your cock, kissing its [cockHead biggest] before replying, \"<i>No, I don't need to practice on myself anymore.  I got you to help with that now, right?</i>\"  Arian plants a kiss on your [cock biggest], before slowly wrapping it around [arian eir] tongue and sucking you right back into [arian eir] cock-hungry maw.");
 		outputText("\n\nYou moan and tell [arian em] that as long as [arian ey] keeps giving you great head, you're more than happy to help [arian em] practice.");
 	}
-	
+
 	outputText("\n\nYou thrust your [cock biggest] as deeply into the lizan's eager little mouth as [arian ey] will let you... oooh, what would they say, if they could see a proud spellcaster like [arian em] sucking you off like this?");
-	
+
 	outputText("\n\nArian doesn't bother replying, not that [arian ey] could with a mouthful of cock.  [arian Ey] braces [arian em]self on your [hips] and begins truly blowing you; intent on draining you of your seed with strong, wet, slurping sucks that resound from the small cracks of the lizan's maw not filled with your [cock biggest].");
-	
+
 	outputText("\n\nYou groan and gasp and hump the lizan's face for all you're worth.  You can feel the familiar pressure of seed building up deep inside you, sparks of pleasure becoming the budding crescendo of orgasm, and you wonder if you should warn Arian of what's coming...");
-	
+
 	outputText("\n\n[arian Ey] never slows down, even as [arian ey] looks up to you, trying to catch a glimpse of your face to make sure [arian ey]'s pleasuring you well.  When your eyes meet, you swear you can see the lizan mage smiling at you, even thought [arian eir] mouthful of cock prevents you from catching a good glimpse of [arian eir] face.  [arian Ey] moans with delight as you take hold of [arian eir] head and begin guiding [arian em].");
-	
+
 	outputText("\n\nWith a few last huffs and gasps, it finally comes.  Orgasm rips through your flesh and sends your cum cascading from out of your [cock biggest] into Arian's suckling mouth - no point worrying about whether or not [arian ey] wants it in the mouth now, it's here and [arian ey]'ll just have to deal with it.");
-	
+
 	outputText("\n\nArian is surprised when the first jet of cum hits [arian em] straight in [arian eir] throat, but never stops sucking.  Somehow Arian manages to drink your cum as fast as you can pump it into [arian eir] eager maw; by the time you're done, Arian has developed a ");
 	if(player.cumQ() < 250) outputText("small");
 	else if(player.cumQ() < 1500) outputText("big");
 	else outputText("huge");
 	outputText(" pot belly. [arian Ey] lets go of your dick with a sigh of pleasure and lays back on the bed.  \"<i>Ah... I'm full.</i>\"");
-	
+
 	outputText("\n\nYou tell [arian em] that [arian ey] looks full");
 	if(player.cumQ() >= 1500) outputText(", in fact, you're amazed [arian ey] didn't pop with how much [arian ey] drank");
 	outputText("; is [arian ey] sure [arian ey]'s all right?");
-	
+
 	outputText("\n\nArian yawns, revealing [arian eir] toothy maw.  \"<i>Yes, I just need a nap.</i>\"  You chuckle and tell [arian em] that [arian ey] should at least get under the covers.  \"<i>Too... tired to bother.</i>\"  Arian replies with a second yawn.  Seeing no reason not to be gallant, you step forward and help Arian climb to [arian eir] feet");
 	if(player.cumQ() >= 1000) outputText(" which, considering the fact [arian ey] looks like a mother ready to birth a toddler from the size of [arian eir] belly, isn't as easy as you'd think");
 	outputText(".  Letting the lizan use your shoulder, you pull [arian eir] sheets up and help [arian em] back in the bed, where [arian ey] flops down with a protest of springs");
 	if(player.cumQ() >= 250) outputText(", [arian eir] gut audibly sloshing as the cum inside is churned by the impact");
 	outputText(".");
-	
+
 	outputText("\n\n\"<i>Thanks, [name].</i>\"  Arian yawns once more and closes [arian eir] eyes.  You smile and give the sleeping lizan an affectionate pat on the head; then dress yourself and make your way");
 	if(!arianFollower()) outputText(" back to camp, stopping only to notify Laika and Boon that Arian is sleeping.");
 	else outputText(" out of Arian's tent.");
@@ -1909,17 +1909,17 @@ private function penetrateArian():void {
 	outputText("You admire the transgendered lizan's body, from [arian eir] feminized features, down past [arian eir] [arian chest], all the way to [arian eir] shapely thighs.  You tell Arian that the change looks very good on [arian em]; few boys would really be so naturally pretty when turned into a ");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) outputText(arianMF("maleherm.", "dickgirl."));
 	else outputText("girl.");
-	
+
 	outputText("\n\nArian smiles and averts [arian eir] eyes, rubbing one arm.  \"<i>You really think so?</i>\"  [arian Ey] bites [arian eir] lower lip in nervousness.");
-	
+
 	outputText("\n\nYou nod your head, insisting that you do think so.  With a lustful purr, you ask just how [arian ey] would like to try out [arian eir] girl parts, maybe see just how pretty [arian ey] can feel with the right... encouragement?");
-	
+
 	outputText("\n\n\"<i>Of course!  I would love it.  So what should I do?</i>\" [arian ey] asks, tail waving lazily behind [arian em] as [arian ey] awaits further instructions.  \"<i>Should I help you get ready first?</i>\"  [arian Ey] looks down between your legs to see your half-erect cock");
 	if(player.cockTotal() > 1) outputText("s");
 	outputText(".  \"<i>Err... readier?</i>\"  [arian ey] asks, smiling nervously.");
-	
+
 	outputText("\n\nYou smile, and tell [arian em] that, seeing as how this is fairly new to [arian em], you'll try and let [arian em] take charge.  You sashay over to [arian eir] bed and lay down on your back, [eachCock] jutting proudly into the air, before telling Arian you want [arian em] to straddle you.");
-	
+
 	outputText("\n\n[arian Ey] nods, [arian eir] liquid lust dropping over your [legs] as [arian ey] straddles you");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] == 3) {
 		outputText(", [arian eir] exposed cock");
@@ -1933,20 +1933,20 @@ private function penetrateArian():void {
 		outputText(" hiding place, already at full mast in anticipation");
 	}
 	outputText(".  Arian swallows audibly.  \"<i>What now?</i>\" [arian ey] asks, already panting in lust.");
-	
+
 	outputText("\n\nYou gently reach up and take hold of the lizan's hips, telling [arian em] that first, you need to connect, slowly guiding [arian em] down, feeling [arian eir] all-too-human folds parting around the tip of your cock.");
-	
+
 	outputText("\n\nArian moans and tries to speed things up by impaling herself on [oneCock], but the pleasure of the insertion makes [arian em] lose [arian eir] balance and [arian ey] falls face down on your [chest].  \"<i>Ah!  S-sorry!</i>\"  [arian Ey] smiles nervously at you.");
-	
+
 	outputText("\n\nYou smile at [arian em] and pat [arian em] on the cheek, telling [arian em] to take it easy; there's no need to rush this.  With painstaking deliberation, you continue gently inserting yourself into the ");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] == 0) outputText("female");
 	else outputText("herm");
 	outputText(" lizan, until you have managed to hilt yourself inside of [arian em].");
 
 	outputText("\n\nArian shudders, rubbing [arian eir] stretched pussy lips against your groin.  \"<i>This feels so good.  I never thought I'd ever feel something like this.  Your cock is filling me up, and I love it.  I can feel everything... every little twitch, every little vein, the texture... everything.</i>\"");
-	
+
 	outputText("\n\nYou whisper to [arian em] that the best is yet to come, and then start to slowly buck your hips up and down, gradually increasing the tempo, murmuring in pleasure as you feel [arian eir] slick, wet netherlips hungrily kissing you in response.");
-	
+
 	outputText("\n\nArian moans throatily, gyrating [arian eir] hips against your intruding shaft, until [arian ey] starts to slowly rise and fall, trying [arian eir] best to keep up with your rhythm.  \"<i>So wet... I'm so wet, and the sounds!  I feel so hot... sexy... wanted.  Oh, [name] fuck me!  Take me!</i>\" [arian ey] says, supporting [arian em]self on either side of your head, looking down at you with half-lidded, lust-driven eyes, panting hotly down at you as [arian ey] bucks [arian eir] hips against your thrusts.");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
 		outputText("  [arian Eir] ");
@@ -1955,10 +1955,10 @@ private function penetrateArian():void {
 		outputText(" bobs just out of your field of vision, leaking pre all over your belly.");
 	}
 	outputText("\n\nYou smile at the lizan, who is clearly adjusting to [arian eir] new gender with aplomb, and procede to pick up the pace, trying to match the increasing tempo of [arian eir] thrusts and ensure [arian ey] enjoys [arian em]self as much as possible.  It's no sacrifice, after all, especially given the way [arian eir] cunt is sucking hungrily on your cock, grinding with walls that ripple harder and harder as you thrust into [arian em] more and more vigorously.");
-	
+
 	if (flags[kFLAGS.ARIAN_BREASTS] > 0) outputText("\n\nArian smiles down at you, licking [arian eir] lips.  \"<i>[name], please,</i>\" [arian ey] moans throatily, half to show [arian ey]'s paying attention, half from pleasure. \"<i>My breasts... please?</i>\"  [arian Ey] asks, panting, never stopping [arian eir] bucking against you.");
 	outputText("\n\nYou unthinkingly reach up and take the lizan's [arian chestAdj] bosom in your hands, caressing the small, cherry-like nubs of [arian eir] nipples, caressing the so-so-smooth scales that cover it, creating a texture at once alien and erotic.  Arian sighs in pleasure as you continue to massage [arian eir] breasts.  \"<i>Do you like them?  My breasts?  Does it feel weird that I have breasts, despite being a lizan?</i>\"  You hoarsely whisper to [arian eir] that you love them, and while it was strange at first, there's certainly many odder things about this world, and you think they're part of [arian eir] natural charms.");
-	
+
 	outputText("\n\nArian moans appreciatively and grinds [arian eir] hips against you.  \"<i>I'm so happy to hear you say that; you really know how to make a girl feel appreciated.</i>\"  You note that it feels a little strange to hear Arian so easily referring to \"<i>herself</i>\" as a girl.  Arian fidgets and averts [arian eir] eyes.  \"<i>I-I can't help it.  When you're buried in my pussy I just... feel girly - pretty.</i>\"  That might be because [arian ey] is so very pretty, you can't resist saying, even as you continue to thrust into [arian em].  \"<i>Oh [name]... F-fuck me.  Make me feel beautiful!  Make me cum!  I want you to fuck me as hard as you can.  Please....</i>\"");
 
 	outputText("\n\nYou promise [arian em] you will, but with [arian em] on top, you can't really exert that much control.  Swinging [arian eir] tail to the side along with [arian eir] body, Arian quickly rolls over, never breaking contact, nor stopping bucking against you, even as [arian eir] legs close behind you and [arian ey] loops [arian eir] arms around your neck.  [arian Ey] looks up at you, panting, with half-lidded eyes, then [arian ey] smiles.  \"<i>What about now?</i>\"");
@@ -1969,12 +1969,12 @@ private function penetrateArian():void {
 		outputText("a small rope of pre over [arian eir] belly, anticipating what's to come as [arian ey] braces [arian em]self for the inevitable pounding you're about to give [arian em].");
 	}
 	outputText("\n\nNow, you tell [arian em], you can really start, and you do your best to live up to your promise, pounding [arian em] as hard and fast as you can, without being so rough that you hurt [arian em] in the process.  \"<i>Ahm... yesssss... so good.  Fuck me raw!  Oh!  Paint my walls with your hot cum!</i>\"");
-	
+
 	outputText("\n\nArian has quite the dirty mouth on [arian em], you manage to joke, even as you pound [arian em] with all you have.");
 	outputText("\n\n\"<i>That's... Ah!</i>\"  Arian's words catch in [arian eir] throat, and instead [arian ey] moans, \"<i>J-just cum!  Please!  I need it!</i>\"");
-	
+
 	outputText("\n\nWell, it's rude to cum before a " + arianMF("maleherm", "lady") + ", so you're not giving in, not until [arian ey] cums first, you manage to gasp, though in truth you're struggling to keep from blowing.  \"<i>Oh!  Cum!  Cum with meeeee!</i>\"");
-	
+
 	outputText("\n\n");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
 		outputText("Arian's ");
@@ -1986,12 +1986,12 @@ private function penetrateArian():void {
 	if(player.balls == 0) outputText("you");
 	else outputText("your [balls]");
 	outputText(".");
-	
+
 	outputText("\n\nFinally having kept your promise, you give yourself over to the inevitable. ");
 	if(player.hasVagina()) outputText(" A wash of fluids spills down your body from your cunt as it spasms in release and y");
 	else outputText("Y");
 	outputText("ou unleash your essence right into the lizan's burning womb.");
-	
+
 	//(Low Cum amount)
 	if(player.cumQ() < 250) {
 		outputText("\n\nArian's pussy is clamping down so hard on your dick, that you can feel it as the cum stretches your urethra, gathering at the tip, and exploding outwards.  Contracting walls carrying the seed deep into the awaiting womb that lies beyond.  You hug the shuddering lizan tightly as you thrust against [arian em] a few more times, delivering the last few ropes of cum and collapsing atop [arian em].");
@@ -2004,15 +2004,15 @@ private function penetrateArian():void {
 	else {
 		outputText("\n\nYou threaten to blow the poor lizan straight off your " + cockDescript(x) + " with the sheer force of your cum.  Hosing down [arian eir] walls to the point [arian ey] can't hope to contain all of your powerful jets, you draw [arian em] close, and Arian groans, returning the gesture with a tight hug of [arian eir] own.  \"<i>Ugh, my belly... so much... so good,</i>\" [arian ey] moans, and you continue to torment [arian eir] body with your prodigious load.  The sheets under the two of you have since turned into a wet mess of mixed juices, covering both of your lower bodies in the aftermath of you tryst; and it's not until you thrust into [arian em] a couple more times, to ensure you're completely spent, that you collapse on top of [arian em], slightly propped up by the protruding, pregnant-looking belly you've given [arian em].");
 	}
-	
+
 	outputText("\n\n\"<i>Aaahhhh...</i>\"  Arian sighs.  \"<i>Sex... feels so good.</i>\"  Caressing the back of your head, [arian ey] gently pulls you into a quick kiss.  \"<i>If this is how it'll feel every time we do this, then I have no regrets about turning into a girl,</i>\" [arian ey] says, one hand snaking it's way between the two of you to rub [arian eir] ");
 	if(player.cumQ() < 250) outputText("lean");
 	else if(player.cumQ() < 1000) outputText("full");
 	else outputText("overfilled");
 	outputText(" belly.  \"<i>Stay with me, like this, a little longer?</i>\" Arian asks.");
-	
+
 	outputText("\n\nYou take [arian eir] free hand in your own and tell [arian em] that, if [arian ey] wants you to, you can stay for at least a little while longer.  \"<i>I'd like that... just a while.</i>\"  Arian does [arian eir] best to nuzzle you.  With no compelling reason not to, you nuzzle [arian em] back and content yourself with laying there, enjoying the mutual afterglow.");
-	
+
 	outputText("\n\nEventually, though, you announce that you should probably get going.  As nice as it is to stay here with [arian em], you have duties to attend to.  Arian smiles at you, and gives you a little peck on the lips.  \"<i>I understand, but come see me again soon, please.</i>\"  You promise [arian em] you will and extract yourself from the affectionate lizan's embrace.  You quickly find your clothes and get dressed, then leave.");
 	player.sexReward("vaginalFluids","Dick");
 	dynStats("sen", -1);
@@ -2036,13 +2036,13 @@ private function getButtWreckedByArian():void {
 	else if(flags[kFLAGS.ARIAN_ANAL_XP] < 66) outputText("\n\n\"<i>I like it when you use my ass, but if you want me to use yours, I would gladly comply.  That is, if you're sure you want me to...?</i>\"");
 	//(if AnalXP <= 100)
 	else outputText("\n\n\"<i>I really love it when you fill me up, and personally I'd prefer we do it that way, but if you're really sure you want me to, I'll try and make you feel as good as you feel inside me.</i>\"");
-	
+
 	outputText("\n\nYou smile seductively and nod, telling [arian em] that you're sure you want [arian em] to do you that way.");
-	
+
 	outputText("\n\n\"<i>Okay, then.  How should we do this?  I don't want to do something wrong and end up hurting you...</i>\"");
-	
+
 	outputText("\n\nYou smirk and reach out a hand to caress the lizan's [arian chest], stage-whispering to [arian em] that [arian ey] just needs to lie down on [arian eir] bed and you'll take care of things from there...");
-	
+
 	outputText("\n\nArian swallow audibly, but complies.  Slowly [arian ey] lets [arian em]self fall back onto [arian eir] bed, fidgeting as [arian eir] ");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] >= 3) {
 		outputText("exposed cock");
@@ -2056,46 +2056,46 @@ private function getButtWreckedByArian():void {
 		else outputText(" peeks out of its");
 		outputText(" hiding place, rising to full mast.");
 	}
-	
+
 	outputText("\n\nYou sashay yourself towards the prone lizan, straddling [arian eir] legs and reaching out to grasp [arian eir] ");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("primary ");
 	outputText("cock.  Slowly and gently you begin to stroke its strange, knobbly surface, your fingers eliciting moans and gasps from Arian as [arian ey] shudders under your touch.  Precum begins to ooze from the reptilian prick's head, and you purposefully rub it into [arian eir] shaft as a kind of makeshift lubricant.");
-	
+
 	outputText("\n\n\"<i>Ohm... T-this feels great, [name], b-but if you keep this up, I won't be able to hold back!</i>\" Arian pants, [arian eir] shaft");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
 	outputText(" throbbing against your hands.");
-	
+
 	outputText("\n\nWell, that would be a shame; it might be a little rough, but you'll have to make do with what you've got.  With that in mind, you cease your stroking, and start sliding yourself up Arian's body, until your [ass] is positioned above [arian eir] jutting prick.  With slow, deliberate motions, you slowly start to impale yourself upon it...");
-	
+
 	player.buttChange(arianCockSize(),true,true,false);
-	
+
 	outputText("\n\n\"<i>Argh!  T-this is too much!</i>\"  With a groan of pleasure Arian shoots [arian eir] cum into your bowels, lubricating it enough to allow you to easily slide down onto [arian eir] shaft.");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("  [arian Eir] other shaft twiches and sprays your " + (player.tailType == Tail.NONE ? "back" : "tail") + ".");
-	
+
 	outputText("\n\nYou sigh and cluck your tongue; Arian really needs to work on [arian eir] stamina - [arian ey] loses [arian emself] to the pleasure too easily, which you gently point out to [arian em].");
-	
+
 	outputText("\n\n\"<i>S-sorry...</i>\"  Well, it can't be helped.  You'll just have to try again some other time... \"<i>No!  Wait!</i>\"  Arian grabs your hips.  \"<i>I-I can still go on!</i>\"  Really?  Because you're pretty sure you can feel [arian em] going soft right this instant...  \"<i>Y-yes... just give me a moment.</i>\"");
-	
+
 	outputText("\n\nArian looks up at you, panting; [arian eir] hands begin roaming your body, caressing your [hips], your [butt], your [chest].  For a moment, you actually feel [arian eir] bulbous shaft throb within you, but maybe [arian ey] needs a little push to make things go faster?  You smirk.");
-	
+
 	outputText("\n\nWith that, you bend over and kiss [arian em], slipping your tongue into [arian eir] mouth to wrestle with [arian eir] own long, dexterous tongue.  Withdrawing, you send a hand reaching down between [arian eir] legs, squeezing [arian eir] ass, ");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("stroking [arian eir] other cock and sliding it between your ass cheeks, ");
 	outputText("caressing the base of [arian eir] tail.  With a devious grin, you begin to gently but insistently slide your finger into [arian eir] ");
 	if(flags[kFLAGS.ARIAN_ANAL_XP] > 66) outputText("eager ");
 	outputText("ass, probing for [arian eir] prostrate...");
-	
+
 	outputText("\n\nThe reaction is almost instantaneous; Arian moans into your kiss and you feel [arian eir] lizan cock");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
 	else outputText(" practically jump back to full mast, even surprising you with Arian's eagerness.");
-	
+
 	outputText("\n\nYou grin and coyly muse to yourself that maybe Arian makes up for [arian eir] quickness at climaxing with the speed with which [arian ey] can recover.");
-	
+
 	outputText("\n\nArian bites [arian eir] lower lip nervously.  \"<i>I can't help myself if you keep touching me like that.</i>\"  [arian Ey] closes [arian eir] eyes and turns to the side, [arian eir] hands clutching your [hips] and [arian eir] toes curling behind you.  You can't help but gently pat [arian em] on [arian eir] head and tell [arian em] that [arian ey] looks really cute when [arian ey] acts like an embarrassed virgin, especially after having already cum inside you.  Arian just turns to smile nervously at you.  \"<i>I... can we... start moving now?</i>\"");
-	
+
 	outputText("\n\nYes, yes you can, you tell [arian em], and for emphasis you begin to rise and fall, ");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("sliding [arian eir] neglected prick through your ass-cheeks, ");
 	outputText("clenching your inner walls to grip and feel the excitingly unusual lumpy, bulbous texture of [arian eir] shaft inside you.  You moan and gasp, telling [arian em] that [arian ey] feels so unique, and yet [arian ey] stimulates you so wonderfully.");
-	
+
 	outputText("\n\nThe lizan mage can barely contain [arian emself] as [arian ey] tosses and turns on [arian eir] bed, gasping and moaning at your ministrations.  You lick your lips as you continue to ride [arian em], ");
 	if(player.hasVagina()) outputText("cunt dripping with arousal");
 	if(player.hasCock() && player.hasVagina()) outputText(" and ");
@@ -2106,7 +2106,7 @@ private function getButtWreckedByArian():void {
 	}
 	if (player.gender == 0) outputText("null body shiverring with pleasure")//Would look weird without Genderless text.
 	outputText(".  You're so close now, you can feel it.  You tell Arian you're going to cum, and beg [arian em] to cum with you.");
-	
+
 	outputText("\n\nAs if on cue, Arian gasps and [arian eir] shaft");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s twitch");
 	else outputText(" twitches");
@@ -2115,21 +2115,21 @@ private function getButtWreckedByArian():void {
 	outputText(", as Arian climaxes");
 	if (flags[kFLAGS.ARIAN_VAGINA] > 0) outputText(", [arian eir] own pussy clenching and drizzling juices on the matted sheets beneath the two of you.");
 	else outputText(".");
-	
+
 	outputText("\n\nWith a cry of glee, you orgasm, giving yourself over to the pleasures of the act.  Your ass clenches around the bulbous shaft intruding in your bowels, trying to wring it of all its delicious load.");
 	if(player.hasCock()) outputText("  [EachCock] spasms and shoots rope after rope of cum, painting Arian's [arian chest] white, as well as the groaning lizan's face.");
 	if(player.hasVagina()) outputText("  Your [pussy], though unattended, joins in the perverted display, leaking copious amount of fluids on top of the prone lizan.");
-	
+
 	outputText("\n\n\"<i>Ahhhhh...</i>\"  Arian sighs, going limp on [arian eir] bed.  You follow shortly, laying down on top of [arian em], embracing [arian em] as [arian ey] does the same.  \"<i>[name], you're amazing.</i>\"");
-	
+
 	outputText("\n\nWith a pleased grin, you tell [arian em] that [arian ey]'s not too shabby [arian em]self, either.  So, how did [arian ey] like being the pitcher?");
-	
+
 	//(if AnalXP < 33)
 	if(flags[kFLAGS.ARIAN_ANAL_XP] < 33) {
 		outputText("\n\n\"<i>Wow, that felt really good.  Did it feel good for you too, [name]?  I hope it did... wow,</i>\"  Arian pants.");
-		
+
 		outputText("\n\nYou smile and pat your lover on the head, assuring [arian em] that it was good for you, too.");
-		
+
 		outputText("\n\n\"<i>I'm glad,</i>\" [arian ey] replies, nuzzling you in affection.");
 	}
 	//(if AnalXP < 66)
@@ -2142,9 +2142,9 @@ private function getButtWreckedByArian():void {
 	else {
 		outputText("\n\n\"<i>That was great!  Now why don't you return the favor and use me instead?  After watching you sit on my shaft like that, I want to be fucked too.</i>\"  [arian Ey] bites [arian eir] lower lip, tail waving as best as it can underneath the two of you.");
 		outputText("\n\nYou laugh; Arian, you are such a greedy little buttslut, aren't you?  That's what you say to him.");
-		
+
 		outputText("\n\nGrinning nervously, [arian ey] says, \"<i>I can't help it.  It feels really good.  Besides, you made me that way, so take some responsibility.</i>\"  Then [arian ey] swallows.  \"<i>Not that I mean to imply I didn't like it... or anything of the sort.</i>\"");
-		
+
 		outputText("\n\nAnd what if you want to be the catcher sometimes, huh?  [arian Ey]'s got such a wonderful cock, how can [arian ey] deny you the pleasure of taking it up the ass?  [arian Ey]'s so greedy, you tell [arian em], playfully tapping [arian em] on the nose.  [arian Ey] whimpers.  \"<i>Okay, I like being the pitcher too, but can you do me now?  Please?</i>\"  [arian Ey] asks, eagerly wiggling [arian eir] hips.");
 		outputText("\n\nYou contemplate it...");
 		//(if PC has a cock){
@@ -2181,12 +2181,12 @@ private function suckAriansDick():void {
 		outputText(images.showImage("arianmale-home-suckariandick"));
 	outputText("You make a show of lewdly licking your lips and ask Arian if [arian ey]'d be willing to let you have a little taste of lizan essence...?");
 	outputText("\n\n\"<i>Are you sure?  I could do something for you if you feel like,</i>\" Arian offers.");
-	
+
 	outputText("\n\nYou shake your head insistently; you want to do something for [arian em] this time, you tell your reptilian lover.");
 	outputText("\n\n\"<i>Ok... if that's what you really want to do.  So... what should I do?</i>\" the lizan mage asks, fidgeting in barely contained excitement, tapping [arian eir] fingers in anticipation.");
-	
+
 	outputText("\n\nJust get on the bed, you instruct [arian em]; you're certain you can take care of the rest.");
-	
+
 	outputText("\n\n\"<i>All right,</i>\" Arian replies nervously, [arian eir] ");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 3) {
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("exposed cocks hardening to full mast");
@@ -2202,53 +2202,53 @@ private function suckAriansDick():void {
 	outputText("\n\nYou approach [arian em] and position yourself before [arian em], contemplating how to begin.  You reach out with one hand and start to stroke [arian eir] ");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("uppermost ");
 	outputText("cock, marveling at the strange textures of its bumpy, knobbly, bulbous surface.  It feels so strange to you, and you continue to stroke it eagerly.");
-	
+
 	outputText("\n\nArian can only moan at your ministrations, eagerly humping your hand, desperate for your touch.  \"<i>Oh, my... it... it feels so good when it's someone else's hand...</i>\" [arian Eir] ");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("twin shafts tremble and throb against your hand; pre quickly forming on the tips only to slowly slide down the bulbous surface of Arian's lizan pricks");
 	else outputText("shaft trembles and throbs against your hand; pre quickly forming on the tip only to slowly slide down the bulbous surface of Arian's lizan prick");
 	outputText(".  You continue to slide your hand along the increasingly slick surface, playfully asking if your hand really feels that good to [arian em]?");
-	
+
 	outputText("\n\n\"<i>Yesssss... Oh!  If you keep this up I won't be able to last long.</i>\"  Arian pants, [arian eir] three-toed feet curling with each stroke, hands gripping the sheets tightly.");
-	
+
 	outputText("\n\nYou smile at [arian em] with an innocent expression quite out of place for what you're doing, and then lean in to give [arian eir] cock");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
 	outputText(" a long, loving, slurpy lick.  The taste is surprising; a sort of sugary-tinted spice, not the usual salt of another creature.  It's actually quite pleasant, and you find yourself running your tongue up and down [arian eir] prick as if it were some kind of candied stick, eagerly sucking and slobbering as you coax more of [arian eir] yummy goo from its strangely-shaped tip.");
-	
+
 	outputText("\n\nArian contorts with each loving lick, grunting and groaning in pleasure.  \"<i>[name], I'm going to cum!</i>\"  [arian Ey] warns you, and judging by the way [arian eir] shaft is throbbing [arian ey] looks just about ready.");
-	
+
 	outputText("\n\nIn other circumstances, you'd probably tease [arian em] about having no staying power, but, seeing how the wind's blowing, you instead put your mouth to better use and envelop [arian eir] cock, suckling and slurping like a baby on a nipple as more of that strange spicy-sweet cum trickles steadily into your mouth.");
-	
+
 	outputText("\n\nUnable to hold back any longer, Arian's hands pull on the sheets as [arian eir] ");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("twin cocks throb");
 	else outputText("cock throbs");
 	outputText(" one more time and erupts into your waiting mouth");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText(" and chin");
 	outputText(".  [arian Eir] legs close around your back, effectively keeping you from moving too far away as [arian ey] finishes giving you all of [arian eir] load.");
-	
+
 	outputText("\n\nYou simply go with what [arian ey] wants and focus on guzzling down every last drop, continuing to lick and tease even as you swallow mouthful after creamy mouthful");
 	if (flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText(", oblivious to the second cock spewing cum all over your [chest] in your eagerness");
 	outputText(".  ");
 	outputText("After [arian ey] finally finishes, you continue to lick and suckle for a few minutes longer, making sure you've lapped up every last drop.  Then and then alone do you lift your head, flirtatiously licking your lips to tease the now-spent lizan.");
-	
+
 	outputText("\n\nArian watches you slack jawed and panting.  \"<i>That... that was great!</i>\"  [arian ey] exclaims happily.  \"<i>I hope I didn't taste too bad.  I mean, I heard there is food that can make it taste better, but... well....</i>\" [arian Ey] smiles nervously.");
-	
+
 	outputText("\n\nYou confess that, truthfully, the taste was unusual, but hardly unpleasant.  So, did your little lizard like the way you licked [arian eir] lolly to reach the creamy center?  You jest.");
-	
+
 	outputText("\n\n\"<i>Yes, I liked it very much!  Though I hope you'll let me return the favor... somehow,</i>\"  [arian Ey] says, releasing you from between [arian eir] legs, while [arian eir] tail lazily curls to gently massage your neck in a sign of affection.");
-	
+
 	//[NoCock:
 	if(!player.hasCock()) outputText("\n\nYou tell [arian ey] you'll think of some way [arian ey] can return the favor,");
 	else outputText("\n\nWell, you happen to have a creamy lolly of your own that [arian ey] could lick, you tease,");
 	outputText(" rolling your neck in pleasure as [arian ey] rubs it with [arian eir] reptilian tail.");
-	
+
 	outputText("\n\nArian bites [arian eir] lips and twirls [arian eir] fingers.  \"<i>Well, I hope I can do something... anything... for you soon.  I really enjoy spending time with you, [name].</i>\" [arian Ey] smiles at you.");
-	
+
 	outputText("\n\nSmiling wryly, you jokingly tell the lizan mage that the only reason [arian ey] happens to enjoy your company is because of all the sex [arian ey]'s getting.  Arian gasps and immediately blurts out, \"<i>No! Of course not!  I would love to be in your company even if we didn't do anything!</i>\"  [arian Ey] gasps once more and shamefully hides [arian eir] face when [arian ey] realizes [arian ey]'s sporting another erection.  \"<i>S-sorry!  I can't help it!</i>\" [arian ey] fumbles, trying to cover [arian emself].");
 
 	outputText("\n\nYou just smile and pat [arian em] on the cheek, telling [arian em] that [arian ey]'s adorable when [arian ey] blushes.  You give [arian eir] newly-stiffened cock a good firm stroke");
 	if(flags[kFLAGS.ARIAN_VAGINA] > 0) outputText(" and tickle [arian eir] cunt with a finger");
 	outputText(" for emphasis, kiss [arian em] gently on the tip of [arian eir] nose, and then get your clothes together, planning on getting dressed and heading back out again.");
-	
+
 	outputText("\n\n\"<i>Uuuh... see you soon?</i>\"");
 	outputText("\n\nYou throw [arian em] a smirk over your shoulder, shake your [ass] for [arian eir] benefit, and head on out.");
 	player.sexReward("cum", "Lips");
@@ -2291,9 +2291,9 @@ private function getFuckedScene(dp:Boolean = false):void {
 	if(dp) outputText("twin cocks");
 	else outputText("cock");
 	outputText(" a bit of a workout?");
-	
+
 	outputText("\n\nArian swallows audibly.  \"<i>Are you suggesting that we... and that I... put it in?</i>\"  Grinning, you nod in affirmation, telling [arian em] that there's no need to be shy about it... at least not since your relationship escalated to the current level.");
-	
+
 	outputText("\n\n\"<i>Ok... how do you want to do this?</i>\"  You motion for the lizan to get up.  Arian eagerly complies and gets off [arian eir] bed.  You teasingly take [arian eir] place on the bed, looking up at [arian em] as you ");
 	if(player.isBiped()) outputText("spread your [legs] and ");
 	outputText("expose your [vagina] to [arian eir] viewing pleasure.  The reaction is almost instantaneous; Arian's ");
@@ -2305,11 +2305,11 @@ private function getFuckedScene(dp:Boolean = false):void {
 	if(dp) outputText("their");
 	else outputText("its");
 	outputText(" bulbous, throbbing glory.");
-	
+
 	outputText("\n\nWith a smile, you tell [arian em] that despite [arian eir] initial bout of shyness, [arian eir] body seems to know exactly what to do.  Arian simply laughs in nervousness.  You wait for a short while, until finally you tell [arian em] that [arian ey] should position [arian emself] at your opening");
 	if(dp) outputText("s");
 	outputText(" and get ready to thrust in; otherwise neither of you are going to be feeling good any time soon.");
-	
+
 	outputText("\n\nSnapping to [arian eir] senses, Arian quickly ");
 	outputText("kneels between your [legs]");
 	outputText(", aligning the tip of ");
@@ -2322,61 +2322,61 @@ private function getFuckedScene(dp:Boolean = false):void {
 	outputText(".  [arian Ey] looks at you, waiting for you to confirm that [arian ey] should indeed get going.  You smile and nod");
 	if(player.hasLongTail()) outputText(", looping your tail around [arian eir] waist");
 	outputText(".");
-	
+
 	outputText("\n\nArian smiles right back at you and finally begins easing [arian emself] inside you.");
-	
+
 	//(if ArianDblCock == 1) //DP PC
 	if(dp) {
 		outputText("\n\nHesitantly, the lizan tries to fit both of [arian eir] cocks into your [vagina] and [asshole] at the same time.  You sigh at the intrusion and look at [arian eir] face; Arian has a look of absolute bliss on [arian eir], you can even see that the lizan is beginning to drool a bit.  The texture of Arian's twin cocks might be very similar, but they feel entirely different on both your ass and pussy.");
-		
+
 		outputText("\n\nThe bulbous orbs dotting the length work somewhat like beads, as they work over your resistance, each time one of them presses in, you moan and brace yourself for the next, larger bulb.  Gently but insistently Arian presses forward, quite happy to try and take both of your holes at the same time.  \"<i>This isn't hurting you, is it?</i>\" [arian ey] asks, still understandably nervous about your relationship.");
-		
+
 		outputText("\n\nYou shake your head and tell [arian em] that you're fine.  [arian Eir] cocks just feel... different... from what you're used to seeing around; you remark that they seem built to rub against your most sensitive spots inside both your ass and your vagina.  Still, if [arian ey] doesn't hurry up and fill you up, you might have to take matters into your own hands.  It's not nice to keep a girl waiting.");
 
 		outputText("\n\nArian fumbles and begins penetrating you with more gusto.  \"<i>S-sorry, I just don't want to hurt you...</i>\"  You sigh and tell [arian em] that you aren't made of glass.  [arian Ey] can be a little rough, though if [arian ey] overdoes it you'll have to stop [arian em].  Still, you can take something like this!");
-		
+
 		outputText("\n\nYou take hold of [arian eir] arms and pull [arian em] up towards you, making the lizan lose [arian eir] balance and fully penetrate you.");
 		//(Enlargement/Virginity loss messages)
 		player.cuntChange(arianCockSize(),true,true,false);
 		player.buttChange(arianCockSize(),true,true,false);
-		
+
 		outputText("\n\nThe lizan moans in shock at the deed, as if [arian ey] still can't believe this is actually happening.  [arian Eir] fingers clutch you tightly, but [arian ey] doesn't make any further motions - more likely [arian ey] can't bring himself to thrust just yet, still full of that nervous virgin behavior.");
 	}
 	else
 	{ //Only one pole for that hole.
 		outputText("\n\nArian nervously begins to thrust [arian eir] strange, bumpy cock into your cunt, timidly inserting an inch or two and then withdrawing, as if unable to bring [arian em]self to fully penetrate you.");
-		
+
 		outputText("\n\nYou moan at the initial intrusion, and sigh as [arian ey] pulls out.  Impatient and bothered by [arian eir] impromptu teasing, you ask what's gotten into [arian em] to make [arian em] withdraw?  You're already more than ready for this.");
-		
+
 		outputText("\n\n\"<i>I-I'm sorry, it's just....  Well, I'm not used to this, you know.</i>\"  Arian's eyes are downcast, and you're certain you can see a faint tinge of red around [arian eir] face, [arian eir] albinism allowing [arian em] to blush in a way you're not sure a normal lizan could.  \"<i>It... it's so overwhelming to finally be with a woman, never mind a woman like you.</i>\"");
-		
+
 		outputText("\n\nSighing at the lizan's inexperience, you gently take [arian eir] hands in yours and guide them around you, telling [arian em] to hug you");
 		if(player.hasLongTail()) outputText(", further encouraging [arian em] to do so, by looping your tail around [arian eir] waist");
 		outputText(".  The lizan doesn't need much encouragement to comply, easily snuggling against you, breast to breast, and sighing softly.  \"<i>I'm sorry.  Sometimes I wonder why you bother doing something like this, with someone like me,</i>\" [arian ey] says, a hint of sadness in [arian eir] voice.");
-		
+
 		outputText("\n\nYou reply that you bother because Arian is cute and you happen to like [arian em].  [arian Ey] should forget about [arian eir] insecurities and give [arian emself] some credit.  Still, you are horny, and judging by the prodding you feel on your [leg], so is [arian ey].  You don't bother saying anything more, gently reaching down to align [arian eir] shaft with your [vagina] and then pinch on the base of [arian eir] tail.");
-		
+
 		outputText("\n\nArian lets out a tiny squeak of shock at the pinching sensation, which instinctively makes [arian em] thrust [arian emself] forward, embedding [arian emself] in you to the hilt.");
 		//(Enlargement/Virginity loss messages)
 		player.cuntChange(arianCockSize(),true,true,false);
-		
+
 		outputText("\n\nYou gasp in pleasure at the sudden intrusion; then hug your lizan lover closer, stroking [arian eir] back.  You ask if that was so difficult?");
-		
+
 		outputText("\n\n\"<i>N-not difficult, no.  But hard, all the same,</i>\" Arian replies.  Did [arian ey] just make a joke?");
 	}
-	
+
 	outputText("\n\nSmiling, you gently tap [arian em] on the nose and tell [arian em] that unless [arian ey] expects you to do all the work, the two of you won't get anything done if [arian ey] just lets [arian eir] shaft");
 	if(dp) outputText("s");
 	outputText(" sit inside you.");
-	
+
 	outputText("\n\nThe lizan promptly makes [arian em]self busy, awkwardly thrusting in and out, pumping in a clumsy attempt to pleasure you both.  While you appreciate [arian eir] enthusiasm, just randomly thrusting inside you won't give you the pleasure you so crave.  You tell Arian to stop for a moment.");
-	
+
 	outputText("\n\nArian does so, blinking curiously at you.  \"<i>Did I hurt you?  Am I doing something wrong?  I'm sorry!</i>\" the lizan blurts you.  Laughing, you tell [arian em] to calm down.  [arian Ey] didn't do anything wrong, and [arian ey] certainly didn't hurt you.  \"<i>So, what's wrong then?</i>\" Arian asks.  [arian Ey] then blinks in realisation and pouts.  \"<i>I'm not doing that badly, am I?</i>\"  Rubbing [arian eir] back, you tell [arian em] that just thrusting [arian em]self inside you without any technique won't make you feel good.");
-	
+
 	outputText("\n\n\"<i>I'm sorry,</i>\" [arian ey] sighs.  It's ok, you tell [arian em], you'll just have to guide [arian em] through the process.  Grasping on the base of [arian eir] tail, you begin guiding the inexperienced lizan, using [arian eir] tail like a control stick.");
-	
+
 	outputText("\n\nArian moans and shivers at the pleasure, but it doesn't stop [arian em] from catching on; indeed, [arian ey] proves [arian em]self a quick study and starts to preempt your ‘instructions'.  \"<i>I-I can't tell you how incredible this is, [name].  You're so warm and wet inside,</i>\" [arian ey] murmurs to you, too caught up in the sensations of sex to really flatter you.");
-	
+
 	outputText("\n\nYou moan alongside your lizan lover, replying that [arian ey] feels just as good.  [arian Eir] ");
 	if(dp) outputText("twin bulbous shafts feel");
 	else outputText("bulbous shaft feels");
@@ -2386,21 +2386,21 @@ private function getFuckedScene(dp:Boolean = false):void {
 	outputText(" bumps massage your entrance");
 	if(dp) outputText("s");
 	outputText(" unlike anything else.  You praise the lizan on being a quick study, letting go of [arian eir] tail and grabbing onto [arian eir] scaly shoulders instead, giving [arian em] a few more directions so [arian ey] can catch your most sensitive spots.");
-	
+
 	outputText("\n\nArian suddenly clenches and gasps, moaning several times and arching [arian eir] back before [arian ey] can't hold it back anymore and climaxes inside of you, filling your [cunt] ");
 	if(dp) outputText("and [ass] ");
 	outputText("with [arian eir] sticky wet seed.");
-	
+
 	outputText("\n\nYou moan as [arian ey] fills you with [arian eir] lizan seed, then immediately sigh in disappointment as [arian ey] slumps down on top of you, nuzzling against you tenderly.  \"<i>That was incredible.  Hey, what's wrong?  Why didn't you cum?</i>\" Arian asks, curious yet sated.  Well, you just didn't have time to, but it's okay.  You'll find some way to relieve yourself, and it did feel good for the time it lasted.  You pat [arian eir] head, smiling at the lizan, despite being annoyed at not being able to climax.");
-	
+
 	outputText("\n\n\"<i>You mean, I didn't...?  No, no that's not acceptable!</i>\"  Arian growls.  To your surprise, you suddenly feel [arian eir] flaccid member");
 	if(dp) outputText("s");
 	outputText(" swelling inside you, the lizan grabbing your shoulders and starting to thrust [arian em]self back into you once more.");
-	
+
 	outputText("\n\nYou groan in as much surprise as pleasure, bracing yourself against Arian as [arian ey] begins fucking you with as much enthusiasm as when you two started.  You are genuinely impressed.  This is not something a newcomer to sex would be able to pull off.  You decide to thank and congratulate the lizan for [arian eir] dedication with a kiss.");
-	
+
 	outputText("\n\nArian promptly redoubles [arian eir] efforts, while trying to kiss you back in appreciation of the gesture.  You lose yourself in the pleasure and closeness of the act, fucking and kissing.  Slowly you feel a familiar pressure build in your loins, and you know it won't be long before you finally achieve your so, so desired, orgasm.");
-	
+
 	outputText("\n\nArian [arian emself] lets out a cry of relief; having finally achieved [arian eir] goal in helping you orgasm means [arian ey] can give in to the sensations [arian ey] is being overwhelmed by, spraying your ");
 	if(dp) outputText("cavities");
 	else outputText("cavity");
@@ -2412,13 +2412,13 @@ private function getFuckedScene(dp:Boolean = false):void {
 	outputText(" best to milk the poor lizan of all [arian ey] is worth, until finally with one last spasm, you slump down and release the lizan shaft");
 	if(dp) outputText("s");
 	outputText(" deeply embedded inside you, some of your mixed juices running down to mat Arian's bed.");
-	
+
 	outputText("\n\n[arian Ey] lays there, panting softly from the exertion, then somehow finds the strength to give you a weak yet cheeky grin.  \"<i>So, how was I this time?</i>\" [arian ey] asks.  Panting, you tell [arian em] that [arian ey] was great.  You didn't expect [arian em] to be able to get a second erection so quickly, especially after having just cum.  \"<i>Well, I've learned a few tricks at the academy from some of the more, uh, restricted tomes, shall we say?  Not enough that I can do anything major, or even worth teaching, but enough for... something like this....</i>\"");
-	
+
 	outputText("\n\nGrinning at [arian em], you question just why would [arian ey] have picked up this one particular spell?  Arian does that weird pseudo-blush of [arian eirs] again.  \"<i>A fellow can dream of finding someone special someday, can't they?</i>\"  That's all [arian ey]'ll say on the subject, despite your coaxing.");
-	
+
 	outputText("\n\nYou decide to drop the subject for the moment and tell [arian em] that as enjoyable as it was to spend time with [arian em], you must return to your duties now.  Arian simply nods, wearing [arian eir] best stoic expression.  \"<i>I understand... but, please, come back when you can, all right?</i>\"  You smile and tell [arian em] you will, caressing [arian eir] scaly cheek, then with a cheeky grin, let [arian em] know that next time you expect at least four more performances from [arian em].  Arian's eyes bulge at your suggestion, half in fear and half in lust.  \"<i>I... I can't possibly do that!  I mean, I don't have the energy,</i>\"  [arian Ey] declares, swallowing audibly and averting [arian eir] eyes.");
-	
+
 	outputText("\n\nGrinning, you pull [arian em] into a final kiss, telling [arian em] this is just something for [arian em] to think about.  Having said that, you quickly redress and excuse yourself, leaving one flustered lizan behind to rest.");
 	player.sexReward("cum","Vaginal");
 	if (dp) player.sexReward("cum","Anal");
@@ -2437,67 +2437,67 @@ private function doublePenetrateArian():void {
 	var x:int = player.cockThatFits(arianCapacity);
 	var y:int = player.cockThatFits2(arianCapacity);
 	outputText("You look over your feminine lizard lover, and feel your [cocks] starting to stir in your [armor].  Since you have enough tools for the job, and Arian has enough holes, you ask if Arian would be willing to let you fuck [Arian em] in both [Arian eir] ass and pussy at the same time?");
-	
+
 	outputText("\n\nArian bites [arian eir] lower lip, fidgeting a bit at your suggestion.  \"<i>Sure.  I mean... that's the way sex is supposed to be with lizan females, and I do have the parts now.</i>\"");
-	
+
 	outputText("\n\nArian rolls around, laying face down on [arian eir] bed, [arian eir] rump held high to allow you easy access to both [arian eir] ");
 	if(flags[kFLAGS.ARIAN_ANAL_XP] <= 33) outputText("tight");
 	else if(flags[kFLAGS.ARIAN_ANAL_XP] <= 66) outputText("loose");
 	else outputText("throbbing");
 	outputText(" ass and dripping wet vagina; a pair of clawed hands reach behind to spread [arian eir] butt open for you.  \"<i>Okay, I'm ready.</i>\"  Arian says, looking behind at you.");
-	
+
 	outputText("\n\nYou sidle gently into the bed behind [arian em] and gently squeeze [arian eir] full, round cheeks, rubbing them before moving your hand into [arian eir] crack in an effort to massage both anus and pussy at the same time.  You roll the palm of your hand against [arian eir] back passage and stroke [arian eir] softly scaled vulva lips with your fingers, asking how that feels.  \"<i>G-good,</i>\" Arian replies, shuddering.");
-	
+
 	//(if ArianAnalXP < 33)
 	if(flags[kFLAGS.ARIAN_ANAL_XP] < 33) {
 		outputText("\n\nYou slide your finger inside of Arian's pussy, getting it nice and slick with [arian eir] juices, and then remove your hand; lining the finger up with [arian eir] ass, you start pressing insistently against [arian eir] back hole; it takes some effort, but finally [arian eir] back passage yields and Arian moans as your finger presses past [arian eir] sphincter and into [arian eir] warm innards.  You smile and tell Arian [arian ey]'s really tight back here.");
-		
+
 		outputText("\n\n\"<i>Hmm... we don't get to use my ass much, so of course it'll be tight.  Just try not to be too rough, please?  It kinda hurts.</i>\"");
-		
+
 		outputText("\n\nYou assure [arian em] that you'll be gentle; and with [arian eir] pussy getting some as well, it should be easier for [arian em] to adjust.  That said, you carefully align your shafts and start to press them home.  It takes some effort to push inside [arian eir] ass, but [arian eir] pussy readily accepts you into its warm, wet embrace.");
-		
+
 		outputText("\n\n\"<i>Ooohhh!</i>\" Arian's initial cry of pain turns into a deep moan of pleasure as you finally make your way inside.  You stop to give [arian em] some time to adjust.  \"<i>I feel so stuffed... it hurts, but feels good at the same time.  Hhmmm... keep moving, please.</i>\"  You do as [arian ey] asks, and slowly push yourself to the hilt.");
 	}
 	//(else if ArianAnalXP < 66)
 	else if(flags[kFLAGS.ARIAN_ANAL_XP] < 66) {
 		outputText("\n\nYou know Arian's no stranger to anal sex, but you still figure it's polite to lube your finger up to some extent first.  Your fingers stroke and caress, sliding in and out of [arian eir] moist depths, and you remove your hand to begin probing into [arian eir] tailhole.  The well-trained orifice happily accepts you, posing little resistance as you begin sliding your femcum-slick digits inside.");
-		
+
 		outputText("\n\n\"<i>Aah, that feels nice.  I feel like such a girl, being treated like that...</i>\"");
-		
+
 		outputText("\n\nWell, of course, [arian ey] is a girl, you grin.  Why shouldn't you treat [arian em] like this, especially if it makes [arian em] happy?  \"<i>W-well, I'm not really a girl.  I mean... not originally, but it does make me happy.  Why don't you stick it in?</i>\"  [arian Ey] smiles nervously back at you.");
-		
+
 		outputText("\n\nWell, if [arian ey]'s really so interested.  You quickly align yourself and start to press forward, gently inserting yourself into the two eager holes your lover has.  \"<i>Yesssss... don't stop until I'm fully stuffed,</i>\" Arian says, [arian eir] tail wagging lazily above.  With a chuckle, you tap it away so you can finish pressing [arian em], all the way to the hilt.");
 	}
 	else {
 		outputText("\n\nFor politeness' sake more than anything, you painstakingly rub and massage Arian's dripping wet cunny with your fingers, getting them nice and lubed before you start poking at the greedy little hole under Arian's tail.  You don't meet any resistance at all; indeed, it seems to deliberately wrinkle itself in order to slurp your fingers inside, the muscles squeezing in an effort to hold you in there.  You smile to yourself, telling Arian that [arian eir] little rosebud is indeed a naughty little thing, and you didn't expect any less.");
-		
+
 		outputText("\n\nArian shudders in pleasure, pushing back to allow [arian eir] ass to suck more of your finger in.  \"<i>Hmm... it's like that thanks to you.  Not that I'm complaining.  I love it when you take me from behind.</i>\"");
-		
+
 		outputText("\n\nDoes [arian ey] really, now, you ask?  Are both of [arian eir] greedy little holes anxious for a nice sausage to stuff themselves with, hmm?  \"<i>Yesss.... I need you.  Please... make me feel good... like a girl,</i>\" Arian begs.");
-		
+
 		outputText("\n\nWell, if that's what [arian ey] wants, who are you to deny [arian em]?  You promptly position yourself and begin slowly sliding yourself home.");
-		
+
 		outputText("\n\n\"<i>Hmm... come on, [name].  You know you can go faster than that, don't tease me!</i>\"  Arian protests, pushing back at you, while [arian eir] tail wraps itself around your waist to pull you inside.");
-		
+
 		outputText("\n\nWell, both [arian eir] holes need a little tenderness, you point out.  Still, you hasten your pace, pushing inside [arian eir] hungry holes until you've hilted yourself.");
 	}
-	
+
 	outputText("\n\nYou moan and squeeze Arian's scaly yet luscious asscheeks, asking how [arian ey] enjoys [arian eir] double-serve of stuffing?  Rolling [arian eir] hips against your own, [arian ey] replies, \"<i>Let's just say that I'm beginning to get why we lizans are built the way we are.  Take me now!</i>\" [arian ey] demands.");
-	
+
 	outputText("\n\nYou deliver a slap to [arian eir] perky little butt, the crack of flesh on flesh ringing out as you then tell [arian em] not to get greedy; there's no race to be won here.  \"<i>Ow!  B-but... I want you!</i>\"  [arian Ey] pushes back at you insistently.  And you want [arian em] as well, you tell [arian em], but still, no need to be so bossy.  Arian pouts.  \"<i>Sorry...</i>\"");
-	
+
 	outputText("\n\nThat's better, you say.  With that, you start to thrust yourself into [arian eir] two holes.  Penetrating both of Arian's holes is a unique feeling; [arian eir] ass hugs your " + cockDescript(y) + " tightly, trying to prevent you from moving as it does its best to keep you hilted deeply within; while [arian eir] pussy, so slick and moist, massages your shaft expertly. For a moment you wonder if you even have to move.");
-	
+
 	outputText("\n\n\"<i>Oooh, [name]... you have no idea how wonderful this feels.  I feel so full... so good... so wanted... I love you!  Fertilize my eggs!</i>\"  You groan and smirk, commenting that maybe Arian's getting a bit too caught up in this, unless [arian ey]'s telling you that this ex-boy really wants to be a mother?  \"<i>Me... a mother... d-don't stop!  I want you as deep inside me as possible!</i>\"  You moan as [arian eir] two holes ripple around your intruding shafts, striving to suck you deeper and deeper inside of [arian em].  You allow [arian em] to lead, but warn [arian em] that you just might end up making [arian em] a mother whether [arian ey] wants to be or not if [arian ey] doesn't temper [arian eir] enthusiasm.");
-	
+
 	outputText("\n\n\"<i>What do you think I'm trying to do!?  Now get in here and paint my womb white!</i>\" Arian snaps, bracing [arian em]self on [arian eir] bed and allowing [arian eir] ass and pussy both to suck you in with surprising force.  As soon as you're hilted within both holes, [arian eir] ass clamps shut on your " + cockDescript(y) + ", while [arian eir] pussy's contractions begin truly milking you for all you're worth.  Stuck as you are, you have no option but to sit back and enjoy [arian eir] contractions as you feel yourself nearing the edge of an inevitable orgasm.");
-	
+
 	outputText("\n\nYou still can't quite drown your surprise at how this is making [arian em] act, but if that's what [arian ey] wants.  Besides, with the vice-like grip [arian eir] holes have on your cocks, it's not as if you have a choice, right?  You thrust two, three more times with all the ferocity you can muster, grab [arian eir] ass and holler as your climax finally erupts from your twin dicks.");
-	
+
 	//(Low Cum Amount)
 	if(player.cumQ() <= 250) {
 		outputText("\n\nYour [cocks] explode inside Arian's eager holes, giving them the liquid warmth they so crave.  The massage that your two cocks are receiving only enhance the intense feeling, and you find yourself cumming more than usual.  They don't stop massaging you for more, even as you stop unloading.");
-		
+
 		outputText("\n\n\"<i>More, I need more for my eggs!</i>\" Arian demands, yet you are truly spent...");
 	}
 	//(Medium Cum Amount)
@@ -2507,41 +2507,41 @@ private function doublePenetrateArian():void {
 		else outputText("your [balls]");
 
 		outputText(" of their load; a load Arian is not only pleased to accept, but also eager to relieve you of every single stray drop off.  The tightness of [arian eir] ass, pressing down on your " + cockDescript(y) + ", [arian eir] pussy milking on your " + cockDescript(x) + ".  How could anyone refuse such an invitation?  You let yourself go, stuffing the eager lizan with more cum than you thought yourself capable of producing.");
-		
+
 		outputText("\n\n\"<i>M-more,</i>\" Arian pleads, even as [arian eir] belly starts to distend.");
 	}
 	//(High Cum Amount)
 	else {
 		outputText("\n\nYou cum with such force, that if Arian's ass wasn't clamping down on your " + cockDescript(y) + " so tightly, you'd be sure [arian ey] was going to get pushed off.  \"<i>So much cum!  Yesssss!</i>\" Arian moans, as you quickly give [arian eir] usually lithe belly a very blatant bump.  Even though your prodigious amount of cum is enough to completely fill the eager lizan-girl, [arian eir] ass and pussy work overtime to ensure you're completely spent; and you have no desire to resist.");
-		
+
 		outputText("\n\nBy the time you're finished, Arian's belly is positively bulging.  \"<i>Ahhh... eggs... cum... yes...</i>\" [arian ey] states in a stupor.");
 	}
 	outputText("\n\nArian's ass goes slack around your " + cockDescript(y) + ", and [arian ey] slowly slides off your shaft to plop on [arian eir] bed; eyes closed in bliss, as [arian ey] takes a short nap.");
-	
+
 	//(if ArianDblPenChat == 0)
 	if(flags[kFLAGS.ARIAN_DOUBLE_PENETRATION_CHAT] == 0) {
 		outputText("\n\nBreathing a sigh of relief, you gently pat Arian on the ass and comment that you didn't expect [arian em] to be so eager to lay a batch of fertilized eggs, and you certainly didn't expect [arian em] to be so... bossy.");
-		
+
 		outputText("\n\nArian's eyes snap open and [arian ey] quickly rolls around to look you in the eyes.  \"<i>Oh my!  Please, forgive me, [name].  I swear I don't know what came over me.  It was... sorry!</i>\"  [arian Ey] bows [arian eir] head down in shame.");
-		
+
 		outputText("\n\nYou just laugh.  So, it looks like [arian ey] wasn't really in control, huh?  Well, you should have figured [arian ey]'d have problems with it; this is a situation [arian ey] was never really supposed to be in, after all.");
-		
+
 		outputText("\n\n\"<i>I'm really sorry...</i>\"");
-		
+
 		outputText("\n\nYou tell [arian em] that [arian ey] doesn't need to apologise, but you do need to know; are you going to be a father now?  Is [arian ey] really pregnant as a result of the sex you just had with [arian em]?");
-		
+
 		outputText("\n\nArian shakes [arian eir] head.  \"<i>Not really.  I didn't have a clutch of eggs for you to fertilize, so the answer is no,</i>\" [arian ey] says, with a slight tinge of disappointment.");
-		
+
 		outputText("\n\nYou ask why [arian ey] sounds so disappointed; [arian ey] lived [arian eir] life as a male before [arian ey] met you - does [arian ey] really want to embrace womanhood so thoroughly as to lay a clutch of eggs?");
-		
+
 		outputText("\n\nArian covers [arian eir] face and shakes [arian eir] body in a way that you can only describe as... girly.  \"<i>Sorry, I have all these urges, and... well... I wouldn't be opposed to laying a clutch fathered by you, to be honest.</i>\"");
-		
+
 		outputText("\n\nYou're not sure what to say about that, so you simply ask if [arian ey] enjoyed herself.");
-		
+
 		outputText("\n\n\"<i>Very much!</i>\"  Arian grins happily.  You smile and pat [arian em] on the head, telling [arian em] that's good to hear; maybe you should do this again sometime?");
-		
+
 		outputText("\n\n\"<i>I'd like it if we did.</i>\"");
-		
+
 		outputText("\n\nYou tell [arian em] you'll remember that, then politely redress and make your way out of [arian eir] ");
 		if(!arianFollower()) outputText("bedchambers");
 		else outputText("tent");
@@ -2549,11 +2549,11 @@ private function doublePenetrateArian():void {
 	}
 	else {
 		outputText("\n\nBreathing a sigh of relief, you gently pat Arian on the ass and comment that it's always a surprise how [arian ey] acts bossy when you're having sex like that.");
-		
+
 		outputText("\n\nArian lazily opens [arian eir] eyes and rolls around to face you, rubbing [arian eir] belly.  \"<i>Hmm, I don't know why I act like that.  I just can't control it.</i>\"");
-		
+
 		outputText("\n\nYou tell [arian em] it's actually funny to see [arian em] change like that, since normally [arian ey] would never demand anything of you.  You would never have guessed [arian ey] had that... bossy side to [arian em].  Arian bites [arian eir] lower lip.  \"<i>Sorry about that by the way.</i>\"");
-		
+
 		outputText("\n\nYou shake your head, telling [arian em] it's no trouble then gently pat [arian em] on [arian eir] head and re-dress, excusing yourself out of [arian eir] ");
 		if(!arianFollower()) outputText("bedchambers");
 		else outputText("tent");
@@ -2576,9 +2576,9 @@ private function arianDocking():void {
 	else
 		outputText(images.showImage("arianmale-home-docking"));
 	outputText("You set your eyes on Arian's genital slit, and then smile at [arian em].  You ask how [arian ey]'d feel about ‘hiding' your cock, rather than [arian eirs], inside [arian eir] slit?");
-	
+
 	outputText("\n\nArian shudders a bit.  \"<i>That... would feel kinda weird, I think, but it's not unheard of among certain lizan couples.  If you want to try that, I'm okay with it.</i>\"");
-	
+
 	outputText("\n\nYou tell [arian em] that, yes, you want to try it - you're sorry, but it just sounds so kinky; and besides that, ");
 	//(if ArianDblCock == 0)
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] == 0) {
@@ -2587,13 +2587,13 @@ private function arianDocking():void {
 	else {
 		outputText("[arian ey]'s already hiding two in there... an extra cock won't make such a huge difference, would it?");
 	}
-	
+
 	outputText("\n\n\"<i>I suppose you're right.  Okay then, let's try.</i>\"  Arian lays on [arian eir] back, spreading [arian eir] legs to give you access to [arian eir] genital slit, gently touching the soft folds that hide [arian eir] ");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("pair of ");
 	outputText("pecker");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
 	outputText(" from your prying eyes.");
-	
+
 	outputText("\n\nYou gently push away [arian eir] hands, running your fingers over the strange, almost woman-like folds, rubbing against the soft, smooth scales that cover [arian em] there.  You gently massage [arian em], making [arian em] groan softly at the stimulation, before working up the courage to begin gently probing inside.  It's wet and slick, the muscles squeezing your fingers tightly, and you don't have too far to go before you can feel yourself touching the bulbous, unmistakable shape");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
 	outputText(" of Arian's dick");
@@ -2601,29 +2601,29 @@ private function arianDocking():void {
 	outputText(".  You brush your fingers against the tip");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
 	outputText(", seeing what kind of reaction that will elicit from your scaly lover.");
-	
+
 	outputText("\n\nArian groans.  \"<i>Hmm, if you keep doing that, I won't be able to keep it inside for you.</i>\"");
-	
+
 	outputText("\n\nYou tell [arian em] that would be a crying shame, and gently remove your fingers.  Arian whimpers in disappointment.  \"<i>Awww, I was fine with having a handjob instead.</i>\"  [arian Ey] smiles mischievously at you.");
-	
+
 	outputText("\n\nOh no, you tell [arian em]; you started out with something more unusual in mind, and you're going to finish it.  Quickly giving your own [cock smallest] a few strokes to help coax it into the right mindset, you aim it into Arian's cock-slit and, looping your arms around [arian eir] neck for balance, begin to press forward and gently feed it into the literal boy-pussy.");
-	
+
 	outputText("\n\nThe fit is so very tight, warmer than the rest of [arian em] for reasons you don't care enough to contemplate at this moment, and slick with lubricating fluids.  It's so strange, yet so hot... and once you have your [cock smallest]");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] == 0) outputText(" brushing up against [arian eir] own lizan pecker");
 	else outputText("sandwiched between [arian eir] two lizard dicks");
 	outputText(", the friction is absolutely incredible, sending sparks of pleasure cascading along your shaft.  You moan in delicious lust and tell Arian that this is absolutely incredible.");
-	
+
 	outputText("\n\n[arian Eir] expression is difficult to read; you can tell there is an obvious discomfort in the lizan's face, but at the same time, [arian ey]'s panting in excitement.  \"<i>Ugh, It feels stuffed... but also good.  Your cock rubbing against my own... t-try moving your hips.</i>\"");
-	
+
 	outputText("\n\nYou shift your arms from around [arian eir] neck to around [arian eir] waist and do as [arian ey] asks, pulling your hips back and then inserting them forward, just like you were trying to fuck a pussy.  The slimy, knobbly, bulbous texture of [arian eir] ");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("twin cocks");
 	else outputText("cock");
 	outputText(" slides across your intruding shaft as you go, and [arian eir] sheathe-walls grip and squeeze as best they can, leaving you moaning and panting like a bitch in heat.  Arian's moans of pleasure join yours, [arian eir] twitching bulbous shaft");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
 	outputText(" massaging your [cock smallest] almost like a vagina would.  Shaky hands grab a hold of your shoulders, helping you down and up on Arian's male slit.  \"<i>Oh, Marae!  It feels like I'm getting an internal handjob... it feEels so... so good!  H - harder... almost cumming!</i>\" [arian ey] pleads, as [arian ey] breathes hotly on your face; panting like a bitch in heat.");
-	
+
 	outputText("\n\nNot, you gasp back, if you don't come first... With that desperate promise (warning? Plea? Who cares?) you piston yourself back and forth four more times and then howl at the ceiling above as you cum into Arian's makeshift vagina.");
-	
+
 	//(Low Cum Amount)
 	if(player.cumQ() < 250) {
 		outputText("\n\nEven if your load is not that big to begin with; there is little room inside Arian's cramped genital slit, and you soon find yourself overflowing the little crevice.");
@@ -2636,13 +2636,13 @@ private function arianDocking():void {
 	else {
 		outputText("\n\nYour prodigious load is so huge, not even goblins can hope to hold all of it inside.  So it's no wonder all it takes is a single jet to make Arian's little crevice erupt with backflow of your cum, painting your belly as well as [arian eirs] with a perverted geyser of white.");
 	}
-	
+
 	outputText("\n\nSpent, you slump down on the lizan's [arian chest].  With a sense of urgency Arian looks pleadingly at you, feebly pushing your shoulders away.  \"<i>P-pull out, please!</i>\"");
-	
+
 	outputText("\n\nYou ask [arian em] what's wrong, too caught up in the feelings of your release to obey [arian em] immediately. \"<i>Need... to cum... no room!</i>\" [arian ey] says, groaning.  Realizing what's wrong, you hasten to obey - you don't want [arian em] to burst!  You pull your cum-slick shaft from [arian eir] cock-slit, waiting to see if [arian ey]'ll manage to poke [arian eir] own cock");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
 	outputText(" out before cumming.");
-	
+
 	outputText("\n\nArian groans in relief as a small white eruption comes out of [arian eir] cum-filled slit, soaking [arian eir] white scales in your combined jism.  Then, a ");
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("pair of cummy masts emerge");
 	else outputText("cummy mast emerges");
@@ -2650,17 +2650,17 @@ private function arianDocking():void {
 	if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("their");
 	else outputText("its");
 	outputText(" hiding place.  \"<i>Ahhh,</i>\" is all Arian says, before slumping down.");
-	
+
 	outputText("\n\nYou pat [arian em] on the shoulder in a friendly fashion and, with a wicked grin on your face, ask if [arian ey] enjoyed that too.");
-	
+
 	outputText("\n\nArian sighs and looks at you.  \"<i>It was good.  Weird... but good.  Though, I don't think I'd ever felt so much pressure on my balls before; if you hadn't pulled out in time, I might have busted a nut.</i>\"  [arian Ey] smiles tiredly.");
-	
+
 	outputText("\n\nYou draw [arian em] into a deep kiss, holding [arian em] tight and kissing [arian em] until [arian eir] need for air forces you to disengage. Cocking your head to the side, you stroke [arian eir] face gently, telling [arian em] that you're glad [arian ey] wasn't hurt. After all, you need your little lap-lizard in tiptop shape.");
-	
+
 	outputText("\n\nArian gives you a winning grin.  \"<i>I wonder why,</i>\"  [arian ey] says, rubbing at [arian eir] used slit.");
-	
+
 	outputText("\n\nYou tell [arian em] the sex is nice, but there's other things in [arian eir] favor too.  Then, you kiss [arian em] again before [arian ey] can ask what those are.  While [arian ey]'s left reeling, blissed out and goofy from the sexual overwhelm, you quietly slip out of [arian eir] bed, pull your clothes back on and slip away, blowing [arian em] a kiss before you depart.");
-	
+
 	//Player returns to camp
 	player.sexReward("cum","Dick");
 	dynStats("sen", 1);
@@ -2671,11 +2671,11 @@ private function arianDocking():void {
 private function giveArianAnItem():void {
 	clearOutput();
 	outputText("Thinking about the many items in your possession, you ask if Arian would be willing to take something for you?");
-	
+
 	//(if ArianHealth < 10) //May not give anything.
 	if(flags[kFLAGS.ARIAN_HEALTH] < 10) {
 		outputText("\n\n\"<i>Uhh... I'd rather not.  I'm not feeling very well, and I don't think it's wise for me to be drinking anything, well... strange.</i>\"");
-		
+
 		outputText("\n\nYou nod your head in understanding and change the subject; if you want to give Arian any of the potions you've found, you'll need to nurse [arian em] back to strength first.");
 		//Display other Arian interaction options
 		arianHomeMenu();
@@ -2683,7 +2683,7 @@ private function giveArianAnItem():void {
 	}
 	else if(flags[kFLAGS.ARIAN_HEALTH] < 20) { //May only give Vitality T.
 		outputText("\n\n\"<i>Is it medicine you've brought me?  If so I'll be happy to take it; otherwise I think we should wait until I'm better; especially after that scolding you gave me earlier...</i>\"");
-		
+
 		//If PC has Vitality T. go to Give VT section. Otherwise, play below:
 		if(!player.hasItem(consumables.VITAL_T)) {
 			outputText("\n\nYou admit you don't have any medicine on you at the moment, and change the subject.");
@@ -2696,7 +2696,7 @@ private function giveArianAnItem():void {
 		outputText("\n\n\"<i>Well, I guess it's okay.  I don't think you'd ever give me anything harmful, and if you have anything to... err... spice up the sex, I'd be happy to take it.</i>\"  Arian blushes.");
 		//Display PC inventory
 	}
-	
+
 	menu();
 	if(flags[kFLAGS.ARIAN_HEALTH] >= 20) {
 		addButton(0, consumables.P_DRAFT.shortName, giveIncubusDraftToArian)
@@ -2731,25 +2731,25 @@ private function giveArianAnItem():void {
 private function arianVitalityTincture():void {
 	clearOutput();
 	outputText("Fishing around amongst your pockets, you withdraw a vial of that strange potion Giacomo peddles and offer it to the sickly lizan, explaining it will bolster [arian eir] constitution and fill [arian em] with permanent vitality.");
-	
+
 	outputText("\n\nArian smiles gratefully at you.  \"<i>Thanks for doing this for me, [name].</i>\"");
-	
+
 	outputText("\n\nYou tell [arian em] it's no trouble, then smirk and note it's not as if that sleazy peddler's hard to find out there in the wasteland, anyway.  You see the look on the lizan's face and hasten to assure [arian em] that you're certain the potion works, you just don't trust that weasely merchant as far as you can throw him.");
-	
+
 	outputText("\n\n\"<i>If you say so...</i>\" Arian takes the potion and uncorks the vial.  \"<i>Here goes.</i>\"  [arian Ey] chugs the potion down at once, making a face once [arian ey]'s done.  \"<i>Ugh... If I didn't know better I'd say you're trying to murder my taste buds.</i>\"");
 
 	outputText("\n\nSurely it's not that bad?  The potion smelled vaguely like cherries, it can't be as bad as [arian ey]'s is making it to be...");
-	
+
 	outputText("\n\nArian shakes [arian eir] head.  \"<i>It's medicine... medicine is never good.  And it has cherries.  I hate cherries,</i>\" Arian notes in disgust.");
-	
+
 	outputText("\n\nYou apologize, but, hey, medicine just tends to taste nasty anyway.  Still, it's doing [arian em] the world of good, now isn't it?");
-	
+
 	outputText("\n\n\"<i>I guess I do feel better.  Thank you [name].</i>\" Arian smiles at you, already looking a bit better.");
     if (arianHealth(10) == 100)
         outputText(" \"<i>In fact... I don't think I need those potions anymore. I'll probably keep a couple of them just in case, but since I don't use my magic too often these days, I'm completely fine.</i>\"");
-	
+
 	outputText("\n\nYou smile and stroke the lizan gently on [arian eir] head, telling [arian em] that [arian ey]'s welcome.  Now, you think it's time [arian ey] laid [arian em]self back down and got some rest; give the medicine time to work.  You promise you'll try and come back to see [arian em] later, but right now, [arian ey] needs to get some more rest.  Arian nods and settles [arian em]self on [arian eir] bed.");
-	
+
 	player.consumeItem(consumables.VITAL_T);
 	doNext(camp.returnToCampUseOneHour);
 }
@@ -2765,21 +2765,21 @@ private function giveIncubusDraftToArian():void {
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) outputText("make [arian eir] cock bigger");
 	else outputText("have a touch of [arian eir] old malehood back");
 	outputText(".");
-	
+
 	outputText("\n\nArian blushes.  \"<i>I don't mind the way I am now, but if you want me to take it I'd be happy to.</i>\"  Arian smiles nervously at you.");
-	
+
 	outputText("\n\nYou tell [arian em] that you would like [arian em] to take it, and hold it out to the lizan with greater emphasis.  Arian takes the draft, uncorks it and chugs it down.");
-	
+
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] == 0) {
 		flags[kFLAGS.ARIAN_COCK_SIZE]++;
 		outputText("\n\nThe changes start at once.  Arian shudders as a wave of arousal hits [arian em] and quickly opens [arian eir] robes to watch in awe as a slit appears above [arian eir] juicy feminine cunt.  It overflows with natural lubricant, and for a moment you think Arian is growing a second vagina.  The thought is quickly forgotten as you watch a reptilian, bulbous, purple dick emerge from its depths; it grows to an average size before Arian moans and cums, spraying [arian emself] with [arian eir] newly acquired tool.");
-		
+
 		outputText("\n\nYou make a show of smirking and shaking your head.  My, but Arian needs to work on [arian eir] control, now doesn't [arian ey]?  To think [arian ey]'d cum just from growing a sweet little cock like this.  You reach out and stroke the hermaphroditic member, gently trailing your fingers across its reptilian bumps and nodules.  A tiny part of you shivers in anticipation of it plumbing into your ");
 		if(player.hasVagina()) outputText("[vagina] and ");
 		outputText("[asshole].");
-		
+
 		outputText("\n\n\"<i>Wait!  I'm still sensi-Ahhh!</i>\"  Arian's shaft throbs and another jet of cum arches through the air to hit [arian em] squarely on [arian eir] face.  Panting, Arian says, \"<i>I-I think I need a rest now...</i>\"  [arian Ey] collapses on [arian eir] bed, prehensile, reptilian tail waving about in a display of enjoyment.");
-		
+
 		outputText("\n\nA part of you wonders if maybe [arian ey]'s hoping you'll join [arian em] in bed, but then you take a closer look and concede that [arian ey] is genuinely tired.  You stroke [arian em] affectionately on [arian eir] scaly cheek and politely excuse yourself, heading back to camp.");
 		dynStats("lus", 10+player.lib/20, "scale", false);
 	}
@@ -2790,7 +2790,7 @@ private function giveIncubusDraftToArian():void {
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] == 0) outputText("shaft emerges from its hiding place.  It throbs and grows, settling in its");
 		else outputText("pair of shafts emerge from their hiding place.  They throb and grow, settling in their");
 		outputText(" new size as Arian moans and cums all over [arian em]self.");
-		
+
 		outputText("\n\nYou gently flick a strand of cum off of the lizan's belly.  So, how does [arian ey] like the new and improved lizard cock?  Arian swallows audibly and tries to retract [arian eir] cock");
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s back into their");
 		else outputText(" back into its");
@@ -2798,11 +2798,11 @@ private function giveIncubusDraftToArian():void {
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] == 2) {
 			dynStats("lus", 10+player.lib/20, "scale", false);
 			outputText("\n\n[arian Ey] manages to tuck it in, although you have the impression you wouldn't have to reach too far inside to feel its tip.");
-			
+
 			outputText("\n\n\"<i>It's a tight fit, but I think I can still keep it inside,</i>\" Arian sighs in pleasure.  \"<i>It did feel good though; thank you, [name].</i>\"");
-			
+
 			outputText("\n\nYou smirk and tell [arian em] that maybe you'll ask [arian em] to show you how it feels in an up-close and private demonstration later, but, for now, you'll let [arian em] get some sleep.  Arian nods, blushing.  \"<i>I'm looking forward to it.</i>\"  [arian Ey] smiles nervously at you.");
-			
+
 			outputText("\n\nYou smirk and pat [arian eir] head, tell [arian em] you'll come back for it when you can, and then politely excuse yourself.");
 		}
 		else {
@@ -2810,25 +2810,25 @@ private function giveIncubusDraftToArian():void {
 			if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("them");
 			else outputText("it");
 			outputText(" until two thirds are inside, then it doesn't look like [arian ey] can take in anymore.\n\n\"<i>W-Wow, ");
-			
+
 			if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("they're so big I can't even manage to hide them,</i>\" Arian pants as the tip of [arian eir] cocks hang");
 			else outputText("\n\n\"it's so big I can't even manage to hide it,</i>\" Arian pants as the tip of [arian eir] cock hangs");
 			outputText(" limply, exposed for all to see.");
 
 			outputText("\n\nYou can't resist reaching down and gently tweaking the exposed tip.  Mmm... your little " + arianMF("boy-toy","herm-toy") + " is going to be a very naughty thing from now on, you tease, unless [arian ey] intends to start wearing a loincloth?");
-			
+
 			outputText("\n\nArian shudders at your touch.  \"<i>I-I'd have to ask Boon for one of [arian eir].  I don't have any here.</i>\"  Arian blushes.");
-			
+
 			outputText("\n\nYou smile playfully at [arian em] and ask if [arian ey] would like you to go and fetch one now?");
-			
+
 			outputText("\n\n\"<i>N-No!  I couldn't stand it if Boon and Laika found out I look like this,</i>\" Arian says, pointing towards [arian eir] exposed shaft");
 			if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
 			outputText(".");
-			
+
 			//if ArianHerm:
 			if(flags[kFLAGS.ARIAN_VAGINA] > 0) {
 				outputText("\n\nYou can't resist quirking an eyebrow and asking if this is really more embarrassing than revealing that [arian ey]'d grown an egg-filled womb and a pussy to use with it?  \"<i>Well, yes!  They'll give you a hard time too for getting me to do this, you know?</i>\" Arian protests.");
-				
+
 				outputText("\n\nYou smile and tap [arian em] playfully on the nose, pointing out the difference between you and [arian em] is that you don't care what two overprotective ferrets have to say about how [arian ey] looks.  You think [arian ey]'s hot like this.  Arian blushes at that.  \"<i>Then... I'll go without wearing a loincloth?</i>\"  You tell [arian em] that'd be very naughty, but you think it'd be kind of sexy, too.  Arian smiles nervously, \"<i>Ok, then that's what I'll do... c-can't wait to use it...</i>\" [arian Eir] tip");
 				if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s start");
 				else outputText(" starts");
@@ -2836,13 +2836,13 @@ private function giveIncubusDraftToArian():void {
 			}
 			else {
 				outputText("\n\nYou admit it probably would be a bit embarrassing, especially if Boon's bigger than Arian is now.  [arian Ey] blushes.  \"<i>Well, he really isn't. If anything it might be tight.  I might have to go without one...</i>\"");
-				
+
 				outputText("\n\nYou raise an eyebrow, and ask if [arian ey]'s not secretly at least a little happy about that?  After all, big dicks seem to be pretty admired in this sex-mad world.  Arian looks away in embarrassment, but smiles all the same.  \"<i>It is pretty big, isn't it?  I guess it's not that bad.</i>\"");
-				
+
 				outputText("\n\nYou point out you wouldn't have given the lizan such a big dick if you didn't think they were sexy.  To be honest, you'd kind of like to know [arian ey] was going around with this impressive monster hanging out under [arian eir] robes; it's very flattering.  \"<i>T-then I won't use one.</i>\"  Arian's cock hardens a bit.  \"<i>Although it might be hard to hide my... urges.</i>\"  Arian looks at you nervously.");
 			}
 			outputText("\n\nYou give the lizan a kiss on the cheek, and ask if [arian ey]'s sure [arian ey] doesn't want to give it a test run before you go.  Arian's cock hardens, pointing at you and throbbing at the idea, even as a small droplet of cum gathers on [arian eir] tip; Arian fumbles and makes an attempt to hide [arian eir] excitement.  \"<i>T-this is going to take some getting used to...</i>\"");
-			
+
 			outputText("\n\nYou apologize and tell the lizan you've teased [arian em] enough; you'll give [arian em] a chance to calm down, and politely excuse yourself to head back to camp.");
 		}
 	}
@@ -2853,7 +2853,7 @@ private function giveIncubusDraftToArian():void {
 		outputText("\n\n\"<i>Well, at least my chest won't feel so heavy anymore.  I hope you're not disappointed?</i>\" Arian asks, panting.");
 		outputText("\n\nYou just smile back at [arian em] and tell [arian em] you can live with it.  Arian sighs.  \"<i>Good, they did feel kinda nice, though.</i>\"  You detect a hint of disappointment in [arian eir] voice.");
 		outputText("\n\nConfused, you comment that [arian ey] was hatched as a boy; you'd have thought [arian ey]'d be more comfortable to be flatter up there.  [arian Ey] blushes. \"<i>I-....  You've convinced me there are... perks related to that.</i>\"  [arian Ey] bites [arian eir] lower lip.  \"<i>Not that I miss having big breasts.  My back will also thank me, but they did feel nice and....</i>\"  Arian giggles.  \"<i>Laika would always give me the funniest looks, since she's kinda... flat.</i>\"");
-		
+
 		outputText("\n\nYou wonder if maybe Laika had ulterior motives for those looks, but keep that thought to yourself. You ask if Arian would like to do something, or if you should leave [arian em] to get on with [arian eir] work? [arian Ey] looks at you expectantly. \"<i>I wouldn't refuse if you wanted to do anything.</i>\", [arian eir] dick growing hard at your suggestion.");
 		//Display sex menu
 		arianSexMenu(false);
@@ -2885,17 +2885,17 @@ private function giveIncubusDraftToArian():void {
 			outputText("\n\nYou note that [arian ey] was quite pretty, but you think [arian ey]'s just as handsome now.  Besides, being all-guy means no more dealing with eggs, right?");
 			outputText("\n\nArian blushes, averting [arian eir] eyes in embarrassment.  \"<i>It wasn't that bad... the whole deal with the eggs I mean.</i>\"");
 			outputText("\n\n[arian Ey] can really say that?  After actually going through the painful process of laying them?  Because, if [arian ey] can, well, you think you'd have to call Arian one of the manliest men you've met in this world.");
-		
+
 			outputText("\n\nArian smiles at you.  \"<i>It didn't hurt that much.</i>\"  Then [arian ey] blushes.  \"<i>It felt kinda nice... actually.</i>\"");
-		
+
 			outputText("\n\nYou just shake your head and clap [arian em] on the shoulder.  Well, maybe you'll give [arian em] [arian eir] vagina back, if [arian ey] really didn't mind being half-girl that much.  But, right now, you think [arian ey] should try and get used to being all-man again.");
-		
+
 			outputText("\n\nArian averts [arian eir] eyes.  \"<i>Of course.  If that's what you think.</i>\"");
-		
+
 			outputText("\n\nYou reply that is what you think.  So, does [arian ey] feel up to doing anything else, or should you leave [arian em] to get some rest?");
-		
+
 			outputText("\n\nArian's cock begins hardening.  \"<i>Well, I wouldn't mind doing anything else... if you want to.</i>\"");
-		
+
 	}}
 	else if(flags[kFLAGS.ARIAN_VAGINA] > 0 && (!flags[kFLAGS.HYPER_HAPPY])){
 		outputText("\n\nArian shudders as [arian ey] feels the changes sweep through [arian em], but rather than settling on [arian eir] huge lizan shaft, the warmth that precedes change settles between [arian eir] legs, and [arian ey] watches in wonder as the lips of [arian eir] wet fuckhole join together, becoming smooth scales as well. \"<i>I guess I'm male now?</i>\"");
@@ -2904,15 +2904,15 @@ private function giveIncubusDraftToArian():void {
 		outputText("\n\nYou note that being all-guy means no more dealing with eggs, right?");
 		outputText("\n\nArian blushes, averting [arian eir] eyes in embarrassment.  \"<i>It wasn't that bad... the whole deal with the eggs I mean.</i>\"");
 		outputText("\n\nHe can really say that?  After actually going through the painful process of laying them?  Because, if [arian ey] can, well, you think you'd have to call Arian one of the manliest men you've met in this world.");
-		
+
 		outputText("\n\nArian smiles at you.  \"<i>It didn't hurt that much.</i>\"  Then [arian ey] blushes.  \"<i>It felt kinda nice... actually.</i>\"");
-		
+
 		outputText("\n\nYou just shake your head and clap [arian em] on the shoulder.  Well, maybe you'll give [arian em] [arian eir] vagina back, if [arian ey] really didn't mind being half-girl that much.  But, right now, you think [arian ey] should try and get used to being all-man again.");
-		
+
 		outputText("\n\nArian averts [arian eir] eyes.  \"<i>Of course.  If that's what you think.</i>\"");
-		
+
 		outputText("\n\nYou reply that is what you think.  So, does [arian ey] feel up to doing anything else, or should you leave [arian em] to get some rest?");
-		
+
 		outputText("\n\nArian's cock begins hardening.  \"<i>Well, I wouldn't mind doing anything else... if you want to.</i>\"");
 	}
 	else { //Nothing happens.
@@ -2940,9 +2940,9 @@ private function succubiMilkForArian():void {
 	outputText("Fishing out the bottle of purified demon's milk, you ask if Arian is willing to get ");
 	if(flags[kFLAGS.ARIAN_VAGINA] > 0) outputText("further ");
 	outputText("in touch with [arian eir] feminine side.  For you?");
-	
+
 	outputText("\n\nArian bites [arian eir] lower lip.  \"<i>For you?  Of course I wouldn't mind it.</i>\"  You pass over the bottle, and watch as [arian ey] removes the cork and drinks its contents.");
-	
+
 	//(if ArianVagina == 0) //Arian... you look so pretty!
 	if(flags[kFLAGS.ARIAN_VAGINA] == 0) {
 		flags[kFLAGS.ARIAN_VAGINA]++;
@@ -2954,18 +2954,18 @@ private function succubiMilkForArian():void {
 		else outputText(" hardens fully out of its");
 		outputText(" hiding place, rock hard and throbbing.");
 		outputText("\n\nYou tell [arian em] you'll get [arian em] something cold to drink, turning towards the door.  \"<i>H-hurry, please!</i>\"  You need no further encouragement and quickly race to the kitchen, where you grab a jug of water from the coldbox and run back with it, as quickly as you dare.");
-		
+
 		outputText("\n\nAs soon as you enter Arian's room, [arian ey] sweeps the jug from your hands and begins downing the water.  You watch in amazement as [arian ey] drains the jug of all its water, some stray droplets falling on [arian eir] exposed scales, forming small rivulets that trace [arian eir] increasingly feminine curves.  Once Arian is done [arian ey] sighs with relief, quietly handing you the jug and wiping [arian eir] lips with a forearm.  \"<i>Thanks, [name].  I really needed that.</i>\" [arian Ey] smiles at you, no longer hot to the point of boiling.  [arian Eir] previously erect cock");
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
 		outputText(" having already softened and retracted");
 		//if ArianCockSize >= 3:
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] == 3) outputText(" as far as it'll go");
 		outputText(" into its protective slit.");
-		
+
 		outputText("\n\nYou cautiously ask if Arian is feeling okay; [arian ey]'s just undergone quite the dramatic change. [arian Ey] looks [arian emself] over, running [arian eir] hands across [arian eir] newly feminized body.  \"<i>I guess I'm fine.  I certainly feel fine, at least.</i>\"");
-		
+
 		outputText("\n\nYou can't help noting [arian ey] looks pretty fine, too.  Arian blushes at your comment.  \"<i>Umm... thanks.</i>\"  One of Arian's questing hands find [arian eir] newly formed slit, and [arian ey] gasps in pleasure as [arian ey] circles [arian eir] soft labia with a clawed finger, smearing some of [arian eir] juices on [arian eir] finger.  [arian Ey] lifts the finger to [arian eir] face and watch the moisture drip from [arian eir] digit; then, without sparing a thought, [arian ey] takes the finger into [arian eir] mouth and begins lightly sucking on the digit.");
-		
+
 		outputText("\n\nYou pointedly cough and tell [arian em] that, while you're not necessarily minding if [arian ey] wants to try out [arian eir] new body, does [arian ey] really want to put on a show for you, or would [arian ey] rather you leave?  Arian snaps out of [arian eir] trance, blushing in embarrassment.  \"<i>Oh! Sorry!</i>\"  Arian attempts to cover [arian eir] breasts and crotch with [arian eir] arms. [arian Ey] fidgets a bit, then smiles nervously at you.  \"<i>Umm, Maybe you'd like to help me get used to my new body?</i>\" Arian averts [arian eir] eyes, blushing furiously at what [arian ey] just said.");
 		outputText("\n\nYou step forward and gently run your hands over [arian eir] newfound breasts. Well, if that's what [arian ey]'s in the mood for, you're game.");
 
@@ -2975,11 +2975,11 @@ private function succubiMilkForArian():void {
 		outputText("\n\nWarmth sweeps through Arian's body, eliciting a gasp and a moan. Soon the warmth settles on [arian eir] chest, and [arian ey] opens [arian eir] robes to gaze at the change that is taking place.");
 		outputText("\n\nYou both watch as the smooth scales of [arian eir] chest begin flaking off, making way for a pair of erect nipples; following the growth of said nipples, [arian eir] previously flat chest begins inflating, growing into perky scaly breasts.");
 		outputText("\n\nArian gropes [arian eir] newly formed breasts tentatively and gasps in pleasure at their softness and sensitivity. \"<i>It feels nice.</i>\"  Looking at you with a blush, Arian asks, \"<i>Would you like to touch them?</i>\"");
-		
+
 		outputText("\n\nSeeing no reason to pass up the opportunity, you reach out and gently take hold of them, rolling their weight around in your hands.  You make a show of remarking to Arian that you had no idea scaly boobs could be so wonderfully soft and perky.");
-		
+
 		outputText("\n\nArian gasps and sighs as you gently massage [arian eir] breasts.  \"<i>[name]... this feels good.</i>\"");
-		
+
 		outputText("\n\nYou note it feels pretty nice for you as well.  Still, does [arian ey] maybe want to turn things up a notch in the intimacy department?  Arian blushes.  \"<i>You won't hear me complain.</i>\"  [arian Ey] starts fidgeting");
 			if(flags[kFLAGS.ARIAN_COCK_SIZE] >= 3) outputText(" and [arian eir] exposed shaft begins to grow hard");
 			outputText(".");
@@ -2987,27 +2987,27 @@ private function succubiMilkForArian():void {
 	else if(flags[kFLAGS.ARIAN_BREASTS] < 3 && flags[kFLAGS.ARIAN_BREASTS] > 0) {
 		flags[kFLAGS.ARIAN_BREASTS]++;
 		outputText("\n\nWarmth sweeps through Arian's body, eliciting a gasp and a moan.  Soon the warmth settles on [arian eir] mounds, and [arian ey] opens [arian eir] robes to gaze at the change that is taking place.");
-		
+
 		//(if ArianBreasts == 2)
 		if(flags[kFLAGS.ARIAN_BREASTS] == 2) {
 			outputText("\n\nArian's perky breasts inflate into perfect, soft-looking mounds.  Arian gropes [arian eir] newly enlarged breasts tentatively and gasps in pleasure at their softness and sensitivity.  \"<i>It feels nice.</i>\"  Looking at you with a blush, Arian asks, \"<i>Would you like to touch them?</i>\"");
-			
+
 			outputText("\n\nSeeing no reason to pass up the opportunity, you reach out and gently take hold of them, rolling their weight around in your hands.  You make a show of remarking to Arian that you had no idea scaly boobs could be so wonderfully soft and perky.");
-			
+
 			outputText("\n\nArian gasps and sighs as you gently massage [arian eir] breasts.  \"<i>[name]... this feels good.</i>\"");
-			
+
 			outputText("\n\nYou note it feels pretty nice for you as well.  Still, does Arian maybe want to turn things up a notch in the intimacy department?  Arian blushes.  \"<i>You won't hear me complain.</i>\"  [arian Ey] starts fidgeting");
 			if(flags[kFLAGS.ARIAN_COCK_SIZE] >= 3) outputText(" and [arian eir] exposed shaft begins to grow hard");
 			outputText(".");
 		}
 		else {
 			outputText("\n\nArian's generous mounds inflate once more. [arian Ey] gasps in pleasure, their growth also enhancing the lizan's sensitivity.  Once their expansion is finished, Arian lifts the huge orbs in awe.  \"<i>T-they're huge... and so heavy.</i>\"  [arian Ey] rolls the breasts in [arian eir] hands, gently touching [arian eir] soft scales and sensitive nipples, gasping and panting in pleasure.");
-			
+
 			outputText("\n\nYou note they look pretty big as well; why, [arian ey] must be the bustiest lizan you've ever seen.  Arian blushes, and bites [arian eir] lower lip.  \"<i>Do you like them?</i>\"  You give [arian em] a flat look and reach out to caress the breasts.  If you didn't like big breasts, well, why would you have asked [arian em] to grow them this big?  But is [arian ey] comfortable with them being like this?");
 			outputText("\n\nArian shudders at your touch.  \"<i>They are kind of heavy, but if you really like them, I don't mind keeping them.</i>\" [arian Ey] smiles nervously at you.  \"<i>I hope you will help me carry them?</i>\"  [arian Ey] fidgets");
 			if(flags[kFLAGS.ARIAN_COCK_SIZE] == 3) outputText(" and you see [arian eir] exposed shaft slowly rising to point at you");
 			outputText(".");
-			
+
 			outputText("\n\nYou cup the bountiful scaly bosom in your hands and tell [arian em] that's something you're quite willing to do.  Still, perhaps [arian ey]'d rather... take the weight off of [arian eir] feet, mm?  You finish, leaning in to dart a playful lick across the tip of [arian eir] snout to make your insinuations more obvious.");
 			outputText("\n\nArian blushes furiously, but smiles at you all the same.  \"<i>I... would love to.</i>\"");
 		}
@@ -3015,23 +3015,23 @@ private function succubiMilkForArian():void {
 	//(else If ArianCockSize > 1) //Dick shrinkage.
 	else if(flags[kFLAGS.ARIAN_COCK_SIZE] > 1 && (!flags[kFLAGS.HYPER_HAPPY])){
 		outputText("\n\nWarmth flows throughout Arian's body, and [arian ey] moans in obvious pleasure.  Then, [arian ey] opens [arian eir] robes and looks at [arian eir] rock-hard bulbous shaft.  It throbs as if edging a massive orgasm, but much to Arian's surprise it starts to shrink, until it finally grows limp and hides itself in its protective slit.  \"<i>I... didn't expect that,</i>\" [arian ey] remarks.");
-		
+
 		outputText("\n\nYou note it's not that surprising; the potion in question is a feminizer, so it must be shrinking away the only trace of [arian eir] masculinity left - [arian eir] cock");
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
 		outputText(".  \"<i>Oh... that's good.  Right?</i>\" Arian looks at you nervously.  You think it over, and confess that while you are more attracted to women than men, you won't force Arian to become fully female if [arian ey] doesn't want to.");
 		outputText("\n\nArian smiles at your consideration.  \"<i>Thank you, [name], but if you'd prefer me to be a girl... err... completely female, I wouldn't object.  I'm fine either way.</i>\" [arian Ey] grins.");
-		
+
 		outputText("\n\nYou ask, then, if Arian's so comfortable with [arian eir] girly side, maybe [arian ey]'d like to try out [arian eir] more female parts?  Arian blushes and averts [arian eir] eyes, nodding lightly.");
 	}
 	else if(flags[kFLAGS.ARIAN_COCK_SIZE] == 1 && flags[kFLAGS.ARIAN_DOUBLE_COCK] >= 1 && (!flags[kFLAGS.HYPER_HAPPY])) {
 		outputText("\n\nWarmth flows throughout Arian's body, and [arian ey] moans in obvious pleasure.  Then [arian ey] opens [arian eir] robes and looks at [arian eir] pair of rock-hard bulbous shafts.  They throb as if edging a massive orgasm, but much to Arian's surprise they begin to merge, until only one reptilian dick remains; finally it grows limp and recedes into its hiding place.  \"<i>They fused into one,</i>\" Arian remarks.");
-		
+
 		outputText("\n\nMaybe it's because of the increasingly high femininity the milk is bestowing on [arian em], you suggest?");
-		
+
 		outputText("\n\n\"<i>Maybe... that's good, right?</i>\" Arian asks.  You simply meet [arian eir] gaze levelly and tell [arian em] that it's good if [arian ey] wants it to be good; if [arian ey]'s uncomfortable with what you're doing to [arian em], [arian ey] needs to tell you and you'll stop, you promise.");
-		
+
 		outputText("\n\n\"<i>No!  I'm fine!</i>\" Arian insists.  \"<i>I'm just not used to, well... reshaping my body like this.  But if you think I look better this way, then I'm happy to comply.</i>\"  Arian smiles.");
-		
+
 		outputText("\n\nYou tell [arian em] that, for what it's worth, you do think [arian ey]'s beautiful, then give [arian em] a lustful grin and ask if [arian ey]'d like you to show [arian em] just how beautiful?");
 		outputText("\n\nArian blushes.  \"<i>I... show me...</i>\"");
 		flags[kFLAGS.ARIAN_DOUBLE_COCK] = 0;
@@ -3039,32 +3039,32 @@ private function succubiMilkForArian():void {
 	else if(flags[kFLAGS.ARIAN_COCK_SIZE] == 1 && (!flags[kFLAGS.HYPER_HAPPY])) {
 		flags[kFLAGS.ARIAN_COCK_SIZE] = 0;
 		outputText("\n\nWarmth flows throughout Arian's body, and [arian ey] moans in obvious pleasure.  Then, [arian ey] opens [arian eir] robes and look at [arian eir] rock-hard bulbous shaft.  It throbs and slowly recedes back into its hiding place.  An indignant rope of cum shoots into the air, splashing on [arian eir] belly as the slit containing the last of [arian eir] malehood finally closes up, leaving only smooth scales in its wake.  Arian pants, \"<i>Looks like I'm completely female now.</i>\"");
-		
+
 		outputText("\n\nYou agree with [arian eir] summary, and then note [arian ey]'s taking this quite calmly.  You mean, it had to be a shock just growing a pussy and laying eggs all the time, but now [arian ey] doesn't even have [arian eir] cock to go with it.");
-		
+
 		outputText("\n\nArian looks at you, blushing.  \"<i>Do you think I'm pretty?</i>\"");
-		
+
 		outputText("\n\nYou tell [arian eir] that, yes, [arian ey] makes a very pretty girl.");
-		
+
 		outputText("\n\nArian fidgets.  \"<i>Then, that's all I need.</i>\"  [arian Ey] smiles at you.");
-		
+
 		outputText("\n\nYou just look at [arian em] steadily; is [arian ey] really sure about that?  You did this to [arian em], surely you can bring [arian em] something to undo it, if only partially?");
-		
+
 		outputText("\n\nArian shakes [arian eir] head.  \"<i>I'm fine, [name].  Really. If I didn't want or wasn't okay with anything I'd have said so by now.  So trust me when I say I'm fine.  Besides, this doesn't feel half bad, and I get to have you.</i>\"  [arian Ey] blushes.");
-		
+
 		outputText("\n\n\"<i>Get to have you.... or perhaps,</i>\" you grin, \"<i>the proper question should be how, hmm?</i>\"");
-		
+
 		outputText("\n\nArian bites [arian eir] lower lip.  \"<i>Umm, we could do something I guess.  If you're up for it?</i>\"  Arian fidgets.");
 	}
 	else { //Nothing happens.
 		outputText("\n\nWarmth flows throughout Arian's body, and [arian ey] moans in obvious pleasure.  But suddenly, the warmth goes away, and [arian ey] opens [arian eir] robes to inspect the changes.  Nothing seems changed.  \"<i>I guess I can't get any more girly than being an actual girl,</i>\" Arian remarks.");
-		
+
 		outputText("\n\nYou note that's the obvious imposition.  Still, if [arian ey] wants to at least grow [arian eir] penis back, you're sure you can find [arian em] something, you offer; [arian ey]'s clearly devoted to you, a little token kindness won't hurt you, you think.");
-		
+
 		outputText("\n\nArian shakes [arian eir] head.  \"<i>No, I'm fine.  Unless you want me to have a penis?</i>\"");
-		
+
 		outputText("\n\nYou tell [arian em] that you'll think about it; right now, you want to take the all-new, all-girl Arian out for a spin... if [arian ey]'ll let you, of course?");
-		
+
 		outputText("\n\nArian smiles and fidgets. \"<i>I could go for a spin...</i>\"");
 	}
 	//Display Sex Options.
@@ -3077,20 +3077,20 @@ private function giveArianLactaid():void {
 	clearOutput();
 	player.consumeItem(consumables.LACTAID);
 	outputText("Your hand closes around the vial of lactation-inducing potion that is Lactaid.  You almost reject it automatically, but then you stop and think.  There's odder things in this world, after all.  You remove the vial and ask Arian if [arian ey] would be willing to let you see what lizan milk tastes like.");
-	
+
 	outputText("\n\n\"<i>I don't know.  Lizans don't actually lactate, since we lay eggs, so I don't know if this...</i>\"  Arian squints [arian eir] eyes to read the label on the vial you're holding.  \"<i>...Lactaid will even work.  But if you want to try, I suppose it couldn't hurt... right?</i>\"  Arian smiles nervously.");
-	
+
 	outputText("\n\nYou assure the lizan that, at worst, it'd just fail to do anything, and hand the vial of lactaid to [arian em].  [arian Ey] takes the offered bottle and smiles at you.  \"<i>All right.</i>\"");
-	
+
 	outputText("\n\nArian removes the cork and downs thick milky liquid, passing you the emptied vial.  \"<i>That tasted kinda nice...</i>\"");
-	
+
 	outputText("\n\nThe two of you sit in awkward silence, awaiting for anything to happen.");
-	
+
 	if(flags[kFLAGS.ARIAN_BREASTS] == 0) {
 		outputText("\n\nAfter some time, Arian sighs and opens [arian eir] robes, rubbing [arian eir] chest.  \"<i>I don't think it worked.  At least... I don't feel any different.</i>\"");
-		
+
 		outputText("\n\nYou note that's strange, and wonder what could have stopped it working.  You shrug and suggest maybe it was Arian's lack of existing breasts?  Still, no harm done; would Arian maybe like to do something else instead?");
-		
+
 		outputText("\n\nHe shrugs and closes [arian eir] robes.  \"<i>I'm sorry it didn't work, [name].  If you want to do something else, just say so.</i>\"  Arian smiles at you.");
 		menu();
 		addButton(0,"Next",giveArianAnItem);
@@ -3099,9 +3099,9 @@ private function giveArianLactaid():void {
 		fatigue(-15);
 		HPChange(player.maxHP() * .2, false);
 		outputText("\n\nAfter some time, Arian begins panting, sweating as [arian eir] body temperature goes up.  \"<i>I feel... hot.</i>\"  In an attempt to lower [arian eir] body temperature, Arian discards [arian eir] robes and lays down on [arian eir] bed, fanning [arian emself] with [arian eir] clawed hands.");
-		
+
 		outputText("\n\nYou approach [arian em] cautiously, asking if [arian ey]'s okay.");
-		
+
 		outputText("\n\n\"<i>My breasts feel ticklish.</i>\"  Suddenly, Arian gasps in pleasure");
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] == 3) outputText(", [arian eir] exposed cock growing hard as [arian ey] flushes with arousal");
 		outputText(".  [arian Eir] hands grip the sheets and you watch [arian eir] ");
@@ -3109,23 +3109,23 @@ private function giveArianLactaid():void {
 		else if(flags[kFLAGS.ARIAN_BREASTS] == 2) outputText("luscious");
 		else outputText("pillowy");
 		outputText(" breasts grow before your eyes.  \"<i>My breasts... d-do something, [name]!</i>\" Arian pleads.  Unsure of what you should be doing, you grab [arian eir] breasts and begin kneading them as they grow in your hands; [arian eir] erect nipples poking your palms.  \"<i>Ah... that feels good!  Don't stop!</i>\"");
-		
+
 		outputText("\n\nYou can't resist a wry comment asking if this was maybe a ploy by Arian to get you to massage [arian eir] breasts?  Because [arian ey] seriously didn't need to play games if that's what [arian ey] wanted.  [arian Eir] only reply is a moan of pleasure.  You chuckle and shake your head, continuing the massage, and that's when you notice dampness growing across your palms; lifting your hand up, you visually confirm and report to Arian that it worked; [arian ey]'s making milk.  That must be why [arian eir] breasts grew; to make room for the milk.");
-		
+
 		outputText("\n\n\"<i>G-great.  So, I guess it worked.  What do we do now?</i>\" Arian asks, still panting.");
-		
+
 		outputText("\n\nDoes [arian ey] really have to ask?  You tease.  Giving [arian eir] newly bountiful breasts a squeeze, you bend down and kiss [arian eir] right nipple, softly sucking it between your lips.  The first few drops are not what you might have expected; it's surprisingly warm, with a taste reminiscent of sweet milk and herbal tea that you find tasty and relaxing all at once.  You need no further incentive to start suckling in earnest, rolling your reptilian lover's nipple around with your tongue to coax forth more yummy lizan milk.");
-		
+
 		outputText("\n\nArian moans and begins caressing the back of your head.  \"<i>Hmm, this is so weird, but not bad weird.  I never dreamed I would ever have breasts, much less nurse someone... with my own milk that is.  How does it taste?  Is it good?</i>\"  Arian asks, softly stroking your [hair].");
-		
+
 		outputText("\n\nRather than answer verbally, you take a particularly deep suckle and release [arian eir] nipple, holding the milk in your mouth as you pull the surprised lizan into a kiss, letting [arian em] literally taste [arian eir] own medicine as you pass the milk from your mouth to [arian eirs].  Arian is too stunned to do anything but gulp down the offered milk.  [arian Ey] drops [arian eir] hands and focuses only on sucking down the offered milk.  Once you've run out of milk, you break the kiss, playfully lick a stray droplet from the corner of [arian eir] mouth, then return your attention to [arian eir] breast.  The lizan mage hugs your head to [arian eir] breast, still stunned.  \"<i>D-drink all you want,</i>\" [arian ey] says in a daze.");
-		
+
 		outputText("\n\nYou need no further encouragement and start thirstily draining Arian of all the milk [arian ey] has to offer, the lizan moaning and sighing as [arian ey] writhes gently underneath you.  Finally, any questions about whether or not the effects of this Lactaid are permanent are answered; you've drunk [arian em] dry, and with a quiet burp you get off of [arian em], somewhat gingerly touching your strained belly.");
 		player.refillHunger(10 + (10 * flags[kFLAGS.ARIAN_BREASTS]));
 		outputText("\n\nArian sighs in relief.  \"<i>That felt nice.  Maybe we can do it again sometime?</i>\"");
 
 		outputText("\n\nIf [arian ey]'s willing, then certainly, you tell [arian em], but you'll need to track down another vial first.  You think Arian should have a rest before then.  [arian Ey] nods and kneads [arian eir] now emptied breasts.");
-		
+
 		//(if ArianBreasts < 3)
 		if(flags[kFLAGS.ARIAN_BREASTS] < 3) {
 			flags[kFLAGS.ARIAN_BREASTS]++;
@@ -3133,9 +3133,9 @@ private function giveArianLactaid():void {
 			outputText("\n\nYou look at them curiously, and then decide (and tell [arian em]) that, yes, they have gotten bigger.  Probably a side effect of expanding to contain and produce the milk [arian ey] just fed you.");
 		}
 		outputText("\n\nArian smiles tiredly.  \"<i>I think I'll rest for a little bit now... maybe you should too?</i>\"  [arian Ey] suggests, pointing at your bloated belly.");
-		
+
 		outputText("\n\nYou agree, and ask if [arian ey]'ll be okay if you show yourself out.  Arian nods and yawns.  \"<i>I'll see you later then, [name].</i>\"");
-		
+
 		outputText("\n\nYou leave [arian em] to get some sleep and quietly show yourself out, planning to work off your meal elsewhere.");
 		doNext(camp.returnToCampUseOneHour);
 	}
@@ -3153,7 +3153,7 @@ private function giveArianReducto():void {
 	if(flags[kFLAGS.ARIAN_BREASTS] > 0) addButton(0,"Breasts",useReductoOnAriansBreasts);
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) addButton(1,"Cock",useReductoOnArianCocks);
 	addButton(2,"Asshole",useReductoOnAriansAsshole);
-	
+
 }
 
 //Breasts:
@@ -3166,9 +3166,9 @@ private function useReductoOnAriansBreasts():void {
 	else if(flags[kFLAGS.ARIAN_BREASTS] == 2) outputText("generous");
 	else outputText("pillowy");
 	outputText(" breasts.  \"<i>Okay... I suppose it would be good to lose a bit of weight up here and spare my back.</i>\" [arian Ey] smiles, opening the tube of Reducto and [arian eir] robes; then squeezing the contents of the paste [arian eir] hands.");
-	
+
 	outputText("\n\nArian kneads [arian eir] breasts, lathering the paste all over them.  You can't help but note that this is kinda sexy. [arian Eir] breasts glisten in the light of the room.  Once [arian ey] is done, [arian ey] cleans [arian eir] hands with a piece of cloth that was laying nearby and waits for the Reducto's effect.");
-	
+
 	//(if ArianBreasts > 1)
 	if(flags[kFLAGS.ARIAN_BREASTS] > 1 || (flags[kFLAGS.ARIAN_BREASTS] == 1 && rand(6) == 0)) {
 		outputText("\n\nArian gasps and the two of you watch as [arian eir] breasts slowly shrink, setting into a smaller size.  You reach forward and feel [arian eir] breasts; it's a much better fit for your hands now.");
@@ -3191,14 +3191,14 @@ private function useReductoOnArianCocks():void {
 	player.consumeItem(consumables.REDUCTO);
 	outputText("You point at [arian eir] crotch, mentioning that you'd like [arian em] to be smaller.");
 	outputText("\n\n\"<i>Oh, ok then.</i>\"  Arian opens [arian eir] robes and squeezes the tube of Reducto on an open palm.");
-	
+
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] == 3) {
 		flags[kFLAGS.ARIAN_COCK_SIZE]--;
 		outputText("\n\nThen, [arian ey] slowly teases [arian eir] ");
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("pair of exposed lizard cocks");
 		else outputText("exposed lizard cock");
 		outputText(" into full erection.  Finally [arian ey] begins applying the paste.");
-		
+
 		outputText("\n\nThe changes are almost immediate; Arian groans and watches as [arian eir] oversized dick");
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s slowly shrink");
 		else outputText(" slowly shrinks");
@@ -3206,7 +3206,7 @@ private function useReductoOnArianCocks():void {
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s back into their");
 		else outputText(" back into its");
 		outputText(" hiding place; it's a tight fit, but it fits.");
-		
+
 		outputText("\n\n\"<i>Phew.  I won't say I didn't enjoy being that size, but it feels a lot more natural and comfortable now that I don't have to walk about exposed.</i>\"  You nod in agreement.  \"<i>So, is there anything else you'd like to do?</i>\"");
 		//(Back to Options menus)
 	}
@@ -3216,7 +3216,7 @@ private function useReductoOnArianCocks():void {
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s from their");
 		else outputText(" from its");
 		outputText(" tight hiding place, and into full erection.  Finally [arian ey] begins applying the Reducto.");
-		
+
 		outputText("\n\nIt takes mere moments for the changes to occur; Arian groans in slight discomfort as [arian eir] cock");
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s return to their");
 		else outputText(" returns to its");
@@ -3224,21 +3224,21 @@ private function useReductoOnArianCocks():void {
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("them");
 		else outputText("it");
 		outputText(" back into [arian eir] genital slit.");
-		
+
 		outputText("\n\n\"<i>Well, it seems I'm back to being average sized,</i>\" Arian says with a tinge of disappointment.   You tell [arian em] that average can be good too, in fact you happen to like average.  The lizan instantly cheers up and smiles at you.  \"<i>Thanks, [name].  Is there anything else you'd like to do, now?</i>\"");
 	}
 	else if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) {
 		outputText("Then, [arian ey] coaxes [arian eir] twin reptilian-peckers out of their hiding place.  Finally [arian ey] applies the paste to both shafts in turn.");
-		
+
 		outputText("\n\nIt takes a short while for anything to happen, but when it does Arian groans.  \"<i>S-something feels different.  Ugh, this feels weird.</i>\"  You two watch as [arian eir] shafts slowly reduce in size, then to your surprise merge together forming one average-sized cock, much like the one Arian sported before.");
-		
+
 		outputText("\n\n\"<i>I guess I'm back to begin a lizan with a single cock,</i>\" Arian says with a slight tinge of regret.  You cheer [arian em] up by saying that's the way you prefer it, besides is it really that bad, having only one cock?  Arian smiles at you.  \"<i>I guess it isn't too bad, just unusual for my species, but if you like me like this, then I'm okay with it.</i>\"  You nod and pat [arian em] gently on the head.  \"<i>So... is there anything else you'd like to do?</i>\"");
 		//(Back to Options menus)
 	}
 	else
 	{ //Nothing happens
 		outputText("\n\nThen coaxes [arian eir] snake-dick out of its hiding place.  Finally [arian ey] applies the paste on [arian eir] dick and wait patiently for the changes to begin.");
-		
+
 		outputText("\n\nThe two of you wait for a while, but when no change happens Arian speaks up, \"<i>I guess... nothing changed?</i>\"  You're inclined to agree, something should've happened already.  Well that doesn't matter, you'll just have to try something else.  \"<i>Okay... so, anything else you'd like to do?</i>\"");
 	}
 	//(Back to Options menus)
@@ -3263,38 +3263,38 @@ private function useReductoOnAriansAsshole():void {
 	if(flags[kFLAGS.ARIAN_ANAL_XP] <= 1) {
 		outputText("\n\n\"<i>I don't know if I can get any tighter than this, but... go ahead,</i>\" Arian says, smiling nervously at you.");
 		outputText("\n\nYou poke and prod gently but insistently at Arian's ass, but are forced to concede the truth; you can barely get one of your fingers inside [arian eir] tight anus, and you have little reason to suspect that it would do much good even if you could get it inside.");
-		
+
 		outputText("\n\n\"<i>I guess it's no use after all,</i>\" Arian chuckles.  \"<i>I imagine if you did manage to apply it you'd make my ass disappear.  Now that would be weird.</i>\"");
-		
+
 		outputText("\n\n[arian Ey]'s not wrong there, you agree.  Still, would [arian ey] maybe like to do something else, seeing as how that was a bust?  Arian nods.  \"<i>Of course.  What would you like to do?</i>\"");
 	}
 	//(else if AnalXP < 33)
 	else if(flags[kFLAGS.ARIAN_ANAL_XP] < 33) {
 		outputText("\n\n\"<i>I think I'm still pretty tight back there, but if you want me to be tighter, go ahead,</i>\" Arian says, smiling nervously at you.");
-		
+
 		outputText("\n\nYou gently press your fingers against the hole in question; like Arian noted, it's tight and resists your effort, but you manage, with some difficulty, to slide first one finger and then the other inside, allowing you to start coating the inner walls with Reducto cream.  You can feel the walls growing taut as you work - indeed, it promptly shrinks down almost painfully around your fingers, and you have to struggle as hard to pull them out as you had to push them in to begin with.");
-		
+
 		outputText("\n\nArian groans as you finally manage to pull your fingers out.  \"<i>I don't think it'll feel that much different when you decide to put it back there again, but I hope it'll feel good for you anyway.  Just promise you'll be gentle, ok?</i>\"");
-		
+
 		outputText("\n\nYou promise [arian em] that you'll take care of [arian em].  \"<i>So, anything else you'd like to do?</i>\"");
 		flags[kFLAGS.ARIAN_ANAL_XP] = 1;
 	}
 	else if (flags[kFLAGS.ARIAN_ANAL_XP] < 66) {
 		flags[kFLAGS.ARIAN_ANAL_XP] -= 33;
 		outputText("\n\n\"<i>To be honest, I had kind of gotten used to the feeling... sorta.  It will be a bit painful to go back to being that tight back there, but if that's what you'd like, go ahead,</i>\" Arian says, smiling at you.");
-		
+
 		outputText("\n\nYou slide two fingers easily inside [arian eir] stretched out back passage, rubbing the interior of [arian eir] anus with the magical shrinking cream.  You end up applying a third finger for ease of application; [arian ey]'s certainly loose enough to take it.  You can feel it shrinking around you as you work, but you still have little difficulty sliding your fingers back out.");
-		
+
 		outputText("\n\nArian moans as you pull out your fingers.  \"<i>And I was just getting used to being taken from behind.  Somehow I get the feeling it won't feel just as good, but I'm glad to make a little sacrifice for you.</i>\"  [arian Ey] smiles at you.");
-		
+
 		outputText("\n\nYou smile back, thanking [arian em] for catering to your wishes, even though [arian ey] doesn't have to.  Arian grins at you.  \"<i>Don't worry about that.  I want to make you feel good...</i>\"  Stroking [arian eir] exposed ass, you tell [arian em] that [arian eir] efforts are appreciated and promise to make [arian em] feel just as good in return.  Arian smiles.  \"<i>Okay, it's a deal.  So, anything else you'd like to do?</i>\"");
 	}
 	else if (flags[kFLAGS.ARIAN_ANAL_XP] <= 100) {
 		flags[kFLAGS.ARIAN_ANAL_XP] -= 33;
 		outputText("\n\n\"<i>I just know it won't feel quite as good back there if you shrink my ass, but maybe this is for the best?  Perhaps I might have let the feeling get to me.  Maybe I did become too much of a buttslut...</i>\"  Arian lowers [arian eir] head.");
-		
+
 		outputText("\n\nYou can't resist patting the lizan's head and assuring [arian em] that, yeah, [arian ey] is a slut when it comes to [arian eir] ass, but the way [arian ey] goes about being a slut is honestly kind of cute.  You just want to see if tightening [arian em] back up will make things even better, now [arian ey]'s got the experience of loving a great assfuck.");
-		
+
 		outputText("\n\nYou push your way into Arian's butt and almost find your whole hand sliding down [arian eir] well-trained 'boyslut pussy', which prompts a lewd moan from the anal-loving lizan");
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
 			outputText(", [arian eir] cock");
@@ -3307,7 +3307,7 @@ private function useReductoOnAriansAsshole():void {
 			outputText("[arian eir] pussy growing wet from the stimulation");
 		}
 		outputText(".  You playfully shake your head and slap [arian em] on the butt, then use it for balance as you start to pump the blade of your fist inside and out, smearing the cream copiously around to restore some of [arian eir] once-virginal anal tightness to [arian em].  Eventually, you've used up all the cream and [arian eir] ass definitely feels tighter, so you decide to pull out.");
-		
+
 		outputText("\n\nArian whimpers.  \"<i>It feels a bit less sensitive now, but I'm sure it'll still feel pretty good when you do me from behind.</i>\"  Arian smiles.  \"<i>Anything else you'd like to do?</i>\"");
 	}
 	//Back
@@ -3322,21 +3322,21 @@ private function giveArianReptilum():void {
 	clearOutput();
 	player.consumeItem(consumables.REPTLUM);
 	outputText("Fingering the vial of reptilium, you smirk to yourself.  Quickly wiping it off your face, you instruct Arian to close [arian eir] eyes and open [arian eir] mouth, as you have a special surprise for [arian em].");
-	
+
 	outputText("\n\nArian, quickly complies.  \"<i>Okay, but can you at least tell me what is this about?</i>\"  [arian ey] asks in curiosity.");
-	
+
 	outputText("\n\nYou cluck your tongue in a disappointed tone and point out that a surprise isn't a surprise if you tell [arian em] what it is.");
-	
+
 	outputText("\n\n\"<i>Aww, fine then, but I hope this isn't a practical joke... not that I don't trust you, [name].</i>\"  [arian Ey] smiles nervously.");
-	
+
 	outputText("\n\nYou assure [arian em] that [arian ey]'ll enjoy this, but first, to make sure [arian ey] doesn't go peeking... you grab a handy strip of cloth and wind it about [arian eir] face, covering [arian eirs] eyes in a makeshift blindfold.");
-	
+
 	outputText("\n\n\"<i>Aww, come on, you can trust me.  I promise not to peek!</i>\"");
 
 	outputText("\n\nYou tell [arian em] it's more fun this way, popping the bottle of Reptilium open as you do so and following your words up by tipping it into the lizan's carelessly open mouth.");
-	
+
 	outputText("\n\n\"<i>I sweagrlpff-</i>\" the lizan's protests are cut short by the stream of cool reptilum being poured down [arian eir] throat.  [arian Ey] chokes a bit, but quickly adapts, drinking eagerly.  When you finish tipping the bottle and remove it from [arian eir] lips, Arian coughs a bit and licks [arian eir] lips.  \"<i>Hmm... that tasted good, what was it?</i>\"");
-	
+
 	outputText("\n\nYou tell [arian em] [arian ey]'ll just have to wait to find out, taking off [arian eir] blindfold and smiling wryly at [arian em].  \"<i>Umm... ok...</i>\"");
 	//(if ArianFirstRept == 1)
 	if(flags[kFLAGS.ARIAN_FIRST_REPTILUM] == 0) {
@@ -3352,19 +3352,19 @@ private function giveArianReptilum():void {
 	//(if ArianFirstRept == 1)
 	if(flags[kFLAGS.ARIAN_FIRST_REPTILUM] == 1) outputText("\n\nYou blink; aura?  What is the lizan talking about?  And what would make [arian em] think colors are tasty - or even edible?");
 	else outputText("\n\nChuckling, you tell [arian em] that if [arian ey]'s so curious, [arian ey] should try it.");
-	
+
 	outputText("\n\nArian suddenly gets up and takes a lick off your cheek.  \"<i>Yum... didn't know rainbows tasted like cloud ice-cream.</i>\"  [arian Ey] begins laughing uncontrollably.  You wipe [arian eir] saliva off your cheek and look in amazement as [arian ey] continues to laugh for no apparent reason.");
-	
+
 	outputText("\n\n\"<i>Hey [name], cats are flexible right?  Think I would turn into one if I could lick my butt?  I'd be a sexy kitten!</i>\"  Arian does away with [arian eir] robes, tossing them around and bending over as far as [arian ey] can in an attempt to lick at [arian eir] butt.  \"<i>J-just a bit more....  Help me here, [name]!  I want to turn into a cat so we can roleplay!  I'll be Mittens and you can be Fishbreath!</i>\"");
-	
+
 	//(if ArianFirstRept == 1)
 	if(flags[kFLAGS.ARIAN_FIRST_REPTILUM] == 1) {
 		outputText("\n\nFeeling a touch nervous, you ask if [arian ey]'s feeling all right.  \"<i>All right?  I'm super!</i>\" [arian ey] replies, giggling madly.");
 	}
 	else outputText("\n\nYou were kinda waiting for this part.  [arian Ey] might not know it, but Arian's flexibility is truly impressive for a non-feline.  Just a few extra inches of tongue and [arian ey] actually manages to lick [arian eir] belly!");
-	
+
 	outputText("\n\nAt one point the bending lizan gives up and falls flat on [arian eir] back, then gets right up eyeing you with a glow in [arian eir] eyes.  \"<i>That was a stupid idea!  I know just how to make it!  I can lick your butt instead!  Do you think it tastes like cloud ice-cream like your rainbow aura?</i>\"");
-	
+
 	outputText("\n\nYou shake your head and tell [arian em] you'd rather [arian ey] didn't lick your butt.  Why don't you go and get [arian em] some candy instead?  \"<i>Candy!?  I love candy!  You can smear chocolate on yourself and I could lick it clean! Then we'd get chocolate flavored cloud ice-cream with [race] musk!  What a great idea!  Get your undies off so I can get started!</i>\"  [arian Ey] pounces on you, effectively removing your underpants and exposing your ");
 	if(player.hasCock()) {
 		outputText(multiCockDescriptLight());
@@ -3377,12 +3377,12 @@ private function giveArianReptilum():void {
 	else if(player.hasVagina()) outputText("pussy all the way from the back to the tip of your [clit]");
 	else outputText("your sweaty crotch");
 	outputText(".  \"<i>Yummy!  I could use seconds, but roleplay time is over; let's... masturbate each other!</i>\"  [arian Ey] begins stroking [arian eir] ");
-	
+
 	if (flags[kFLAGS.ARIAN_VAGINA] > 0)
 		outputText(images.showImage("arianfemale-home-mutualmasturbation"));
 	else
 		outputText(images.showImage("arianmale-home-mutualmasturbation"));
-	
+
 		if(flags[kFLAGS.ARIAN_COCK_SIZE] == 1) {
 		outputText("quickly erecting lizan cock");
 		if(flags[kFLAGS.ARIAN_DOUBLE_COCK] > 0) outputText("s");
@@ -3390,14 +3390,14 @@ private function giveArianReptilum():void {
 	}
 	if(flags[kFLAGS.ARIAN_VAGINA] > 0) outputText("slavering vagina");
 	outputText(".");
-	
+
 	outputText("\n\nArian must be high; normally [arian ey] needs a little encouragement to put on a show like this.  Still, who are you to pass up on a free show from your lizan lover?");
-	
+
 	outputText("\n\nLaughing and moaning uncontrollably Arian says, \"<i>Wow, [name].  Your hands feel really good!  Kind of familiar too!</i>\"");
-	
+
 	outputText("\n\n[arian Ey]'s clearly so daffy that [arian ey] doesn't realize [arian ey]'s the one touching [arian em]self.  Still, this is amusing, rather than scary, so you're content to watch and let the show play out.  It's kind of a turn on...");
 	dynStats("lus", (5+player.lib/10), "scale", false);
-	
+
 	var tfed:Boolean = false;
 	outputText("\n\nArian's giggling suddenly stops as [arian ey] finally orgasms, ");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
@@ -3411,30 +3411,30 @@ private function giveArianReptilum():void {
 	else outputText("[arian eir] vagina doing")
 	if(flags[kFLAGS.ARIAN_VAGINA] > 0) outputText(" its best to soak [arian eir] bed with lizan femcum");
 	outputText(".");
-	
+
 	outputText("\n\nLooking at you dizzily, Arian smiles and says, \"<i>That was fun, [name].  You have truly gifted hands!</i>\"  You repress a laugh; this was just too much fun, and tell [arian em] that credit is due where it's due.  You leave it to the dazed lizan to eventually decipher if you're saying you were the one with the gifted hands or you were encouraging [arian em] to recognize that [arian ey] is the one with the gifted hands.");
-	
+
 	//(if (random <= 50%) && (ArianDblCock == 0) && (ArianCockSize != 0)
 	if(rand(2) == 0 && flags[kFLAGS.ARIAN_DOUBLE_COCK] == 0 && flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
 		outputText("\n\n\"<i>Ugh... something feels weird...</i>\"  Arian looks down at [arian eir] crotch.  You follow [arian eir] eyes and see a second cock growing.  It grows until it's the same size as Arian's original cock, and once the transformation is over, Arian bursts out in uncontrollable laughter.");
-		
+
 		outputText("\n\n\"<i>Look, [name]!  You did me so hard I'm seeing double!</i>\"  [arian Ey] moves [arian eir] hands to touch [arian eir] sensitive twin members.  \"<i>Whoa! I'm feeling double too!</i>\"  Eventually the laughter dies down and the lizan collapses on [arian eir] back, snoring in a quick nap.");
 		tfed = true;
 	}
 	else {
 		outputText("\n\nArian's mouth opens into a wide yawn.  \"<i>Hmm... nappy time...</i>\"  [arian Ey] flops on [arian eir] back and begins snoring in a quick nap.");
 	}
-	
+
 	outputText("\n\nYou chortle quietly to yourself.  Talk about your anticlimactic finishers.   Still, you can't resist stroking Arian gently on the head; looks like [arian ey] quite enjoyed [arian emself] with that.  You remove your hand in surprise when Arian suddenly gets up, rubbing at [arian eir] eyes.  \"<i>Wha... hey [name].  Sorry, I guess I fell asleep.</i>\"  Looking down at [arian emself], [arian ey] realizes the state [arian ey]'s in.  For a moment [arian ey] looks confused... but then smiles.  \"<i>I guess we wound up having sex, right?  Was it good?  Sorry, but I'm a bit dizzy and can't recall exactly what happened.</i>\"");
 	outputText("\n\nYou tell [arian em] it was definitely interesting.  [arian Ey] really seemed to get wired up off of your little surprise.");
-	
+
 	if(tfed) {
 		outputText("\n\n\"<i>Hmm... I still feel sensitive all over...</i>\"  [arian Eir] hand absently touches [arian eir] still half-erect twin dicks.  \"<i>Wha?</i>\"  Looking down at [arian eir] crotch, Arian finally realizes [arian ey] has two dicks.");
-		
+
 		outputText("\n\n\"<i>Two... but, I was....  Was that you, [name]?</i>\"");
-		
+
 		outputText("\n\nYou smile and nod your head; does [arian ey] like them?");
-		
+
 		outputText("\n\n\"<i>Like them?  I love them!  You have no idea how much I longed to... to... to actually have two dicks like most of my people.  Thank you so much for this wonderful suprise [name]!</i>\"  [arian Ey] grins happily at you.");
 		flags[kFLAGS.ARIAN_DOUBLE_COCK] = 1;
 	}
@@ -3442,11 +3442,11 @@ private function giveArianReptilum():void {
 		outputText("\n\n\"<i>I guess I did...</i>\"  [arian Ey] smiles tiredly at you.  \"<i>Thank you for the wonderful surprise, [name].</i>\"");
 	}
 	outputText("\n\nYou laugh lightly and tell [arian em] that you should be the one thanking [arian em].");
-	
+
 	outputText("\n\nThe lizan looks at you in confusion, and is about to ask you something when a yawn interrupts [arian eir] line of thought.  \"<i>Ok... I'm glad you liked whatever we did...  -gonna take a nap now.</i>\"");
 
 	outputText("\n\nYou gently pull the covers up over the tired lizan, stroke [arian eir] head fondly, and quietly excuse yourself from [arian eir] sleeping quarters.");
-	
+
 	//Player gains Lust.
 	doNext(camp.returnToCampUseOneHour);
 }
@@ -3521,37 +3521,37 @@ private function giveArianScalesDyeVial():void {
 private function treatCorruption():void {
 	clearOutput();
 	outputText("You ask Arian if [arian ey] thinks [arian ey] can help you reduce some of the taint that has infected your soul.");
-	
+
 	if(flags[kFLAGS.ARIAN_TREATMENT] == 1) {
 		outputText("\n\nArian solemnly shakes [arian eir] head.  \"<i>Sorry, [name].  But I have already treated you once today, and if I did it again it could be hazardous to you... sorry.</i>\"");
-		
+
 		outputText("\n\nYou apologize.  You had forgotten how much that taxes [arian em], and you will come back for further treatments tomorrow.  However, there is something else [arian ey] can help you with...");
 		arianHomeMenu();
 		//Back to previous menu.
 	}
 	else {
 		outputText("\n\nArian nods.  \"<i>Of course!  Just hold my hands.</i>\"  [arian Ey] extends [arian eir] hands, waiting for you to get into position.");
-		
+
 		outputText("\n\nYou take hold of [arian eir] smoothly-scaled hands with your own, and wait patiently for [arian em] to begin.");
-		
+
 		outputText("\n\n\"<i>Now I need you to close your eyes, and focus on breathing... deeply and calmly.  You should feel a weird electric sensation, but try to relax.</i>\"");
-		
+
 		outputText("\n\nYou nod your head, close your eyes, and begin to slowly, rhythmically inhale and exhale, calming yourself down as instructed.");
-		
+
 		outputText("\n\nIt takes a while, but eventually you begin to feel the strange sensation Arian told you about.  It courses through your arms, and spreads throughout your body.  After a moment, you feel your body going numb with the sensation, and that's when you notice something else....  For a moment, it feels like you're being hugged tightly by a ghost.  It feels like it's there and isn't at the same time.  Invisible hands roam your body, and slowly, you feel like pieces of you are being removed.  It's not a bad sensation, and it certainly doesn't hurt, but it's... uncomfortable.");
-		
+
 		outputText("\n\n\"<i>That's enough.  You can open your eyes now,</i>\" Arian says, as all the strange sensations coursing through your body abruptly stop.  You release the lizan mage's clawed hands and realize that you're panting... as if you had exerted some sort of physical activity.");
-		
+
 		outputText("\n\nNoticing your concern Arian smiles.  \"<i>Don't worry, [name].  Just take a few moments to regain your breath and you should feel better.</i>\"");
-		
+
 		outputText("\n\nYou do as you are instructed, and note that, once you do feel better, you literally feel better; your thoughts are less clouded by corruption than they were before");
 		dynStats("cor", -1);
 		fatigue(20);
 		if(player.cor == 0) outputText(" - in fact, you're quite sure that Arian has purified you entirely");
 		outputText(".  You thank the lizan for [arian eir] magical treatment.");
-		
+
 		outputText("\n\n\"<i>You're welcome,</i>\" [arian ey] replies with a smile.  \"<i>Just remember that we can only do this once per day.  Any more and it would be hazardous, for both of us.</i>\"");
-		
+
 		outputText("\n\nYou acknowledge what [arian ey] is saying, promise you'll try and be more careful in the future, thank [arian em] once more, and then excuse yourself.");
 		flags[kFLAGS.ARIAN_TREATMENT]++;
 		doNext(camp.returnToCampUseOneHour);
@@ -3569,11 +3569,11 @@ private function imbueTalisman():void {
 	outputText("You tell Arian that, if it's not too much trouble, you'd like [arian em] to ");
 	if(player.hasKeyItem("Arian's Talisman") >= 0) outputText("place a spell in the enchanted talisman [arian ey] created for you");
 	else outputText("change the spell in the talisman [arian ey] created for you");
-	
+
 	outputText(".\n\n\"<i>Of course.</i>\"  Arian goes to [arian eir] work desk to fetch a small parchment and present it to you.  \"<i>Here's all the spells I can Imbue your talisman with and the materials needed.</i>\"");
-	
+
 	outputText("\n\nYou start observing the parchment, contemplating your choices.  So, what spell will you have [arian em] place in the talisman?");
-	
+
 	/*The list:
 	Healing Spell: 2x Wet Cloth and 2x Vitality T. - Heals the PC, no chance for failure.
 	Lust Reduction Spell: 2x Lust Draft and 1x Fuck Draft. - Reduces the PC's current lust, no chance for failure.
@@ -3596,19 +3596,19 @@ private function imbueTalisman():void {
 private function arianSpellPlace(spell:String):void {
 	clearOutput();
 	outputText("You tell Arian that you want [arian em] to place the " + spell + " spell in your talisman for you.");
-	
+
 	outputText("\n\n\"<i>Okay. Please, hand me the ingredients and I'll have it imbued in a moment.</i>\"  [arian Ey] smiles at you.  Fishing around amongst your belongings, you gather the necessary items and hold them out to the lizan.");
-	
+
 	outputText("\n\nArian eagerly nabs the offered ingredients and moves to [arian eir] work desk.  [arian Ey] takes a nearby bowl and fills it with water, then looks around.  \"<i>Hmm... I'm forgetting something... oh, right!  I'm going to have to ask you for your talisman, too, [name].</i>\"  [arian Ey] extends a hand to you.");
-	
+
 	outputText("\n\nYou can't resist noting you were expecting [arian em] to say that, plucking it from your neck and passing it to the reptilian wizard.");
-	
+
 	outputText("\n\n\"<i>Erm... right.  Now I need to focus.</i>\"  [arian Ey] places your talisman in the bowl, submerging it in water, then closes [arian eir] eyes and begins focusing [arian eir] magic.  Shortly after, the ingredients you offered suddenly burst into flames, burning until only their ashes are left; the ashes float into the bowl and mix with the water inside.");
-	
+
 	outputText("\n\nA soft hum emanates from within the bowl and the water begins glowing.  It doesn't take long for the humming to fade; Arian reaches inside the bowl and lifts your talisman for you to see.  \"<i>Here you go, [name].</i>\"");
-	
+
 	outputText("\n\nYou thank [arian em] and accept the talisman, feeling the pulsating energies within for a few moments before placing it back around your neck.  You thank Arian for [arian eir] help, assuring [arian em] that this will surely help you in your travels through these lands.");
-	
+
 	outputText("\n\n(<b>Your talisman has been imbued with the " + spell + ". You can use it from the M. Specials menu in combat.</b>)\n\n");
 	clearCharges();
 	if(spell == "Shielding Spell") {
@@ -3659,21 +3659,21 @@ public function sleepWithArian(newl:Boolean = false):void {
 	spriteSelect(SpriteDb.s_arian);
 	flags[kFLAGS.SLEEP_WITH] = "Arian";
 	outputText("Tired after a whole day of adventuring, you decide to retire and catch some shut-eye.  While going through the day's events, you recall Arian had offered to let you stay in [arian eir] tent and sleep with [arian em] in [arian eir] bed.  Your tired body could surely use a soft bed today, and maybe a certain lizan to keep you company too.  With that in mind, you head to [arian eir] tent.");
-	
+
 	outputText("\n\nInside, you find the " + arianMF("male","girly") + " lizan standing naked before [arian eir] bed, stretching [arian eir] arms and tail as widely as they can and groaning with satisfaction as [arian eir] joints pop.  Apparently not having noticed you arrive, [arian ey] hums to [arian emself] as [arian ey] busies [arian emself] with the covers of [arian eir] bed, bending over and letting you get a good look at [arian eir] sweet ass.  You appreciate the view for a few moments, and then gently cough to announce your presence.");
-	
+
 	outputText("\n\nStartled, Arian tries [arian eir] best to cover [arian eir] privates and finally notices you standing just inside.  \"<i>Oh, hello [name].  S-sorry, I'm not decent... I was just getting ready to turn in.  Can I help you with something?</i>\"");
-	
+
 	outputText("\n\nYou smile at [arian em] and ask if that invitation to join [arian em] in bed for the night still stands.  You just don't really feel like going to bed alone tonight, you explain.");
-	
+
 	outputText("\n\nArian nods enthusiastically.  \"<i>Of course!  Let me just put some comfortable robes on.  Usually I just sleep naked, but since you're here....</i>\"");
-	
+
 	outputText("\n\nYou quickly interject that if that's how [arian ey] prefers to sleep, well, [arian ey] doesn't need to change that for you.  If it'll make [arian em] more comfortable, in fact, you'll sleep naked with [arian em] as well.");
-	
+
 	outputText("\n\n\"<i>Really?  Umm... well, they say it's easier to share body heat with skin contact, so...</i>\"  Arian trails off twirling [arian eir] fingers, no longer bothering to cover [arian emself] up.");
-	
+
 	outputText("\n\nYou make no secret of your visual appreciation, telling [arian em] that the view is definitely nice, and then you start to strip down, making a little show out of it for your lizan lover.");
-	
+
 	outputText("\n\nArian fidgets and watches enraptured as you peel off each piece of your [armor].  ");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
 		outputText("You can clearly see [arian eir] exposed cock");
@@ -3682,21 +3682,21 @@ public function sleepWithArian(newl:Boolean = false):void {
 	}
 	if(flags[kFLAGS.ARIAN_VAGINA] > 0) outputText("You can tell that [arian ey] is aroused by the little show, despite [arian eir] body doing a good job of hiding it.  ");
 	outputText("You just let [arian em] squirm, pretending you don't see [arian eir] reactions, and then, indicating the bed, you ask which of you should get in first.");
-	
+
 	outputText("\n\nArian steps aside and motions for you to hop in first.  \"<i>Don't worry, I've cleaned the sheets recently, so there shouldn't be a problem... in case you're worried.</i>\"");
-	
+
 	outputText("\n\nWorried?  You smirk and ask whatever you could be worried about, even as you saunter over and slide yourself onto the bed.  You smile and wiggle with appreciation, telling Arian how wonderful [arian eir] sheets and soft mattress feel after so long sleeping in a bedroll on the hard ground.");
-	
+
 	outputText("\n\nArian smiles at you.  \"<i>I'm glad you're comfortable.  Just know that I'll always have a spot for you under my bedsheets.</i>\"  Oh?  Is that a proposal of a little... light exercise before bed, hmm?  You tease the lizan.  Averting [arian eir] gaze and biting [arian eir] lower lip, Arian quickly blurts out.  \"<i>No!  I mean... I wouldn't mind... but I, umm....  I'll just be getting in under the covers, if you don't mind.</i>\"  You chuckle and motion for [arian em] to come hither.");
 
 	outputText("\n\nArian lays down beside you, and scoots over, trying to get as close as possible to you.  You promptly wrap your arms around [arian eir] waist, and then wrap your [legs] around [arian em] for good measure, nuzzling yourself against [arian eir] smooth scales.");
-	
+
 	outputText("\n\nArian sighs in happiness at your close contact.  \"<i>It feels so good to have your " + player.skinFurScales() + " against my scales.  So warm...</i>\" [arian ey] sidles up against you, [arian eir] tail draping over your waist as [arian ey] sinks into your embrace.  You just squeeze [arian em] a little tighter and hold [arian em] close, saying nothing aside from a quiet whisper to sleep well.  \"<i>Good night, [name],</i>\" [arian ey] whispers back, before extending a hand toward the globe illuminating the tent and snapping [arian eir] fingers, shutting down the light.");
 	awardAchievement("My Tent's (not) Better Than Yours", kACHIEVEMENTS.GENERAL_MY_TENT_NOT_BETTER, true, true);
 	//(if AnalXP <33)
 	if(flags[kFLAGS.ARIAN_ANAL_XP] < 33) {
 		outputText("\n\nA strange sensation, combined with a soft sound, stirs you from your sleep.  You realize that Arian is stirring in [arian eir] sleep, softly mumbling to [arian em]self as [arian eir] tail gently swishes to and fro under the covers, sometimes accidentally running its warm length over your " + player.skinFurScales() + ".");
-		
+
 		outputText("\n\nAt first you think the lizan might actually be awake, but under further inspection you realize that [arian ey] is just sleep-talking.  Should you listen in or just go back to sleep?");
 		menu();
 		addButton(0,"Listen",listenToLowAnalXPArian);
@@ -3771,7 +3771,7 @@ private function listenToMediumAnalXPArian():void {
 	outputText("\n\n\"<i>Really?  What flavor?</i>\"");
 	outputText("\n\nYou tell [arian em] it's a surprise.");
 	outputText("\n\n\"<i>Hmm, okay then.  Shove it in.</i>\"  Arian lifts [arian eir] tail out of the way, wiggling [arian eir] hips against you.");
-	
+
 	//(if PC has a cock)
 	if(player.hasCock()) {
 		outputText("\n\nWell, if this is what [arian ey] wants, you're happy to oblige.  Your hand slips under the covers to start stroking your [cock smallest], gently coaxing yourself to erection.  Once you've gotten yourself sufficiently stiff, you wrap your arms around the lizan's waist for balance and start pushing yourself in.");
@@ -3779,7 +3779,7 @@ private function listenToMediumAnalXPArian():void {
 	else {
 		outputText("\n\nGiven you're rather lacking in the penis department, you decide to make do with your fingers; it is what [arian ey] wants, right?  Copiously lubricating your middle finger with saliva, you wriggle it between [arian eir] soft asscheeks and begin gently pushing it into [arian eir] tight little pucker.");
 	}
-	
+
 	outputText("\n\nArian moans.  \"<i>Such a familiar flavor...  Why didn't you tell me you were [name] flavored?  I love muffins... I love [name] muffins...</i>\"");
 	outputText("\n\nYou blink in surprise; is Arian really asleep, you wonder?  No, [arian ey]'s got to be awake, otherwise how could [arian ey] realize you're actually fucking [arian eir] ass?  \"<i>Hmm... tasty...</i>\"  You lean over the lizan, ");
 	if(player.hasCock()) outputText("cock");
@@ -3805,7 +3805,7 @@ private function dontTeaseHighAnalXPArian():void {
 //[=Tease=]
 private function teaseHighAnalXPArian():void {
 	clearOutput();
-	
+
 	if (flags[kFLAGS.ARIAN_VAGINA] > 0)
 		outputText(images.showImage("arianfemale-camp-dreamingArian"));
 	else
@@ -3833,9 +3833,9 @@ private function teaseHighAnalXPArian():void {
 		outputText("\n\nPity you don't have the necessary parts to play with [arian em], though.  Still, maybe if you do something a little special for him, [arian ey]'ll calm down and let you get some sleep...?");
 		outputText("\n\nWith anyone else, you'd probably lube your fingers up first; given what a total buttslut Arian's turned [arian emself] into, though, you doubt [arian ey] needs it.  Gently, you begin pressing against [arian eir] puckered tailhole with two fingers; eagerly it slips open, allowing you access with what you'd swear was a soft slurping sound. The interior is wet and slick, more like an aroused pussy than a normal anus, and you start to slowly thrust your fingers in and out of the warm, wet depths.");
 		outputText("\n\nPulling your hand out becomes increasingly difficult as Arian's ass basically sucks you in like a vacuum.  \"<i>Ohh... not stuffing... but feels good too....</i>\"");
-		
+
 		outputText("\n\nYou wonder if maybe you should grow a cock... that, or try to tighten up Arian's ass so [arian ey] stops being so obsessed with getting it stuffed full of cock.  As you ponder this deep conundrum, you continue pistoning your fingers into the buttslut lizan's ass; you wonder if you can make [arian em] cum with just this alone...?");
-		
+
 		outputText("\n\n\"<i>Hmm, you missed a spot.</i>\"  Arian begins humping your fingers eagerly, trying to shove them as deep inside [arian eir] greedy ass as [arian ey] can.");
 		outputText("\n\nYou continue pumping inside of the clearly pleased lizan for a while, but eventually you grow bored; as much as [arian ey] might be enjoying this, it's not really doing anything for you, and you still want to get some sleep.  You give [arian em] one last, deep thrust, and then try to withdraw your fingers only to find that you can't.  The greedy lizard-ass won't let you go!");
 		outputText("\n\n\"<i>No, if you remove the stuffing the bagels won't be tasty...</i>\" Arian mutters, still asleep.");
@@ -3865,19 +3865,19 @@ public function wakeUpAfterArianSleep():void {
 			outputText("\n\nArian's head pokes from under the covers.  \"<i>I suppose you're right... but that's still an impressive sight,</i>\"  [arian ey] says pointing at your erect cock");
 			if(player.cockTotal() > 1) outputText("s");
 			outputText(".");
-			
+
 			outputText("\n\nWell, Arian gives you quite an incentive to sprout it.  Even in [arian eir] sleep, [arian ey]'s a masterful tease, you tell [arian em].");
 			outputText("\n\nArian grins apologetically.  \"<i>Sorry... didn't mean to tease you or anything, [name].  Do you want me to help you with that?</i>\"");
 			outputText("\n\n\"<i>Well, if you're so inclined</i>\", you tell [arian em], though the grin on your face makes it obvious you'd welcome a little attention from your reptilian playmate.");
 			outputText("\n\n\"<i>All right!  Sit down,</i>\" [arian ey] says, getting up and motioning towards [arian eir] bed.");
-			
+
 			outputText("\n\nYou easily catch on to what the lizan has in mind and, with a smile, do as you are told, baring your crotch so to give [arian em] the best access.");
-			
+
 			outputText("\n\nArian promptly nuzzles your [cocks], rubbing [arian eir] face all over ");
 			if(player.cockTotal() == 1) outputText("it");
 			else outputText("them");
 			outputText(" shamelessly until a dollop of pre forms on the tip of your [cock biggest].  \"<i>[name]?</i>\"  You give a deliberate groan, playing up how much you're enjoying this for Arian's benefit and smiling at [arian em].  \"<i>Thanks for the breakfast,</i>\"  [arian ey] says with a smile, then proceeds to take the entirety of your [cock] past [arian eir] lips and down [arian eir] throat.  You can't resist chuckling and patting [arian em] on the head.");
-			
+
 			outputText("\n\nThe lizan mage looks up as best as [arian ey] can while bobbing on your shaft, trying to gauge your reaction and making sure [arian ey]'s doing a good job of blowing you.  You smile and make it quite clear that you're enjoying this, then let out a hollow moan as your morning wood goes soft with a decent-sized explosion of cum into the lizan's sucking mouth.");
 			outputText("\n\nArian's eyes bulge with surprise and [arian ey] begins drinking down in earnest, moaning in enjoyment, which proves to be a mistake... shortly after a particularly lengthy moan, [arian ey] tries to swallow and winds up choking.  Some cum escapes [arian em] through [arian eir] nose and [arian ey] quickly pulls away, coughing.  Unfortunately for [arian em], you're still cumming, and the result that even as [arian ey] gags and splutters, you keep on spurting cum all over [arian eir] face until you've emptied yourself.  You sigh in relief, then, with a hint of guilt, ask Arian if [arian ey]'s all right?");
 			outputText("\n\nWiping your seed off [arian eir] eyes, [arian ey] says, \"<i>I'm fine... should have been more careful... and don't worry about the facial either, all I need is a few moments to clean myself up.</i>\"  [arian ey] gets up and walks towards a jug filled with water [arian ey] keeps nearby.");
@@ -3885,14 +3885,14 @@ public function wakeUpAfterArianSleep():void {
 		}
 		else if(flags[kFLAGS.ARIAN_ANAL_XP] < 66) {
 			outputText("With a wide yawn, you open your eyes and realize your dreams have been chased away by your sudden bout of wakefulness.  Arian seems to still be asleep; you take a short moment to snuggle up to the curled lizan, rubbing your erect cock up [arian eir] butt crack.  Despite going soft and slipping out of the lizan's warm innards, you still have to contend with a morning wood... so you dutifully hump yourself between the lizan's buttcheeks, poking the base of [arian eir] tail with your protruding shaft.");
-			
+
 			outputText("\n\n\"<i>Hmm, I'm awake already, stop poking me,</i>\" Arian protests, rubbing the sleep off [arian eir] eyes and turning to look at you over [arian eir] shoulder.  \"<i>Morning, [name].  You don't have to keep poking me under the tail to wake me up,</i>\" [arian ey] says, a bit grumpy.  Then [arian ey] realizes that your hands are still occupied hugging [arian em], so what's poking [arian em] is...  \"<i>Oh!  Sorry about that, [name]!  I thought you wanted something... I mean, maybe you do want something?</i>\"  [arian ey] smiles nervously at you.");
-			
+
 			outputText("\n\nYou make a show of pursing your lips.  The question might be, you decide, does Arian want to do something?  After all, those were rather mixed signals [arian ey] sent you last night...");
 			outputText("\n\n\"<i>Mixed signals?  Did I do something in the night!?</i>\" [arian ey] asks worried.");
 			outputText("\n\nWell, you tell [arian em], first [arian ey] started acting like [arian ey] really, really wanted you to fuck [arian eir] ass.  Then, just when you were getting all steamed up and ready to start, [arian ey] suddenly stopped.  So you were left to try and get back to sleep despite a raging hard-on.  It was really rather annoying, you tell [arian em].");
 			outputText("\n\n\"<i>Oh... umm... sorry.  I was probably sleep talking.  Doesn't happen too often, but well....  Sorry, I had no intention of getting you all worked up for nothing.</i>\"");
-			
+
 			outputText("\n\nYou tell [arian em] that's a start.  Still, you think Arian might want you to work off this morning wood with [arian em], hmm?  Would [arian ey] like it if you held [arian em] close and gave [arian eir] ass a good hard fuck?");
 			outputText("\n\nArian scratches [arian eir] chin, smiling nervously.  \"<i>Well, I wouldn't be opposed, if you want to.</i>\"");
 			outputText("\n\nYou promptly seize the lizan in a tight embrace, already guiding your [cock smallest] towards " + arianMF("his naughty boy-pussy","her tail-hole") + " with a smile on your face.  You teasingly muse aloud about who was saying you were giving [arian em] the choice to say no?");
@@ -3904,13 +3904,13 @@ public function wakeUpAfterArianSleep():void {
 			outputText("\n\nMaybe we should do this more often, you tell Arian.  The two of you stay locked in an embrace for a little while longer, enjoying this morning's afterglow until Arian decides to break the silence.  \"<i>Maybe we should get ready for the day ahead?  Not that I mind staying like this all day.</i>\"");
 			outputText("\n\nYou agree, and messily pull yourself free of the lizan's tight ass, getting off of your lover's back and stretching out your stiff muscles.  Arian does the same, taking care to keep [arian eir] ass closed as tightly as possible, to avoid losing any of your earlier deposit.  \"<i>Say, [name].  If you put your clothes on now, they're going to get all dirty.  So, why not get that cleaned up?</i>\" the lizan mage comments, pointing at your cum-slickened shaft.");
 			outputText("\n\nYou agree with the lizan, and start looking around for a convenient rag to clean yourself off with.  But before you can spot one, you feel a familiar lizan's mouth encompass your shaft and begin sucking earnestly, making sure to get your shaft squeaky clean, even as you begin sporting another erection.  With a slurp, Arian pulls free of your shaft, leaving it to bob in the cool air of the morning as [arian ey] grins at you, wiping [arian eir] mouth with the back of [arian eir] arm.  \"<i>There.  I cleaned you up.</i>\"  [arian Ey] grins.");
-			
+
 			outputText("\n\nYou chuckle and tap the sneaky little lizard on [arian eir] nose, pointing out that [arian ey] did do so, but now [arian ey] got you hard again.  So, what are you supposed to do like this?  As pleasant as it sounds, you can't spend the day buried in [arian eir] tight little ass.  For emphasis, you spank the lizan sharply on the closest ass-cheek, producing a gobbet of cum trickling from [arian eir] used tailhole.");
-			
+
 			outputText("\n\nArian yelps, moving [arian eir] hands to plug [arian eir] behind.  [arian Ey] looks at you and smiles nervously.  \"<i>Sorry, [name].  I couldn't contain myself.  It looked so tasty,</i>\"  [arian ey] licks [arian eir] lips for emphasis.");
-			
+
 			outputText("\n\nYou smile and chuckle; for a respected mage, Arian really has such a perverted side, and you tell [arian em] this.  As [arian ey] looks embarrassed, you sigh and declare you'll just have to put up with it, and start to redress yourself.");
-			
+
 			outputText("\n\n\"<i>Sorry about that.  I'll make it up to you later, if you want,</i>\"  [arian ey] offers, walking towards a small closet to fetch a towel.  You tell [arian em] that you'll hold [arian em] up to that, finish redressing, and head outside to start your day.");
 		}
 		else { // AnalXP <= 100
@@ -3936,11 +3936,11 @@ public function wakeUpAfterArianSleep():void {
 				outputText(" squirting white ropes of lizan cum all over the bedsheets");
 			}
 			outputText("; what a naughty little lizan.");
-			
+
 			outputText("\n\nYou can't resist playfully teasing Arian that [arian ey] is such a buttslut.  ");
 			if(!player.hasVagina()) outputText("Did [arian ey] always know [arian ey] wanted a man to top [arian em], or is this development new to [arian em]?");
 			else outputText("Does [arian ey] really get off on having a girl with a dick of her own fuck [arian em] like a girl, hmm?");
-			
+
 			outputText("\n\n\"<i>No... but I love it regardless!  Fill me with your seed, please!</i>\"  Arian begs, moaning and eagerly awaiting your deposit.");
 			outputText("\n\nYou thrust into [arian em] thrice more, then, with a hollow cry, let out all the seed you can to sate your lovely little buttslut's thirst.  And this time, you can properly focus on cumming, too.");
 			//(Low cum amount)
@@ -3951,9 +3951,9 @@ public function wakeUpAfterArianSleep():void {
 			}
 			//(High cum amount)
 			else outputText("\n\nA veritable eruption explodes from within your cock and out of your tip, flooding the lizan's buttslut with the results [arian ey] craved.  \"<i>Yesssss!  Best... morning... ever,</i>\"  [arian ey] says, completely blissed out, tongue lolling out, as your prodigious amount of cum inflates [arian em] like a balloon.");
-			
+
 			outputText("\n\n\"<i>Hmm... [name], I loved waking up like this.  How about sleeping with me again tonight,</i>\"  Arian suggests, smiling in [arian eir] afterglow.");
-			
+
 			outputText("\n\nYou are silent for a moment, instead concentrating on pulling your cock out of the lizan's ass.  Once you are free, you slap [arian em] playfully on the butt and tell [arian em] you'll think about it.");
 			outputText("\n\n\"<i>Hmm... please do...</i>\"  Arian's mouth opens in a wide yawn.  \"<i>Still a bit sleepy.  I think I'll take a nap now, if you'll excuse me.</i>\"");
 			outputText("\n\nYou chuckle and tell Arian [arian ey]'s such a lazy little lizard, stroking [arian eir] head affectionately before getting dressed and leaving to start your day.");
@@ -3974,11 +3974,11 @@ public function wakeUpAfterArianSleep():void {
 		}
 		else if(flags[kFLAGS.ARIAN_ANAL_XP] < 66) {
 			outputText("You awaken with a yawn, still snuggling against your scaly sleeping partner.  You slip quietly from the bed and give a good stretch, enjoying the feeling but trying not to wake Arian up.  Shortly after you're done, the lizan's maw opens into a wide toothy yawn of [arian eir] own, rubbing the sleep off [arian eir] eyes, [arian ey] looks about until [arian ey] spots you.  \"<i>Good morning, [name]!</i>\" [arian ey] says cheerfully, getting up and lazily stretching [arian emself] as well.  \"<i>Sleep well?</i>\"");
-			
+
 			outputText("\n\nYou did and ask if [arian ey] also slept well.  Rather than replying, the lizan bites [arian eir] lower lip and begins fidgeting in what appears to be embarrassment.  You ask what the matter is, your expression making it clear you aren't going anywhere until [arian ey] talks about it.");
 			outputText("\n\n\"<i>Well, I did sleep well.  It's just that I also had the strangest... dream.</i>\"  [arian Ey] swallows audibly.  Oh?  And what was this dream about?  You ask in a playful tone, but you think you have an idea already...");
 			outputText("\n\n\"<i>Uhh... well, I was... and then... I... had things... done to me...</i>\" [arian ey] explains nervously.");
-			
+
 			outputText("\n\nYou shake your head and tell [arian em] that you didn't understand a word of that.  Fidgeting, the lizan recomposes [arian emself] and begins explaining once more.  \"<i>I-I dreamt I was... well... a muffin and... uhh... I needed my fillings, but the baker kept teasing me by putting the wrong needles in my... bottom... and... well... there was no cream... so... uuh...</i>\"  Embarrassed beyond belief, the lizan just stops talking and just fiddles [arian eir] fingers, white cheeks tinted with the distinct rosy-pink tone that comes with embarrassment.");
 			outputText("\n\nYou smile and can't resist stroking your fingers across the lizan's still naked ass, squeezing the round plumpness of [arian eir] cheeks and stroking [arian eir] slutty butt-pucker, just to see how [arian ey]'ll] react.  Arian whimpers, as [arian eir] ");
 			if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
@@ -3998,24 +3998,24 @@ public function wakeUpAfterArianSleep():void {
 			}
 			if(flags[kFLAGS.ARIAN_VAGINA] > 0) outputText("moist pussy begins forming a stream of juices that gently runs its course through the inside of Arian's thighs, evaporating before hitting the floor due to the lizan's currently elevated body heat.");
 			outputText(" [arian Ey] pants, eyes glazed.  \"<i>Uhh... [name]...</i>\"");
-			
+
 			outputText("\n\nYou smile at [arian em] gently and step back, pulling on your clothes and giving [arian em] a tender kiss on the cheek before you slap [arian eir] bum and head off to start another day.  \"<i>[name].  Visit me soon... please?</i>\" you hear Arian say as you leave, still panting and flustered due to [arian eir] arousal.");
 			dynStats("lus", 10, "scale", false);
 		}
 		else { // AnalXP <= 100
 			outputText("You yawn quietly as you find yourself waking up to another new day.  You note that your hand doesn't feel as cramped as you'd expected; in fact, it turns out that your little buttslut must have let your fingers go sometime after you'd gone back to sleep.  You sigh gently and pat Arian on the back; the thought slips into your mind that maybe [arian ey] would like it more if you'd grow a new cock, so you can fuck [arian em] up the ass the way [arian ey] clearly enjoys so much...");
 			outputText("\n\nArian yawns widely, licking [arian eir] lips and turning to the side to greet you with a sleepy smile.  \"<i>Morning, [name],</i>\" [arian ey] says, rubbing the sleep off [arian eir] eyes; [arian eir] tail slowly creeps its way over your midriff.  \"<i>Sleep well?</i>\"");
-			
+
 			outputText("\n\nYou tell [arian em] that you did, though there was a little problem in the middle of the night, a knowing smirk on your features as you say this.  Concerned, Arian asks, \"<i>What happened.</i>\"");
-			
+
 			outputText("\n\nOh, nothing that probably couldn't be solved by your regrowing a cock, you joke.  Arian looks confused.  \"<i>Whatever do you mean by that?</i>\"");
-			
+
 			outputText("\n\nYou just smile at [arian em] and tell [arian em] not to worry [arian eir] pretty little head, or [arian eir] cute little butt.  You pat [arian em] on the ass playfully, then swing your [legs] off of the bed and get up, ready to start getting dressed.  Arian still looks mildly confused, but decides to get off bed and start getting dressed as well.  During the whole process [arian ey] keeps shooting you longing glances.");
-			
+
 			outputText("\n\nYou finish pulling your clothes on and, unable to resist your curiosity, ask your little love-lizard why [arian ey] keeps looking at you like that?");
-			
+
 			outputText("\n\nArian fiddles [arian eir] fingers.  \"<i>What you said earlier.  I... would really appreciate it if you grew a nice, big, thick cock... full of cum...</i>\"  Arian trails off, licking [arian eir] lips dreamily and fidgeting slightly.");
-			
+
 			outputText("\n\nYou teasingly ask if [arian ey]'s really gotten that used to you reaming [arian eir] ass like that - why, you would have thought [arian ey]'d prefer it if you stopped.  Arian averts [arian eir] eyes and bites [arian eir] lower lip.  \"<i>No, I mean....  I didn't like it... much... at first.  But, I guess the feeling kinda grew on me, and... well... I've been feeling just so empty lately.</i>\"  [arian Ey] swallows audibly.  \"<i>What I mean to say is... yes, I like it when you poke me back there.</i>\"  [arian Ey] hides [arian eir] face in embarrassment, though [arian ey] fidgets in what you've come to recognize as an indication [arian ey] is aroused.  You can't resist smiling, then stepping over to clasp the still-naked lizan's bum, fingers slipping around to gently tease the entrance of [arian eir] well-trained back pucker, which flexes and tries to entice your fingers inside.  You tell [arian em] you'll consider growing a cock back, tap [arian em] on the nose with the very fingers you were just teasing [arian em] with, and then leave to start a new day.");
 			dynStats("lus", 10, "scale", false);
 		}
@@ -4037,38 +4037,38 @@ public function arianEggingEvent():void {
 		flags[kFLAGS.ARIAN_EGG_CHAT]++;
 
 		outputText("As you are about to enter Arian's tent, you hear a moan emanate from within.  Those aren't moans of pleasure though.  They are moans of discomfort.  Wondering if the lizan is all right, you decide to enter [arian eir] tent.");
-		
+
 		outputText("\n\nArian is laying on [arian eir] bed, naked, as [arian ey] rubs [arian eir] belly in a slow circular motion.  You rush to [arian eir] side and ask what happened?");
-		
+
 		outputText("\n\n\"<i>Uh?  Oh, hello [name].  Just feeling a bit sick, that's all.</i>\"  Arian smiles, somewhat embarrassed, and adds, \"<i>You see... it's that time... when girls... y'know.</i>\"  [arian Ey] giggles.");
-		
+
 		outputText("\n\nYou sigh in relief, for a moment you thought [arian eir] health problems might have returned.  So... this means [arian ey]'s growing a clutch of eggs inside [arian em]?");
-		
+
 		outputText("\n\nArian nods in confirmation.  \"<i>That's right.  Lizan females grow unfertilized eggs inside them and must lay those every 30 days.  Today just happens to be my day.  This is the time when a male would... fertilize... the eggs and then the female would lay a clutch of fertile eggs.</i>\"");
-		
+
 		outputText("\n\nYou listen attentively, then a question hits you.  Wouldn't lizans overpopulate if they lay eggs in clutches?  Or are those clutches particularly small?");
-		
+
 		outputText("\n\nArian shakes [arian eir] head.  \"<i>No. Usually we lay clutches of 10 or so eggs, but despite all the eggs being fertilized, not all of them will mature into a healthy baby.  Usually only one or a couple manage to mature.</i>\"  That's sad to hear, you comment. [arian Ey] smiles and shrugs.  \"<i>It's just the way we're built...</i>\"");
-		
+
 		outputText("\n\nYou ask if anyone could fertilize [arian eir] egg. Arian, fidgets and bites [arian eir] lower lip.  \"<i>Well... yes.  Why do you ask?  Are you... maybe... interested?</i>\"  You give it some thought... and tell [arian em] that you were just curious, but who knows... maybe in the future.");
-		
+
 		outputText("\n\nArian averts [arian eir] eyes, smiling happily.  \"<i>Maybe, but I have to say this is not the way I saw myself having a family.  I always thought I'd be the one helping lay... you know?</i>\"  You nod, does that make [arian em] uncomfortable? [arian Ey] shakes [arian eir] head.  \"<i>Not at all, if there's anyone I'd pick to father my children, that would certainly be you, [name].</i>\"  [arian Ey] smiles at you, and you smile right back at [arian em].");
-		
+
 		outputText("\n\nSo... unless you plan on having a family with [arian em]... sex is out of the question.  Arian blurts out, \"<i>No!</i>\"  You recoil in surprise at [arian eir] sudden outburst; [arian ey] covers [arian eir] mouth and smiles nervously.  \"<i>S-sorry... must be the hormones making me moody... regardless... no.  I have placed an enchantment on myself, and you won't be able to impregnate me unless we remove that.  So... someday when we're both ready and willing... hehe.</i>\"  [arian Ey] fidgets, laughing nervously.");
-		
+
 		outputText("\n\nYou tell [arian em] that it's reassuring to hear that [arian ey]'s being careful about this matter.");
 		outputText("\n\n\"<i>Of course, parenthood is a big responsibility,</i>\" Arian notes.");
-		
+
 		outputText("\n\nYou nod your head.  Then, curious, you ask what [arian ey]'ll do with the eggs after [arian ey]'s laid them, if there's going to be nothing inside of them?");
-		
+
 		outputText("\n\n\"<i>Usually we'd just eat them, since they're rich in protein and good for the health of the mother, but I think I can try and create something useful for you.  You know how there are magical colored eggs that are said to have transformative effects, right?  I could try to use my magic and grow a few eggs with the color of your choosing.</i>\"");
-		
+
 		outputText("\n\nYou tell [arian em] that could be very helpful in your quest, but you don't want [arian em] to strain [arian em]self; can [arian ey] do it without hurting [arian em]self?");
-		
+
 		outputText("\n\nArian puffs [arian eir] chest out proudly.  \"<i>Of course I can!  Though magic can be unpredictable sometimes, I am a master mage, and something as simple as imbuing my own eggs with magic is no trouble at all...  but I appreciate your concern all the same.</i>\"  [arian Ey] smiles at you.");
-		
+
 		outputText("\n\nIf that's the case, you tell [arian em], then you would appreciate it if [arian ey] could try creating colored eggs for you from [arian eir] unfertilized eggs.");
-		
+
 		outputText("\n\n\"<i>Sure!  Which color do you want?</i>\"");
 	}
 	else {
@@ -4093,7 +4093,7 @@ private function pickAnEggArian(color:String = "pink"):void {
 	outputText("You tell Arian you'd like [arian em] to make you a " + color + " egg.");
 	outputText("\n\n\"<i>All right,</i>\" [arian ey] replies, closing [arian eir] eyes and beginning to focus [arian eir] magic.");
 	outputText("\n\nYou watch in wonder as a " + color + " light seems to gather within Arian's belly, slowly fading away.  The lizan mage smiles and opens [arian eir] eyes, tail waving lazily behind [arian em] in happiness.  \"<i>It's done.  I tried to get all my eggs imbued, but I won't know if I was successful or not until they're laid.</i>\"");
-	
+
 	outputText("\n\nYou thank [arian em] for [arian eir] efforts, give [arian em] a quick peck on the cheek, and then encourage [arian em] to get some rest.  Arian nods.  \"<i>I should be ready to lay tomorrow, so don't forget to visit.</i>\"");
 	outputText("\n\nYou nod in understanding and wave to [arian em] as you leave [arian eir] tent.");
 	flags[kFLAGS.ARIAN_EGG_COUNTER] = 1;
@@ -4120,16 +4120,16 @@ public function arianLaysEggs():void {
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) outputText("herm");
 	else outputText("girl");
 	outputText(" squatting over a wooden basin, one hand between [arian eir] legs, massaging [arian eir] dripping treasure, while the other is rubbing [arian eir] belly to try and coax the eggs out of [arian em].");
-	
+
 	outputText("\n\nYou see [arian em] sway momentarily, too focused on the task at hand to even notice you.  Fearing [arian ey] might lose [arian eir] balance and fall, you quickly move behind [arian em], hugging and steadying [arian em].");
-	
+
 	outputText("\n\nThe lizan ");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) outputText("herm" + arianMF("-boy", ""));
 	else outputText("female");
 	outputText(" is sucking in great lungfuls of air, slowly hissing them out as [arian ey] soldiers on through the contractions of [arian eir] womb.  So intent on [arian eir] labors is [arian ey] that [arian ey] doesn't recognize your presence, at first.  After a few moments, however, [arian eir] eyes finally recognize you're there and [arian ey] gives you a brave smile.  \"<i>Ah, hello, [name]; sorry you had to catch me like this - I was hoping I'd have this over and done before you saw it,</i>\" [arian ey] notes apologetically.");
-	
+
 	outputText("\n\nYou scold [arian em], telling [arian em] [arian ey] should've called you when [arian ey] was getting ready to lay; you would have gladly helped.  You tighten the hug, bringing [arian em] closer to your chest, one hand moving to meet hers as [arian ey] slowly massages [arian eir] belly.  You entwine your fingers with [arian eirs] and help [arian em] massage [arian eir] belly.");
-	
+
 	outputText("\n\n\"<i>Mmm... thank you, [name], that does feel nicer when it's someone else.  This wouldn't be so bad if I knew it was going to be a baby at the end of it, but I go through all this for nothing more than a quick snack.  I can kind of understand why harpies have always been so nuts about getting fertilized when they're full of eggs, now: it's not so much that they - or I - want to be moms so badly as it is just so annoying to go through this for absolutely no reward at the end of it,</i>\" the lizan notes, sighing heavily and leaning against you for support.");
 
 	outputText("\n\nStill, you are very thankful for [arian em] doing this for you.  Then you note that [arian ey] seems to really have fallen into [arian eir] role as a " + arianMF("hermboy","girl") + ".  You would never expect to hear this kind of comment from someone who was a man before... but it's cute that Arian is acting this way, and you enjoy [arian em] the way [arian ey] is now.  You give [arian em] a peck on the cheek for emphasis.  Now, [arian ey] has a clutch to lay, and you'll be here during all the steps necessary to do so.  You take [arian eir] hand off [arian eir] belly and place it against your midriff, then proceed to rub [arian eir] belly by yourself. With your other hand, you release [arian em] and do the same, your hand massaging [arian eir] pussy lips, replacing [arian eir] hand shortly as you tease and massage the contracting opening to [arian eir] depths.");
@@ -4139,26 +4139,26 @@ public function arianLaysEggs():void {
 	outputText("\n\nNever stopping your ministrations, you ask what you should do?  Arian doesn't have time to answer though, as you feel one of the egg shaped lumps beginning its journey down the lizan's birth canal.  You feel [arian eir] pussy dilating, far faster than it should on any woman, and for a moment you worry as the egg passes quickly, falling into your waiting hand.  You barely have time to safely place it on the basin as another egg soon falls into your hand.  Arian's belly vibrates with the rapid contractions, rapidly reducing in size as the eggs make their way out.");
 
 	outputText("\n\n\"<i>Nnng... once it finally starts, it's over quick, so don't worry, [name].  I'll be done in a minute,</i>\" [arian ey] promises you.");
-	
+
 	outputText("\n\nYou nod, though [arian ey] can't see you from this position.  You whisper that [arian ey] is a very brave girl to face this kind of ordeal... and you can't deny that seeing [arian em] laying eggs like this has a certain appeal. [arian Ey] looks very sexy. You tell [arian em] that this is good practice for when [arian ey]'s laying fertile eggs. You hope [arian ey]'ll look as sexy as [arian ey] looks now, once the time comes.");
 
 	outputText("\n\nThe lizan laughs, a rather pitch-switching sound as [arian eir] uterus continues flexing.  \"<i>If you really think I'm sexy like this, [name], then I sure hope we'll end up doing this for real sooner rather than later. Oooh... not much more left in me now,</i>\" [arian ey] says, closing [arian eir] eyes and continuing to push. As [arian ey] said, within moments, [arian eir] belly is flat as normal, while the last few eggs have clattered into the straw-lined basin [arian ey]'s been squatting over.  With a hissing sigh of relief, [arian ey] gingerly straightens up and steps over it. \"<i>I... can you please get me some cool water, [name]? I have a jug over there?</i>\" [arian ey] asks, pointing in the appropriate direction.");
-	
+
 	outputText("\n\nOf course you can, you reply. You gently help [arian em] down on the floor from [arian eir] squat, and head towards the jug [arian ey] indicated.  Looking about, you quickly spot a mug and fill it with water, bringing the cool liquid back to the panting lizan.  [arian Ey] takes it from you and gulps down a sizable mouthful of it, then pours some over [arian eir] head.  \"<i>Ohhh... that feels better.  Why don't you check the eggs, see if our little experiment worked?  I'm just going to regain my strength,</i>\" [arian ey] suggests.");
-	
+
 	outputText("\n\nYou nod your head, and begin sorting through the eggs.  Most of them look like common eggs, not that much different from large chicken eggs.  Eventually, you find one that seems to be appropriate.  Separating this egg from the others, you check one more time and find out that Arian only managed to lay one " + color + " egg.  Still, that's good enough for you.  You take the egg and turn to place it gently on the nearby counter.  When you turn to check up on Arian though, you spot the lizan casually lifting one of the \"<i>normal</i>\" eggs, sizing it up.");
-	
+
 	outputText("\n\nArian pays no attention to you, instead hungrily inspecting [arian eir] just-laid egg.  A trickle of drool oozes out of the corner of [arian eir] mouth and is lapped up with a quick flick of a long tongue before [arian ey] opens [arian eir] jaws and crams the whole egg inside.  [arian Ey] mouths it around before [arian ey] manages to puncture it, audibly sucking out the insides before spitting the crushed but still-intact eggshell out into [arian eir] hand.  [arian Ey] grabs another and gobbles it down with the same eagerness as before, spitting out the shell after sucking out the contents.");
-	
+
 	outputText("\n\nYou cough, trying to remind the hungry lizan before you, that you're still in the room...");
 
 	outputText("\n\n[arian Ey] pauses, just about to cram another egg into [arian eir] mouth, and looks sheepish.  \"<i>Ah... sorry, [name].  I'm just so hungry and, well, it's not like there's anything else in these things, right?  Or did you want to try one?</i>\" [arian ey] suddenly suggests, offering [arian eir] latest 'treat' to you.");
 
 	outputText("\n\nYou politely refuse, telling [arian em] that [arian ey] probably needs it more than you do, since [arian ey] just went through labor.  Anyways you should probably be going.  You thank the lizan for the " + color + " egg and tell [arian em] to enjoy [arian eir]... meal... and point out that, while you personally appreciate the view, [arian ey] should probably put on some clothes later.");
 	outputText("\n\nArian gasps and quickly covers [arian em]self, smiling nervously to you.  \"<i>Thank you for pointing that out, [name].  Although,</i>\" [arian ey] giggles nervously.  \"<i>If you'd rather I stay naked, I'm willing to do that for you...</i>\"  You give the idea some thought... but decide to tell [arian em] that you'd prefer [arian ey] put on some clothes next time you visit.  Otherwise you miss out on having [arian em] sensuously strip for you, you laugh.");
-	
+
 	outputText("\n\n\"<i>Well, that's one way to look at it, I guess.</i>\"  Arian laughs.  \"<i>So, if you don't want to join me, a lady needs to have [arian eir] breakfast,</i>\" [arian ey] tells you, then swallows another egg whole, letting out a very unladylike belch.  \"<i>Okay, that was a bit too much to swallow,</i>\" [arian ey] admits, blood flushing the pale scales of [arian eir] face in one of [arian eir] pseudo-blushes.");
-	
+
 	outputText("\n\nYou laugh at Arian's reaction, telling [arian em] that you don't mind.  You should go right now.  You turn to pocket the egg and leave Arian's tent, bidding the lizan farewell before you do.\n\n");
 	//(PC obtains (Large) Egg of the [color] asked message.)
 	var itype:ItemType;
@@ -4188,22 +4188,22 @@ private function arianDildoFun():void {
 		if(player.hasKeyItem("Dildo") >= 0) outputText("bought from Giacomo");
 		else outputText("got from Tamani");
 		outputText(", asking if [arian ey]'s willing to give this a try.");
-		
+
 		outputText("\n\nThe lizan averts [arian eir] eyes in embarrassment.  \"<i>Umm... I guess I'm okay with it?</i>\"  [arian Ey] fidgets a bit.  \"<i>But I've never used anything when... much less something like that.</i>\"");
-		
+
 		outputText("\n\nYou shush [arian em] gently, assuring [arian em] that it'll be all right; you'll be here to help [arian em] get comfortable with it and to show [arian em] how to use it right.  Besides, it's much better than [arian eir] fingers....");
-		
+
 		outputText("\n\n\"<i>A-All right then.</i>\"  [arian Ey] smiles nervously.");
 	}
 	else {
 		outputText("You present your dildo to Arian again, telling [arian em] that this time, you want to play with your toys - after all, [arian ey] enjoyed it so much the first time.");
-		
+
 		outputText("\n\nArian fidgets in embarrassment.  \"<i>Okay.</i>\"");
 	}
 	flags[kFLAGS.TIMES_ARIAN_DILDOED]++;
-	
+
 	outputText("\n\nYou carefully put the dildo down beside the pillow before turning to Arian and pulling [arian em] into an embrace, arms around [arian eir] waist, before spinning [arian em] around, sweeping [arian em] off [arian eir] feet, and dropping [arian em] flat on the bed.  [arian Ey] giggles nervously as you slide yourself into position, straddling [arian em] and pinning [arian eir] wrists to the bed beside [arian eir] head, leaving [arian em] helpless.  Your tongue slides out of your lips in a lecherous gesture before you bend your head down and kiss [arian em] first on one dark nipple, and then on the other.  Arian wriggles and squirms underneath you as you start to plant quick, soft, gentle kisses up [arian eir] torso and towards [arian eir] neck, diligently kissing your way towards [arian eir] lips.  Once there, you plant a butterfly kiss on [arian eir] lips, but that's not enough; you release your grip on [arian eir] wrists and instead place a soft but authoritative palm on each of [arian eir] cheeks, pinning [arian em] in place as you passionately consume [arian eir] lips with your own.");
-	
+
 	outputText("\n\nYour lizan lover reciprocates your kiss, [arian eir] scaled arms wrapping around you as [arian ey] hugs you tightly, legs instinctively spreading to allow you access.  You continue to suckle at [arian eir] lips, forcefully probing at them with your tongue to see if [arian ey] will allow you access.  Even as you do this, you settle yourself more comfortably upon [arian eir] body and slide a hand down [arian eir] torso, over [arian eir] belly until you reach between [arian eir] legs.  ");
 
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
@@ -4213,17 +4213,17 @@ private function arianDildoFun():void {
 	}
 	else outputText("Y");
 	outputText("ou slide first one finger into [arian eir] slick pussy and then another, gently caressing [arian eir] inner labia to see if you can find [arian eir] sweet spots.  Arian's eyes open in surprise as the first pang of pleasure hits [arian em], [arian ey] moans into your kiss.  [arian Eir] tongue darts to dance with your own in excitement.");
-	
+
 	outputText("\n\nYou allow [arian eir] tongue to wrestle with yours, suckling lewdly upon it and watching as Arian writhes and moans underneath you, totally in your thrall.  But, enough is enough when it comes to a warm-up; you break the kiss and remove your hand from [arian eir] cunt.  Arian protests feebly, but you shush [arian em], caressing [arian eir] cheek as you declare that the time for warming up is over.  With your other hand, you reach for the nearby dildo and then slap it between [arian eir] [arian chest].  It's time [arian ey] put on a little show for you....");
-	
+
 	outputText("\n\nThe lizan mage swallows nervously, but nods in understanding.  You give [arian em] one last kiss for being so obedient, squeeze [arian eir] breasts in passing, and then drag yourself off of [arian em], deliberately scraping your [vagina] over [arian eir] belly as you go and shivering with pleasure at the sensations [arian eir] smoothly scaly skin sends through your cunt.  You hop off of the bed and reposition yourself sitting upright at the base, where you have a perfect seat for whatever [arian ey] plans on doing next.");
-	
+
 	outputText("\n\nArian takes the dildo in hand, gripping and releasing it to watch the rubber shift under [arian eir] touch.  [arian Ey] looks nervously at you one more time and then opens [arian eir] mouth wide.  [arian Ey] slips the dildo between [arian eir] lips, suckling softly, wetting it with [arian eir] saliva.  Not bad, not bad at all for a beginner, and you nod your head, encouraging [arian em] that [arian ey]'s getting off to a good start.  Arian blinks in understanding and continues to lather the rubber shaft in saliva.");
-	
+
 	outputText("\n\n[arian Ey] pops the dildo out of [arian eir] mouth, satisfied with its current wetness.  With one hand, [arian ey] cups a breast and rubs the tip of the dildo on [arian eir] erect nipple, moaning at the stimulation.  [arian Eir] eyes glance at you to see if [arian ey]'s pleasing you.  You shift so that [arian ey] can see your naked form, letting [arian em] watch as your hands slip teasingly down to your love canal's entrance.  You moan softly, starting to frig yourself in excitement at the show [arian ey]'s putting on.  Emboldened by your display, Arian smiles and licks the tip of the dildo once more.  [arian Ey] moans as [arian ey] strokes [arian eir] other nipple, setting the dildo between [arian eir] breasts to run its length along [arian eir] cleavage.  Whenever the dildo grows dry, [arian ey] takes it back to [arian eir] mouth to lather it again with a drawn out slurp.  [arian Ey]'s starting to get in the mood, you notice.");
-	
+
 	outputText("\n\nYou clap your hands all of a sudden, startling Arian out of [arian eir] oral ravishing.  You crawl your way up to [arian em], your motions smooth and seductive, gently taking the dildo from [arian eir] unresisting fingers as you coil yourself around [arian em].  [arian Ey]'s been putting on a very nice show, you stage whisper to [arian em], but this isn't really what you wanted to see.  You're going to give [arian em] a hand and show [arian em] just how good this can really be....");
-	
+
 	outputText("\n\nYou start by seductively wrapping your own tongue around the dildo, sloppily kissing it and slurping on it, sucking eagerly at the taste of [arian eir] saliva and making sure it's good and sodden with both your mixed juices.  Then, you hold the dripping wet toy up to [arian em] for [arian eir] inspection.  [arian Ey] looks at the dildo enraptured, panting in excitement.  Then, now that [arian ey]'s good and excited, you bring the dildo down to the junction of [arian eir] legs, ");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
 		outputText("brushing it tantalizingly across the sensitive skin of [arian eir] pre-oozing cock");
@@ -4231,11 +4231,11 @@ private function arianDildoFun():void {
 		outputText(", before ");
 	}
 	outputText("brushing it against [arian eir] outer lips, stroking it up and down each labium, rubbing it against [arian eir] clitoris, gently pushing the very tip of it into [arian eir] cunt only to then withdraw it before it can really start to stretch [arian eir] cunt.");
-	
+
 	outputText("\n\nArian moans and fidgets as you play with [arian eir] body, moaning and gasping at the friction generated by the rubber dildo.  \"<i>Oh, [name].  T-that feels great!</i>\" [arian ey] moans in delight, bucking against the dildo in an attempt to find purchase.");
-	
+
 	outputText("\n\nIf it feels so good, then why doesn't [arian ey] prove it, you ask [arian em], continuing to tease [arian em] with the dildo but refusing to put it in, your free hand stroking your [clit] and fingerfucking your [vagina] at an excited pace.  Isn't [arian ey] just dying to have this fake-cock between [arian eir] legs, spreading [arian eir] pussy wide and stretching out [arian eir] gut until [arian ey]'s a helpless puddle of fuck?  Why doesn't [arian ey] show you that's what [arian ey] wants?");
-	
+
 	outputText("\n\nArian looks at you in confusion.  \"<i>Prove it? ...Ah!</i>\" [arian ey] moans loudly, bucking wildly against your teases.  Yes, prove it... and with that, you take a firm grip on the dildo and roughly thrust it as far into Arian's cunt as the horny lizan will let it enter!  The " + arianMF("", "she-") + "lizan's maw opens in a look of surprise; instead of a scream, all [arian ey] can manage is a gasp.  You make sure to commit the image to memory for moments.  Arian closes [arian eir] eyes and moans - a throaty moan, a moan of pleasure.  [arian Eir] face contorts as [arian eir] vaginal walls clamp down on the rubbery intruder.  ");
 	if(flags[kFLAGS.ARIAN_COCK_SIZE] > 0) {
 		outputText("[arian Eir] cock");
@@ -4244,37 +4244,37 @@ private function arianDildoFun():void {
 		outputText(" as a jet of whiteness escapes. ");
 	}
 	outputText("You can feel it... the suddenness of your penetration brought the poor lizan mage to an instant orgasm.");
-	
+
 	outputText("\n\nGrinning wickedly to yourself, you sprawl yourself across your reptilian " + arianMF("boy","girl") + "friend, hungrily kissing [arian em] and sucking [arian eir] long, prehensile tongue into your mouth to play with it - and to muffle any further screams of ecstasy.  With one hand, you grope [arian eir] [arian chestAdj] boobs, while with the other you continue to plunge the dildo back and forth inside of [arian em], sliding it out - not easy, with how tightly [arian ey] grips it in [arian eir] cunt - before roughly pounding it home again, a repetitive motion to burrow for [arian eir] cervix and to leave [arian em] a quivering pile under you.  The poor lizan is helpless against your relentless assault.  All Arian manages is squeals of pleasure and wanton moans of desperate lust.");
-	
+
 	outputText("\n\nYou keep this up for minute after delightfully entertaining minute, before you decide that [arian ey]'s had [arian eir] fun; now it's your turn.  You try to tug the dildo free of [arian eir] clenching cunt, but [arian ey] just quakes and moans as another orgasm rips through [arian eir] body - [arian ey]'s holding the toy so tightly inside [arian em] that you can't get it out!  You let go of it and pat [arian eir] cheek, tauntingly complaining that [arian ey]'s not being fair.");
-	
+
 	outputText("\n\nArian groans, opening [arian eir] eyes slightly to look at you.  \"<i>W-What do you... mean by that?</i>\" [arian ey] asks, clearly not recovered after [arian eir] climax.");
-	
+
 	outputText("\n\nWhy, [arian ey]'s hogging the dildo all to [arian em]self, you reply, making another failed attempt at pulling it free for emphasis.  [arian Ey] gets to get off, but you get no fun for yourself - now, does that seem fair to [arian em]?  Hmm?  Arian pants, shaking [arian eir] head.  \"<i>Sorry...</i>\"  [arian Ey] attempts to even out [arian eir] breathing enough to at least speak normally.");
 
 	outputText("\n\n\"<i>Sorry, [name].  I don't think you can pull the dildo out of me yet.  That would... well... it would be too much for me.  So please.  Just don't, at least for now.</i>\"  You crawl off of [arian em] slightly, so [arian ey] can move more freely and so you can watch [arian em] at work.  \"<i>I think I can help you with your problem though.</i>\"  Interested, you give [arian em] the signal to go ahead.  [arian Ey] begins chanting a spell and within moments you watch in amusement.  Your dildo's base begins extruding itself, growing into a familiar phallic shape.  Soon enough you're looking at an exact replica of the dildo currently buried in your lizan girlfriend.  Clever girl....");
 
 	outputText("\n\nArian smiles tiredly.  \"<i>There.  Forgive me, [name], but I'm too tired to move right now.</i>\"  That's all right; you can move for [arian em], you reply, already shifting yourself into position, bringing your [vagina] into alignment to start impaling yourself on your now double-ended dildo.");
-	
+
 	outputText("\n\nYou shift and thrash, moaning lewdly as you stroke every spot that you know will bring you pleasure; in your aroused state, it's easy to get into things.  Each thrust you make earns an ecstatic groan from your girlfriend as it shifts the dildo inside [arian eir] over-aroused pussy.  You hump and you grind and you squeeze, a tug of war between your two netherlips as you and Arian fight for possession of your favorite toy.  You can feel the pleasure overwhelming you, sparks of arousal setting your brain on fire; you're close... oh, gods, you're so close!");
-	
+
 	outputText("\n\nWith one mighty clench and tug, you pull the dildo free of Arian's love-hole, throwing your head back and crying out as you climax, the waves of orgasm washing through you, your whole body quaking in pleasure.  When at last it ends, you let yourself fall limply back on the bed with a sigh of relief, your pussy slackening and letting your dildo fall free.");
-	
+
 	outputText("\n\nOnce you catch your breath, you absently reach down and bring your favorite toy up to your face, you watch as it slowly reverts back to its original form, though still dripping with your mixed juices.  Smiling openly, you inform Arian that you may just be the luckiest " + player.mf("boy", "girl") + " in Mareth, to have a " + arianMF("herm-boy", "girl") + "friend like [arian em].");
-	
+
 	outputText("\n\nArian pants, still winded, though [arian eir] breathing seems to have returned to a more normal level.  [arian Ey] can't help but grin at your compliment.  \"<i>Don't be silly, [name].  I'm the lucky one.  But I'm really glad you think so highly of me.</i>\"  Why shouldn't you?  [arian Ey] gave up [arian eir] birth-gender, just to better please you - why, any girl who passed up a chance to snap up someone as sweet as Arian was a fool, but they'll never amend their mistake, because [arian ey]'s all yours now.  With that you slither around in the bed so that you can glomp onto your " + arianMF("herm-boy", "girl") + "friend, rubbing your " + player.skinFurScales() + " cheek against [arian eir] own smooth scales, hugging [arian em] tightly to you.");
 
 	outputText("\n\nArian rubs [arian em]self back at you affectionately.  \"<i>I love you, [name].</i>\"  You just hold [arian em] and let [arian em] feel your warmth.  Then, you realise you're still holding a sopping wet dildo in one hand, and you casually present it to Arian, holding it in front of [arian eir] face and telling [arian em] to clean it.  Before [arian ey] can protest, you point out that <b>[arian ey]</b> got the most fun out of it, and <b>[arian ey]</b> made most of the mess, so that makes it <b>[arian eir]</b> responsibility to clean it up.  You waggle it in front of [arian eir] snout for emphasis.");
-	
+
 	outputText("\n\nArian blinks at your words, but concedes with a smile.  \"<i>Of course.</i>\"  [arian Ey] opens [arian eir] mouth and lets [arian eir] tongue roll out, inviting you to place the dildo into [arian eir] open mouth.  You promptly slide the fake-cock gently home, letting [arian em] start at [arian eir] own pace.");
-	
+
 	outputText("\n\n[arian Ey] cleans it diligently, and from the looks of it, [arian ey]'s also enjoying [arian em]self immensely.  Arian's eyes are closed most of the time, but you notice that [arian ey] opens them to glance at you and smile to [arian em]self.  Whatever's going through [arian eir] head must be very pleasant.  It takes only a couple of minutes before you pull the dildo out to inspect it.  Lizan spit shines in the light of the ambience, and from what you can see... there's not a single trace of your, or Arian's, juices left on the dildo.  With a smile, you pat your lizan on the head, congratulating [arian em] on a job well done.");
-	
+
 	outputText("\n\n\"<i>Thank you, but I'm not done yet.</i>\"  You look at [arian em], wondering what [arian ey] has in mind.  Arian slithers along your body, until [arian eir] face is hovering your [vagina].  A knowing smirk crosses your lips and you relax, eager to let [arian em] get to work.  [arian Ey] gently spreads your legs and begins licking, making sure to drink in all of your juice.");
-	
+
 	outputText("\n\nYou gasp and shudder, moaning softly as [arian ey] pleasures your oversensitive love canal.  It doesn't take long, maybe a minute or two, before you are writhing in a mini-orgasm, your female fluids gushing into your lover's eager mouth, bathing [arian eir] probing tongue.  [arian Ey] makes sure to lap it all, not keen on letting even a single drop be wasted.  \"<i>Hmm, delicious,</i>\" Arian says as [arian ey] licks [arian eir] lips clean of leftovers.");
-	
+
 	outputText("\n\nYou heave a sigh of contentment and authoritatively drag your little lizan slut into your arms, wrapping yourself around [arian em] in a cuddle and making it quite clear you don't intend to let [arian em] go anywhere any time soon.  Fortunately, [arian ey] seems quite eager to be there, and so you shut your eyes and allow yourself to slowly drift off to sleep.  Before you fully embrace unconsciousness, though, you place a gentle hand on Arian's pussy, stroking [arian em] softly - not to arouse [arian em] yet again, but just to let [arian em] feel a loving touch there, in the place that brings you both such pleasures....");
 
 	player.sexReward("vaginalFluids","Vaginal");

--- a/classes/classes/Scenes/NPCs/AyaneFollower.as
+++ b/classes/classes/Scenes/NPCs/AyaneFollower.as
@@ -102,7 +102,7 @@ public function ayaneTalkPriestess():void
 	outputText("You would like to discuss various things with Ayane; starting with her role as priestess.\n\n");
 	outputText("\"<i>My role? Um... Well, while most kitsune are satisfied enjoying a simple life, caught between a good prank and good lovemaking, one needs to remember to thank the one who made us who and what we are. Taoth, like any god, has worshipers; and by studying The Trickster's pranks and dogma, one can attain some form of personal enlightenment. Life is a farce, in and of itself; a game to be played to the bitter end, best to take it with a smile rather than tears.</i>\"\n\n");
 	doNext(ayaneTalkMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 
 public function ayaneTalkTaoth():void
@@ -113,7 +113,7 @@ public function ayaneTalkTaoth():void
 	outputText("So in theory the reason he's the prankster of the pantheon is because everyone else is way too serious?\n\n");
 	outputText("Ayane nods at this statement. \"<i>Deities could do with smiling more or with knowing how to have a good time. Taoth is here to remind them and us that order cannot exist without chaos, otherwise the world would be a bleak place indeed.</i>\"\n\n");
 	doNext(ayaneTalkMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 
 public function ayaneTalkPrayer():void
@@ -128,7 +128,7 @@ public function ayaneTalkPrayer():void
 		outputText("You have no idea, but you are quite sure he’s out there, preparing yet another huge prank for the demons.\n\n");
 	}
 	doNext(ayaneTalkMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 
 public function ayaneShop():void {
@@ -443,7 +443,7 @@ private function BelisaAyaneTalk():void {
 	outputText("You ask your resident priestess about curing cursed injuries. Immediately, Ayane springs up, eyes wide as she looks you up and down. \"<i>My " + player.mf("lord", "lady") + ", are you hurt?!</i>\" You hastily explain that it’s not for you, but rather, for a friend. Ayane listens as you describe Belisa’s predicament, and she shakes her head sadly. ");
 	outputText("\"<i>I’m afraid I cannot help you. Curses tied to specific injuries are rather difficult to remove, and I sadly don’t have the ability to cure such maladies yet.</i>\" You thank Ayane for her assistance, and she shakes her head sadly. \"<i>I did nothing, [name].</i>\"\n\n");
 	doNext(ayaneCampMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 
 //======================================================================================================

--- a/classes/classes/Scenes/NPCs/BelisaFollower.as
+++ b/classes/classes/Scenes/NPCs/BelisaFollower.as
@@ -39,11 +39,11 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 	public static var HolyBand6Cap:Number;
 	public static var HolyBand7:Number;
 	public static var HolyBand7Cap:Number;
-	
+
 	public function stateObjectName():String {
 		return "BelisaFollower";
 	}
-	
+
 	public function resetState():void {
 		BelisaEncounternum = 0;
 	 	BelisaAffectionMeter = 0;
@@ -72,7 +72,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		HolyBand7 = 0;
 		HolyBand7Cap = 0;
 	}
-	
+
 	public function saveToObject():Object {
 		return {
 			"BelisaEncounternum": BelisaEncounternum,
@@ -103,7 +103,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 			"HolyBand7Cap": HolyBand7Cap
 		};
 	}
-	
+
 	public function loadFromObject(o:Object, ignoreErrors:Boolean):void {
 		if (o) {
 			BelisaEncounternum = o["BelisaEncounternum"];
@@ -137,24 +137,24 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 			resetState();
 		}
 	}
-	
+
 	public function BelisaFollower()
 	{
 		Saves.registerSaveableState(this);
 	}
-	
+
 	private function BelisaHolyBands():Boolean {
 		if (HolyBand1 > 0 || HolyBand2 > 0 || HolyBand3Cap > 0 || HolyBand4 > 0 || HolyBand5 > 0 || HolyBand6 > 0 || HolyBand7 > 0) return true;
 		return false;
 	}
-	
+
 	public function BelisaAffection(changes:Number = 0):Number {
 		BelisaAffectionMeter += changes;
 		if (BelisaAffectionMeter > 120) BelisaAffectionMeter = 120;
 		if (BelisaAffectionMeter < 0) BelisaAffectionMeter = 0;
 		return BelisaAffectionMeter;
 	}
-	
+
 	public function firstEncounter():void {
 		clearOutput();
 		outputText("You stride through the swamp. It seems to be quieter than normal. You think you hear the telltale hissing of a Drider, but nothing pops out at you. You check your feet, but there’s no web traps around you. Still, you’re in drider territory, and you put your back to a willow tree, holding your [weapon] ready.\n\n");
@@ -168,7 +168,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		BelisaEncounternum = 1;
 		startCombat(new CorruptedDrider());
 	}
-	
+
 	public function secondEncounter():void {
 		clearOutput();
 		outputText("Your row on the lake is peaceful. For once, the water is calming and still. The wind’s no longer blowing, and the sky above is blue. As you gaze around, something catches your eye.\n\n");
@@ -178,7 +178,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		addButton(2, "No", secondEncounterNo);
 		addButton(3, "Never", secondEncounterNever);
  	}
-	
+
 	public function secondEncounterApproach():void {
 		clearOutput();
 		outputText("You row closer to the odd orb, your curiosity overcoming your caution. On closer inspection, you realize you’ve seen this material before. This structure appears to be made entirely out of spider silk!\n\n");
@@ -194,7 +194,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
  		addButton(3, "Fishing", secondEncounterYesFishing);
 		addButton(4, "NoWorries", secondEncounterYesNoWorries);
 	}
-	
+
 	public function secondEncounterYesDemons():void {
 		outputText("You puff out your chest, exclaiming that you are the champion of Ignam, and you were sent to rid the world of demons and corruption. At your exclamation, her brown eyes narrow.\n\n");
 		outputText("<i>\"...Many have tried, ‘champion’.\"</i> She picks at the left side of her mouth, then catches you looking, hiding her face behind her oversized hat. <i>\"If you’re looking for demons, you won’t find any here, so just go away please.\"</i>\n\n");
@@ -202,14 +202,14 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		addButton(1, "Leave", secondEncounterLeaveAlone);
 		addButton(2, "Nah", secondEncounterNahFight);
 	}
-	
+
 	public function secondEncounterYesCuriosity():void {
 		outputText("You tell the girl that you just wanted to know what this giant ball in the lake was. She sighs. <i>\"I made this. It’s my home.\"</i> She pouts a little, crossing her arms. <i>\"Now can you please let me be?\"</i>\n\n");
 		menu();
 		addButton(1, "Leave", secondEncounterLeaveAlone);
 		addButton(2, "Nah", secondEncounterNahFight);
 	}
-	
+
 	public function secondEncounterYesFishing():void {
 		outputText("You tell her that you were just out on the lake to catch some fish. At this, she sighs. The sphere wriggles, and a dead fish, head pierced with some kind of needle, is thrown into your boat. <i>\"There, you have a fish.\"</i> Her voice quivers, and she points towards the shore. <i>\"Now please... just leave me alone.\"</i>\n\n");
 		inventory.takeItem(consumables.FREFISH, secondEncounterYesFishing2);
@@ -220,24 +220,24 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		addButton(1, "Leave", secondEncounterLeaveAlone);
 		addButton(2, "Nah", secondEncounterNahFight);
 	}
-	
+
 	public function secondEncounterYesNoWorries():void {
 		outputText("You raise your hands, trying to assure her that you mean no harm. Her six eyes soften a little, but she points at the shore, lips quivering. <i>\"Look...Just…\"</i> She inhales shakily. <i>\"Just leave me, please. I don’t know who you are.\"</i>\n\n");
 		menu();
 		addButton(1, "Leave", secondEncounterLeaveAlone);
 		addButton(2, "Nah", secondEncounterNahFight);
 	}
-	
+
 	public function secondEncounterLeaveAlone():void {
 		outputText("You apologize for startling her, and turn your boat around. You blink, realizing you didn’t even get her name. You turn back and ask loudly what the Drider’s name is. As you row away, you can see the white orb sinking beneath the water’s surface. <i>\"Belisa\",</i> you hear on the breeze. You see her eyes, and the ripple on the water as The Drider-No, <i>Belisa,</i> slips underneath the surface of the water, following her home down.\n\n");
 		endEncounter();
 	}
-	
+
 	public function secondEncounterNahFight():void {
 		outputText("You grin at her, asking what the rush is. Surely just hanging around isn’t such a big deal, right? You barely finish your sentence before a dagger flashes by your face. Eyes wide, she emerges from her silky home. She’s shaking, but as she comes out revealing her Drider bottom half, complete with eight thin, chitin-covered legs legs and a slender, web-slinging thorax, the daggers in her hands are rock-steady, her lips drawn into a frown.  <i>\"The Name’s B-Belisa. I don’t want to fight you…But you need to leave me alone!\"</i>\n\n");
 		startCombat(new Belisa());
 	}
-	
+
 	public function postFightOptionsWhitefireWait():void {
 		clearOutput();
 		outputText("\"<i>Wait...You’re...Pure. I…</i>\" She looks at you awkwardly, wringing her hands. \"<i>Uh...Sorry?</i>\"  Her cheeks flush, and she turns her head to face somewhere else. You lower your [weapon], as she appears to be no further threat. You ask her why she attacked you, and she looks back at you, her cheeks bright red. ");
@@ -245,20 +245,20 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		BelisaEncounternum = 4;
 		cleanupAfterCombat();
 	}
-	
+
 	public function secondEncounterNo():void {
 		clearOutput();
 		outputText("After a few sidelong glances, you row away from the odd object, shrugging to yourself. This boat trip wasn’t productive, but oddities aren’t entirely unwelcome.\n\n");
 		endEncounter();
 	}
-	
+
 	public function secondEncounterNever():void {
 		clearOutput();
 		outputText("You’ve experienced enough of Mareth to leave curious objects alone. You vow to give this object a wide berth in the future.\n\n");
 		BelisaInGame = false;
 		endEncounter();
 	}
-	
+
 	public function subsequentEncounters():void {
 		clearOutput();
 		outputText("You’re walking along the lake shore, and a glimmer of white on the water’s surface catches your eye. You quickly realize that it’s Belisa’s silk orb. You walk over to the water’s edge, trying to catch a glimpse of the odd little Drider girl.\n\n");
@@ -292,7 +292,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		addButton(4, "Sex", BelisaSex);
 		if (BelisaHolyBands()) addButton(5, "Holy Bands", BelisaHolyBandsManagment).hint("Putting on ot taking of any of the Holy Bands you own. With little Belisa help ;)");
 	}
-	
+
 	public function Encounterback():void {
 		clearOutput();
 		outputText("<i>\"Well, what is it you want then?\"</i>\n\n");
@@ -304,7 +304,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		addButton(4, "Sex", BelisaSex);
 		if (BelisaHolyBands()) addButton(5, "Holy Bands", BelisaHolyBandsManagment).hint("Putting on ot taking of any of the Holy Bands you own. With little Belisa help ;)");
 	}
-	
+
 	public function BelisaTalk():void {
 		clearOutput();
 		outputText("<i>\"You...Just want to...talk?\"</i> She looks at you, confused, as if the thought hadn’t even occurred to her. <i>\"You...Don’t want to…?\"</i> She rolls her eyes, making a ‘jerk-off’ motion with one hand. You tell her that you have no intention of approaching her sexually right now, and she relaxes a little, smiling. <i>\"Okay then...What do you want to talk about?\"</i>\n\n");
@@ -326,7 +326,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		if (BelisaInCamp) addButton(14, "Back", BelisaMainCampMenu);
 		else addButton(14, "Back", Encounterback);
 	}
-	
+
 	public function BelisaTalkYou():void {
 		clearOutput();
 		outputText("<i>\"Oh? You want to talk about yourself?\"</i> Belisa brings a hand to her mouth, a smirk on her face. <i>\"How very arrogant.\"</i> You raise one eyebrow, and she chuckles, the smirk fading from her face. <i>\"I’m kidding, [name]. I’d love to hear about your adventures.\"</i> You talk about the various demons you’ve faced, Zetaz and the portal, and even some stories from your childhood in Ignam. Belisa is a great listener. She laughs when you tell a joke, or when the story turns serious, asks questions, and listens with rapt attention when you talk about the other people you’ve met along your travels.\n\n");
@@ -339,7 +339,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		else {
 			outputText("After some time talking with your Drider friend, you excuse yourself. You still need to keep watch over the portal. Belisa gives you an odd smile, smoothing her robe as she stands. \"<i>Come back when you have some more stories, Champion.</i>\"\n\n");
 			if (BelisaInCamp) {
-				eachMinuteCount(15);
+				advanceMinutes(15);
 				doNext(BelisaTalk);
 			}
 			else endEncounter();
@@ -359,19 +359,19 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		BelisaAffection(5);
 		endEncounter();
 	}
-	
+
 	public function BelisaTalkHome():void {
 		clearOutput();
 		outputText("<i>\"...Well, I lived in a Drider colony not far from the deepwoods.\"</i> Belisa begins, fidgeting with her needles. She begins to work on another robe. <i>\"Mother was grooming me to be our town’s manaweaver...but then the demons came.\"</i> She looks at you, and you give her an odd look. <i>\"Oh...You meant...My house?\"</i> Her face brightens a bit. <i>\"Well...Before they came, Driders could come in different types. The type of the parents didn’t really matter, but certain spider-types are better at certain things than others.\"</i> She realizes she’s gotten off track, and blushes, looking down at her weaving.\n\n");
 		outputText("<i>\"Aaaaaanyways, my silk’s slightly different from most Drider’s. It’s lighter, stronger, and when submerged in water, it can do some really cool things. Momma Oaklee taught me how to keep it waterproof while weaving, and how to do other things with it. So, when I needed a safe place to hide...I made one underwater!\"</i>\n\n");
 		BelisaAffection(5);
 		if (BelisaInCamp) {
-			eachMinuteCount(15);
+			advanceMinutes(15);
 			doNext(BelisaTalk);
 		}
 		else endEncounter();
 	}
-	
+
 	public function BelisaTalkHer():void {
 		clearOutput();
 		outputText("<i>\"You want to learn about...Me?\"</i> Her back legs skitter about, and she seems to have trouble meeting your gaze. <i>\"That depends...What do you want to know?\"</i>\n\n");
@@ -402,7 +402,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 				if ((DriderTown.TyrantiaMaleKids + DriderTown.TyrantiaFemaleKids) > 0) outputText("\"<i>Her kids are surprisingly soft.</i>\" Belisa chuckles. \"<i>Mischievous, but not aggressive or warlike. Not like their mom.</i>\" She smiles down at the meadow, where Tyrantia plays with your kids. \"<i>Unicorn-Driders. Who would’ve thought?</i>\"\n\n");
 			}
 			if (LilyFollower.LilyFollowerState) outputText("\"<i>Lily…Doesn’t look the same as she did before, but that’s going around, it would seem.</i>\" Belisa rubs one of her legs idly. \"<i>Most Driders looked like me, before the demons. She also…Developed some rather odd tastes in the years we spent apart.</i>\"\n\n");
-			eachMinuteCount(15);
+			advanceMinutes(15);
 			doNext(BelisaTalk);
 		}
 		else {
@@ -419,7 +419,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 				addButton(3, "Do", BelisaTalkHerFamilyDo).hint("Tell her");
 			}
 			else {
-				eachMinuteCount(15);
+				advanceMinutes(15);
 				doNext(BelisaTalk);
 			}
 		}
@@ -427,12 +427,12 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 	public function BelisaTalkHerFamilyDo():void {
 		outputText("You clear your throat, and you look Belisa in the eyes. Seeing your seriousness, Belisa looks down and away as you tell her about Lily. \"<i>...If what you say is true…Then my sister is alive!</i>\" She stands. \"<i>If you can convince her to join you…Maybe…</i>\" She looks at you, hope in her eyes. \"<i>I hope to see her someday.</i>\"\n\n");
 		BelisaAffection(10);
-		eachMinuteCount(15);
+		advanceMinutes(15);
 		doNext(BelisaTalk);
 	}
 	public function BelisaTalkHerFamilyDont():void {
 		outputText("You put a hand on Belisa’s shoulder, saying that you can change the topic if she wants. Belisa nods. \"<i>Something lighter, perhaps?</i>\"\n\n");
-		eachMinuteCount(15);
+		advanceMinutes(15);
 		doNext(BelisaTalk);
 	}
 	public function BelisaTalkHerNoherm():void {
@@ -497,7 +497,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 			addButton(3, "Ew", BelisaTalkInjuriesEw);
 		}
 	}
-	
+
 	public function BelisaTalkInjuriesComfort():void {
 		clearOutput();
 		outputText("You tell her that you had no idea how bad it was. <i>\"Yeah, I know. That was kind of the point.\"</i> She sighs. <i>\"But now you know…\"</i>\n\n");
@@ -525,7 +525,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		BelisaAffection(-20);
 		endEncounter();
 	}
-	
+
 	public function BelisaSleepToggle():void {
 		//spriteSelect(SpriteDb.s_electra);
 		clearOutput();
@@ -541,7 +541,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		menu();
 		addButton(0,"Next", BelisaTalk);
 	}
-	
+
 	public function BelisaHang():void {
 		clearOutput();
 		if (BelisaAffectionMeter < 20) {
@@ -560,7 +560,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 			addButton(8, "Back", Encounterback);
 		}
 	}
-	
+
 	public function BelisaHangSpar():void {
 		clearOutput();
 		if (BelisaAffectionMeter < 30) {
@@ -610,7 +610,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 			flags[kFLAGS.BELISA_LVL_UP]++;
 		}
 	}
-	
+
 	public function BelisaHangFish():void {
 		clearOutput();
 		outputText("<i>\"Oh, is that all?\"</i> Belisa pops down under the water, then into her silk orb. \"A-ha!\" She comes out with two odd, hooked spears. <i>\"If you want to fish with me, I’ll teach you how we Driders do it!\"</i>\n\n");
@@ -623,7 +623,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		outputText("<i>\"I forgot how nice it was to have a fishing partner\"</i>, she says simply, taking your hand as you leave the water together. <i>\"Come back soon, okay?\"</i> She looks into your eyes, then pulls her hand away. <i>\"It gets lonely out here.\"</i> You smile to yourself as Belisa dives back into the water, and head back to camp.\n\n");
 		inventory.takeItem(consumables.FREFISH, explorer.done);
 	}
-	
+
 	public function BelisaHangMagic():void {
 		clearOutput();
 		outputText("<i>“Oh, you want to learn the mystic arts?”</i> She gives you a smile. <i>“Well, I’m not the most accomplished mage, but...If it’ll help you, then I can help you along the path.”</i>\n\n");
@@ -656,7 +656,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		BelisaAffection(5);
 		endEncounter();
 	}
-	
+
 	public function BelisaHangHouse():void {
 		clearOutput();
 		outputText("<i>\"Oh, you’re wondering about the house?\"</i> Belisa seems surprised you’re taking an interest in her dwelling. <i>\"I made it from a bit of...Well, no...A lot of silk, some spongy wood from the swamp, and bits and pieces here and there.\"</i> She motions to you, and you follow her onto her vessel-home.\n\n");
@@ -667,7 +667,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		BelisaAffection(5);
 		endEncounter();
 	}
-	
+
 	private function BelisaShop():void {
 		clearOutput();
 		outputText("<i>\"Oh...You want to buy something?\"</i> Belisa blinks her two large eyes, somewhat surprised. <i>\"I-I mean, sure. I’m not sure what you want, but…I have some things for sale, if you want them.\"</i> The little Drider-girl runs to her silk orb, and comes back with a number of boxes attached to her Drider half. <i>\"I have silk for sale. It’s raw, but someone could make it into armor for you...I also have...Underwear.\"</i> ");
@@ -1052,7 +1052,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		}
 		doNext(BelisaHolyBandsManagment);
 	}
-	
+
 	public function BelisaComeCamp():void {
 		clearOutput();
 		outputText("You tell Belisa that Mareth is a dangerous place. She looks at you as if you’re an idiot, hand on her hip. <i>\"Yes, I do know that.\"</i>\n\n");
@@ -1077,7 +1077,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		addButton(1, "Set up", BelisaSetUp);
 		addButton(3, "Kiss", BelisaSmooch);
 	}
-	
+
 	public function BelisaSmooch():void {
 		clearOutput();
 		outputText("You lean in, kissing Belisa on the lips. She flinches, but after a second or so, she wraps her arms around you, her full lips locking with yours as if it’s the most natural thing in the world. You feel one of her front legs on the small of your back, and she pulls you in, her C-cup breasts a pillow against your [chest]. Her tongue is long, and your saliva mixes with hers, a surprisingly sweet taste. You stroke her long, ebony hair, pulling back from the kiss. <i>\"I…\"</i> Belisa begins to talk, but shuts her mouth, her heart clearly beating quickly. <i>\"...You…!\"</i>\n\n");
@@ -1159,7 +1159,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		if (DriderTown.DriderTownComplete) addButton(13, "Back", SceneLib.dridertown.DriderTownEnter).hint("Return to main DriderTown menu.");
 		addButton(14, "Leave", camp.campLoversMenu);
 	}
-	
+
 	public function BelisaAppearance():void {
 		clearOutput();
 		outputText("Belisa, at first glance, appears to be an odd cross between a spider-morph and a drider. She only has two humanlike eyes, with light brown pupils. Her face is mostly humanoid, save for a thin ridge of chitin that adorns her brow like a crown. Long, straight black hair runs down her back, almost touching her Drider back half. The top of her head is shielded from the sun by a large, glistening sun hat that you can only assume was woven from her own silk. Her skin is pale, almost white, and her full lips draw into a natural pout.\n\n");
@@ -1172,7 +1172,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		if (BelisaInCamp) doNext(BelisaMainCampMenu);
 		else doNext(Encounterback);
 	}
-	
+
 	public function BelisaSexMenu(fromCombat:Boolean = false):void {
 		menu();
 		addButton(1, "Fuck", BelisaFuck).disableIf(!player.hasCock(), "Req. a cock!");
@@ -1226,7 +1226,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		if (rng == 1) doNext(BelisaAfterSex1, true);
 		else doNext(BelisaAfterSex2);
 	}
-	
+
 	public function BelisaAnal():void {
 		clearOutput();
 		outputText("You tell Belisa that you want to make love to her. The Drider-girl blushes, wrapping her arms around your waist and gently pulling you in towards her. You let her slide your [armor] off");
@@ -1250,7 +1250,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		player.sexReward("no", "Default");
 		doNext(BelisaAfterSex1);
 	}
-	
+
 	public function BelisaSilkjob():void {
 		clearOutput();
 		outputText("You tell Belisa that you want to try something a little different. She nods, looking down at your endowments. She idly chews on one finger for a moment before nodding once. <i>\"I have an idea.\"</i> She says, a small smile forming on her face. Belisa turns, exposing her spinnerets, and the silk-hole in the middle. <i>\"But this will require some…Precise movements.\"</i> She makes a silken blindfold, covering your eyes. <i>\"Let me guide you.\"</i> She takes your hand, and you feel a warm, wet sensation on each of your fingers. Curious, you curl one, and you hear Belisa gasp. <i>\"Hey…Hold still please.\"</i>\n\n");
@@ -1270,7 +1270,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		player.sexReward("Default", "Dick",true,false);
 		doNext(BelisaAfterSex1);
 	}
-	
+
 	public function BelisaDildo():void {
 		clearOutput();
 		if (player.hasCock()) outputText("<i>\"Not to be...rude, [name], but...wouldn’t you rather use...your…?\"</i> She gently nudges your [cock]. You shake your head, and she looks at you, shrugging her shoulders.\n\n");
@@ -1297,7 +1297,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		player.sexReward("Default", "Vaginal",true,false);
 		doNext(BelisaAfterSex1);
 	}
-	
+
 	public function BelisaAndTyrantia():void {
 		clearOutput();
 		outputText("You wake up to find a familiar figure standing over you. Her five working eyes and dick-shaped weapon give away who it is instantly. Tyrantia waves nervously as you get up. \"<i>Uh...Hey [name], Question...Where did that massive pile of silk on the water come from?</i>\" You tell Tyrantia that there’s a new member of the camp, a Drider. You tell Tyrantia that she’s way smaller than her, and Tyrantia grins a bit, flexing one massive bicep.\n\n");
@@ -1318,7 +1318,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		BelisaEncounternum = 5;
 		doNext(playerMenu);
 	}
-	
+
 	public function BelisaConfession():void {
 		clearOutput();
 		outputText("You wake up to the sounds of struggle in your camp. Suddenly awake, you rush out of your "+(flags[kFLAGS.CAMP_BUILT_CABIN] > 0 ? "cabin":"tent")+", [weapon] drawn. The sounds of struggle seem to be coming from Belisa’s watery home, and you move quickly, rushing towards the sounds. When you see the cause, however, you stop in your tracks. Tyrantia is holding Belisa over her head, one arm holding her by three of her spider legs, and the other holding her upper body in place, her face smooshed into Tyrantia’s considerable bosom. Belisa struggles, but the giant Drider doesn’t really even need to try to keep her there as she walks towards the center of the camp. <i>\"Sister, no! Bad! Stop this at once, and put me down!\"</i> Belisa’s spider-half flails, kicking Tyrantia in the back, to no discernible effect.\n\n");
@@ -1493,7 +1493,7 @@ public class BelisaFollower extends NPCAwareContent implements SaveableState
 		knockUpBelisa();
 		cleanupAfterCombat();
 	}
-	
+
 	private function chanceToFail():Number {
 		var chance:Number = 10;
 		chance += Math.min(player.cumQ() / 25,40);

--- a/classes/classes/Scenes/NPCs/CeaniScene.as
+++ b/classes/classes/Scenes/NPCs/CeaniScene.as
@@ -72,8 +72,7 @@ public function basicarcherytraining2():void
 		outputText("Ceani pulls you in, kiss your cheek and walk away, swiftly jumping back into the sea. What a thoughtful gift.\n\n");
 		flags[kFLAGS.CEANI_ARCHERY_TRAINING] = 4;
 		bowSkill(10);
-		explorer.stopExploring();
-		inventory.takeItem(weaponsrange.SHUNHAR, camp.returnToCampUseTwoHours);
+		inventory.takeItem(weaponsrange.SHUNHAR, curry(explorer.done,120));
 	}
 	else if ((flags[kFLAGS.CEANI_ARCHERY_TRAINING] == 2 || flags[kFLAGS.CEANI_ARCHERY_TRAINING] == 3)) {
 		outputText("You seek out Ceani and ask her if she could resume your training. Both of you head to the training ground. Once there, she helps you to position yourself properly and show you how to throw the javelins. You do so for a few hours, moving to recover your weapon every few shots. ");
@@ -85,8 +84,7 @@ public function basicarcherytraining2():void
 		if (flags[kFLAGS.CEANI_ARCHERY_TRAINING] == 2) flags[kFLAGS.CEANI_ARCHERY_TRAINING] = 3;
 		flags[kFLAGS.CEANI_DAILY_TRAINING] = 1;
 		bowSkill(10);
-		explorer.stopExploring();
-		doNext(camp.returnToCampUseTwoHours);
+		endEncounter(120);
 	}
 	else {
 		outputText("You seek out Ceani and ask her if she could train you in the use of ranged weapons.\n\n");
@@ -104,8 +102,7 @@ public function basicarcherytraining2():void
 			player.createStatusEffect(StatusEffects.Kelt, 10, 0, 0, 0);
 		}
 		else bowSkill(10);
-		explorer.stopExploring();
-		inventory.takeItem(weaponsrange.TRJAVEL, camp.returnToCampUseTwoHours);
+		inventory.takeItem(weaponsrange.TRJAVEL, curry(explorer.done,120));
 	}
 }
 
@@ -137,8 +134,7 @@ public function beachInteractionsAfterArcheryTraining():void
 			outputText("\"<i>Well, better luck next time champ. Still, how about we share a meal? There is more than enough for both of us.</i>\"\n\n");
 			outputText("You eat with Ceani, sharing stories of your recent adventures. After the dinner is over you head back to camp.\n\n");
 			player.refillHunger(25);
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 		}
 	}
 	else if (player.hasItem(consumables.FISHFIL) || player.hasItem(consumables.FREFISH)) {
@@ -416,8 +412,7 @@ public function underwaterDateMaleVer():void
 	if (player.cocks[x].cockLength < 22) outputText(" Still something tells you if your cock was bigger Ceani might like it more. Your dick felt like a small key trying to fit an oversized lock.");
 	outputText("\n\n");
 	player.sexReward("vaginalFluids","Dick");
-	explorer.stopExploring();
-	doNext(camp.returnToCampUseTwoHours);
+	endEncounter(120);
 }
 
 public function underwaterDateFemaleVer():void
@@ -441,8 +436,7 @@ public function underwaterDateFemaleVer():void
 		player.sexReward("vaginalFluids");
 		ceaniAffection(6);
 	}
-	explorer.stopExploring();
-	doNext(camp.returnToCampUseTwoHours);
+	endEncounter(120);
 }
 
 public function beachInteractionsDateOnTheBeach0():void
@@ -533,8 +527,7 @@ public function beachDateMaleVer():void {
 	if (player.cocks[x].cockLength < 22) outputText(" Still something tells you if your cock was bigger Ceani might like it more. Your dick felt like a small key trying to fit an oversized lock.");
 	outputText("\n\n");
 	player.sexReward("vaginalFluids","Dick");
-	explorer.stopExploring();
-	doNext(camp.returnToCampUseTwoHours);
+	endEncounter(120);
 }
 
 public function beachDateFemaleVer():void {
@@ -561,8 +554,7 @@ public function beachDateFemaleVer():void {
 		ceaniAffection(6);
 	}
 	player.sexReward("vaginalFluids", "Lips");
-	explorer.stopExploring();
-	doNext(camp.returnToCampUseTwoHours);
+	endEncounter(120);
 }
 
 public function come2campCeani():void

--- a/classes/classes/Scenes/NPCs/CelessScene.as
+++ b/classes/classes/Scenes/NPCs/CelessScene.as
@@ -352,8 +352,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		outputText("<i>\""+ player.mf("Dad", "Mom") +", is something wrong?\"</i>\n" +
 		"You reply that no… Although you wistfully hope she will stay cute like this forever, despite knowing perfectly well that she will not.\n" +
 		"While you would like to spend more time enjoying your role as a parent you still have a lot of things to do, so you simply tell her to stay at camp for now whenever you're not here for her safety.");
-		explorer.stopExploring();
-		doNext(camp.returnToCampUseFourHours);
+		endEncounter(120);
 	}
 
 	//dialogue: 0 for Celess.
@@ -767,7 +766,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 		findArmor();
 		inventory.takeItem(armors.CTPALAD, explorer.done);
 	}
-	
+
 	public function nightmareDefeated():void {
 		_age = _ageDidPregnancy;
 		_questFinished = _finishedNightmare;
@@ -1008,7 +1007,7 @@ public class CelessScene extends XXCNPC implements TimeAwareInterface {
 			}
 		}
 	}
-	
+
 	private function get myLocals():*{
 		return {
 			$name : _name,

--- a/classes/classes/Scenes/NPCs/DianaFollower.as
+++ b/classes/classes/Scenes/NPCs/DianaFollower.as
@@ -637,7 +637,7 @@ public function mainCampMenu():void {
 	}
 	addButton(8, "Uncurse", uncurseItemsMenu)
 			.disableIf(player.equippedKnownCursedItems().length == 0 && player.carriedKnownCursedItems().length == 0, "You don't have any cursed items");
-	
+
 	if (BelisaFollower.BelisaQuestOn && !BelisaFollower.BelisaQuestComp) addButton(13, "ToothacheQ", BelisaDianaTalk);
 	addButton(14, "Back", camp.campLoversMenu);
 }
@@ -724,7 +724,7 @@ public function HealingScene():void {
 	HPChange(player.maxOverHP(), true);
 	EngineCore.changeFatigue( -(Math.round(player.maxFatigue() * 0.5)));
 	doNext(mainCampMenu);
-	eachMinuteCount(45);
+	advanceMinutes(45);
 }
 
 public function CuringCurseScene1():void {	//value related curses removal
@@ -741,7 +741,7 @@ public function CuringCurseScene1():void {	//value related curses removal
 		player.removeCurse(stat, 10,3);
 	}
 	doNext(mainCampMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function CuringCurseScene2():void {	//bonus multi related curses removal
 	clearOutput();
@@ -759,7 +759,7 @@ public function CuringCurseScene2():void {	//bonus multi related curses removal
 		}
 	}
 	doNext(mainCampMenu);
-	eachMinuteCount(30);
+	advanceMinutes(30);
 }
 
 public function mainSexMenu():void {

--- a/classes/classes/Scenes/NPCs/DriderTown.as
+++ b/classes/classes/Scenes/NPCs/DriderTown.as
@@ -9,9 +9,9 @@ import classes.GlobalFlags.kFLAGS;
 import classes.Items.UndergarmentLib;
 import classes.Scenes.SceneLib;
 import classes.internals.SaveableState;
-	
+
 	use namespace CoC;
-	
+
 	public class DriderTown extends NPCAwareContent implements SaveableState {
 		public static var DriderTownComplete:Boolean;
 		public static var SisterBangEnabled:Boolean;
@@ -44,7 +44,7 @@ import classes.internals.SaveableState;
 		public static var TyrantiaKidsEggsHatching:Number;
 		public static var TyrantiaKidsEggsHatching1:Number;
 		public static var TyrantiaKidsEggsHatching2:Number;
-		
+
 		public function stateObjectName():String {
 			return "DriderTown";
 		}
@@ -226,7 +226,7 @@ public function BelisaBroodmotherMoment():void {
 	outputText("You nod, wrapping your arms around Belisa’s upper body, holding her close. The expectant broodmother lets out a little sigh. \"<i>Sorry, but...I needed that.</i>\" She walks back to her house, and you watch her, slightly concerned. At least the pregnancy won’t last long.\n\n");
 	BelisaPregnancy -= 24;
 	doNext(playerMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 public function BelisaEggLaying():void {
 	clearOutput();
@@ -250,7 +250,7 @@ public function BelisaEggLaying():void {
 		BelisaKidsEggsHatching = 120;
 	}
 	doNext(playerMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function BelisaEggsHatched():void {
 	clearOutput();
@@ -274,7 +274,7 @@ public function BelisaEggsHatched():void {
 		BelisaKidsEggs2 = 0;
 	}
 	doNext(playerMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 
 public function LilyEggLayingPC():void {
@@ -301,7 +301,7 @@ public function LilyEggLayingPC():void {
 		LilyKidsPCEggsHatching = 120;
 	}
 	doNext(playerMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 public function LilyEggsHatchedPC():void {
 	clearOutput();
@@ -325,7 +325,7 @@ public function LilyEggsHatchedPC():void {
 		LilyKidsPCEggs2 = 0;
 	}
 	doNext(playerMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 
 public function TyrantiaBroodmotherMoment():void {
@@ -335,7 +335,7 @@ public function TyrantiaBroodmotherMoment():void {
 	outputText("<i>“I love you.”</i> She lets go of you, going back to her hutch. <i>“Even though you made it so I can’t fight for another day.”</i> She rubs the top of your head. <i>“Asshole.”</i> Her smile takes the sting entirely out of those words. You can tell that, despite everything, your Drider giantess is very happy.\n\n");
 	TyrantiaPregnancy -= 24;
 	doNext(playerMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 public function TyrantiaEggLaying():void {
 	clearOutput();
@@ -359,7 +359,7 @@ public function TyrantiaEggLaying():void {
 		TyrantiaKidsEggsHatching = 120;
 	}
 	doNext(playerMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function TyrantiaEggsHatched():void {
     var kidsHatched:int =
@@ -412,7 +412,7 @@ public function TyrantiaEggsHatched():void {
 		TyrantiaKidsEggs2 = 0;
 	}
 	doNext(playerMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 
 public function SpooderSleep():void {

--- a/classes/classes/Scenes/NPCs/ElectraFollower.as
+++ b/classes/classes/Scenes/NPCs/ElectraFollower.as
@@ -144,6 +144,7 @@ public function ElectraRecruitingSure():void {
 	flags[kFLAGS.ELECTRA_LVL_UP] = 1;
 	flags[kFLAGS.ELECTRA_DEFEATS_COUNTER] = 0;
 	flags[kFLAGS.ELECTRA_DAILY_STORM_JEWEL] = 0;
+	explorer.stopExploring();
 	doNext(playerMenu);
 }
 public function ElectraRecruitingNah():void {

--- a/classes/classes/Scenes/NPCs/EmberScene.as
+++ b/classes/classes/Scenes/NPCs/EmberScene.as
@@ -478,7 +478,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         eggMenu();
 
     }
-    
+
     private function eggDescribe():void {
         var genderColor:Array = ["white", "blue", "pink", "lavender"];
         outputText("\nThe egg has a " +genderColor[flags[kFLAGS.EMBER_GENDER]]+ " tone");
@@ -2847,8 +2847,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
 
         outputText("\n\nYour decency restored, you return to camp.");
         flags[kFLAGS.EMBER_PUSSY_FUCK_COUNT]++;
-        explorer.stopExploring();
-        doNext(camp.returnToCampUseTwoHours);
+        endEncounter(120);
     }
 
     //Get Penetrated - also horse-proof, sorry folks! (Z)
@@ -4153,8 +4152,7 @@ public class EmberScene extends NPCAwareContent implements TimeAwareInterface {
         outputText("\n\nYou head off yourself, ready to resume the rest of your day.");
         //2 hours pass, PC's fatigue is healed some, Libido is reduced.
         fatigue(-20);
-        explorer.stopExploring();
-        doNext(camp.returnToCampUseTwoHours);
+        endEncounter(120);
     }
 
     //Sleep with Ember!

--- a/classes/classes/Scenes/NPCs/EvangelineFollower.as
+++ b/classes/classes/Scenes/NPCs/EvangelineFollower.as
@@ -269,7 +269,7 @@ private function TalkYourEyes():void {
 	evangelineAffection(1);
 	if (EvangelineTalks == 0) EvangelineTalks = 1;
 	doNext(evangelineTalkMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 private function TalkDemons():void {
 	clearOutput();
@@ -281,7 +281,7 @@ private function TalkDemons():void {
 	evangelineAffection(1);
 	if (EvangelineTalks == 1) EvangelineTalks = 2;
 	doNext(evangelineTalkMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 private function TalkPastLife1():void {
 	clearOutput();
@@ -297,7 +297,7 @@ private function TalkPastLife1():void {
 	evangelineAffection(1);
 	if (EvangelineTalks == 2) EvangelineTalks = 3;
 	doNext(evangelineTalkMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 private function TalkYourFather():void {
 	clearOutput();
@@ -312,7 +312,7 @@ private function TalkYourFather():void {
 	evangelineAffection(1);
 	if (EvangelineTalks == 3) EvangelineTalks = 4;
 	doNext(evangelineTalkMenu);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }/*
 private function TalkPastLife2():void {
 	clearOutput();
@@ -321,7 +321,7 @@ private function TalkPastLife2():void {
 	evangelineAffection(1);zajmie miejsce PastTalk1 w menu
 	if (EvangelineTalks == 0) EvangelineTalks += 1;
 	doNext(evangelineTalkMenu);
-	eachMinuteCount(15);
+	advanceTimeNoEvents(15);
 }
 private function TalkPastLife3():void {
 	clearOutput();
@@ -329,7 +329,7 @@ private function TalkPastLife3():void {
 	evangelineAffection(1);zajmie miejsce PastTalk2 w menu
 	if (EvangelineTalks == 0) EvangelineTalks += 1;//ustalić na jakiej wartości flagi bedzie sie pokazywać
 	doNext(evangelineTalkMenu);
-	eachMinuteCount(15);
+	advanceTimeNoEvents(15);
 }
 private function TalkYourEyes():void {
 	clearOutput();
@@ -337,7 +337,7 @@ private function TalkYourEyes():void {
 	evangelineAffection(1);
 	if (EvangelineTalks == 4) EvangelineTalks += 1;//ustalić na jakiej wartości flagi bedzie sie pokazywać
 	doNext(evangelineTalkMenu);
-	eachMinuteCount(15);
+	advanceTimeNoEvents(15);
 }
 private function TalkYourEyes():void {
 	clearOutput();
@@ -345,7 +345,7 @@ private function TalkYourEyes():void {
 	evangelineAffection(1);
 	if (EvangelineTalks == 5) EvangelineTalks += 1;//ustalić na jakiej wartości flagi bedzie sie pokazywać
 	doNext(evangelineTalkMenu);
-	eachMinuteCount(15);
+	advanceTimeNoEvents(15);
 }
 private function TalkYourEyes():void {
 	clearOutput();
@@ -353,7 +353,7 @@ private function TalkYourEyes():void {
 	evangelineAffection(1);
 	if (EvangelineTalks == 6) EvangelineTalks += 1;//ustalić na jakiej wartości flagi bedzie sie pokazywać
 	doNext(evangelineTalkMenu);
-	eachMinuteCount(15);
+	advanceTimeNoEvents(15);
 }
 */
 private function evangelineSexMenu():void {
@@ -808,7 +808,7 @@ private function MakingWhiteAbyssalInkPotion():void {
 		inventory.tryAddMultipleItemsToPlayer(useables.D_E_ICHOR, 10);
 		doNext(ingredientsMenu);
 	}
-	
+
 private function LvLUp():void {
 	clearOutput();
 	outputText("\"<i>So [name] how much gems will you give me this time for my recovery or new experiments?</i>\" Asks Evangeline waiting for your decision.");
@@ -965,7 +965,7 @@ private function curingWendigo():void {
 		outputText("\"<i>Look, I will need five pure peaches and five purity philters to fix this up, how you get the two is up to you.</i>\"\n\n");
 		player.addPerkValue(PerkLib.WendigoCurse, 1, 1);
 		doNext(camp.campFollowers);
-		eachMinuteCount(15);
+		advanceMinutes(15);
 	}
 }
 
@@ -1050,7 +1050,7 @@ private function curingJiangshi():void {
 		outputText("\"<i>Look, I will need five vitality tinctures and five purity philters to fix this up, how you get the two is up to you.</i>\"\n\n");
 		flags[kFLAGS.CURSE_OF_THE_JIANGSHI]++;
 		doNext(camp.campFollowers);
-		eachMinuteCount(15);
+		advanceMinutes(15);
 	}
 }
 
@@ -1221,7 +1221,7 @@ private function IMutationsSelector(page:int = 0):void {
 		outputText("Evangeline gets to brewing the mutagen. An half hour later, the injection is ready. She has you laid down into a makeshift seat.\n\n");
 		outputText("\"<i>This might sting a little… bear it with me [name].</i>\"\n\n");
 		outputText("You don't have the time to gasp before she pushes the injection in. The transformative in the wound burns at first but then spreads to your organ as it slowly changes to acquire new inhuman property. The transformation was successful.");
-		eachMinuteCount(15);
+		advanceMinutes(15);
 		doNext(InternalMutations);
 	}
 }

--- a/classes/classes/Scenes/NPCs/IsabellaFollowerScene.as
+++ b/classes/classes/Scenes/NPCs/IsabellaFollowerScene.as
@@ -1413,8 +1413,7 @@ private function isabellaBarnFuckPartII():void {
 	dynStats("sen", -3);
 	fatigue(-25);
 	isabellaKnockUpAttempt();
-	explorer.stopExploring();
-	doNext(camp.returnToCampUseTwoHours);
+	endEncounter(120);
 }
 
 //------------

--- a/classes/classes/Scenes/NPCs/JojoScene.as
+++ b/classes/classes/Scenes/NPCs/JojoScene.as
@@ -22,7 +22,7 @@ public class JojoScene extends NPCAwareContent implements TimeAwareInterface {
 	public static const JOJO_NOSEX_2:int      = -2;
 	// Jojo agreed to sex
 	public static const JOJO_SEXED:int        = -3;
-	
+
 
     public static var monk:Number = JOJO_NOT_MET;
 
@@ -1885,8 +1885,7 @@ public function jojoFollowerMeditate(doClear:Boolean = true):void {
 				outputText("As you move away from the mouse, you step into a huge puddle of Jojo's creamy rodent cum and look back. You see that his dick, still trapped under his body and pointing behind the two of you, blasted long ropes of thick mouse spunk far into the depths of the forest.  Feeling beyond satisfied, you give your mouse slut a quick scratch behind the ear as he passes out – cum splattered and smiling.");
 			}
 			player.sexReward("no", "Dick");
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 		}
 
 //Bee on C. Jojo: Finished (Fenoxo) (Zedit)
@@ -1966,7 +1965,7 @@ public function lowCorruptionJojoEncounter():void
 		outputText("The blow does little more than leave you momentarily dazed but isn’t enough to knock you over.  You shake it off and ready your [weapon] as you assume a fighting stance.\n\n");
 	else // Was originally isNaga() only, but this will also cover Drider just as well
 		outputText("You recoil as you are struck, but the force of the blow does little more than leave you momentarily dazed. You assume a fighting stance, ready to defend yourself.\n\n");
-	
+
 	outputText("To your surprise you are greeted with the visage of a rather surprised mouse.\n\n");
 
 	outputText("\"<i>Oh... erm... I’m sorry.  You spooked me,</i>\" he says apologetically, rubbing the back of his neck in embarrassment.\n\n");
@@ -2111,8 +2110,7 @@ public function meditateInForest():void {
 				//get a small talisman if not have one
 				player.createKeyItem("Jojo's Talisman", 0, 0, 0, 0);
 			}
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 			return;
 		}
 		else
@@ -2121,13 +2119,10 @@ public function meditateInForest():void {
 	if (player.statusEffectv1(StatusEffects.JojoMeditationCount) % 5 == 0)
 	{
 		outputText("\n\nYou ponder and get an idea - the mouse could stay at your camp.  There's safety in numbers, and it would be easier for the two of you to get together for meditation sessions.  Do you want Jojo's company at camp?");
-		explorer.stopExploring();
-		doYesNo(jojoScene.acceptJojoIntoYourCamp, camp.returnToCampUseTwoHours);
-		return;
+		doYesNo(jojoScene.acceptJojoIntoYourCamp, curry(explorer.done,120));
 	} else {
 		outputText("\n\nHe bows his head sadly and dismisses you.");
-		explorer.stopExploring();
-		doNext(camp.returnToCampUseTwoHours);
+		endEncounter(120);
 	}
 }
 
@@ -2290,7 +2285,7 @@ private function TyrantiaEggQuestJoJo():void {
 	clearOutput();
 	outputText("You ask Jojo about his holy mantras and abilities, and if he could purify the unborn in such a way. You tell him about Tyrantia’s desire to have a family, and her guilt over her own corruption and how that’d affect a child.\n\n");
 	outputText("Jojo shakes his head, sending a ripple through his fur. \"<i>My methods draw upon a conscious desire to be free from taint and corruption.</i>\" He sits down. \"<i>I will meditate on your request, but I do not believe that I can help you.</i>\" You thank Jojo for his time and walk away, heavy-hearted.");
-	eachMinuteCount(15);
+	advanceMinutes(15);
 	doNext(talkMenu);
 }
 
@@ -2319,7 +2314,7 @@ public function jojoTalkVillage():void
 		outputText("Looks like Jojo’s childhood wasn’t so bad. A little sickly sweet and void of wet pussies and drooling dicks but not bad. You tell him you’re happy to have him near you and he smiles for ear to ear, ignorant of your thoughts.\n\n");
 	}
 	doNext(talkMenu); // Dunno where exactly to kick back to, fuck it, back to camp yo!
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 
 //Joining the Monks convo
@@ -2335,7 +2330,7 @@ public function jojoTalkJoiningTheMonks():void
 	outputText("\"<i>The temple became very important to me.  I read about the world, I spoke to the clergy and I sat and thought.  I was enraptured with learning but I didn’t want to be a priest, I don’t know why... I guess it just didn’t appeal to me.  When I first saw the monks visiting the temple, it was like dawn breaking.  After that I waited until I was old enough to join and made the short pilgrimage to the Monastery of the Celestial Lotus.</i>\"\n\n");
 	outputText("Jojo wears this quiet little smile as he finishes.  Then he chuckles and says, \"<i>Thank you for the memories, [name].  I enjoy our talks.</i>\"\n\n");
 	doNext(talkMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 
 //Fall of the Monks convo
@@ -2352,7 +2347,7 @@ public function jojoTalkFallOfTheMonks():void
 	outputText("You try to comfort Jojo, telling him he couldn’t have made a difference being but a single mouse, but he waves you off.  He tells you he is fine and thanks you for your concern.\n\n");
 	outputText("You can tell the story has affected him, but you’re surprised to hear the resolve in his voice and see the defiant strength in his eyes. Excusing yourself, you rise and leave him to do as he will.\n\n");
 	doNext(talkMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 
 //Forest Convo
@@ -2398,7 +2393,7 @@ public function jojoTalkForestConvo():void
 	outputText("He gives you an appraising look before looking away, \"<i>Until I met you, [name], my only purpose had been to find the demons who destroyed my order and make them pay for the lives they took.  That is why I was in the forest, I was in the middle of a harsh training regimen to increase my power and skill so that I may seek out those evil brutes who took everything I loved away from me... but vengeance is not the way of the Celestial Lotus.  The Celestial doesn’t train bullies or assassins.  Finding you and aiding in your quest to protect your village from these demonic creatures of perversion gave me new purpose and would make my departed brothers and sisters proud.  I can’t honestly say I’ve given up on having my vengeance but... I will aid you in your quest first if for nothing more than to honor our friendship and honor the memory of the order and its teachings.</i>\n\n");
 	outputText("Looking renewed and at peace despite the emotional storm you know must be raging within his tiny frame Jojo returns to what he was doing after thanking you for giving him new purpose.\n\n");
 	doNext(talkMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 
 //Yourself
@@ -2462,7 +2457,7 @@ public function jojoTalkYourOrigin():void // Prob tack on some interaction count
 	}
 	outputText("Jojo smiles now that he has gotten to know you a little better. After a little bit more small talk, the two of you decide the conversation is over and part ways.\n\n");
 	doNext(talkMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 
 //Dungeon Convo: Factory
@@ -2486,7 +2481,7 @@ public function jojoTalkFactory():void
 	}
 	outputText("Once the two of you are done discussing the demonic factory Jojo excuses himself to think on what you’ve told him.\n\n");
 	doNext(talkMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 
 //Dungeon Convo: Sand Cave
@@ -2575,7 +2570,7 @@ public function jojoTalkSandCave():void
 	}
 	outputText("Having concluded the conversation the two of you stand and Jojo gives you an appreciative pat on the shoulder, seeming more fond of you.\n\n");
 	doNext(talkMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 
 //Training

--- a/classes/classes/Scenes/NPCs/KihaFollower.as
+++ b/classes/classes/Scenes/NPCs/KihaFollower.as
@@ -2441,8 +2441,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("You walk back to camp together, reveling in each other’s company. You can feel her emotional reactions to everything, from her hand in yours (glee) to the cawing of some swamp birds (annoyance and hunger).\n\n");
         outputText("As you reach camp, Kiha puts a hand on each of your shoulders. \"<i>… One more thing.</i>\" She says. \"<i>The ring… It can tell you where I am… and the other way around.</i>\" She blushes, and you can hear her voice waver. \"<i>… Just in case.</i>\"\n\n");
         ProposalStatus = 3;
-        explorer.stopExploring();
-        doNext(camp.returnToCampUseTwoHours);
+        endEncounter(120);
     }
 
     public function KihaProposalDelay():void {
@@ -2450,8 +2449,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("Stunned into silence, you sit back down without another word. After a few seconds, Kiha whispers your name, and you look back at her. “W-well?” You tell Kiha that this is really sudden. You didn’t expect this… hell, you didn’t expect to find love here, let alone something like this. Kiha’s tail lies still behind her, and her eyes moisten. “So… that’s a no?” She’s almost whispering at this point, her dusky skin sallow and the color draining from her scales. \n\n"+
                     "You kneel down in front of Kiha, and you tell her that you’re sorry. You need some time to process all this. You tell the distraught dragoness that you love her, you do, but that you’re a bit overwhelmed. “O-oh… ” Kiha seems a little better at that, but she clearly was hoping to win you over tonight. You pick her up off the ground, giving your lover a hug. Kiha hugs back, but you can feel her tears on your back. “Well… Tell me when you make up your mind… I’ll be at camp if you need me.”");
         ProposalStatus = 4;
-        explorer.stopExploring();
-        doNext(camp.returnToCampUseTwoHours);
+        endEncounter(120);
     }
 
     public function KihaProposalNo():void {
@@ -2460,8 +2458,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         outputText("\"<i>… So I really am just another piece in your harem.</i>\" Kiha closes her eyes. \"<i>… Thank you for telling me earlier.</i>\" Her sarcasm is bitter, and you can all but see her walls going back up. You reach a hand out to Kiha, but the hot-headed dragoness lets loose a gout of flame. You jump back, and Kiha glares at you. \"<i>Just… leave me alone, [name]. Go back to camp.</i>\" You delay, and she roars her rage, spitting more flame at you. \"<i>GO!!!</i>\"\n\n");
         outputText("You head back to camp, her angered voice ringing in your ears.\n\n");
         ProposalStatus = 6;
-        explorer.stopExploring();
-        doNext(camp.returnToCampUseTwoHours);
+        endEncounter(120);
     }
 
     public function KihaMarriedHug():void {
@@ -2859,13 +2856,13 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
         if (DemonLab.MainAreaComplete < 4) {
             outputText("“<i>… Well, I’m working on some stuff… Mainly just trying to find out what happened… Put up some gravestones… Maybe a shrine?</i>” Kiha seems at a loss. “<i>… Mainly just… I want anyone who comes by to… see that there were people there.</i>” She sighs. “<i>Thanks for worrying, though… It means a lot to me, even if I don’t show it.</i>”\n\n");
             outputText("\n\n");
-            eachMinuteCount(15);
+            advanceMinutes(15);
             doNext(TalkWithKiha);
         }
         if (DemonLab.MainAreaComplete == 4) {
 			if (FlameSpreaderKillCount > 0 && FlameSpreaderKillCount < 5) {
 				outputText("“<i>Finding those abominations has been hard.</i>” She admits. “<i>They’re fast, and hard to kill.</i>” She gives you a wry smile. “<i>But you seem to just run into them, don’t you, my idiot?</i>” Her smile fades. “<i>I’ve dug graves for them, and… Made some markers. Now… I just need to fill them. Those people are gone, and there’s no way to bring them back… But at least I can make sure they rest.</i>”\n\n");
-				eachMinuteCount(15);
+				advanceMinutes(15);
 				doNext(TalkWithKiha);
 			}
 			if (FlameSpreaderKillCount >= 5 && !FlameSpreaderBossKilled) {
@@ -2940,7 +2937,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
                 + "“<i>Okay, fine. I’ll play nice.</i>” Kiha mutters. “<i>You’re lucky [name]’s around.</i>” \n"
                 + "\n"
                 + "“<i>Funny, I was going to say the same to you.</i>” Ember fires back");
-            eachMinuteCount(15);
+            advanceMinutes(15);
             doNext(playerMenu);
         }
 
@@ -2949,7 +2946,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
             outputText("You tell Ember to lay off Kiha. Just because she wasn’t born a dragon doesn’t make her flames any less real. \n"
                 + "\n"
                 + "“<i>Almost like I’ve been saying that since you hatched!</i>” Kiha throws her hands into the air. “<i>Get it through your thick head! Just because you’re a dragon doesn’t mean shit anymore!</i>” Ember staggers back, as if punched. [Ember ey] looks down, then opens [ember eir] mouth, spewing flame at you and Kiha. You cover your eyes, and by the time you open them again, Ember’s already taken off. Kiha gives you a respectful nod.");
-            eachMinuteCount(15);
+            advanceMinutes(15);
             doNext(playerMenu);
         }
 
@@ -2958,7 +2955,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
             outputText("You sheepishly tell Kiha that Ember does have a point. While Kiha is a dragon now, she wasn’t born one. \n"
                 + "\n"
                 + "“<i>See, even [name] can recognize the difference between us.</i>” Ember laughs haughtily. “<i>So leave me be, faker.</i>” Kiha gives you a heated glare, then spits on the ground at Ember’s feet. “<i>We never should have sheltered your kind.</i>” She turns her back, heading back to her section of the camp.");
-            eachMinuteCount(15);
+            advanceMinutes(15);
             doNext(playerMenu);
         }
 
@@ -2977,7 +2974,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
                 + "“<i>And what is it, fake dragon?</i>” Ember scowls, rolling her eyes, and in that moment, Kiha strikes, landing a solid uppercut along Ember’s jaw. You watch as Ember, launched backwards by Kiha’s strength, hits [ember eir] head on a tree. \n"
                 + "\n"
                 + "“<i>Fucking stop calling me that, you arrogant shit!</i>” Kiha takes off towards the forest. Ember growls, kicking off and baring her talons as she chases after.");
-            eachMinuteCount(15);
+            advanceMinutes(15);
             doNext(playerMenu);
         }
     }
@@ -2997,7 +2994,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
             + "“<i>W-well, I suppose you’re an adequate sparring partner.</i>” Kiha says, rubbing her wing. “<i>Good to see you’ve kept the rust off.</i>” \n"
             + "\n"
             + "You clear your throat, and the two monstrous ladies turn. You grin, saying that you’re glad you have such powerful allies. They seem to enjoy the praise, Tyrantia blushing and Kiha nodding, a small smile forming.\n\n");
-        eachMinuteCount(15);
+        advanceMinutes(15);
         if (fromTyrantia) outputText("You say that you came to check up on the resident giantess, and Kiha nods, rubbing her wing. “<i>I’ll just be down by the water.</i>”");
         else outputText("You tell Kiha that you came to see her, and she nods. “<i>Alright. What do you want, doofus?</i>” Tyrantia excuses herself, heading down to the river to wash up.");
     }
@@ -3035,7 +3032,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
             + "\n"
             + "“<i>Only if we hunt on the way.</i>” Kiha chimes in, still glowering at Sidonie. “<i>I’m still hungry.</i>” \n"
             + "The two women walk off towards the woods, axes in hand, but from the tone, you’re confident they won’t kill each other at least.\n");
-        eachMinuteCount(15);
+        advanceMinutes(15);
         doNext(playerMenu);
     }
 
@@ -3112,7 +3109,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
             + "Kiha almost laughs at your spider-girl’s nervousness. “<i>Lots of talking. Some pointless, some not. Look, I’m not gonna try and burn your house down… And I’m… Sorry if I insulted your weaving.</i>” \n"
             + "\n"
             + "“<i>You’re not?</i>” Belisa seems to relax a little at that. “<i>Okay… I guess that’s a start… </i>”  The two start talking, and you excuse yourself. They’re not fighting, good enough.");
-        eachMinuteCount(15);
+        advanceMinutes(15);
         doNext(playerMenu);
     }
 
@@ -3160,7 +3157,7 @@ private function warmLoverKihaIntro(output:Boolean = true):void {
                 "“<i>… She’s not the only one who has to deal with that. With those fucking demons, there’s a lot of pent up lust to go around. And the last thing I want is to get some of those stupid fuzzy ears, just because SHE couldn’t keep her juice to herself.</i>” Kiha huffs, sending a bit of smoke into the air. [pg]"+
                 "You ask Kiha if she has trouble dealing with that sort of thing, and she gives you a glare. “<i>Pervert</i>”, she says simply, before taking off."
         );
-        eachMinuteCount(15);
+        advanceMinutes(15);
         doNext(playerMenu);
     }
 

--- a/classes/classes/Scenes/NPCs/Konstantin.as
+++ b/classes/classes/Scenes/NPCs/Konstantin.as
@@ -183,7 +183,7 @@ public class Konstantin extends NPCAwareContent
 			explorer.stopExploring();
 			doNext(camp.returnToCampUseTwoHours);
 		}
-		
+
 		public function KonstantinMainCampMenu():void {
 			clearOutput();
 			outputText("Wanting to chat with the large bear-morph, you reach around where he is. Konstantin waves at you and beckons you to sit near him.\n\n");
@@ -197,7 +197,7 @@ public class Konstantin extends NPCAwareContent
 			addButton(7, "Tinkering", KonstantinTinkeringMenu).hint("Add some temporary boosts to you weapons or armor.");
 			addButton(14, "Leave", camp.campFollowers);
 		}
-		
+
 		public function KonstantinAppearance():void {
 			clearOutput();
 			outputText("Konstantin is a 8ft 10in tall bear-morph. He has a thick, soft layer of caramel brown fur covering almost every bit of his body, except on his underbelly, where the brown acquires a sandy coloration. The overall fluffy look of his fur makes you immediately think of a giant teddy bear. He covers himself in a simple, white cotton shirt, and covers his lower body with a working overall. Girding his ursine feet he has two black, sturdy boots. When he’s not working he opts for using an attire which is a bit more relaxed, with a loose, colorful shirt and baggy shorts.\n\n");
@@ -208,7 +208,7 @@ public class Konstantin extends NPCAwareContent
 			outputText("Between his nice derriere, Konstantin has a tight-looking anus, right where it belongs.");
 			doNext(KonstantinMainCampMenu);
 		}
-		
+
 		public function KonstantinTalkMenu():void {
 			clearOutput();
 			outputText("You sit at his side, and tell him that you want to chat with him a bit. He stops what he’s doing and sits to your side.\n\n");
@@ -233,7 +233,7 @@ public class Konstantin extends NPCAwareContent
 			outputText("Wanting to divert my mind from the loneliness feeling, I focus on improved my smithing skill, so I spent the next couple of years practicing. Every now and then a customer passed through the forest me and requested my services, and then one day, one of them kept coming with more regularity...but I bet that you know what happened after that.</i>\"\n\n");
 			outputText("With a smirk, you answer that you do. Thanking him for his conversation, you return to your taks.\n\n");
 			doNext(KonstantinTalkMenu);
-			eachMinuteCount(5);
+			advanceMinutes(5);
 		}
 		public function KonstantinTalkHisWork():void {
 			clearOutput();
@@ -259,7 +259,7 @@ public class Konstantin extends NPCAwareContent
 			}
 			outputText(".</i>\"\n\nThanking him for his conversation, you leave Konstantin to his own things.\n\n");
 			doNext(KonstantinTalkMenu);
-			eachMinuteCount(5);
+			advanceMinutes(5);
 		}
 		public function KonstantinTalkTheCamp():void {
 			clearOutput();
@@ -287,7 +287,7 @@ public class Konstantin extends NPCAwareContent
 				outputText("\"<i>So all in all, I think that this is a great places. Good company, no demons in the proximity, and a great potential for the years to come.</i>\"\n\n");
 			}
 			doNext(KonstantinTalkMenu);
-			eachMinuteCount(5);
+			advanceMinutes(5);
 		}
 		public function KonstantinTalkBetterSmiting():void {
 			clearOutput();
@@ -297,9 +297,9 @@ public class Konstantin extends NPCAwareContent
 			outputText("<b>Unlocked Smelting!</b>\n\n");
 			flags[kFLAGS.KONSTANTIN_FOLLOWER] = 3;
 			doNext(KonstantinTalkMenu);
-			eachMinuteCount(5);
+			advanceMinutes(5);
 		}
-		
+
 		public function KonstantinSmithingMenu():void {
 			clearOutput();
 			outputText("Seeing how Konstantin is working with armor and plating pieces, you happen to ask him if he could assemble some of the materials that you’ve found during your travels in Mareth into something useful to wear and protect yourself.\n\n");
@@ -417,7 +417,7 @@ public class Konstantin extends NPCAwareContent
 			if (player.hasItem(useables.DBAPLAT) && player.hasItem(weapons.DEPRAVA)) addButton(12, "Ascensus", KonstantinCraftingDepravitoAscensus);
 			addButton(14, "Back", KonstantinSmithingMenu);
 		}
-		
+
 		private function KonstantinCraftingNotEnoughMaterials1():void {
 			clearOutput();
 			outputText("\"<i>Nah, " + player.mf("man", "girl") + ". I’ll need more of that stuff to start doing something. Five pieces, as I’ve said. If you happen to gather them somehow, look for me and we’ll work something.</i>\"\n\n");
@@ -909,7 +909,7 @@ public class Konstantin extends NPCAwareContent
 			outputText("<b>Got "+atype+" arrowheads!</b>\n\n");
 			inventory.takeItem(itype, camp.returnToCampUseOneHour);
 		}
-		
+
 		private function KonstantinCraftingThePhalluspear():void {
 			clearOutput();
 			player.destroyItems(weapons.SPEAR, 1);
@@ -982,7 +982,7 @@ public class Konstantin extends NPCAwareContent
 			outputText("You take the staff. From the first touch you feel the immense arcane power within the wood.\n\n");
 			inventory.takeItem(weapons.ASCENSU, camp.returnToCampUseFourHours);
 		}
-		
+
 		public function KonstantinSmeltingMenu():void {
 			clearOutput();
 			outputText("Konstantin eyes you expectantly.\n\n");
@@ -1040,12 +1040,12 @@ public class Konstantin extends NPCAwareContent
 				Crafting.BagSlot03 += 5;
 				break;
 			case 3: //1 Ebonbloom
-				if (Crafting.BagSlot05 > 0) Crafting.BagSlot05 -= 1; 
+				if (Crafting.BagSlot05 > 0) Crafting.BagSlot05 -= 1;
 				else player.destroyItems(useables.EBONBLO, 1);
 				itype = useables.EBONING;
 				break;
 			case 4: //5 Ebonblooms
-				if (Crafting.BagSlot05 > 4) Crafting.BagSlot05 -= 5; 
+				if (Crafting.BagSlot05 > 4) Crafting.BagSlot05 -= 5;
 				else player.destroyItems(useables.EBONBLO, 5);
 				Crafting.BagSlot06 += 5;
 				break;
@@ -1055,7 +1055,7 @@ public class Konstantin extends NPCAwareContent
 			if (craft == 2 || craft == 4) doNext(camp.returnToCampUseOneHour);
 			else inventory.takeItem(itype, camp.returnToCampUseOneHour);
 		}
-		
+
 		public function KonstantinTinkeringMenu():void {
 			clearOutput();
 			outputText("You pay another visit to Konstantine, and find him working on his furnace near his tent. He smiles warmly and greets you, after what you ask him if he can help you with your stuff.\n\n");
@@ -1069,7 +1069,7 @@ public class Konstantin extends NPCAwareContent
 			else addButton(1, "Weapon", meetKonstantinAtForestWeapon);
 			addButton(2, "Nothing", meetKonstantinAtForestNothing);
 		}
-		
+
 		public function KonstantinSexMenu():void {
 			clearOutput();
 			if (flags[kFLAGS.KONSTANTIN_SEX_MENU] == 1) {

--- a/classes/classes/Scenes/NPCs/LilyFollower.as
+++ b/classes/classes/Scenes/NPCs/LilyFollower.as
@@ -12,7 +12,7 @@ import classes.display.SpriteDb;
 import classes.internals.SaveableState;
 
 use namespace CoC;
-	
+
 	public class LilyFollower extends NPCAwareContent implements SaveableState {
 		public static var LilyHairColor:String;
 		public static var LilySkinTone:String;
@@ -115,7 +115,7 @@ use namespace CoC;
 			startCombat(new Lily());
 			//doNext(playerMenu);
 		}
-		
+
 		public function LilyAfterBattle():void {
 			clearOutput();
 			if (LilySubmissivenessMeter<=20) outputText("The Drider Woman falls onto her side, baring her teeth at you. <i>\"I...Won’t…\"</i> She draws her bow back, aiming with shaking hands, but the arrow flies past. <i>\"Damn you\"</i>. She watches, anger in her gaze, as you approach. <i>\"Well...What do you want?\"</i>\n\n");
@@ -213,7 +213,7 @@ use namespace CoC;
 			lilyAffection(5);
 			cleanupAfterCombat();
 		}
-		
+
 		public function LilySubComeCamp():void {
 			clearOutput();
 			if (!recalling) outputText("<b>New scene is unlocked in 'Recall' menu!</b>\n\n");
@@ -227,7 +227,7 @@ use namespace CoC;
 				.disableIf(player.isGenderless(), "Not for genderless ones.")
 				.disableIf(TyrantiaFollower.TyrantiaFollowerStage < 4, "Maybe there's an alternative?", "???");
 		}
-		
+
 		public function LilyTyrantia3some1st():void {
 			clearOutput();
 			outputText("Struck by a fun idea, you decide to leave your Drider-toy tied up to a tree outside camp. You tell your toy that you’ll be back soon, and that she’d better be ready for a fucking.\n\n");
@@ -244,7 +244,7 @@ use namespace CoC;
 			addButton(1, "Fuck", LilyTyrantia3Fuck).disableIf(!player.hasCock(), "Req. a cock!");
 			addButton(2, "LickYou", LilyTyrantia3Lick).disableIf(!player.hasVagina(), "Req. a vagina!");
 		}
-		
+
 		public function LilyTyrantia3some():void {
 			clearOutput();
 			outputText("You leave Lily tied up at a small tree, not far from camp, and come back in, getting your giantess lover’s attention. You ask her if she’d like to have some family bonding time with you and her little sister. Tyrantia grabs her Dick, giving you a thumbs up. She follows you out to the tree, whistling in appreciation at the sight of her little sister, bound, gagged and blindfolded.\n\n");
@@ -253,7 +253,7 @@ use namespace CoC;
 			addButton(1, "Fuck", LilyTyrantia3Fuck).disableIf(!player.hasCock(), "Req. a cock!");
 			addButton(2, "LickYou", LilyTyrantia3Lick).disableIf(!player.hasVagina(), "Req. a vagina!");
 		}
-		
+
 		public function LilyTyrantia3Fuck():void {
 			outputText("You undress slowly, then step in. Practically whining with need, Lily’s bound hands quiver as she tries to bring them to her soaking quim. You take your time, then as she struggles with her bindings, you bring your hand to her slit, rubbing the length of her womanhood with one finger. Lily shivers, chitin-covered knees quivering.\n\n");
 			outputText("She bites down on a moan of arousal as you bring a second finger in, sinking your fingers in, just to the first knuckle. She quivers as you begin fingering her, slowly teasing Lily with your hands. She tries to hold herself back, but Lily begins panting, quad breasts shaking as you slowly pick up the pace, sinking your fingers deeper, flicking her clit with your tongue.\n\n");
@@ -281,7 +281,7 @@ use namespace CoC;
 			if (!LilyFollowerState || recalling) LilyTyrantiaAfterFirst();
 			else LilyTyrantiaAfterSex();
 		}
-		
+
 		public function LilyTyrantiaAfterFirst():void {
 			outputText("<i>\"Wh-who else was there? I...You’re my [master], but I didn’t...I didn’t...want…Anyone else to-\"</i> She takes the blindfold off, and her mouth flies open as she beholds your giantess lover beside you, licking Lily’s leavings off her Dick.\n\n");
 			outputText("<i>\"Oh, hey sis.\"</i> Tyrantia says, swallowing some of her sister’s spunk. <i>\"Fancy meeting you here.\"</i>\n\n");
@@ -292,7 +292,7 @@ use namespace CoC;
 			outputText("<i>\"Now we’ve had our fun, can I show her around?\"</i> Tyrantia asks, and you nod. Tyrantia takes her sister by the hand. <i>\"Well, you’ve already sampled the best part, but the rest of this place isn’t bad either.\"</i> The two Driders saunter towards Tyrantia’s section of camp.\n\n");
 			doNext(recalling ? recallWakeUp : LilyComeCampConclusion);
 		}
-		
+
 		public function LilyTyrantiaAfterSex():void {
 			outputText("Tyrantia unbinds her little sister, who simply stares up at her, tongue out and eyes glazed over. <i>\"Good girl,\"</i> your giantess says simply, patting Lily’s head. The smaller Drider looks over at you, a blissed out look on her face.\n\n");
 			outputText("<i>\"[master], that…was…\"</i> Lily shakes, and you reach to her face, cupping her cheek in your palm. You tell your pet she did well, and Lily smiles, eyes closing as she flops the rest of the way to the ground.\n\n");
@@ -300,7 +300,7 @@ use namespace CoC;
 			endEncounter();
 		}
 
-		
+
 		public function LilyEnterCamp():void {
 			clearOutput();
 			outputText("You bring Lily near your camp, and turn around again to look at your Drider-toy. Her legs are shaking, and her quad tits tremble as she’s working at her blindfold with her elbows. She manages to lever the blindfold off, and she looks at the camp with a somewhat impressed look on her face. <i>\"[master], is this your camp?\"</i> She asks, and you smile, taking your pet’s face in your hands.\n\n");
@@ -309,7 +309,7 @@ use namespace CoC;
 			outputText("You give Lily a gentle shove, and she nods, understanding what you mean. She runs towards a tree near the river, not far from camp. You head back into camp, and as you turn back towards Lily’s Tree, you can already see her spinning out threads.\n\n");
 			LilyComeCampConclusion();
 		}
-		
+
 		public function LilyBringCamp():void {
 			clearOutput();
 			outputText("You ask Lily about her life in the swamp. She shrugs, looking around. <i>\"It’s nice for a Drider like me, although to be honest, the neighbors aren’t exactly ideal\".</i> She looks at you, a pained smile on her face. <i>\"I enjoy a good tussle or lay as much as the next gal, but...Those...Things aren’t even a good fuck. They’re all for tying you up, but they’ve got no finesse...Not to mention the dicks on them. I like a good lay, but they’re...Wrong\".</i> She looks down at herself. <i>\"Not that I can really talk...I became like them, living in the swamp.\"</i>\n\n");
@@ -322,7 +322,7 @@ use namespace CoC;
 			outputText("You leave Lily to her own devices, as she begins to spin her thread, scuttling up the trunk and weaving lines between the branches. You know from experience it won’t take her long to finish her construction, if her thread-volume before is anything to judge by.\n\n");
 			LilyComeCampConclusion();
 		}
-		
+
 		private function LilyComeCampConclusion():void {
 			if (amilyScene.amilyFollower() && !amilyScene.amilyCorrupt()) {
 				outputText("As you watch Lily leave to make her house, your mousey lover pokes her head out from a nearby rock. <i>\"Uh…Hey.\"</i> Amily comes out, keeping one eye on Lily. <i>\"Can I talk with you for a second?\"</i> You nod, and she sits down.\n\n");
@@ -353,7 +353,7 @@ use namespace CoC;
 			DriderTown.LilyKidsPCPregnancy = 0;
 			cleanupAfterCombat(explorer.done);
 		}
-		
+
 		public function LilySex():void {
 			clearOutput();
 			if (LilyFollowerState) outputText("You step in, slipping one hand into Lily’s sopping quim. She gasps, shuddering, and you take a step back. Lily gives you a smirk, rubbing one of her nipples. <i>\"Oh, are we in the mood for some fun, [name]?</i>\n\n");
@@ -378,7 +378,7 @@ use namespace CoC;
 			addButton(1, "ThrFuck", LilyThroatFuck).disableIf(!player.hasCock(), "Req. a cock!");
 			addButton(2, "Facemount", LilyFaceSit).disableIf(!player.hasVagina(), "Req. a vagina!");
 		}
-		
+
 		public function LilyThroatFuck():void {
 			clearOutput();
 			outputText("You put both of your hands on her shoulders, pushing down. Her legs fold underneath her, and she closes her mouth, apparently anticipating your next move. You shake your head, grabbing the Drider’s nose and pinning her nostrils shut with one hand. You grab her hair with your other hand, shaking her head roughly.\n\n");
@@ -391,7 +391,7 @@ use namespace CoC;
 			player.sexReward("saliva","Dick");
             cleanupAfterCombat();
 		}
-		
+
 		public function LilyFaceSit():void {
 			clearOutput();
 			outputText("Taking calm strides around your trussed up spider-slut, you drop your hands between your own legs. Gently, you rub your [clit], giving your captive a nice, long look at your pussy. You ask the Drider if she can see what’s wrong.\n\n");
@@ -409,7 +409,7 @@ use namespace CoC;
 			player.sexReward("saliva");
             cleanupAfterCombat();
 		}
-		
+
 		public function LilyJillOff():void {
 			clearOutput();
 			outputText("You walk up to her, forcing the drider back. Despite her best efforts, her legs are still weak, and all she does is fall backward, arching her back over her spider half.\n\n");
@@ -444,7 +444,7 @@ use namespace CoC;
 				.disableIf(LilySubmissivenessMeter < 100, "Maybe if she's a full sub?", "???")
 				.disableIf(!LilyFollowerState, "Not yet!", "???");
 		}
-		
+
 		public function LilyBondageTree():void {
 			clearOutput();
 			outputText("You decide that there is no time like the present. You roughly pull Lily over to a nearby tree, shoving her Drider back half up against the hardwood. Blind, backed into a wall, and horny, Lily pushes back ever so slightly. You press harder, getting an aroused moan from the Drider. Lily’s protests subside, and you can see a bit of drool running down her cheek.\n\n");
@@ -452,7 +452,7 @@ use namespace CoC;
 			addButton(1, "Vagfuck", LilyBondageTreeVagfuck).disableIf(!player.hasCock(), "Req. a cock!");
 			addButton(2, "LegJill", LilyBondageTreeLilyLegs).disableIf(!player.hasVagina(), "Req. a vagina!");
 		}
-		
+
 		public function LilyBondageCabin():void {
 			clearOutput();
 			outputText("You take Lily by the chain on her four, pierced nipples, forcing her to blindly follow you into your cabin. Catching sight of one of the ceiling beams, you make a loop out of spider-silk, tossing your crude rope over the beam. Belisa squirms, letting out a surprised moan as her arms are lifted, forced up and over her head.\n\n");
@@ -463,7 +463,7 @@ use namespace CoC;
 			addButton(2, "Fuck", LilyBondageCabinFuck).disableIf(!player.hasCock(), "Req. a cock!");
 			addButton(4, "Tease", LilyBondageCabinTease);
 		}
-		
+
 		public function LilyBondageCabinWait():void {
 			clearOutput();
 			outputText("For a few minutes, you stay perfectly still and quiet, letting her skitter around the cabin on her leash. She hits the bed with her frontmost legs, then slows down, whimpering. Her pussy is still drooling, but her whimpers of arousal begin to get lower, and sadder. You watch as she begins to think you abandoned her there, blind and gagged, with nobody to come and get her.\n\n");
@@ -477,7 +477,7 @@ use namespace CoC;
 			addButton(2, "Fuck", LilyBondageCabinFuck).disableIf(!player.hasCock(), "Req. a cock!");
 			addButton(4, "Tease", LilyBondageCabinTease);
 		}
-		
+
 		public function LilyBondageCabinAssDangle():void {
 			clearOutput();
 			outputText("You grin, an idea forming in your head. You run your hands along her womanly back, her black hair. Lily pulls at her bindings, but you slap her thorax, right next to her silk-hole. You tell Lily to make more silk, and are rewarded with a spurt of crude strands. You slap her again, getting more silk, and you grin, wrapping several strands around each of your Drider-pet’s legs, twisting the strands together, then tossing the rope over one of the cabin’s support beams. You come back around to her front, still holding your improvised ropes. Lily tilts her head, slightly confused.\n\n");
@@ -498,7 +498,7 @@ use namespace CoC;
 			lilyAffection(5);
 			endEncounter();
 		}
-		
+
 		public function LilyBondageCabinDildo():void {
 			clearOutput();
 			outputText("<i></i>\n\n");
@@ -507,7 +507,7 @@ use namespace CoC;
 			player.sexReward("vaginalFluids","Pussy");
 			endEncounter();
 		}
-		
+
 		public function LilyBondageCabinFuck():void {
 			clearOutput();
 			outputText("You whisper into her ear, asking her if she wants your big, [cock] inside you. If she wants to be stuffed, filled with cum, bred like the little spider-bitch she is. Lily groans, sticking her quad breasts in your direction. <i>\"Mmm!\"</i> You remove the gag, informing her that you can’t hear her.\n\n");
@@ -523,7 +523,7 @@ use namespace CoC;
 			player.sexReward("vaginalFluids","Dick");
 			inventory.takeItem(useables.T_SSILK, explorer.done);
 		}
-		
+
 		public function LilyBondageCabinTease():void {
 			clearOutput();
 			outputText("You grin, an idea forming in your head. You run your hands along her womanly back, her black hair. Lily pulls at her bindings, but you slap her thorax, right next to her silk-hole. You tell Lily to make more silk, and are rewarded with a spurt of crude strands. You slap her again, getting more silk, and you grin, wrapping several strands around each of your Drider-pet’s legs, twisting the strands together, then tossing the rope over one of the cabin’s support beams. You come back around to her front, still holding your improvised ropes. Lily tilts her head, slightly confused.\n\n");
@@ -547,7 +547,7 @@ use namespace CoC;
 			player.sexReward("vaginalFluids");
 			endEncounter();
 		}
-		
+
 		public function Lily3Somes():void {
 			clearOutput();
 			outputText("You grin at your submissive Drider-bitch, telling her to hold on a second. You know that she wants some fun, but you grin, telling her that she’s going to have some other company tonight. Lily’s eyes widen in excitement, and she rubs her hands together.\n\n");
@@ -576,14 +576,14 @@ use namespace CoC;
 			addButton(0, "S.Sandwich", SandwichSidonie).disableIf(!player.hasCock(), "Req. a cock!");
 			addButton(1, "S.Dom", SidonieDom);
 		}
-		
+
 		public function LilySpitRoast():void {
 			clearOutput();
 			outputText("\n\n");
 			player.sexReward("vaginalFluids");
 			endEncounter();
 		}
-		
+
 		public function SandwichSidonie():void {
 			clearOutput();
 			outputText("You undress, your [cock] already rock hard. You give yourself a pump, then slide over to Sidonie. You slowly strip your equine lover, giving Lily plenty of time to take in the luscious breasts, the heavy muscles, and most of all, the massive tool of Sidonie. You tell Sidonie that she gets her turn first, and that you’ll jump in after you...warm yourself up.\n\n");
@@ -606,7 +606,7 @@ use namespace CoC;
 			LilyAffectionMeter += 10;
 			endEncounter();
 		}
-		
+
 		public function SidonieDom():void {
 			clearOutput();
 			outputText("Slipping your hand down Sidonie’s hotpants, you grip her tool. She flinches, but doesn’t move. You tell Sidonie that you’ve always wondered what Lily saw in being the bottom...Until now. You slowly, sensually begin to stroke Sidonie off, rubbing the tip of her glorious tool until she pulls her hotpants down, her veiny rod on full display. Lily, watching, blushes bright red, her own cooter still dripping with lust.\n\n");
@@ -733,10 +733,10 @@ use namespace CoC;
 			outputText("You point at Joy, somewhat curious as to what the bumbling bimbo will choose to do. Joy squeals with delight, leaping onto your Drider-toy’s back, grabbing her shoulders and slapping her spinnerets hard.\n\n");
 			outputText("<i>\"Cmon, try and throw me off!\"</i> She yells, and Lily is all too happy to comply. She throws herself into the air, wiggles from side to side, and keeps changing angles. Joy holds on for dear life, eyes widening and mouth wide open as her furry ass slams repeatedly into Lily’s hard carapace. After a particularly wide buck and hard jump, one of Joy’s hands is wrenched from Lily’s shoulder. Once that happens, it isn’t long before your mouse-bimbo is sent flying.\n\n");
 			outputText("<i>\"WHEEEEEEeeeee...\"</i> she’s thrown a good twenty feet, hitting the grass rolling. Bruised but unharmed, Joy springs back up, giggling as she dances from side to side.\n\n");
-			eachMinuteCount(15);
+			advanceMinutes(15);
 			doNext(playerMenu);
 		}
-		
+
 		public function LilyBondageTreeVagfuck():void {
 			clearOutput();
 			outputText("You step in, slapping Lily’s front legs aside. Smiling, you disrobe, pulling your [cock] out. Taking your shaft in one hand, you rub yourself, blood rushing to your [cock]. Now rock-hard, you look at your tied up fucktoy as she moans, her pussy already dripping.\n\n");
@@ -750,7 +750,7 @@ use namespace CoC;
 			lilyAffection(5);
             cleanupAfterCombat();
 		}
-		
+
 		public function LilyBondageTreeLilyLegs():void {
 			clearOutput();
 			outputText("Eyeing the Drider-woman’s spider-legs, you get an idea. You put your hands on her shoulders, forcing the Drider to lie down. You take the tip of her leg in one hand, running your fingers along the smooth chitin.\n\n");
@@ -768,7 +768,7 @@ use namespace CoC;
 			addButton(1, "No", LilyDenied);
 			addButton(2, "Sure", LilyReward);
 		}
-		
+
 		public function LilyDenied():void {
 			clearOutput();
 			outputText("You laugh, saying that if she’s a good girl and isn’t so needy next time, you’ll consider it. She wails, flailing angrily against the restraints as you redress and walk away.\n\n");
@@ -776,7 +776,7 @@ use namespace CoC;
 			lilyAffection(-5);
             cleanupAfterCombat();
 		}
-		
+
 		public function LilyReward():void {
 			clearOutput();
 			outputText("You stand, shakily, and lean in. You pull the gag aside, further down her neck, and you remove the blindfold. Lily’s eyes are widened, worried, but as you bring a hand to her dripping pussy, flicking her black button, the relief on your Drider-toy’s face is obvious.\n\n");
@@ -792,7 +792,7 @@ use namespace CoC;
 			lilyAffection(5);
             cleanupAfterCombat();
 		}
-		
+
 		private function chanceToFail():Number {
 			var chance:Number = 10;
 			chance += Math.min(player.cumQ() / 25,40);
@@ -805,7 +805,7 @@ use namespace CoC;
 				if (flags[kFLAGS.SCENEHUNTER_PRINT_CHECKS]) outputText("\n<b>Lily is pregnant!</b>");
 			}
 		}
-		
+
 		public function LilyCampFollower(back:Boolean = false):void {
 			clearOutput();
 			if (!back) {
@@ -826,7 +826,7 @@ use namespace CoC;
 			if (DriderTown.DriderTownComplete) addButton(13, "Back", SceneLib.dridertown.DriderTownEnter).hint("Return to main DriderTown menu.");
 			addButton(14, "Leave", camp.campLoversMenu);
 		}
-		
+
 		public function LilyFollowerSex():void {
 			clearOutput();
 			outputText("You give Lily a waggle of your eyebrows, before stepping in, grabbing the chain crossing her chest and pulling. Lily gives you a moan, but says nothing. Her body, however, is honest. Lily's cunt begins drooling almost immediately, and her back legs tap rapidly.\n\n");
@@ -840,7 +840,7 @@ use namespace CoC;
 				.disableIf(!LilyFollowerState, "Not yet!", "???");
 			addButton(4, "Back",LilyCampFollower, true);
 		}
-		
+
 		public function LilyAppearance():void {
 			clearOutput();
 			outputText("Lily is a Drider, at first glance not that different from the others in the swamp. Her six eyes are violet, glowing slightly when it’s dark. Her dark lips shimmer, with twin fangs poking out from the upper lips. Her " + LilySkinTone + " skin is smooth, and her nakedness lets you see all of it, from her forehead down to her waist, where the supple skin smoothly transitions into shining black chitin. Her human hands transition into the same black chitin at her forearms, then back at her shoulders, almost like she’s wearing chitin bracers.\n\n");
@@ -849,7 +849,7 @@ use namespace CoC;
 			outputText("As she sees you looking at her, Lily gives you a sly three-eyed wink, sliding a hand down her waist, making eye contact with you as she rubs her rapidly swelling ebony pussy lips with one hand.\n\n");
 			doNext(LilyCampFollower, true);
 		}
-		
+
 		public function LearningWithLily():void {
 			clearOutput();
 			if (LilyTalked > 4) {
@@ -888,7 +888,7 @@ use namespace CoC;
 			outputText("You tell Lily that you’d rather not right now, and that you wanted to get to know her better. Your lover-toy nods, shuddering.\n\n");
 			outputText("\"<i>I want...Are you sure?</i>\"\n\n");
 			outputText("You assure her that you’re not interested in plundering her booty right now. Lily throws a glob of old webbing at you, and you chuckle to yourself as you climb down the tree, walking away from Lily’s home.\n\n");
-			eachMinuteCount(10);
+			advanceMinutes(10);
 			doNext(playerMenu);
 		}
 		public function LearningWithLilyYes(book:Number):void {
@@ -913,10 +913,10 @@ use namespace CoC;
 				default:
 					outputText("You have encounterd a BUG and i not mean drider-bug but just... BUG. Report to Ormale/Aimozg this (not at all drider) BUG.");
 			}
-			eachMinuteCount(30);
+			advanceMinutes(30);
 			doNext(playerMenu);
 		}
-		
+
 		public function LilySpar():void {
 			spriteSelect(SpriteDb.s_drider);
 			clearOutput();

--- a/classes/classes/Scenes/NPCs/LunaFollower.as
+++ b/classes/classes/Scenes/NPCs/LunaFollower.as
@@ -182,7 +182,7 @@ public class LunaFollower extends NPCAwareContent implements SaveableState
 			lunaJealousy(-100);
 			lunaAffection(2);
 			doNext(talkMenuLuna);
-			eachMinuteCount(15);
+			advanceMinutes(15);
 		}
 		public function talkMenuLunaWhatCanSheDo():void {
 			spriteSelect(SpriteDb.s_luna_maid);
@@ -195,7 +195,7 @@ public class LunaFollower extends NPCAwareContent implements SaveableState
 			if (flags[kFLAGS.LUNA_FOLLOWER] < 5)flags[kFLAGS.LUNA_FOLLOWER] = 5;
 			lunaJealousy(-100);
 			doNext(talkMenuLuna);
-			eachMinuteCount(15);
+			advanceMinutes(15);
 		}
 		public function talkMenuLunaHuman():void {
 			spriteSelect(SpriteDb.s_luna_maid);
@@ -235,7 +235,7 @@ public class LunaFollower extends NPCAwareContent implements SaveableState
 			lunaJealousy(-100);
 			lunaAffection(2);
 			doNext(talkMenuLuna);
-			eachMinuteCount(15);
+			advanceMinutes(15);
 		}
 		public function talkMenuLunaCampThoughts():void {
 			spriteSelect(SpriteDb.s_luna_maid);
@@ -246,7 +246,7 @@ public class LunaFollower extends NPCAwareContent implements SaveableState
 			lunaJealousy(-100);
 			lunaAffection(2);
 			doNext(talkMenuLuna);
-			eachMinuteCount(15);
+			advanceMinutes(15);
 		}
 		public function talkMenuLunaStopJealousy():void {
 			spriteSelect(SpriteDb.s_luna_maid);
@@ -264,7 +264,7 @@ public class LunaFollower extends NPCAwareContent implements SaveableState
 			lunaJealousy(-100);
 			lunaAffection(2);
 			doNext(talkMenuLuna);
-			eachMinuteCount(15);
+			advanceMinutes(15);
 		}
 		public function talkMenuLunaLycanthropy():void {
 			spriteSelect(SpriteDb.s_luna_maid);
@@ -285,7 +285,7 @@ public class LunaFollower extends NPCAwareContent implements SaveableState
 			lunaJealousy(-100);
 			lunaAffection(2);
 			doNext(talkMenuLuna);
-			eachMinuteCount(15);
+			advanceMinutes(15);
 		}
 		public function talkMenuBiteMe():void {
 			spriteSelect(SpriteDb.s_luna_maid);

--- a/classes/classes/Scenes/NPCs/MarbleScene.as
+++ b/classes/classes/Scenes/NPCs/MarbleScene.as
@@ -9,12 +9,12 @@ import classes.display.SpriteDb;
 import coc.view.CoCButton;
 
 public class MarbleScene extends NPCAwareContent implements TimeAwareInterface {
-		
+
 //Farm cow-girl Marble:
 //Marble is a resident of Whitney's farm, who resides in the barn.  She is a cow anthropomorph who is mostly human in appearance, but has numerous cow-like features such as a tail, horns, ears, and hoofs. The player can strike up a relationship with her based on tenderness and being friendly to each other. Her favorite activity is to give her milk to the player if she likes them enough, or if they help her with her chores.  The only problem is that her milk is addictive; of course, when the player meets her she doesn't know this. While the player doesn't get high from drinking it, Marble's milk makes the player character feel good as strengthening them for awhile as well after they drink it (in the form of Marble's Milk status effect), this is to encourage the player to consume it. Once the player has become addicted, they can try to find a way to combat their addiction, or choose to live with her because of it. Getting out of the addiction is really hard on the player since their character's stats fall whenever they fight it.  I deliberately wrote her to appear as harmless and nice as possible, just a friendly face that likes the player. However, she can change considerably once she finds out her milk is addictive, either becoming really depressed and hating herself for what she unconsciously did to the player; or she may start to take advantage of her new found power and become slowly corrupted by it. She is also very strong and can wield a mean hammer. If she likes the player enough, she can join them at their camp once they either become completely dependent or get out of their addiction.
 
 //Marble's Variables:
-//I propose that these variables appear while in debug mode at the start of every event where the player meets Marble 
+//I propose that these variables appear while in debug mode at the start of every event where the player meets Marble
 //in an abbreviated form (ex, aff:25, add:10, isA:0)
 //trace("Marble Stats: Aff-"+player.statusEffectv1(StatusEffects.Marble)+" Add-" + player.statusEffectv2(StatusEffects.Marble) + " isA-" + player.statusEffectv3(StatusEffects.Marble) + ".");
 //affection (0-100) - how much Marble likes the player, raised by visiting, helping her, and generally being nice. Determines what she is willing to do for the player, and how things turn out after the addiction event (30+, she will nurse the player; 60+, she will have sex with the player; 100, she wants to live with the player).
@@ -113,7 +113,7 @@ public function timeChange():Boolean
     }
     if (!player.hasStatusEffect(StatusEffects.Infested)) flags[kFLAGS.MARBLE_GROSSED_OUT_BECAUSE_WORM_INFESTATION] = 0;
     if (player.hasStatusEffect(StatusEffects.MarblesMilk) && !player.hasPerk(PerkLib.MarblesMilk)) {
-        //Decrement time remaining by 1		
+        //Decrement time remaining by 1
         player.addStatusValue(StatusEffects.MarblesMilk,1,-1);
         //Remove the status and stat boosts when time runs out on the milk
         if (player.statusEffectv1(StatusEffects.MarblesMilk) <= 0) {
@@ -121,7 +121,7 @@ public function timeChange():Boolean
             player.buff("MarblesMilk").remove();
             player.removeStatusEffect(StatusEffects.MarblesMilk);
             //Text for when Marble's Milk effect wears off:
-            //[addiction is 10 or less] 
+            //[addiction is 10 or less]
             if (player.statusEffectv2(StatusEffects.Marble) <= 10) outputText("\nYou feel the euphoria from drinking Marble's milk fade from you. Only now that it's gone do you notice that it was actually making you tougher.\n");
             //[addiction is 11-30]
             else if (player.statusEffectv2(StatusEffects.Marble) <= 30) outputText("\nYou feel a slight sense of loss as the euphoria from Marble's milk fades. You kinda want to drink more, but the desire is not overpowering.\n");
@@ -144,7 +144,7 @@ public function timeChange():Boolean
                     player.addCurse("int", 5, 2);
                 }
             }
-        }			
+        }
     }
     //Go into withdrawl if your addicted and don't have a reason not to be withdrawn.
     if (player.statusEffectv3(StatusEffects.Marble) > 0 && !player.hasPerk(PerkLib.MarbleResistant) && !player.hasPerk(PerkLib.MarblesMilk) && player.statusEffectv2(StatusEffects.Marble) > 25) {
@@ -486,9 +486,9 @@ private function apologizetoWalkingTitsIMEANMARBLE():void {
 	marbleSprite();
 	outputText("Wanting to make up for before, you apologize for your behavior and ask Marble if there is a way you could make it up to her.  She's pleasantly surprised by your answer, and after a few moments of contemplation says, \"<i>Well, all right then.  My breasts are still a bit sore - after all, I have to milk them every day - so do you think you could give them that personal touch?</i>\"  You figured she would ask this of you... quite the one-track mind.");
 	outputText("\n\nMarble looks around before ducking inside the field of tall stalks of grain next to her.  After a moment, you follow her into the crops that are waving in the breeze.  Her trail through the many plants isn't that hard to follow, but from the sounds of the giggles up ahead, this has turned into a game.");
-	//Basic scene 
+	//Basic scene
 	outputText("You give chase after the bovine woman, wandering around the many plants in search of the runaway.  Her constant giggling makes sure you know you're going in the right direction, but sometimes she likes to double back or make false trails so the game is more interesting.  ");
-	//[(intelligence check; <15, 15-40, 41+) 
+	//[(intelligence check; <15, 15-40, 41+)
 	if(player.inte < 15) outputText("Eventually you find Marble stopped, looking towards you with her hands in the air saying, \"<i>You caught me!  Come here.</i>\"  She beckons you towards her chest, and you don't make her wait.");
 	else if(player.inte < 40) outputText("Eventually you find Marble stopped and waiting for you.  She puts her hands in the air and says, \"<i>You caught me!</i>\"  It's fairly clear she's given herself up, but when she folds her hands in front of her chest and presses her breasts together, then tells you to come over, you aren't complaining.");
 	else outputText("It isn't too hard to figure out that Marble isn't really trying, and you easily catch her off guard on one of her double backs.  She doesn't even notice you until you peek out from between the stalks next to her, reaching out and getting a handful of her backside.  \"<i>Clever " + player.mf("boy","girl") + "...</i>\" she says.");
@@ -587,7 +587,7 @@ private function forceFeedMarble():void {
 	outputText("\n\n\"<i>There, now I can squeeze these big milky boobs of yours all I want and not make that much of a mess.</i>\"");
 	outputText("\n\nYou know there's still going to be a mess whether Marble is fully dressed or butt-ass naked, but not showing your audience these big, delicious tits would be bad showmanship, right?  As for your own needs, another few streams of your milk have pooled in Marble's mouth.  You squeeze her again, forcing her milk to trickle through your fingers, soaking your hand and the length of your arm with the stuff, but she bears these assaults with her eyes closed in determination.  Apparently you're not going to get anywhere with brutal groping, so you stop squeezing her milky jug and start playing with the sensitive, swollen nipple.  Her eyes fly open as surprise writes itself across her features.");
 	outputText("\n\n\"<i>I know how it feels to be milked, Marble, so I'm gonna stop... until you start nursing like a good girl.  After all, it only seems fair.</i>\"  You playfully tug and twist her little milk bud again, prompting her to moan into your breast.");
-	outputText("\n\nLooks like you successfully put Marble in a tough place, giving her the cow-girl equivalent of blue balls. Her eyes look around, trying to look for anything to help her decide what to do next.  Finally she lets out a muffled sigh, closes her eyes and swallows her pride - along with your milk.  Her nursing is slow, soothing and a bit pleasurable.  This cow definitely has the technique to suck a teat.  Her lips lock around the nipple as her tongue laps over and around it, prompting streams of your warm milk to go down her throat.  Her determined face has softened into that of a peaceful sleeper, and she's completely docile as you pop one nipple out and the other in, as if she were regressing to the mental state of an infant."); 
+	outputText("\n\nLooks like you successfully put Marble in a tough place, giving her the cow-girl equivalent of blue balls. Her eyes look around, trying to look for anything to help her decide what to do next.  Finally she lets out a muffled sigh, closes her eyes and swallows her pride - along with your milk.  Her nursing is slow, soothing and a bit pleasurable.  This cow definitely has the technique to suck a teat.  Her lips lock around the nipple as her tongue laps over and around it, prompting streams of your warm milk to go down her throat.  Her determined face has softened into that of a peaceful sleeper, and she's completely docile as you pop one nipple out and the other in, as if she were regressing to the mental state of an infant.");
 	outputText("\n\nShe's keeping her end of the bargain, so you might as well give her jugs a very thorough hand-milking.  You grab her soft teat and begin to squeeze and pull at it, forcing muffled moans and groans out of her as powerful jets of her milk shoot from her chest - giving you an idea.  As you expertly aim streams down the field, various members of the crowd let out a few words of admiration as they catch onto what you're doing.  Trails of milk meet and mingle as you squirt Marble's nipple onto the dry, packed soil... spelling out, in irregular, runny letters, \"<i>[name]</i>\".  You keep up the rough milking, adding doodles and embellishes, until her breast milk runs low and her tit has shrunk by at least two cup sizes.  If she were to stand up right now, she would be comically lopsided.  It's as funny an idea as you've heard yet.");
 	outputText("\n\nShe relaxes her mouth as she feels the tugging stop, and gradually returns to awareness.  \"<i>Wh- Hey!  You have to do the other breast!</i>\"");
 	outputText("\n\n\"<i>I'm sorry,</i>\" you say, cupping your still-half-full tits, \"<i>but bad girls who don't drink all their milk should be punished.</i>\"  She can only look at you, wide-eyed and trembling with rage, as you pull away - and yet, even her trembles are funny, with one tit wobbling wildly and the other hardly moving at all.");
@@ -683,7 +683,7 @@ public function encounterMarbleExploring():void {
 			doYesNo(drinkMarbleMilk,playerRefusesMarbleMilk);
 			//player chooses yes/no
 		}
-		//[if addiction is 40 or over] 
+		//[if addiction is 40 or over]
 		else {
 			outputText("\n\nYou really want some of that milk and eagerly agree.\n\n");
 			doNext(drinkMarbleMilk);
@@ -791,7 +791,7 @@ public function encounterMarbleExploring2():void {
 		}
 	}
 }
-	
+
 //(player chose no, player has not had sex with Marble)
 private function turnDownMarbleSexFirstTime():void {
 	marbleSprite();
@@ -834,7 +834,7 @@ public function helpMarble1():void {
 	marbleSprite();
 	clearOutput();
 	outputText("\"<i>You know, Marble is moving some produce right now. How about you go help her out?</i>\" Whitney suggests. You agree to help the well-endowed anthropomorph and Whitney directs you to the storage shed. You arrive to find that Marble is quite busy carrying stacks of crates into the barn. She gives you a smile when she sees you and calls out, \"<i>Hey, sweetie! Nice to see you.</i>\" When you tell her you came to help her smile broadens. \"<i>Oh, I'd love to have some help. It'll save me some trips if you give me a hand,</i>\" she says happily before putting on a serious face and continuing, \"<i>but don't strain yourself sweetie, these are heavy. I don't want you to get hurt.</i>\" With that, you get to work with her.\n\n");
-	//[player str <20] 
+	//[player str <20]
 	if(player.str < 20) outputText("Unfortunately, the crates are quite heavy and you end up having to stick with small ones to keep up with Marble's pace. She doesn't appear to mind, just enjoying having someone to talk to while she works, even if it doesn't save her many trips.\n\n");
 	//[player str >=20, <50]
 	if(player.str >= 20 && player.str < 50) outputText("You try your best, but for every crate you carry, Marble caries three. She doesn't mind though, since you'll end up saving her a quarter of the trips she would have had to make.\n\n");
@@ -861,13 +861,13 @@ public function helpMarble2():void {
 	clearOutput();
 	outputText("You run into Whitney at the farm, and ask if there's something you could do.\n\n");
 	outputText("\"<i>I've got it; you can help Marble do some weeding. She's in the field over there right now,</i>\" Whitney says, pointing to a nearby pasture. Nodding to her, you set off to help the pretty cow-girl with her chores. It takes you a while to find her, but you eventually find Marble bent over with her rump in the air.  Once you get closer you realize that she is munching on a weed. \"<i>Oh!</i>\" she exclaims, noticing you.  She hurriedly straightens up and looks around a little embarrassed. \"<i>Hi there sweetie, what are you doing here?</i>\" You explain that Whitney suggested you could help her with the weeding. \"<i>Oh!</i>\" she exclaims again, \"<i>I guess that would be nice, but don't stare at my bum too much while I'm eating, ok?</i>\" You agree and set to work.\n\n");
-	//[player spd <20] 
+	//[player spd <20]
 	if(player.spe < 20) outputText("Even though Marble often stops to munch on a weed, she is still able to get more weeds than you do. Despite her size, she can move surprisingly fast. Regardless, she enjoys simply having you there while she works, and you get to enjoy the view.\n\n");
 	//[player spd >=20, <50]
 	if(player.spe >= 20 && player.spe < 50) outputText("You put in a good effort at cleaning out the weeds, and Marble often gives you a good look at her rear when she finds a tasty looking weed.\n\n");
 	//[player spd >=50, <80]
 	if(player.spe >= 50 && player.spe < 80) outputText("Moving quickly through the fields, you surprise Marble with your speed so much that she jokingly pouts that you're getting to all the tasty weeds before she has a chance to eat them. You still end up getting a few good views of her ass.\n\n");
-	//[player spd >=80] 
+	//[player spd >=80]
 	if(player.spe >= 80) outputText("Weeding the field is a breeze for you, going fast enough that you're able to bring weeds to Marble faster than she can eat them. In the end, you do almost all the work yourself. She does reward you with a good view for your efforts.\n\n");
 	//(increase player spd)
 	dynStats("spe", 1.5);
@@ -898,7 +898,7 @@ private function afterMarbleHelp():Boolean {
 			marbleAddiction(false);
 			return true;
 		}
-		//[player succeeds the int check] 
+		//[player succeeds the int check]
 		else {
 			outputText("While you're working, you are continually plagued by the thought of drinking from Marble's breasts, but you're able to keep those thoughts at bay and continue working normally.\n\n");
 		}
@@ -935,7 +935,7 @@ private function wantMarbleAddiction():void {
 	doNext(camp.returnToCampUseOneHour);
 }
 
-//(player chose don't want) 
+//(player chose don't want)
 private function doNotWantMarbleAddiction():void {
 	marbleSprite();
 	clearOutput();
@@ -969,7 +969,7 @@ public function addictedEncounterHappy(clearS:Boolean = true):void {
 		//Addiction event version 1:
 		if(rand(2) == 0) {
 			outputText("You find Marble in her room, softly humming while reading a book on her bed. You walk up to her, and without looking away from her book she says, \"<i>I can smell your need, sweetie. Are you ready for your drink?</i>\"She sets the book down and turns to you, her hands under her breasts as she leans forward.\n\n");
-			//- inte check to avoid immediately drinking, if succeeded: 
+			//- inte check to avoid immediately drinking, if succeeded:
 			if(player.inte >= 40) {
 				outputText("Will you drink her milk?");
 				//- player chooses yes/no
@@ -1288,7 +1288,7 @@ public function marbleEncounterAddictedNonWithdrawlAshamed():void {
 	//[affection >= 30]
 	if(player.statusEffectv1(StatusEffects.Marble) >= 30) outputText("worriedly ");
 	outputText("for a moment before it dawns on her that you aren't shaking.\n\n");
-	//[affection >= 30] 
+	//[affection >= 30]
 	if(player.statusEffectv1(StatusEffects.Marble) >= 30) outputText("\"<i>Sweetie, w");
 	else outputText("\"<i>W");
 	outputText("hy are you here if you don't need my milk?</i>\" You explain that you just want to enjoy her company like you used to. She gives a genuine smile that probably hasn't been on her face for a while, and the two of you have a meal together in her room. ");
@@ -1349,26 +1349,26 @@ private function extendedMurbelFarmTalkz():void {
 	switch (flags[kFLAGS.MURBLE_FARM_TALK_LEVELS]) {
 		case 0:
 			outputText("During your talk, Marble asks where you're from.");
-			//[if PC is human] 
+			//[if PC is human]
 			if(!player.isRace(Races.HUMAN, 1, false)) {
 				outputText("  \"<i>The only other human I've ever met is that wandering trader Giacomo,</i>\" she tells you \"<i>but he doesn't really talk about himself.  Maybe you could tell me about humans?  I was wondering where they live and what kind of people they are.</i>\"");
-				//[if PC is shorter then 5 feet] 
+				//[if PC is shorter then 5 feet]
 				if(player.tallness < 60) outputText("  Her eyes light up. \"<i>Are they all as cute as you?</i>\"");
-				//[if PC is taller then 6'6" feet] 
+				//[if PC is taller then 6'6" feet]
 				else if(player.tallness > 78) outputText("  \"<i>Are most of you this tall?</i>\"");
 			}
 			//[if PC is cow-girl/cowboi]
 			else if(player.isRace(Races.COW, 1, false)) {
 				outputText("  \"<i>It's so nice to see another of my kind,</i>\" she tells you, \"<i>I haven't seen any since I left home.  Where are you from?</i>\"");
 			}
-			//[if PC is a dogmorph] 
+			//[if PC is a dogmorph]
 			else if(player.isRace(Races.DOG, 1, false)) outputText("  \"<i>I've seen lots of dog-morphs before, are you from Barkersvile?</i>\"");
 			//[if PC is a centaur]
 			else if(player.isRace(Races.CENTAUR, 1, false)) outputText("  \"<i>I've seen a few centaurs before, but they don't seem to have regular homes.  They're nomads, wandering the plains.  Are you the same?</i>\"");
-			//[if PC is not human, cow-girl/cowboi, dogmorph, or centaur] 
+			//[if PC is not human, cow-girl/cowboi, dogmorph, or centaur]
 			else outputText("  \"<i>It's very rare that we get a [race] here.  Are you from around these parts?</i>\"");
 			outputText("\n\nYou sigh and think back for a moment before answering her.");
-			//[if PC is not human anymore] 
+			//[if PC is not human anymore]
 			if(!player.isRace(Races.HUMAN, 1, false)) outputText("\n\nYou start by explaining that you weren't born as what you appear to be; you were once a human.  Marble is surprised by this, but when you start to explain how you came to be what you are, she stops you.  \"<i>You don't need to tell me the power of some of the things in this world.  Mommy taught me how to find LaBova if I ever lose a part of my bovinity,</i>\" she says, winking at you.  \"<i>I don't know of anything that will give humanity though, so I can't really help you if you want to change back...</i>\"  You tell her that's fine and that you'll look on your own if you need to do so.  \"<i>Well then, where is your human home?</i>\" she asks.");
 			outputText("\n\nYou tell her that you aren't from this world, and how you actually passed through a portal to get here, and tell her about your home and your family.  However, you avoid any mention of your mission, or about your village's tradition.  Marble pays close attention to everything you say, and seems to really enjoy the story.  At the end, she stops to think about what you told her.  \"<i>That sounds like a really nice place; I wonder if I'll be able to visit some time?  Well sweetie, you've told me about your family; want to hear about mine?</i>\"  Politely, you say you'd be happy to hear about them.");
 			outputText("\n\nShe smiles and tells you that she was the oldest child of a cow-girl named Hana, and a dog-morph named Roland.  She loved her mother and very much appreciated the many lessons that Hana taught her, but she was always closer to Roland.  He was always kind to her and never demanded anything from her, always helping her in what she wanted to do and accepting anything she did without complaints.  It was he that taught her how to survive and how to fight.  She goes on to say that she had two other younger siblings, both cow-girls, before she left home.");
@@ -1378,7 +1378,7 @@ private function extendedMurbelFarmTalkz():void {
 		//--- Second Conversation ---
 		case 1:
 			outputText("After you've been talking about inconsequential things for a few minutes, Marble asks you, \"<i>Sweetie, do you ever miss your home?  Do you ever wish you could be back with your parents?</i>\"");
-			//[PC is pure] 
+			//[PC is pure]
 			if(player.cor < 33) outputText("\n\nYou sigh and wonder how to word your response for a few moments before telling her that you think about them almost every day; that it's thoughts of home and family that keep you going.");
 			else if(player.cor < 66) outputText("\n\nYou pause a moment before telling her that you used to think about them all the time, but you've since tried to push them from your mind so that you can focus on why you came to this world.");
 			else outputText("You chuckle and say that you hardly think of them with all the other fun things to think about.  Then you pause and say that it is in the moments that you do think about them that keep you from forgetting who you once were.");
@@ -1409,9 +1409,9 @@ private function extendedMurbelFarmTalkz():void {
 		case 4:
 			//Travels and first two lovers
 			outputText("After telling Marble about your explorations of the world thus far, Marble offers to tell you a bit more about her own journey.  \"<i>My family actually lives on the other side of the mountains to the south.</i>\"  She pauses, then chuckles.  \"<i>Or is it to the north?  You know how hard it is to describe direction over long distances, don't you?</i>\" You nod; while you've never had any problem with it back home, you can well imagine how the magic of this realm would eliminate the need for such facility.");
-			outputText("\n\nShe goes on about how she was exploring the mountains and easily dispatching those of demonic taint that wanted to have their way with her.  After wandering around for a few weeks, something a bit more interesting happened.  \"<i>That was when I met the first man I tried to strike up a relationship with.  He was a big strong minotaur that smelled absolutely incredible... but he was a dick.</i>\"  She shakes her head.  \"<i>He tasted my milk once, and I tasted his cum in turn.  Then the next day, he wanted to force that massive cock of his into my womanhood, even though it obviously wasn't going to fit a young girl like me.  I told him no, and he didn't like that, and down came my hammer.  I felt bad about it at first...</i>\"  She shakes her head again.  \"<i>But then when he woke up he decided he wanted to try and force me again!  After that I had his meat on a plate and I was done with him.</i>\"  Her smile at this declaration is more than a little intimidating.  She tells you the only thing that she really remembers vividly from her time with the minotaur was just how wonderful her first nursing was."); 
+			outputText("\n\nShe goes on about how she was exploring the mountains and easily dispatching those of demonic taint that wanted to have their way with her.  After wandering around for a few weeks, something a bit more interesting happened.  \"<i>That was when I met the first man I tried to strike up a relationship with.  He was a big strong minotaur that smelled absolutely incredible... but he was a dick.</i>\"  She shakes her head.  \"<i>He tasted my milk once, and I tasted his cum in turn.  Then the next day, he wanted to force that massive cock of his into my womanhood, even though it obviously wasn't going to fit a young girl like me.  I told him no, and he didn't like that, and down came my hammer.  I felt bad about it at first...</i>\"  She shakes her head again.  \"<i>But then when he woke up he decided he wanted to try and force me again!  After that I had his meat on a plate and I was done with him.</i>\"  Her smile at this declaration is more than a little intimidating.  She tells you the only thing that she really remembers vividly from her time with the minotaur was just how wonderful her first nursing was.");
 			outputText("\n\n\"<i>I left the mountains behind not long after that.  At the time, I thought that I needed to find someone smaller that wasn't going to give me much trouble.  A few years later I chanced upon a nice-looking husky-dog boy named Ansgar.  We actually got along really well, and he loved nursing me so much.  Though, about a week into it, he just walked up to me and said that he couldn't nurse from me anymore.  I was furious at him, and I just blew up in his face over his refusal.  At the end of it all, his hands started shaking and he ran off.</i>\"  She stops at this and says sadly, \"<i>I never saw him again.</i>\"");
-			//[if PC is in the addiction quest or Marble is in camp] 
+			//[if PC is in the addiction quest or Marble is in camp]
 			if(player.statusEffectv3(StatusEffects.Marble) == 2 || player.hasPerk(PerkLib.MarbleResistant)) outputText("\n\n\"<i>I guess it's pretty obvious now why he said he had to stop; he realized he was addicted. I just wish he'd told me at the time so that I knew...</i>\" She sighs.");
 			//[If PC said they want the addiction and (the quest is still on or the PC is addicted)]
 			else if(player.statusEffectv3(StatusEffects.Marble) == 1 || player.hasPerk(PerkLib.MarblesMilk)) outputText("\n\n\"<i>I guess it's pretty obvious now why he said he had to stop; he realized he was addicted.  It's too bad he didn't know how wonderful it is, isn't it?</i>\" She winks at you.");
@@ -1448,7 +1448,7 @@ private function extendedMurbelFarmTalkz():void {
 			if(!player.hasStatusEffect(StatusEffects.CampMarble)) outputText(", except that mission of yours that's so important to you");
 			outputText(".</i>\"");
 			outputText("\n\nYou decide to ask her if she's changed since she left home.  \"<i>Well, I guess I'm a lot more level-headed than I was before, and I'm able to control myself much better when someone refuses to drink my milk.  It still makes me really mad inside, but I keep a lid on it.</i>\"  She stops for a moment.  \"<i>I'm also fairly good at hiding my feelings.");
-			//[if Marble is not in camp] 
+			//[if Marble is not in camp]
 			if(!player.hasStatusEffect(StatusEffects.CampMarble)) {
 				outputText("  I may not show it, but I'm actually really lonely on the inside.");
 				//[if addiction quest is active, and Marble is ashamed of her milk]
@@ -1522,7 +1522,7 @@ public function standardSex():void {
             marbleFuckStatus(1);
         }
 		outputText("Marble smiles at you and leads you towards her bed. She gets you to sit on one end while she moves to the head. As she sits down, she slowly starts to remove her clothes: First she pulls off her top and gives you a full view of her breasts, rubbing and caressing them before running one hand down to her skirt and slipping it off. She pulls her tail up between her breasts and gives you a coy smile as she slips the ribbon on it off.She is now completely naked.  \"<i>Now it's your turn,</i>\" she tells you with a smile.\n\n");
-		//(player is wearing fetish gear)		
+		//(player is wearing fetish gear)
 		if(player.armorName == "bondage patient clothes" ||
 		   player.armorName == "crotch-revealing clothes" || player.armorName == "cute servant's clothes" ||
 		   player.armorName == "maid's clothes" || player.armorName == "servant's clothes") {
@@ -1583,7 +1583,7 @@ public function marbleSex2Continued(genders:int):void {
 		outputText("She gasps slightly and her arms clamp down on you, ");
 		//[player is between 4 and 5 feet in height]
 		if(player.tallness < 60 && player.tallness >= 48) outputText("keeping your head tightly locked between her breasts.  ");
-		//[player is not between 4 and 5 feet in height] 
+		//[player is not between 4 and 5 feet in height]
 		else outputText("keeping your body tightly locked against her.  ");
 		outputText("Her tight grip does nothing to slow your thrusts, only helping to bring both of you closer and closer to sweet release.  Finally, you push into her as far as you can");
 		//[player has a knot and is not more than 8 inches long]
@@ -1922,7 +1922,7 @@ private function marbleKidsPlaytime():void {
 	if(select == 2) {
 		outputText("When you approach the nursery, the faces of your kids immediately light up and as one they cry out, \"<i>" + player.mf("Dad","Mom") + "!  Tell us a story!</i>\"  They crowd around you, excited at the prospect of hearing of your adventures.  It would seem that, once again, the kids will be the ones that decide what will be happening in your time with them.");
 		outputText("\n\nYou launch into another tale of your exploits (that may or may not have actually happened to you) much to the enjoyment of your little ones.  They listen with rapt attention and smiles on their faces as you talk of your successes, worried looks when you sound like you might be in danger, and great cheers when you do make it out all right.");
-		//([corruption check, <=40] 
+		//([corruption check, <=40]
 		if(player.cor < 66) outputText("  You do make sure to skip over the items of a more explicit nature throughout.");
 		outputText("  Eventually your story comes to an end, and you bid farewell to your kids.");
 		//increase fatigue by 5 per kid, decrease lust by 5 per kid, and decrease libido by 1, advance time by 1 hour
@@ -2030,8 +2030,8 @@ private function talkWithMarbleAtCamp():void {
 	//General thoughts:
 	clearOutput();
 	outputText("You call Marble over and the two of you sit down on some rocks to chat.  After thinking a bit, you sort through everything that has happened in this strange land, trying to come up with a new story for your bovine friend.  ");
-	/*check if the player has encountered a major story event that they 
-	have not told Marble about, put it in the temp variable if there is, 
+	/*check if the player has encountered a major story event that they
+	have not told Marble about, put it in the temp variable if there is,
 	otherwise leave it blank*/
 	//earliest story event the player has not told Marble about since she joined the player at camp, alternatively, just the most recent event;
 	//ACTUALLY TALK ABOUT SHIT
@@ -2046,7 +2046,7 @@ private function talkWithMarbleAtCamp():void {
 	else if(player.hasStatusEffect(StatusEffects.FoundFactory) && flags[kFLAGS.MARBLE_CAMPTALK_LEVEL] < 2)
 	{
 		outputText("You tell Marble you found a demonic factory and relate everything you know about it.  \"<i>Be careful in there,</i>\" Marble tells you, \"<i>I'm certain that place will consume you if you're unprepared.</i>\"");
-		flags[kFLAGS.MARBLE_CAMPTALK_LEVEL] = 2;		
+		flags[kFLAGS.MARBLE_CAMPTALK_LEVEL] = 2;
 	}
 	//The player has cleared the factory and shut it down
 	else if(flags[kFLAGS.FACTORY_SHUTDOWN] > 0 && flags[kFLAGS.MARBLE_CAMPTALK_LEVEL] < 3)
@@ -2054,7 +2054,7 @@ private function talkWithMarbleAtCamp():void {
 		outputText("You tell Marble about what you found inside the factory.  She is horrified at what was being done to the other champions and assures you that no one should ever <i>belong</i> in a place like that. You continue and tell of the overseer and her fate. Marble reacts with surprise, ");
 		if(player.hasPerk(PerkLib.OmnibusGift))
 			outputText("and hopes that you've learned your lesson about accepting <i>gifts</i> from demons.  ");
-		else 
+		else
 			outputText("but concludes that what you did was probably for the best.  At least you didn't fall for her trick.  ");
 		outputText("Finally, you tell her how you shut down the factory and what happened to the captured champions.  Marble is shocked that some stayed, but says she doesn't think there is much the two of you could do to help them if they're already addicted. \"<i>You should probably just leave them be, for now.</i>\"");
 		flags[kFLAGS.MARBLE_CAMPTALK_LEVEL] = 3;
@@ -2128,8 +2128,8 @@ private function talkWithMarbleAtCamp():void {
 	else outputText("You have no new stories to share with Marble, so you chat for a bit about inconsequential things.");
 	//New PG for next stuff
 	outputText("\n\n");
-	
-	
+
+
 	//Comments on next course of action, only mentions main story events and quests the player is undergoing
 	outputText("The topic of conversation turns to your mission and you ask Marble what she thinks you should be doing next.  ");
 	//If (player has not yet met Marae)
@@ -2192,27 +2192,27 @@ private function marbleGathered():void {
 	//Vitality potion (12 hours or one day)
 	if (flags[kFLAGS.MARBLE_PURIFICATION_STAGE] != 1 && player.statusEffectv1(StatusEffects.MarbleHasItem) == 0) {
 		inventory.takeItem(consumables.VITAL_T, camp.campLoversMenu);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	}
 	//Pack of nails
 	else if (flags[kFLAGS.MARBLE_PURIFICATION_STAGE] != 1 && player.statusEffectv1(StatusEffects.MarbleHasItem) == 1) {
 		inventory.takeItem(consumables.PONAILS, camp.campLoversMenu);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	}
 	//Tanned Leather clothes, armor, def: 5 (three days)
 	else if (flags[kFLAGS.MARBLE_PURIFICATION_STAGE] != 1 && player.statusEffectv1(StatusEffects.MarbleHasItem) == 2) {
 		inventory.takeItem(armors.LEATHRA, camp.campLoversMenu);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	}
 	//Minotaus horn
 	else if (flags[kFLAGS.MARBLE_PURIFICATION_STAGE] != 1 && player.statusEffectv1(StatusEffects.MarbleHasItem) == 3) {
 		inventory.takeItem(useables.MINOHOR, camp.campLoversMenu);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	}
 	//LaBova, cow girl transformation item (if you'll let me put it here, I'd like to use it as part of the purification quest, the player can still get it if they are addicted)
 	else {
 		inventory.takeItem(consumables.LABOVA_, camp.campLoversMenu);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	}
 	player.removeStatusEffect(StatusEffects.MarbleHasItem);
 }
@@ -2228,7 +2228,7 @@ private function marbleInfo():void {
 	{
 		outputText("She will nurse you every morning automatically to satisfy your addiction.  ");
 		//otherwise tell the player that drinking bottles of her milk is safe
-	} 
+	}
 	else
 	{
 		if(flags[kFLAGS.MARBLE_PURIFIED] == 0) outputText("So long as you don't drink milk from Marble's breasts again, you don't have to worry about getting addicted.  ");
@@ -2338,7 +2338,7 @@ private function marbleCampSexNew():void {
 			outputText("\n\nAt the same time, Marble's right hand is slowly moving down your abdomen, lingering a bit just over your [hips], as she awaits your 'answer'.  Gently, you grab Marble's breast with both hands and slowly guide the " + marbleNip() + " to your thirsty lips.");
 			outputText("\n\n\"<i>Drink, sweetie,</i>\" Marble says, \"<i>Drink of me.</i>\"");
 			outputText("\n\nTaking the teat into your mouth, you start to suck on it.  It doesn't take long for Marble's milk to start flowing, and when it does, she moves her hand lower.");
-			//( [Male/Herm] 
+			//( [Male/Herm]
 			if(cock) outputText("She chuckles as her hand reaches your [cocks].  \"<i>You seem quite ready and eager for something, sweetie.</i>\"");
 			else {
 				outputText("She chuckles as her hand reaches your " + vaginaDescript(0) + ".  ");
@@ -2348,11 +2348,11 @@ private function marbleCampSexNew():void {
 				else outputText("\"<i>Oh my, sweetie; it seems like you need to be toweled off...</i>\"");
 			}
 			outputText("\n\nWithout further ado and with a wide smile on her face, she starts moving her hand, stimulating you. In response, you slightly increase the strength with which you suck on her breast and you're rewarded with a stronger flow of milk into your mouth.");
-			
+
 			if(cock) {
 				outputText("\n\nHer hand continues stroking your [cock], very gently at first, but once you intensify your suckling, she gasps slightly and gives your member an appreciative squeeze, increasing the intensity.  You buck your hips slightly but she just strokes your " + hairDescript() + " as if to calm you down.");
 				outputText("\n\n\"<i>It doesn't hurt, right?  I want to make you feel good, sweetie...  If you keep sucking me, I'll make you feel very, very good.</i>\"");
-				
+
 				outputText("\n\nYou gently moan into her breast in response, causing her to giggle as she plays with the tip of your [cock].  She returns to the pumping motion and increases the pace just as you decide you need something to grab onto - and the most pleasant things at hand are her breasts.  Marble gasps in surprise and moans as you rub her breasts while suckling, and starts jerking you off even faster in response.");
 				if(flags[kFLAGS.MARBLE_DICK_LENGTH] == 0) outputText("  Her thighs seem to be rubbing together, and the place you're lying on feels a tiny bit wet, so you assume it isn't only you who's getting more and more excited by this.");
 				else outputText("  Her thighs are gently rubbing beneath you, and you feel something hard poking you in the back.  You smile around the nipple you have in your mouth.");
@@ -2368,16 +2368,16 @@ private function marbleCampSexNew():void {
 				if(player.cumQ() >= 1000) outputText(", then wipes the nipple clean on the other");
 				outputText(".  \"<i>Now, sweetie, if you'd be so kind to suck on the other one...</i>\"");
 			}
-			//[Female] 
+			//[Female]
 			else {
 				outputText("\n\nHer hand moves onto your pleasure button, starting to gently rub your [clit] as her milk flows into your mouth.  When you intensify your suckling, she gasps slightly and slides a finger into your " + vaginaDescript(0) + ", pumping it in and out as her palm has its way with your [clit].  You buck your hips slightly but she just strokes your " + hairDescript() + " as if to calm you down.");
 				outputText("\n\n\"<i>That feels good, doesn't it, sweetie?  You should suck my breasts some more, I'd really appreciate that.</i>\"");
 				outputText("\n\nYou gently moan into her nipple in response, causing her to giggle as she plays with the tip your " + clitDescript() + ".");
-				//([Normal clit] 
+				//([Normal clit]
 				if(player.clitLength < 3) outputText("\n\nShe rubs it with care but quite intensely, bringing you a tingling, overwhelming pleasure.");
 				else outputText("\n\nShe grabs your clit and strokes it a few times, then grins widely.  \"<i>This is kind of perverse, sweetie.  Is this really one of your lady parts?</i>\"");
 				outputText("  She returns to pumping her fingers in and out of your pussy and, just as she increases the pace, you decide you need something to grab onto - and the most pleasant things at hand are her breasts.  Marble gasps in surprise and moans as you rub her breasts while suckling, and starts fingering you even faster in response.");
-				//( [Female Marble] 
+				//( [Female Marble]
 				if(flags[kFLAGS.MARBLE_DICK_LENGTH] == 0) outputText("  Her thighs seem to be rubbing together, and the place you're lying on feels a tiny bit wet, so you assume it isn't only you who's getting more and more excited by this.");
 				else outputText("  Her thighs are gently rubbing beneath you, and you feel something hard poking you in the back.  You smile around the nipple you have in your mouth.");
 
@@ -2420,12 +2420,12 @@ private function marbleCampSexNew():void {
 			//[if multicock]
 			if(cock && player.cockTotal() > 1) outputText("  She alternatively sucks and jerks every cock you have, making sure there isn't a single meat-tower that isn't being taken care of.");
 			if(player.hasBalls()) outputText("  Her hands softly rub your [balls], making them churn and swell in pure arousal.");
-			
+
 			outputText("\n\nYou moan in ecstasy as her hands and tongue keep ploughing your crotch; impulsively, you grab her head and push her further into your groin, making her effectively ");
 			if(!cock) outputText("tongue-fuck");
 			else outputText("deepthroat");
 			outputText(" you.  Your hips thrust back and forth, enjoying the fluid motion of her tongue working over your wet, saliva-slathered genitals.");
-			//[if cock] 
+			//[if cock]
 			if(cock) {
 				outputText("  Her lips tightly enclose your " + cockDescript(0));
 				if(player.cockTotal() > 1) outputText(" while she strokes another");
@@ -2433,16 +2433,16 @@ private function marbleCampSexNew():void {
 			}
 			//[if vagina]
 			else outputText("  Her flexible, yet firm tongue really feels like a dong and it keeps provoking you with its prolonged digging. With a mighty thrust, you shove her against your " + vaginaDescript() + ", forcing the entirety of her oral muscle inside.");
-					
+
 			outputText("\n\nThe luscious passion of her ministrations eventually proves too much for your abused genitals, and with one last ferocious thrust, you unload your juices in Marble's waiting mouth.");
-			
+
 			//[if cock]
 			if(cock) {
 				outputText("\n\nYour [cock] palpitates, tip twitching on its own against Marble's throat as it liberates your milky essence.  Marble eagerly gulps, drinking with avidity that reminds you of how you ");
 				if(player.hasPerk(PerkLib.MarblesMilk)) outputText("usually");
 				else outputText("used to");
 				outputText(" suckle her tits.");
-				//[if high cum production] 
+				//[if high cum production]
 				if(player.cumQ() >= 500) outputText("  Your [cock] keeps spouting more seed inside her, efficiently distending her belly");
 				//[if cum production is massive]until she looks ready to give birth.[/]
 				if(player.cumQ() > 1500) outputText(" until she looks ready to give birth.");
@@ -2450,7 +2450,7 @@ private function marbleCampSexNew():void {
 			}
 			//[if vagina]
 			else outputText("\n\nYour " + vaginaDescript(0) + " quivers and vibrates before releasing a vigorous discharge of fem-spunk, splattering Marble's lips and mouth; she drinks all your juices with an insatiable cum-thirst.  Her tongue explores your insides as if to make sure there's no girlcum left to absorb.");
-			
+
 			outputText("\n\nMarble keeps sucking and licking your junk even after your orgasm in order to make sure not a single drop has been wasted, and in your post-climax dizziness you let her toy with your genitals until she reaches satiation; she only stops when your crotch is completely devoid of cum.");
 			outputText("\n\nShe eventually gets up and gives you a last tired kiss, \"<i>Hope I've been helpful this time, sweetie...</i>\"  You clean yourselves up and quickly get dressed before parting.");
             sharedEnd();
@@ -2487,7 +2487,7 @@ private function marbleCampSexNew():void {
 				//If clit is too small to be titfucked...
 				if (player.clitLength < 2) {
 					outputText("  Marble runs down each of your legs once with her breasts before unexpectedly plunging two of her fingers inside your " + vaginaDescript(0) + ".");
-				} 
+				}
 				else {
 					outputText("  Marble then pulls your " + clitDescript() + " between her breasts and does her best to pump and stimulate it as though it were a cock.");
 				}
@@ -2529,7 +2529,7 @@ private function marbleCampSexNew():void {
 		if(player.lib >= 50) outputText("  Quietly, you reach down and hook your fingers into the hem of her clothing, allowing her to pull it half off with her next shift and expose her pussy");
 		if(flags[kFLAGS.MARBLE_DICK_LENGTH] > 0) outputText(" and " + marbleCock());
 		outputText(".  \"<i>Why, you shameless " + player.mf("pervert","hussy") + "!</i>\" the cow-girl says in mock-offense, winking at you.");
-	
+
 		outputText("\n\nWhen she gets back to your tail, she turns around once more, and crawls back towards your upper body, while walking her fingers up your tail again.");
 		if(player.gender > 0) {
 			outputText("\n\nBy the time she reaches your genital slit, you're panting with pleasure, and exposing your ready ");
@@ -2547,7 +2547,7 @@ private function marbleCampSexNew():void {
 			outputText(".  You cry out in pleasure, and start to wrap your long tail about Marble's shapely body.  You can't hold back for long, and soon reach orgasmic bliss, all while tightly clinging to your cow-girl lover.");
 			if(player.hasCock()) outputText("  [EachCock] unleashes a load of semen right into her mouth, which she swallows with pink-faced, wanton gusto.");
 			if(player.hasVagina()) outputText("  Your [pussy] runs and squirts as you moan, drooling your juices into the little valley where Marble's breasts press against your scales.");
-		} 
+		}
 		else {
 			outputText("\n\nWhen she reaches where your genitals would be - if you had any - you're panting with pleasure.  Marble gives you a smile and whispers, \"<i>Don't worry sweetie, I know just how to make you cum.</i>\"  She then hugs your body tightly, reaching her arms around and squeezing and slapping your [butt], while slipping a finger into your " + assholeDescript() + ".  You gasp at the surprise, but are soon panting even harder.  The fact that she is still rubbing her breasts on your abdomen even as she teases you helps even more, and you can't help but coil your lower body around Marble, rubbing every part of it on her.  In moments, you cry out in bliss as your unusual anal orgasm washes over you.");
 		}
@@ -2618,11 +2618,11 @@ private function rapeMarble(room:Boolean = false):void {
 	{
 		outputText("tries to slap you.  You easily duck under her hand and start twisting her nipples.  She squeals and begins to go limp under your painful ministrations.  You move her around and force her to kneel, pushing her face down into her bed.  Keeping one of your hands on her nipple, you pull down her skirt and expose her beautiful womanhood and asshole.\n\n");
 		raped = true;
-	} 
+	}
 	else if(player.str >= 80) {
 		outputText("slaps you.  Unperturbed by the hit, you push her back onto the edge of the bed, much to her dismay.  You forcibly flip her over onto her stomach and her knees hit the ground.  You keep one hand on her back to stop her from getting up and use your other to pull down her skirt, exposing her beautiful womanhood and asshole.\n\n");
 		raped = true;
-	} 
+	}
 	if(!raped) {
 		outputText("slaps you. While you are still reeling from the blow, she uses a surprising amount of strength to force you out the door. She slams it behind you and yells, \"<i>Don't you ever come back!</i>\" through the door. You hear her start to cry as you walk away. She seems to be much stronger than she looks. You think to yourself that if you see her again, you won't make the mistake of underestimating her. While lost in your thoughts, you stumble and accidentally fall over.  <i>Maybe you'll teach her a lesson once you've stopped seeing stars.</i>  As you try to get up, you stumble in the other direction and fall over again.  <i>Then again, it may not be worth the trouble.</i>");
         sceneHunter.print("Figure it out yourself. It's possible.");
@@ -2722,7 +2722,7 @@ public function marbleAfterRapeBattle():void {
 //if yes, Marble confronts the player just outside the barn with her hammer in hand
 private function marbleAfterRapeYes():void {
 	marbleSprite();
-	//If choice was yes 
+	//If choice was yes
 	clearOutput();
 	outputText("Deciding to deal with her, you move towards the barn.  However, Marble spots you on your way over and quickly disappears inside.  Just as you get to the entrance, she re-emerges with a large two-handed hammer in hand.  \"<i>Leave right now, or this hammer is going into your head,</i>\" she tells you with an angry look in her eyes and drops into a combat stance.  Will you fight her?");
 	//the player decides if they want to fight or not
@@ -2759,7 +2759,7 @@ public function marbleBadEndFollowup():void {
                 player.tallness < 84 ? "tall" :
                     "very tall";
 	//very short is probably <4.5 feet, short is between 4.5 and 5.5, average is between 5.5 and 6, tall is between 6 and 7, very tall is > 7.
-	
+
 	//BEGIN BAD-ENDNESS
 	outputText("Over time, the two of you learn to get along and accept the way things have gone.  Before long, the two of you become close friends, then even lovers.  At the same time, you learn the ways of life on the farm and adjust to your new life successfully.  As the months pass, things remain much the same from day to day. Until nearly a year later...\n\n\n");
 	//SHIFT ABOVE TO END OF RELEVANT BAD ENDS
@@ -2781,7 +2781,7 @@ public function marbleBadEndFollowup():void {
 	//does he comment on the player's height?
 	if(approxHeight=="very short" || approxHeight=="short") {
 		outputText("Though I see you've gotten a little shorter than I saw you last.  ");
-	} 
+	}
 	else if(approxHeight=="tall" || approxHeight=="very tall") {
 		outputText("You've gotten bigger since I saw you last.  ");
 	}
@@ -2799,7 +2799,7 @@ public function marbleBadEndFollowup():void {
 		else {
 			outputText("\"<i>Really?  Well I guess I should congratulate you on your new family,</i>\" the young champion says with a little uncertainty.  \"<i>Oh, it's not really a new family,<i>\" the other responds as a pair of little girls that look very much like little Marbles come running out of the barn, one chasing the other.  \"<i>Oh wow, you've found a nice family to join,</i>\" the younger champion says, watching the girls run off towards the farm house.  \"<i>Were those twins?</i>\"  \"<i>No,</i>\" the older champion responds, \"<i>Mili is several weeks older than Aura, but they're both my children.</i>\"  The younger champion stares at him incredulously before stammering \"<i>But how?  They're at least a few years old!</i>\"  The older champion puts his arm around the younger one's shoulder and leads him and Marble inside the barn telling him.  \"<i>You have a lot to learn about this world if you're going to last.</i>\"  ");
 		}
-		//girls and those without naughty bits go here 
+		//girls and those without naughty bits go here
 	}
 	else {
 		outputText("A tall female cow-girl then steps out of the barn entrance.  The young champion notes just how pretty she is, if a bit imposing.\n\n");
@@ -2823,7 +2823,7 @@ public function marblePoopsBaybees():void {
 	if (pregnancy.type == PregnancyStore.PREGNANCY_PLAYER) {
 		//Gives birth at 28 days
 		outputText("\nMarble rushes up to you with a concerned look on her face.  \"<i>Sweetie, it's time!  Our child is going to come into the world!</i>\"  She squats down and gets you to kneel next to her, putting your hand against her now gaping womanhood.  You can feel that something is starting to come out of the hole, and you start encouraging Marble as she continues to breathe heavily and occasionally grunt from the effort of pushing the child out.\n\n");
-		
+
 		outputText("As the head comes out of her hole, you can see that it has small nub like horns and cute little bovine ears.  You call to Marble that you can see the head and that it's already starting to look like her.  You hear Marble give a happy laugh between her breaths as she continues to push the child out.  You notice that the smell around Marble is a little different right now, though you can't judge exactly what the difference is.\n\n");
 		if(flags[kFLAGS.MARBLE_PURIFIED] > 0 && rand(2) == 0)
 		{
@@ -2849,7 +2849,7 @@ public function marblePoopsBaybees():void {
 
 			//note that these may have to change, I'm not sure if they'll belong here or not
 			flags[kFLAGS.MARBLE_BOYS]++;  //again, n is the flag for the number of male kids Marble has had
-		} 
+		}
 		else
 		{
 			outputText("After only a few short minutes, the child is pushed out by Marble completely and she gives a satisfied sigh.  You look at the child as it starts bawling and see that it is indeed a little cow-girl that the two of you have brought into the world.  You can already tell that she has all the bovine features that Marble has");
@@ -2860,7 +2860,7 @@ public function marblePoopsBaybees():void {
 			//If (PC is addicted to Marble)
 			if(player.hasPerk(PerkLib.MarblesMilk)) {
 				outputText("\"<i>Don't worry sweetie,</i>\" Marble tells you, \"<i>somehow I know that she won't get addicted.\"</i>  ");
-			} 
+			}
 			else {
 				outputText("\"<i>Oh my,\"</i> Marble says to you, \"<i>It's just as wonderful as when you suckled me when my milk was addictive; I'd forgotten the feeling.\"</i>  ");
 			}
@@ -2920,10 +2920,10 @@ public function marblePoopsBaybees():void {
 		//how big is the pile of eggs?
 		if(rand(2) == 0) {
 			outputText("small pile of eggs next to her.  You ask her what's going on, but Marble stops you and grunts slightly before pushing out one final egg and standing up.  \"<i>Sweetie, I've finished laying the eggs from that elixir,</i>\" she tells you before taking a few breaths and continuing, \"<i>I was actually expecting them to be a bit bigger, but it doesn't really matter.  You're welcome to take one of them, but only one, ok?</i>\"\n\n");
-		} 
+		}
 		else if(rand(2) == 0) {
 			outputText("pile of large eggs next to her.  It looks like a similar egg is coming out of her womanhood right now; it quickly falls to the ground and Marble pushes it into the pile with the others.  It looks she has been at this for a while now. You put your hand on her shoulder and ask her what is going on.  She turns to you and says, \"<i>Ah sweetie, just laying the eggs from the elixir.  I think there is one more.</i>\"  She grunts and pushes out a final egg, before putting it in the pile with the rest.  \"<i>You're welcome to take one of them, but only one, ok?</i>\"\n\n");
-		} 
+		}
 		else {
 			outputText("a rather large pile of eggs under her.  She keeps gasping and moaning as another egg comes plopping down, then another, and another.  You can't believe your eyes at how many eggs are coming out, and how much Marble seems to be enjoying it.  After a minute, the eggs stop coming out, but Marble keeps squatting there and grunting.  You walk over to her and grab her shoulders, forcing her to look you in the eye as you tell her that there are no more.  She looks at you blankly for a moment before shaking her head and putting a hand to her stomach.  \"<i>Oh sweetie, it looks like I've finished laying those eggs from the elixir.  There were a lot more than I was expecting, I guess I spaced out.  It felt so good...</i>\" her eyes start to glaze over again and you give her a shake.  \"<i>Oh!  Sorry, uh, go ahead and take one of the eggs, but please, only the one, ok?</i>\"\n\n");
 		}
@@ -3095,7 +3095,7 @@ private function atNightAskMarbleForSomeSexMaybe():void {
 		outputText("gently ask her if she wants to fool around.  After a moment you hear her breathe out and she says, \"<i>Sorry sweetie, I'm not feeling up to it right now.</i>\"");
 		//Marble cuddles the PC
 		marbleCuddlin();
-	} 
+	}
 	else {
 		outputText("gently ask her if she wants to fool around.  After a moment you hear her breathe out and, with a lewd voice, she says, \"<i>I was worried you'd never ask, sweetie...</i>\"");
 		//trigger Marble sex
@@ -3130,24 +3130,24 @@ private function marbleNightSexIntro(clear:Boolean = true):void {
 		//If (PC has dick) {
 		if(player.cockTotal() > 0) {
 			outputText(multiCockDescriptLight());
-			//If (PC both dick and vag) 
+			//If (PC both dick and vag)
 			if(player.hasVagina()) outputText(" and your ");
 		}
-		//If (PC has vag) 
+		//If (PC has vag)
 		if(player.hasVagina()) outputText(vaginaDescript());
 		outputText(" and gently caresses you.  She whispers into your ear, \"<i>Soon sweetie, soon we'll both get what we want.</i>\"\n\n");
 		outputText("Finished with removing your clothes and her own, Marble releases her grip on your head and turns your body over.\n\n");
-	} 
-	else 
+	}
+	else
 	{
 		outputText("She reaches over and puts her hand onto your waist, gently slipping her hand inside your undergarments to touch your ");
 		//If (PC has dick) {
 		if(player.cockTotal() > 0) {
 			outputText(multiCockDescriptLight());
-			//If (PC both dick and vag) 
+			//If (PC both dick and vag)
 			if(player.hasVagina()) outputText(" and your ");
 		}
-		//If (PC has vag) 
+		//If (PC has vag)
 		if(player.hasVagina()) outputText(vaginaDescript(0));
 		outputText(" while you slip your own hand into her clothes and ");
 		//If (Marble is a herm) {
@@ -3187,7 +3187,7 @@ private function marbleNightSexDudes():void {
 	clearOutput();
 	outputText("You gently lift yourself up and slide the tip of your " + cockDescript(x) + " into her waiting hole.  Ever so slowly, you push yourself further and further in.  Each inch gained brings gentle moans and coos from Marble, encouraging you onward.  ");
 	//Can the PC's main cock go all the way?
-	//If (cock 0 is longer than 8 inches) 
+	//If (cock 0 is longer than 8 inches)
 	if(player.cocks[x].cockLength > 8) {
 		outputText("There is only one thing that will stop your advance: when you reach the end of the line.  \"<i>Keep going sweetie, there is room left.  Make sure you fill me all the way.</i>\"  With a groan, your " + cockDescript(x) + " hits the furthest part of Marble's confines and you can go no further.\n\n");
 	}
@@ -3211,7 +3211,7 @@ private function marbleNightSexDudes():void {
 		else {
 			if(player.biggestTitSize() >= 4) {
 				outputText("landing your " + biggestBreastSizeDescript() + " into Marble's face!  You hear a slight muffled cry underneath you as Marble takes her hands off your hips and lifts you up off of her.  ");
-			} 
+			}
 			else {
 				outputText("crashing down on Marble and doing a good job of flattening her breasts under your size.  \"<i>Hey!</i>\" she cries out, letting go of your hips to lift your body off of her.  ");
 			}
@@ -3219,7 +3219,7 @@ private function marbleNightSexDudes():void {
 		outputText("You look down at her annoyed expression, before grinning at her and beginning to impale her moist and wonderful snatch yourself.  In a moment, her expression changes from a pouty face to one of ecstasy.  The two of you are nearing your peaks now.\n\n");
 	}
 	//nope the PC is the one
-	else 
+	else
 	{
 		outputText("It isn't enough to hold you back for more than a moment, though, and soon you're thrusting deep inside her at a comfortable rhythm for the two of you.  You smile at her and she smiles back as you start fondling and playing with Marble's lovely pillows.  She starts to run her fingers onto her love button, crying out in pleasure as you continue to thrust your " + cockDescript(x) + " inside her.\n\n");
 		//If (PC's breasts are B cups or bigger)
@@ -3231,18 +3231,18 @@ private function marbleNightSexDudes():void {
 	//let's talk about the PC's cum production
 	if(player.cumQ() < 250) {
 		outputText("Marble cries out in joy as your " + cockDescript(x) + " unleashes its load within her insides.  ");
-	} 
+	}
 	else {
 		outputText("Marble gasps in both pleasure and pain as you fill up her insides to almost bursting, and large amounts of your jizz spill out around her slit.  ");
 	}
 	//Now, does the PC have more than one cock?  Cum comes out of those too.
-	if(player.cockTotal() > 1) 
+	if(player.cockTotal() > 1)
 	{
 		outputText("Of course, ");
-		if(player.cockTotal() > 2) { 
+		if(player.cockTotal() > 2) {
 			outputText("the rest of your " + multiCockDescriptLight());
-		} 
-		else { 
+		}
+		else {
 			outputText("your other tool");
 		}
 		outputText(" unleashes its own load, liberally covering both of you.  ");
@@ -3275,7 +3275,7 @@ private function marbleNightSexChicks():void {
 			//If (PC's breasts are D cup or bigger)
 			if(player.biggestTitSize() >= 4) {
 				outputText("Marble takes her hands off your hips and lets you start to rise and fall on her in your own time.  She still rises up to meet you as you descend and lowers herself down each time you rise, matching your timing, but her hands have a much more pressing concern: your " + biggestBreastSizeDescript() + ".  Marble starts working her hands expertly to tease and play with your " + biggestBreastSizeDescript() + ". She seems to know all the right ways to move her fingers, clearly having a lot of experience with her own, and you can't help but moan at the attention.  She giggles and pants in pleasure herself; it seems she may be enjoying this play just as much as you!\n\n");
-			} 
+			}
 			else {
 				outputText("Marble decides it would be a good time to start playing with your " + biggestBreastSizeDescript() + " and starts teasing a " + nippleDescript(0) + " with one of her hands as the other continues to gently lift you up and down.  You moan a little at her ministrations as she smiles at you and says, \"<i>You know, sweetie, maybe those cute little boobies of yours could stand to get a little bigger.  I'm sure I could do some great things to you then.</i>\" With a grin still on her face, she gasps and the two of you feel your climaxes approaching.\n\n");
 			}
@@ -3286,7 +3286,7 @@ private function marbleNightSexChicks():void {
 			//Does Marble help out, or does she go for the PC's breasts?
 			if(player.biggestTitSize() >= 4) {
 				outputText("She reaches her hands up and starts to play with your " + biggestBreastSizeDescript() + ", flicking and toying with them at the same pace that you play with hers.  The two of you start a friendly little contest to see who can stimulate the other's chest better; all the while, you continue to rise and fall above her.\n\n");
-			} 
+			}
 			else {
 				outputText("Marble reaches her hands up and grabs onto yours, pulling them down tightly against her chest.  She gets you to play with each of her " + marbleNips() + " in turn, making sure that you flick them and tease them in just the right way to get her to cry out in ecstasy again and again.\n\n");
 			}
@@ -3322,7 +3322,7 @@ private function marbleNightSexChicks():void {
 			outputText("\"<i>Oh sweetie, am I going too fast for you?  Here, let me give you a chance to catch your breath.</i>\"  She offers as she slows down her rapid movement, letting your mind settle back into place.  ");
 			if(player.biggestTitSize() >= 4) {
 				outputText("Marble takes her hands off your hips and lets you start to rise and fall on her in your own time.  She still rises up to meet you as you descend and lowers herself down each time you rise, matching your timing, but her hands have a much more pressing concern: your " + biggestBreastSizeDescript() + ".  Marble starts working her hands expertly to tease and play with your " + biggestBreastSizeDescript() + ". She seems to know all the right ways to move her fingers, clearly having a lot of experience with her own, and you can't help but moan at the attention.  She giggles and pants in pleasure herself; it seems she may be enjoying this play just as much as you!\n\n");
-			} 
+			}
 			else {
 				outputText("Marble decides it would be a good time to start playing with your " + biggestBreastSizeDescript() + " and starts teasing a " + nippleDescript(0) + " with one of her hands as the other continues to gently lift you up and down.  You moan a little at her ministrations as she smiles at you and says, \"<i>You know, sweetie, maybe those cute little boobies of yours could stand to get a little bigger.  I'm sure I could do some great things to you then.</i>\" With a grin still on her face, she gasps and the two of you feel your climaxes approaching.\n\n");
 			}
@@ -3371,7 +3371,7 @@ private function marblePreggoChance(preggerMult:Number):void {
 	preggerOdds *= preggerMult;
 	//GET HER PREGNANT
 	trace("MARBLE PREGGO ODDS: " + preggerOdds);
-	
+
 	if(rand(100) < preggerOdds && (player.hasPerk(PerkLib.MarblesMilk) || flags[kFLAGS.MARBLE_PURIFICATION_STAGE] >= 5)) {
 		//SHUT UP SHES ALREADY PREGNANT
 		if (!pregnancy.isPregnant) {
@@ -3385,7 +3385,7 @@ private function marblePreggoChance(preggerMult:Number):void {
 	{
 		trace("Knockup failed");
 	}
-	
+
 }
 
 private function marbleSexFinish():void {
@@ -3440,7 +3440,7 @@ private function marbleNomNoms():void {
 		}
         player.sexReward("cum", "Lips", false);
         sharedEnd();
-	} 
+	}
 	function vagF():void {
 		outputText("Marble lifts up her skirt and gives you a clear view of her very wet womanhood.  You lower your head and take a deep breath of her animalistic scent.  It makes you feel a bit giddy and you can feel a wave of arousal pass over you.  You give the walls of her wet box a gentle lick and hear Marble give an approving sigh, before you really get to work.\n\n");
 		outputText("Her taste is almost like honey, and it quickly spurs you on to lick at every part of her walls the best you can.  Marble puts her hand on the back of your head and begins to guide you where she wants you to go.  You push your tongue deeper and deeper inside her, probing every part of her that you can reach.  Though now it seems that Marble wants you to get to the main course; you're soon using your tongue to ease and play with her clit, drawing out more and more excited noises from above you. Finally, you hear her give a cry of joy and her womanhood sprays you with its juices.\n\n");
@@ -3464,7 +3464,7 @@ public function MarbleDigsDraftsYo():void {
 	outputText("You hand Marble the bottle.  She looks at it for a moment before ");
 	if(player.statusEffectv4(StatusEffects.Marble) > 60) {
 		outputText("giving you a smile and saying, \"<i>So you want me to partake in corruption, and to have a nice cock to stick my sweet with?</i>\"  You tell her that the bottle has been purified, so it won't give corruption, but otherwise, you're hoping it gives her the <i>additional</i> effect.  She grins at you and downs the bottle.\n\n");
-	} 
+	}
 	else {
 		outputText("looking at you uncertainly and saying, \"<i>Uh, sweetie, I'm not going to drink this demon stuff.  It'll warp my body, and I think this will give me a cock...</i>\"  You assure her that the draft has been purified, so it won't warp her body or corrupt her... aside from that last effect she mentioned, but that's what you want her to get.  She sighs before yielding, and says, \"<i>Ok sweetie, if you really want me to have one, I'll take it for you.</i>\"  She takes a deep breath before drinking the bottle, and grimaces at the taste.\n\n");
 	}
@@ -3476,7 +3476,7 @@ public function MarbleDigsDraftsYo():void {
 	flags[kFLAGS.MARBLE_DICK_TYPE] = 1;
 	flags[kFLAGS.MARBLE_DICK_LENGTH] = 7;
 	flags[kFLAGS.MARBLE_DICK_THICKNESS] = 2;
-	
+
 }
 
 //Pink egg or large pink egg
@@ -3495,7 +3495,7 @@ private function MarblePEggEffects():void {
 	outputText("You hand Marble the pink egg.  She looks at it thoughtfully for a moment before her eyes light up in recognition.  \"<i>This is one of those magic eggs made from those egg elixirs.  If I remember right, this one removes the male traits of those who eat them.  ");
 	if(player.statusEffectv4(StatusEffects.Marble) > 50 ) {
 		outputText("So my sweet, tired of my cock?  Well, what if I like it?  Do you really want me to get rid of it?</i>\"  You assure her that yes, you do want her to get rid of it.  She frowns at you in annoyance, but ultimately agrees to take the egg.  \"<i>Eventually you'll want it back, I'm sure of it,</i>\" she says just before eating the egg.\n\n");
-	} 
+	}
 	else {
 		outputText("So does this mean you don't want me to have a cock anymore, sweetie?</i>\"  You assure her that yes, you don't want her to have it anymore.  She seems relieved by this and admits, \"<i>Thank you sweetie, I don't think I really liked having it,</i>\" before eating the egg.\n\n");
 	}
@@ -3567,7 +3567,7 @@ public function giveMarbleTheProBovas4Sho():void {
 	clearOutput();
 	marbleSprite();
 	player.consumeItem(consumables.PROBOVA);
-	
+
 	if(flags[kFLAGS.MARBLE_BOVA_LEVEL] == 0) {
 		outputText("Marble nods and downs the contents.  Nothing happens for a moment... then she gasps and grabs at her chest, stumbling forward slightly.  The cow-girl straightens up and releases her grip, then pulls open her top to look at her breasts.  <b>Each is now decorated with sets of four nipples, like the teats of a cow.  She has also gained about 4 inches in height, judging against the backdrop of the camp.</b>  Marble takes a few minutes to test her new nipples, squeezing them gently and sighing as dribbles of milk decorate her areolae in fours instead of one, then looks at you and says, \"<i>This isn't really so bad.  Actually, it feels nice.  If you find another dose, I'm willing to drink it - just to see what happens, of course.</i>\"");
 		//Set Marble's nippes to quads, set her height to 6'8</i>\", increase Marble's vaginal capacity by 10, increase Marble corruption by 4
@@ -3577,8 +3577,8 @@ public function giveMarbleTheProBovas4Sho():void {
 	//end event
 	else {
 		outputText("Marble takes a deep breath and says, \"<i>I'm doing this for you because I love you so much.  Remember that, all right, sweetie?</i>\"  The woman knocks back the contents of the bottle easily and braces herself for the impending changes.  The first movement she makes is to scratch absently on her arm, but this quickly sets off a chain reaction of itching all over her body, <b>and her skin begins erupting in clumps of brown fur, eventually covering her entirely</b>.  Consumed with scratching her unaccustomedly itchy fur, she doesn't notice herself growing taller; <b>to your eyes, it looks like she's gained about 8 inches of height.</b>  The woman cries out in pain and claps her hands over her face, then turns away from you embarrassed, stumbling slightly as she does so.  You reach out to her reflexively, but she turns back quickly, revealing the cause; <b>her face has elongated and re-formed itself into a cow-like muzzle!</b>  The outward changes seem to stop here, but Marble gasps air for a few moments more before looking at you.  You return her gaze; she's no longer a cow-girl, but a full cow-morph.  She gives you a hesitant smile and asks, \"<i>Well, how do I look?</i>\"  There's not much you can say, since she changed at your request, so you give her a reassuring hug and tell her that she looks just as beautiful.");
-		//Set Marble's fur to full body, face to cow-anthro, increase height by 8 inches 
-		//(these don't need to be recorded except with one value), and increase Marble's vaginal capacity by 20, 
+		//Set Marble's fur to full body, face to cow-anthro, increase height by 8 inches
+		//(these don't need to be recorded except with one value), and increase Marble's vaginal capacity by 20,
 		//increase Marble corruption by 4
 		flags[kFLAGS.MARBLE_BOVA_LEVEL] = 2;
 	}
@@ -3595,7 +3595,7 @@ private function marbleAppearance():void {
 	clearOutput();
 	marbleSprite();
 	outputText(images.showImage("monster-marble"));
-	//Gives Marble's appearance screen, some of these values change depending 
+	//Gives Marble's appearance screen, some of these values change depending
 	//on her level of corruption.
 	outputText("Marble is a ");
 	if(flags[kFLAGS.MARBLE_BOVA_LEVEL] == 0) outputText("6 foot 4 ");
@@ -3606,12 +3606,12 @@ private function marbleAppearance():void {
 	else outputText("She has a soft face that is a mix of bovine and human features, with thick brown fur covering her body.  ");
 
 	outputText("Her shoulder-length brown hair is parted by a pair of rounded cow-ears that stick out sideways from her head.  ");
-	
+
 	if(player.statusEffectv4(StatusEffects.Marble) <= 20) outputText("Two small horns grow from her forehead, similar in size and appearance to those on a young female bovine.  ");
 	else if(player.statusEffectv4(StatusEffects.Marble) <= 50) outputText("Two medium-sized horns grow from her forehead, similar in size and appearance to those on a female bovine.  ");
 	else outputText("Two fairly large horns grow from her forehead, similar in appearance to those on a female bovine.  ");
 	outputText("She has wide womanly thighs that draw the attention of those around her, and her large butt fills out her clothing nicely.  A long cow-tail with a puffy tip swishes back and forth between her legs, as if swatting at flies. A pretty bow has been tied to her tail.  Two legs grow down from her waist");
-	
+
 	if(flags[kFLAGS.MARBLE_BOVA_LEVEL] <=1) outputText(", human until about half-way down her thigh.  The lower portion of her legs is covered in thick dark brown fur and ends in a pair of bestial hooves.\n\n");
 	else outputText(" that are oddly jointed and end in a pair of bestial hooves.\n\n");
 
@@ -3619,7 +3619,7 @@ private function marbleAppearance():void {
 	else if(player.statusEffectv4(StatusEffects.Marble) <= 25) outputText("She has two large breasts, each supporting a 0.6-inch lactating " + marbleNip() + ".  She could easily fill a " + marbleBreastSize() + ".\n\n");
 	else if(player.statusEffectv4(StatusEffects.Marble) <= 35) outputText("She has two basketball-sized breasts, each supporting a 0.8-inch milk-seeping " + marbleNip() + ".  She could easily fill a " + marbleBreastSize() + " bra.\n\n");
 	else outputText("She has two basketball-sized breasts, each supporting a 1-inch milk-seeping " + marbleNip() + ".  She could easily fill an " + marbleBreastSize() + " bra.\n\n");
-	
+
 	//Additions to Marble's appearance screen
 	//Marble's Pregnancy
 	//Marble's cock
@@ -3635,14 +3635,14 @@ private function marbleAppearance():void {
 				break;
 		case 6: outputText("Her belly is extremely swollen and occasionally quivers when whatever she is pregnant with moves around.\n\n"); //24+ days in
 	}
-	
+
 	if( (flags[kFLAGS.MARBLE_PURIFICATION_STAGE] < 5 && flags[kFLAGS.MARBLE_LUST] >= 20) || (flags[kFLAGS.MARBLE_PURIFICATION_STAGE] >= 5 && flags[kFLAGS.MARBLE_TIME_SINCE_NURSED_IN_HOURS] >= 4) )
 	{
 		outputText( "<b>Marble is fidgeting around uncomfortably, perhaps she needs to be milked?</b>\n\n" );
 	}
-	
+
 	if(flags[kFLAGS.MARBLE_DICK_TYPE] > 0) outputText("She has grown a " + marbleCock() + " since you brought her to camp. It is " + num2Text(int(flags[kFLAGS.MARBLE_DICK_LENGTH])) + " inches long and " + num2Text(int(flags[kFLAGS.MARBLE_DICK_THICKNESS])) + " inches thick.\n\n");
-	
+
 	if(player.statusEffectv4(StatusEffects.Marble) <= 50) outputText("She has a pussy, with a 0.5 inch clit.\n\n");
 	else if(player.statusEffectv4(StatusEffects.Marble) <= 75) outputText("She has a cunt, with a 0.6 inch clit.  You can see moisture gleaming from it.\n\n");
 	else outputText("She has a fuck-hole, with a 0.7 inch clit.  Moisture gleams in her cunt, its lips slightly parted.\n\n");
@@ -3666,12 +3666,12 @@ private function giveMarbleTailjobRelease():void {
 	outputText("\n\nIt doesn't take long for her to climax after that.  After a few more strokes and pushes against the walls of her pussy, she releases a moo-like moan and you feel her contracting rhythmically around your tail while her cock twitches, releasing a sticky liquid right into the coils.");
 	outputText("\n\nMarble stops moaning soon after and looks at you warmly, stroking your tail again with affection.");
 	//{ OPTIONAL
-	//([Corruption 70+] 
+	//([Corruption 70+]
 	if(player.cor > 70) {
 		outputText("\n\nYou certainly don't mind the proof of your prowess marking your lower body like this, but you can think of something better to do with it.  In fact, you slowly move the tail towards your lips.");
-		//(Normal or Snake tongue) 
+		//(Normal or Snake tongue)
 		if(player.tongue.type == Tongue.SNAKE || player.hasLongTongue()) outputText("  Your tongue runs along the length of the end of your tail, tasting both Marble's feminine secretions and her semen.  She gives you a smoldering gaze as you lick her juices up.  You grin at her.");
-		//(Demon Tongue) 
+		//(Demon Tongue)
 		if(player.hasLongTongue()) outputText("  You decide to put on a show for Marble, moving your tail as you drop out a large piece of your inhumanly long tongue, licking up her secretions sensuously while staring at her.  She quickly blushes under your gaze.");
 		outputText("\n\n\"<i>Sweetie, you wouldn't be trying to make me horny all over again, would you?</i>\"");
 		outputText("\n\n\"<i>Well... certainly, when you're not in the mood, repeating this would be very nice.  I hope we can both have fun together next time, though... Thank you, sweetie.</i>\"");
@@ -3691,37 +3691,37 @@ private function milkMarble():void
 	if( flags[kFLAGS.MARBLE_MILKED_BEFORE] < 1 )
 	{
 		outputText( "With an unusually bright look in her eye, Marble comes up to you and asks, \"<i>Hey sweetie, I was just about to go get milked when I realized that you've never actually been with me for it.  How would you feel about getting a tour of the setup that Whitney has for me?</i>\"  Then a mischievous look crosses her face, \"<i>Maybe we could even do something a little... intimate too?</i>\"" );
-		
+
 		outputText( "[pg]There is no harm in checking out her stall, at least.  You agree to go with her." );
-		
+
 		outputText( "[pg]The two of you hold hands and quickly warp over to Whitney's farm and, with a wave to the proprietor, Marble escorts you to the barn.  The smells of the place are as familiar as ever, but this particular trip has an unusual feel to it since you're going to visit a room you've never been in before." );
-		
+
 		outputText( "[pg]Your lover shows you the stall with her name on it and ushers you inside.  The room is a pretty cozy affair, with a large padded chair and small table in the center, a waist high railing on one side, and a long bench in on the other.  The milking machine hangs from the ceiling on a rail, allowing it be used in any part of the room." );
-		
+
 		outputText( "[pg]Your amorous guide gives an animated rundown of the uses of her pieces of furniture, the chair is what she usually sits in while reading, the bar if she's got stiff legs, and the bench if she's really worn out.  Once finished, you do notice there is a book sitting on the table right now and ask Marble what she's reading.  She uncharacteristically bites her thumb a bit nervously and says in a low voice that it's the book she was reading while doing research when you were addicted to her." );
-		
+
 		outputText( "[pg]Now very curious, you ask her how it is, and how close she is to finishing it.  \"<i>It's a bit embarrassing sweetie, but I've actually barely started it.  Unlike my younger sister, I never started reading until I needed something to do while being milked, and I'm terrible at it.  It can take me months to get through just one book, even if I'm spending several hours reading every day...</i>\"" );
-		
+
 		outputText( "[pg]You apologize for bringing it up and suggest that maybe you should get down to the milking?" );
-		
+
 		outputText( "[pg]She perks up instantly and pulls down " );
 		if( flags[kFLAGS.MARBLE_BOVA_LEVEL] < 1 ) outputText( "two" );
 		else outputText( "eight" );
 		outputText( " suction cups off of the milker machine and carefully attaches them to her nipples, then flips a switch, causing it to come to life.  In an instant, milk starts flowing out of her " + marbleNips() + " into the cups and then up the clear tubes into the machine.  She lets out a relaxed sigh, then turns her gaze back to you." );
-		
+
 		outputText( "[pg]\"<i>Well sweetie, is there something you've got in mind you'd like to do?</i>\"" );
-		
+
 		flags[kFLAGS.MARBLE_MILKED_BEFORE] = 1;
 	}
 	else
 	{
 		outputText( "Sensing that Marble looks like she is going to get milked soon, you offer to escort her to her stall personally." );
-		
+
 		outputText( "[pg]As usual, Marble is pleased at the prospect and agrees instantly, and the two of you head over to her small homely space in Whitney's operation." );
-		
+
 		outputText( "[pg]Once Marble has herself settled in and hooked up, she turns to you and asks if you've got something in mind." );
 	}
-	
+
 	if( flags[kFLAGS.MARBLE_PURIFICATION_STAGE] >= 5 ) flags[kFLAGS.MARBLE_TIME_SINCE_NURSED_IN_HOURS] = 0;
     menu();
     addButton(0, "Cunnilingus", milkMarbleCunnilingling);
@@ -3740,56 +3740,56 @@ private function milkMarble():void
 private function milkMarbleCunnilingling():void
 {
 	clearOutput();
-	
+
 	outputText( "You suggest that maybe she'd like it if you licked her vagina while being milked." );
-	
+
 	outputText( "[pg]A huge smile spreads across her face, \"<i>Oh sweetie, that sounds like it would be wonderful!  You're the best; you know that?</i>\"" );
-	
+
 	outputText( "[pg]She takes a seat on the edge of the chair in the middle of the room and spreads her legs wide.  Her skirt slips up her " );
 	if( flags[kFLAGS.MARBLE_BOVA_LEVEL] < 1 ) outputText( "semi-human" );
 	else outputText( "inhuman" );
 	outputText( " legs, giving you a clear look at her waiting womanhood.  With a coy sideways glance, she wiggles her fingers in invitation for you to go down on her." );
-	
+
 	outputText( "[pg]In order to get the show on the road, you " );
 	if( player.isBiped() ) outputText( "get down on your knees, and slowly crawl forward" );
 	else outputText( "lower your body close to the ground, and slowly inch forward" );
 	outputText( " like an animal who's found something they want.  When you get close to her, your lover runs a finger up the inside of her thigh as her tail sneaks its way up around her waist and drapes itself over your prize." );
-	
+
 	outputText( "[pg]Arriving at a hard brown hoof, you wrap your arm about her coarsely furred leg and rest your head against the bestial appendage.  You stroke and run your fingers through her fur to a soft giggle above you while the machine continues to pump and whirl.  You tease her a bit more before raising yourself up, bit by bit, until you're at eye level with her tail-covered opening. A small tuft of hair decorated with a pink bow is all that hides your goal.  No, it's a present, gift wrapped for you." );
-	
+
 	outputText( "[pg]You take hold of two strands of the bow and tell Marble she shouldn't have given you such a gift." );
-	
+
 	outputText( "[pg]\"<i>Oh, not at all sweetie.  You deserve it!</i>\"" );
-	
+
 	outputText( "[pg]You slip the bow open, unwrapping your present, and pull her tail aside to reveal her moist and inviting opening and exclaim that it was what you always wanted!" );
-	
+
 	outputText( "[pg]\"<i>Oh, I'm so glad you like it.  Why don't you try it out right now?</i>\"" );
-	
+
 	outputText( "[pg]She doesn't have to give you the suggestion twice.  You dive in at once, sticking your [tongue] deep into her recesses, and tasting her cow-girl nectar.  Her folds accept you easily, and an eager moan slips out of the woman above you.  Her fingers run over your [hair] while you withdraw from your initial sortie to scout out the entrance more." );
-	
+
 	outputText( "[pg]In response to your tugging and toying with her outer folds, Marble's hips jerk forward slightly, and you see her love button pulse and engorge itself.  There is a happy moan, and her tail manages to find itself flicking your face.  You swat the pesky wrappings away and continue your efforts at bringing your mate to the height of pleasure.  The next target: her clit." );
-	
+
 	outputText( "[pg]There is a long-drawn-out cry of joy when you bring your [tongue] to the source of her womanly pleasure.  " );
 	if( flags[kFLAGS.MARBLE_DICK_TYPE] > 0 ) outputText( "With the first flick across its pink flesh, Marble grabs ahold of her "+ marbleCock() +", and tightly squeezes it, slowly pushing her hand down it." );
 	else outputText( "With the first flick across its pink flesh, Marble grabs onto an arm of her chair, gripping it tightly." );
 	outputText( "  You can't help but laugh and ask her if your treatment is too much, suggesting that maybe you should save playing more for later." );
-	
+
 	outputText( "[pg]\"<i>No more teasing me, [name], bite me now!</i>\"" );
-	
+
 	outputText( "[pg]How can you refuse such a request?" );
-	
+
 	outputText( "[pg]\"<i>Ahhhhooooo!</i>\"  The wonderful bovine women gives a grateful cry of pleasure as your teeth nip into her nub of engorged skin and a burst of liquid sprays out onto your chin.  " );
 	if( flags[kFLAGS.MARBLE_DICK_TYPE] > 0 ) outputText ("Of course, there is also a spurt of white which sprays out over her lap and your head.  " );
 	outputText( "Obviously, while the milkers don't normally get her aroused, they can seriously amplify the effects of any pleasure she gets." );
-	
+
 	outputText( "[pg]You ask your lover if that was good." );
-	
+
 	outputText( "[pg]\"<i>Lovely. Thanks for giving me the best start to being milked sweetie.</i>\"  She notices that you're all wet, \"<i>Oh, here, let me get that for you.</i>\" and she wipes the fluid off your [face] with a grin." );
-	
+
 	outputText( "[pg]You then tie her bow back up on her tail and say you'll save the rest for later." );
-	
+
 	outputText( "[pg]\"<i>Oh, I'll be looking forward to it.  See you later sweetie!</i>\"  She gives you a slightly awkward peck on the cheek around the milking tubes, that sends you into a blissful state." );
-	
+
 	flags[kFLAGS.MARBLE_LUST] = 10;
 	var pLust:int = int( 20 + ((player.lib + player.cor) / 10) );
 	dynStats( "lus", pLust );
@@ -3802,13 +3802,13 @@ private function milkMarbleFuckDatCowPussy():void
 {
 	var x:int = player.cockThatFits( marbleCuntCapacity() );
 	clearOutput();
-	
+
 	outputText( "You wonder aloud if maybe she'd be interested in a little intercourse action. You'd be perfectly prepared to provide for her." );
-	
+
 	outputText( "[pg]\"<i>Hmm, well, your offer is tempting, but I'm going to have to see what's available before I make a final decision.</i>\"" );
-	
+
 	outputText( "[pg]With a flourish, you remove your [armor] and do a little sweep over your " + cockDescript(x) + ", asking her if everything is to her needs." );
-	
+
 	if((player.hasPerk(PerkLib.BulgeArmor) || player.modArmorName == "backless female teacher's clothes" || player.modArmorName == "bridle bit and saddle set" || player.modArmorName == "headdress, necklaces, and many body-chains" || player.modArmorName == "bondage patient clothes" || player.modArmorName == "crotch-revealing clothes" || player.modArmorName == "cute servant's clothes" || player.modArmorName == "maid's clothes" || player.modArmorName == "servant's clothes") && player.hasCock())
 	{
 		outputText( "[pg]\"<i>I appreciate the little show, but I could already see you just fine.  Come closer so I can get a better idea.</i>\"" );
@@ -3816,11 +3816,11 @@ private function milkMarbleFuckDatCowPussy():void
 	else outputText( "[pg]\"<i>Hmm, yes, I think that will work.  Come closer so I can make a more thorough inspection.</i>\"" );
 
 	outputText( "[pg]You step forward and allow your lover to get \"acquainted\" with your goods." );
-	
+
 	outputText( "[pg]She squats down and makes a show of looking you over carefully, humming to herself along the way.  Her breath tickling your skin slightly and quickly bringing you to full hardness.  With one finger, she taps your tip a few times, then runs it along your glans.  Finally she finishes her examination of your manhood by gripping it in her hand and giving it a few experimental pumps." );
-	
+
 	outputText( "[pg]She stands back up and looks at you with a serious expression on her face.  \"<i>Your penis has met my expectations, and I do believe that I will be taking it into my vagina.  Please lay down on the bench over there and we can begi-hahahahaha!</i>\"  Her face finally cracks and she bursts out laughing over the little game the two of you have been playing." );
-	
+
 	if( player.tallness < 68 )
 	{
 		outputText( "[pg]\"<i>Oh sweetie.</i>\"  She pulls you into a deep hug against her chest.  \"<i>It's too much!  Hah, hahahahaha!  No more joking around.  I need you inside me now.</i>\"  She carefully carries you over to the bench and lays you down on your back, then straddles the bench above your " + cockDescript(x) + ".  \"<i>Are you ready for me?</i>\" she calls out in a deep husky voice, breasts heaving, tail swishing, and all the while the milker machine continues to hum above her." );
@@ -3828,22 +3828,22 @@ private function milkMarbleFuckDatCowPussy():void
 	else
 	{
 		outputText( "[pg]You pull her into a deep hug as she continues to her hysterics and gently caress her hair.  You assure her that if the games are too much, you can skip straight to the action." );
-		
+
 		outputText( "[pg]After a moment she settles down and returns the embrace.  \"<i>Hmmhmm, yes.  No more joking around.  I need you inside me now.</i>\"" );
-		
+
 		outputText( "[pg]You break away from her and casually walk over to the bench and lay down on top of it.  Marble follows immediately behind you, and before you've even finished laying down, she's already standing above with a hungry look on her face, breasts heaving, and tail swishing." );
-		
+
 		outputText( "[pg]\"<i>Are you ready for me?</i>\" she asks in a deep husky voice." );
 	}
-	
+
 	outputText( "[pg]With a grin, you tell her you're always ready for her." );
-	
+
 	outputText( "[pg]The words have barely left your mouth before Marble drops her waist and engulfs your " + cockDescript(x) + ", swallowing it up to the base in a single motion.  \"<i>Ohhhhhh, yes!</i>\"  Marble happily rubs her belly with one hand, while another cubs her breast.  She shakes her hips from side to side a couple of times, savoring the feeling of your cock rubbing back and forth across her insides." );
-	
+
 	outputText( "[pg]Then both hands come down and push down on your stomach, and she begins a rapid forward and backward rocking motion on your member, keeping every bit of your length deep inside her, putting it into a spinning trip around her passage while she starts giving low happy moans of pleasure.  You look up at your lover and get a good view of the expression of bliss upon her face, but also get a chance to see the milk draining from her chest." );
-	
+
 	outputText( "[pg]With each push and pull on your member, there is a rapid spurt of milk that the machine is only just able to keep up with.  After a moment, you realize that it isn't actually able to keep up, her milk is coming out too fast for the milker!  You try to warn your bovine lover, but it's too late.  With a pop, the suction cups fly off of Marble's breasts, spraying milk everywhere, and there is a bang from the machine as it shuts down." );
-	
+
 	outputText( "[pg]\"<i>Oh no!  Damn it, now what?</i>\" Marble stops moving and looks around worried." );
     if (sceneHunter.other) {
         outputText("[pg] <b>What's next?</b>");
@@ -3858,9 +3858,9 @@ private function milkMarbleFuckDatCowPussy():void
 	//==================================
 	function addictF():void {
 		outputText( "[pg]You quickly sit up and take it upon yourself to continue the efforts of the milking machine, bringing with your actions a surprised gasp, followed by a contented sigh, and Marble resuming the movements of her hips.  The ambrosia from her breasts increases in quantity once more, and it actually feels like it's being pumped into your mouth.  You're happy to rise to the challenge of drinking it all while Marble continues to ride your body." );
-		
+
 		outputText( "[pg]Where the machine failed to handle Marble's increased production, you succeed in draining everything.  Heck, the feel of yourself bouncing around Marble's passage while she pushes against you and bounces back and forth only edges you on further than normal.  With one hand on her shoulder for leverage, you use the other to massage her bosom and coax even more milk out of her, greedily devouring as much of your favorite drug as possible." );
-		
+
 		outputText( "[pg]Almost an hour later, the flow from both of Marble's breasts has slowed to a trickle, and both of you have cum at least three times in a haze of both sexual and chemical pleasure.  Marble gives a contented sigh and informs you that she thinks she'll be taking a nap now, wondering whether or not she should make a habit of breaking the milker, given what happens afterwards." );
 		player.sexReward("milk");
         player.sexReward("vaginalFluids", "Dick");
@@ -3877,19 +3877,19 @@ private function milkMarbleFuckDatCowPussy():void
 
     function corruptF():void {
 		outputText( "[pg]The haze given off by Marble's tainted fluids alights a familiar craving at the back of your mind, but you push it back and reach your hands up to her breasts and pinch her nipples.  Marble tenses for a moment, and looks down at you confused.  You tell her that you'll try to keep her entertained while you wait for Whitney to fix things." );
-		
+
 		outputText( "[pg]She begins speaking once more, then goes quiet when you pull on her nipples and try your best to milk her by hand, much the same way that the cows were milked back home.  While nothing actually comes out of her breasts from your touch, she gives an appreciative moan and resumes her rocking against your crotch." );
-		
+
 		outputText( "[pg]After rubbing against you for a bit, the stimulation on your length just isn't enough for you anymore, and try to start thrusting up into your lover's passage.  Marble seems to be in agreement in what she wants, and her motions switch from a gentle rocking into meeting each of your thrusts with a pumping of her own, trying to drain your manhood while you try to drain her breasts." );
-		
+
 		outputText( "[pg]Finally the two of you cry out together in orgasmic pleasure, and you spray out your seed into her passage, mixing with a rush of her own fluids into a slurry of sex juices sloshing around your " + cockDescript(x) + ".  The two of you settle down, with Marble laying down on you contentedly for a moment." );
-		
+
 		outputText( "[pg]Suddenly a voice with a southern drawl call out from above you, \"<i>You kids havin a lots of fun down there?</i>\"" );
-		
+
 		outputText( "[pg]The two of you stare at each other in surprise and tense up." );
-		
+
 		outputText( "[pg]\"<i>Next time, please try to be a bit gentler on the equipment, if ya don't mind.  I'd rather not have to do fix it every time you two get frisky.</i>\"  There is a slam of metal on metal as Whitney finishes working on the broken milker and it whirls back to life." );
-		
+
 		outputText( "[pg]You and Marble each look each other in the eye and burst out laughing.  You then help her reattach the cups and excuse yourself.  Just as you're leaving, Marble blows you a kiss and says, \"<i>We should definitely do this again sometime.  Let's just give Whitney a break first.</i>\"" );
 
 		player.sexReward("milk");
@@ -3901,13 +3901,13 @@ private function milkMarbleFuckDatCowPussy():void
 
     function pureF():void {
 		outputText( "[pg]You assure Marble that it will be fine and grab a bucket that was sitting under the bench and offer to continue her milking by hand.  She looks like she is going to object for a moment before nodding.  You help her turn herself around while keeping your manhood firmly embedded within her.  She puts the bucket down at the end of the bench, and you reach your hands around her to grip her massive mammaries." );
-		
+
 		outputText( "[pg]You roll the soft pliable flesh around in your hands for a few moments, garnering appreciative moans from their owner.  Then you start pinching and pulling on her " + marbleNips() + ", sending a jolt through her body that makes her tail shoot straight up.  Almost instantly after that, she resumes rubbing herself against your manhood, sending it sweeping through her insides once more while her delightfully shaped rear-end slides around against your waist." );
-		
+
 		outputText( "[pg]You give a gasp of pleasure of your own and try your best to properly milk her nipples in the same way that cows back home were milked, in spite of how roughly your milkee is fucking right now.  If anything, being milked has made her more aggressive, and her tail is swishing around madly." );
-		
+
 		outputText( "[pg]It takes a few minutes of effort, but when you find yourself finally closing with the peak of an orgasm, there is a spray followed by a ping. You finally manage to get some milk flowing from Marble's breasts, just in time for her to scream in pleasure and drive herself back into you more forcefully than before.  Her tail shoots straight up again, twitches twice, and you're thrown over the edge as well." );
-		
+
 		outputText( "[pg]The two of you cum together at least three times over the next hour or so, and while your hand milking certainly isn't as efficient as Whitney's machine, it manages well enough in satisfying your bovine lover.  When you go to tell the farmer what happened to her device, she is rather surprised at just how nonchalant and pleasant the two of you were about it.  As she put it, \"<i>Most folks generally feel bad when they go round breaking other people's things.</i>\"  Though, you're certain she knew what you'd been up to.\n\n" );
 
 		player.sexReward("milk");
@@ -3923,41 +3923,41 @@ private function milkMarbleFuckDatCowPussy():void
 private function milkMarbleTakeHerDick():void
 {
 	clearOutput();
-	
+
 	outputText( "You ask her if maybe she wants to penetrate you while she is using that milking machine." );
-	
+
 	outputText( "[pg]She looks thoughtful for a moment, tapping her finger against her lips while her tail swishes back and forth.  With the tubes coming off of her nipples, it actually looks rather comical." );
-	
+
 	outputText( "[pg]Spotting your look, she frowns at you, \"<i>Oh, you think this is silly do you, [name]?  I'll have you know that I'm seriously trying to figure out how to make this work.</i>\"  She indicates her rather physical attachment to the room, and the furnishings it has available to it." );
-	
+
 	outputText( "[pg]You give it a little thought, then suggest that you could lean up against that railing while she fucks you from behind." );
-	
+
 	outputText( "[pg]\"<i>Take you from behind, huh?  I'd really rather look into your eyes while I'm having sex, but there aren't many options here, are there?</i>\"" );
-	
+
 	outputText( "[pg]To silence her complaining, you quickly strip" );
 	if( player.tallness < 56 ) outputText( ", grab a box," );
 	outputText( " and lean against the railing, then shake your [ass] in her direction with your vagina on full display, wet with arousal.  You look back at her to see if you're having the desired effect." );
-	
+
 	outputText( "[pg]Marble is licking her lips with a nervous look on her face while holding her tail in her hand and running her fingers through it's brush.  \"<i>You make a very persuasive argument, sweetie.  Plus, if you're looking at me like that, I guess I really don't have anything to complain about, do I?</i>\"" );
-	
+
 	outputText( "[pg]She strips off her short skirt and takes up a position behind you, hands on your hips and erect cock pressed against your entrance.  You look down between your legs and catch sight of her tail hanging down between her legs, the barest hint of movement to it.  \"<i>Well sweetie, are you ready for me?</i>\"" );
-	
+
 	outputText( "[pg]You retort that if you weren't, you wouldn't have suggested this in the first place." );
-	
+
 	outputText( "[pg]\"<i>Heh, good point.  Alright, here I go...</i>\"  She slowly works her way inside you, inch by inch.  " );
 	if( player.vaginalCapacity() < flags[kFLAGS.MARBLE_DICK_LENGTH] * flags[kFLAGS.MARBLE_DICK_THICKNESS] ) outputText( "With each new bit of length inserted, she waits a few moments for you to adjust to her size, letting you fill out to accommodate her.  " );
 	outputText( "With the final bit of her inserted into you, her tail suddenly shoots straight up out of your sight, and she lets out a long exaggerated sigh of pleasure as the milking machine continues to whirl above her." );
 	player.cuntChange( 8, true, true, false );
-	
+
 	outputText( "[pg]\"<i>Oh sweetie, you feel so wonderful.  I actually feel a bit strange right now, like I want to....</i>\"  She starts thrusting into your entrance with great gusto, eliciting a surprised gasp from you; Marble isn't normally this energetic when it comes to sex!  Being milked is probably making her more aggressive than usual, though given how good she is making you feel, you can't really complain." );
-	
+
 	outputText( "[pg]She starts playing with your backside with her hand, massaging your " );
 	if(player.butt.type <= 4 && !player.isGoo() ) outputText( "taut" );
 	else outputText( "jiggling" );
 	outputText( " flesh while her " + num2Text(Math.round(flags[kFLAGS.MARBLE_DICK_LENGTH])) + " inch length continues to push and pull into your womanhood.  Egged on by her enthusiasm, you start putting in some effort into the sex yourself by pushing your backside tight against her with each push forward and shaking it back and forth with each pull out of your interior." );
-	
+
 	outputText( "[pg]The stimulation sends Marble wild, and in short order she is flooding you with her hermaphroditic seed.  However, she doesn't slow down at all and simply continues to lovingly abuse your backside and mound of pleasure.  You look down between your legs once more to see her tail has started swinging lengthwise with her body, every last inch of her body and mind are fixed on breeding with you, triggering a triumphant laugh from you as you cum yourself." );
-	
+
 	outputText( "[pg]Nearly an hour later, Marble finally calms down and looks down at what she has managed to do to you.  \"<i>Oh my!  Sweetie, I'm sorry, I'm not sure what came over me...</i>\" she freezes when she sees your happy expression, and you inform her that you rather liked seeing that side of her. The two of you will have to do this again some time." );
 
 	player.sexReward("milk");
@@ -3973,33 +3973,33 @@ private function milkMarbleTakeHerDick():void
 private function milkMarbleOnTheBar():void
 {
 	clearOutput();
-	
+
 	outputText( "You suggest that you'd be interested in playing with her while she's draped over the bar on the one side of the room." );
-	
+
 	outputText( "[pg]She narrows her eyes at you, considering the proposition.  \"<i>I don't know sweetie, doesn't really sound like something I'd like that much.  I'd like to be in a position where I can do more than just take it...</i>\"" );
-	
+
 	outputText( "[pg]You assure her that you'll make it good enough that it will be worthwhile to let you have complete control." );
-	
+
 	outputText( "[pg]After a few more moments of thought, Marble gives you a very serious look, \"<i>You don't get complete control, I'll be giving the instructions here, oh, and you'd better do a good job.</i>\"  Suddenly she smiles, \"<i>Otherwise, I'll just have to turn things around!</i>\"" );
-	
+
 	outputText( "[pg]You wonder if maybe you want her to turn things around while she rests her hands on the bar, then drapes herself over it with her breasts swinging underneath.  She turns her head towards you and swings her ribbon decorated tail back and forth a few times.  You'd best not keep her waiting when she actually took you up on your request, so you strip down and step up behind her." );
-	
+
 	outputText( "[pg]\"<i>Alright sweetie, time to get me ready.  Let's see how you do.</i>\"  She turns her head back, and simply waits for you to start while the milking machine continues to hum above her." );
-	
+
 	outputText( "[pg]You start by lifting up her skirt to expose her round ass to the air and the lips of her womanhood below it.  Of course, there is also the base of her tail just above it which continues to swish back and forth somewhat indignantly overtop of her openings.  Next, you take a handful of her generous asscheeks, rolling them around in your hands and kneading the soft bouncy flesh.  Though not as expansive as her bust by any means, Marble undeniably has quite the pleasant backside." );
-	
+
 	outputText( "[pg]\"<i>Hmm,</i>\" comes a pleased moan from the cowgirl in front of you, and her tail lifts up ever so slightly as the first signs of moisture and arousal form around her womanhood." );
-	
+
 	outputText( "[pg]Next, you run a finger across her entrance, teasing her ever so slightly.  A small jolt flies through her body, and her tail shoots straight up." );
-	
+
 	outputText( "[pg]\"<i>Ah, that's a good start sweetie, now, put a finger inside me.</i>\"" );
-	
+
 	outputText( "[pg]The words are barely out of her mouth, when you push your index finger into her lower lips.  There is a low squelch while it slips inside, which starts again when you stir your finger around in a few circles.  This causes Marble's tail to curl around your hand and try to pull your finger out.  Once a little ways out, her tail tries to force your hand back into her waiting snatch." );
-	
+
 	outputText( "[pg]\"<i>Maybe you need my help after all.  Want to let my tail do the talking sweetie?  Let me show you how I like being penetrated.  Then again, your tongue might be nice to feel next too...\"</i>" );
-	
+
 	if( player.cockThatFits(marbleCuntCapacity()) > 0 ) outputText( "[pg]You idly consider grabbing and pulling on her tail, so you could have a chance to take charge, though Marble would probably try and take control in that case for sure..." );
-	
+
 	menu();
 	//addButton( 0, "Follow Tail", sceneHunter.callFitNofit, milkMarbleBarFollowTail, marbleCuntCapacity() );
     addButtonIfTrue(0, "Follow Tail", curry(sceneHunter.callFitNofit, milkMarbleBarFollowTail, marbleCuntCapacity()), "", player.hasCock())
@@ -4019,55 +4019,55 @@ private function milkMarbleBarFollowTail(x:int):void
         y = player.cockThatFits2(marbleCuntCapacity());
         if (y < 0) sceneHunter.print("You could use a second one!");
     }
-	
+
 	outputText( "You ask Marble where her tail will lead you." );
-	
+
 	outputText( "[pg]She gives a low chuckle, \"<i>Why don't you wait and find out?</i>\"" );
-	
+
 	if (fits) {
 		outputText( "[pg]Her ribbon adorned, bovine appendage slowly unwraps from your wrist and instead searches around your crotch for something else.  Eventually the tuff comes into contact with your " + cockDescript(x) + ", and runs its fur across your length lovingly for a few times, then curls around your base and pulls you in towards Marble's waiting womanhood." );
-		
+
 		outputText( "[pg]\"<i>Mhehehe, found it!</i>\"" );
-		
+
 		outputText( "[pg]It was obvious that you couldn't hide from her for long." );
-		
+
 		outputText( "[pg]\"<i>Oh I know sweetie, but it's always so much fun looking.</i>\"" );
-		
+
 		outputText( "[pg]Sliding into her interior is a slow but enjoyable process.  Each inch you pass in makes you want to just slam yourself home in an instant, but you wait to let Marble's tail guide the way.  Finally you're fully inside her, and she lets out a long soft moan of pleasure, followed by shaking her hips side to side a few times." );
 		if(y >= 0) outputText( "  You find your " + cockDescript(y) + " slides up comfortably in between her cheeks, and squeeze them together a bit to give it a nice tight valley of soft flesh to run through." );
-		
+
 		outputText( "[pg]Your guide string tightens up a bit in time with the end of your lover's cry of pleasure.  \"<i>Hmmm, mine, all mine.</i>\" You barely catch Marble whisper under her breath, then her tail relaxes a bit and pushes back against your waist.  Understanding the direction, you pull your cock back out of its \"owner's\" home.  Though you haven't gone far before she tightens on you once more, and you realize that you were supposed to switch directions again. You focus your attention once more on the fluff that's showing you the way." );
-		
+
 		outputText( "[pg]Everything centers onto three things: the feel of aroused cunt surrounding your shaft, rippling and squelching with each slow plunge and retreat from its depths, the soft springy ass and hip curves under your hands that runs oh so pleasantly under your hands, and of course, Marble's tail curled around the base of your " + cockDescript(x) + ".  The sensation of her thin appendage, soaked and sweat yet still soft with fur, constantly quivering and twitching in time with the movements of your two bodies, draws your entire focus." );
 	} else {
 		outputText( "[pg]Her ribbon adorned bovine appendage slowly pulls your hand out of her wet slit and directs you up the side of her rump until you find something hiding out in her pocket.  Her tail rubs against the long hard shape a few times, and then you grasp and pull out a long black rubery object from your lover's skirt: her double dildo." );
-		
+
 		outputText( "[pg]You ask Marble if there is any chance you've found what she wanted?" );
-		
+
 		outputText( "[pg]\"<i>Why yes sweetie.  What gave it away?</i>\"" );
-		
+
 		outputText( "[pg]It was just a hunch." );
-		
+
 		outputText( "[pg]You adjust your grip on her personal toy and press one end against her waiting womanhood.  Just as you're about to ask her if she's ready for it, her tail suddenly jerks forward, sliding the tool inside her.  She gasps while the false cock quickly slides up to its centerpiece into her depths, then giggles when you try to pull it back out. Unfortunately, you find she's clapped down on it hard." );
-		
+
 		outputText( "[pg]\"<i>What's wrong sweetie?  You haven't managed to get stuck, have you?  Here, let me give you a hand....</i>\"" );
-		
+
 		outputText( "[pg]Abruptly, her tail reverses it's pressure and allows you to extract her toy from its sheath - at least a little ways.  Then, you flip directions yourself and push it back in to the hilt.  There is a sharp intake of breath from your lovely lover, and you give her rear a small smack.  In response, she tightens around your wrist, and it sounds like she might be about to get mad at you.  Instead she chuckles a bit." );
-		
+
 		outputText( "[pg]\"<i>Alright, no more teasing.  You're more than just a plaything after all.  I've got to let you do something.</i>\"" );
-		
+
 		outputText( "[pg]Finally, she allows you to freely build her pleasure and tease her body.  You can focus on bringing her to blissful sexual release by playing with her wonderful plump rump, twisting and pumping her with her dildo to the sound of lewd squelching that can just be heard over the hum of the milker and Marble's moans of pleasure, and lastly, the quivering of her tail.  The tail that serves as a subtle guide to the ways of your lover's tunnel." );
 	}
-	
+
 	outputText( "[pg]You're so engaged into the activity, that you barely register a long low call of ecstasy come out of cow-girl mate.  That same cry that is something between a moo and a long sigh that you've come to know very well.  At the same time, she manages to knock the hoses off her breasts, and there is a splash as her milk hits the floor of the stall, which steadily slows to a trickle, then only a few drops." );
-	
+
 	if (fits)
 		outputText( "[pg]Finally, the grip on your root relaxes, and you're finally able to explode inside her. Her tail slowly slips off of you and falls limp next to the connection between your bodies.  Several gasps and groans come out of your lips, and you ask Marble if she was satisfied." );
 	else
 		outputText( "[pg]The hold on your hand tightens to a death grip, and you have no choice but to let go of her dildo and desperately struggle to free your constricted limb from her tail.  When you finally do manage to free yourself, you start rubbing your tingling fingers and ask Marble if putting your hand to sleep was a sign that she was satisfied." );
 
 	outputText( "[pg]Your lover girl straightens up and turns around to face you.  She fixes you with a stern look for a few moments before pulling you into a deep french kiss.  \"<i>Well, if you're always that good at following directions, I'm not sure how I wouldn't be.</i>\"" );
-	
+
 	flags[kFLAGS.MARBLE_LUST] = 10;
 	if (fits) {
 		player.sexReward("milk");
@@ -4085,38 +4085,38 @@ private function milkMarbleBarFollowTail(x:int):void
 private function milkMarbleBarCunnilingling():void
 {
 	clearOutput();
-	
+
 	outputText( "You ask Marble to release your wrist so you can get into a better position for taking care of her.  You're feeling an ache to harvest her other womanly fluid." );
-	
+
 	outputText( "[pg]\"<i>Of course sweetie, I'm feeling very wet down there.  I definitely think I'm going to need you to take care of that.</i>\"" );
-	
+
 	outputText( "[pg]She released you, and allows you to kneel down behind her and get a good whiff of her rich womanly scent.  It throws your mind into a haze for a few moments, and you're brought back out with a swish of wind as her tail swings side to side over her entrance, the base lifted up eagerly.  You rest your head to the side of her entrance, and lean against the part of her body where ass meets thigh while letting one hand play across the other leg." );
-	
+
 	outputText( "[pg]After a moment's climb, you find your fingers curling around the root of her bottom's bestial extension.  An idea strikes you, and you comment on how you need to brush her off before you start harvesting." );
-	
+
 	outputText( "[pg]\"<i>Oh?  What do you mean by that?</i>\" comes a somewhat bemused response." );
-	
+
 	outputText( "[pg]You don't reply, instead you make a small ring with your thumb and finger and slide her tail through the hole as it flicks and swings around.  When you reach the thick hair at the end, you tighten your grip and direct the brush to the entrance of her womanhood." );
-	
+
 	outputText( "[pg]\"<i>Oh!  Ohhhhhhh...</i>\"" );
-	
+
 	outputText( "[pg]A careful dab here, a deeper scope there, and you think she's ready to be harvested.  You get a drop of her fluids of off your brush and give it a taste test.  A quick word of approval to Marble of the quality of her fluids, and you dive into her snatch.  Her deep earthy aroma fills your head as you drink deeply of her fluids, licking around her folds and tasting everything she has to offer.  You hear soft moans of pleasure in approval of your efforts, just barely audible over the hum of the milking machine above you." );
-	
+
 	outputText( "[pg]Now free to do as it wills, you find that Marble's tail has curled around the back of your head, and is trying its hardest to push you deeper into her rear as possible.  At the same time, your lover's hips are rocking side to side, dragging your face across her gash and spreading her fluids all over your [face].  Trying to steady yourself, you grab two big handfuls of her expansive touch, and lower your head slightly.  This act brings her love-button in line with your mouth, and her passage in line with your nose.  Once again you're overwhelmed by the olfactory sensations, and mindlessly lap away at her fluids and engorged clitoris." );
-	
+
 	outputText( "[pg]\"<i>Oh yes, yes!  That's so wonderfuuuuuuul!</i>\"  Marble cries out several more times, as she rides out the orgasm you've brought her to through your efforts to harvest her.  Your reward is to be absolutely drenched in the sweet nectar you've been harvesting all this time, and every drop you catch in your mouth and on your [tongue] is swallowed in an instant.  In the end, you're actually a bit disappointed when her fluids run out." );
-	
+
 	outputText( "[pg]You nuzzle in against her soft bum once more, and bat at her tail playfully for a few moments." );
-	
+
 	outputText( "[pg]\"<i>Hmm, I'd say that you've made standing like this worth the while, [name].  I think I might be willing to go like this again, if you're able to keep up this level of performance.</i>\"" );
-	
+
 	outputText( "[pg]You laugh and assure Marble that when it comes to her, you'll always be giving it your all.  Just before you leave, an impish thought passes through your head for a moment, and you slip her tail's brush to Marble's entrance and push it inside a short ways.  Marble starts from the unexpected sensation, and you explain that you're only cleaning up some stray drops of fluid that might still be hiding away." );
-	
+
 	outputText( "[pg]After a moment, her tail flicks back out of her passage and she shakes her head at you.  \"<i>Thank you for the thought, sweetie, but please don't get me worked up again now, unless you're going to take care of me again.</i>\"" );
-	
+
 	outputText( "[pg]Alright, you'll end the teasing, for now." );
-	
-	
+
+
 	flags[kFLAGS.MARBLE_LUST] = 15;
 	var pLust:int = int( 10 + player.lib / 10 );
 	dynStats( "lus", pLust );
@@ -4131,32 +4131,32 @@ private function milkMarbleBarPullTail():void
 	var x:int = player.cockThatFits( marbleCuntCapacity() );
 	clearOutput();
     sceneHunter.print("If she has a dick, one part is randomized.");
-	
+
 	outputText( "Probably against your better judgment, you decide to take charge and grab onto Marble's tail, roughly untwisting it off of you and yanking it upwards." );
-	
+
 	outputText( "[pg]\"<i>Ow!  What the hell sweetie?!</i>\"" );
-	
+
 	outputText( "[pg]You ignore her protests and smack her ass once, then roughly penetrate her with your " + cockDescript(x) + " while yelling at her to take it." );
-	
+
 	outputText( "[pg]There is a loud clop as Marble stomps her hoof on the ground angrily.  With a huff, she lifts herself up on the bar and kicks back with both her legs, sending you flying onto your back and knocking the wind from your lungs.  You gasp for breath a few times, then look up to see Marble looming over you with a wicked smile on her face." );
-	
+
 	outputText( "[pg]\"<i>I warned you that I'd be taking charge if you couldn't behave yourself, didn't I [name]?</i>\"  She sits down on your stomach, and presses her hand against your [chest], squeezing you somewhat painfully.  \"<i>Now you're going to be punished!</i>\"  Given her expression, you get the impression that maybe she actually wanted you to misbehave!" );
-	
+
 	outputText( "[pg]Your aggressive mate moves forward and straddles your face, shaking her snatch back and forth a few times just above your head.  A few drops of her lubricant drip down onto you, followed by a flick across the nose, delivered by the tail you just grabbed.  At the same time, you're bathed in the deep scent of her aroused sex." );
 	if( flags[kFLAGS.MARBLE_DICK_TYPE] > 0 ) outputText( "  She grabs her erect member, and rubs it against your cheek a few times, spreading around some of her pre-cum." );
-	
+
 	outputText( "[pg]\"<i>You like it when I take charge, don't you?  Hmmhmm, yes...</i>\"" );
-	
+
 	if(flags[kFLAGS.MARBLE_DICK_TYPE] == 0 && rand(2) == 0)
 	{
 		outputText( "[pg]She drops her hips and roughly forces her womanhood down onto your face, cutting off your ability to breathe.  You sputter and gasp underneath her at the sudden suffocation, though it lasts only a few seconds before she releases you." );
-		
+
 		outputText( "[pg]\"<i>Aww, was that too rough?  Don't worry.  I'll be a bit more gentle.</i>\"" );
-		
+
 		outputText( "[pg]Marble then settles herself down a bit more gently, this time giving you plenty of room to breathe while also keeping your mouth tightly locked against her slick passage." );
-		
+
 		outputText( "[pg]\"<i>Alright, let's put that rude tongue of yours to a much better job.  Lick me.</i>\"" );
-		
+
 		outputText( "[pg]You do as you're bid and get an approving smile in response.  Digging deeper inside her, you feel under her folds and plunge into her depths.  " );
 		if(player.tongue.type > Tongue.HUMAN) outputText( "You take full advantage of your inhumanly long tongue to fill her up, running across her passage all the way to the entrance to her womb and then back to her lower lips." );
 		else outputText( "You send your tongue as far into her passage as it will go and wriggle around her lower lips, trying to please your aggressive bovine lover to the best of your abilities." );
@@ -4164,46 +4164,46 @@ private function milkMarbleBarPullTail():void
 	else
 	{
 		outputText( "[pg]She forces your mouth open and pushes her hips forward, roughly shoving her " + num2Text(Math.round(flags[kFLAGS.MARBLE_DICK_LENGTH])) + "-inch cock into your hapless mouth and down your throat.  You choke and sputter in surprise at the sudden suffocation, but it only lasts a few seconds before she pulls back out." );
-		
+
 		outputText( "[pg]\"<i>Aww, was that too rough?  Don't worry, I'll be a bit more gentle.</i>\"" );
-		
+
 		outputText( "[pg]Marble then thrusts forward much more gently, giving you plenty of time to get use to the sensation of her member inside your mouth.  She also is sure to keep herself well outside of your throat." );
-		
+
 		outputText( "[pg]\"<i>Alright, let's put that rude mouth of yours to a much better job.  Suck me.</i>\"" );
-		
+
 		outputText( "[pg]You do as you're bid, and get an approving smile in response.  You wrap tightly around her with your lips and slide your tongue up and down the bottom of her shaft while also playing across the urethra.  She pumps herself into you a few times, and you get a taste of some of her pre-cum." );
 	}
-	
+
 	outputText( "[pg]Marble lifts her hips back up after a few moments, with a curt nod.  \"<i>Now, you've got to take care of my tail.  It stings after you pulled on it like that, I want you to apologize to it and kiss it better.</i>\"  She then turns around and gives you a good view of that very tail, which seems to be swinging back and forth rather half-heartedly." );
-	
+
 	outputText( "[pg]There, there, you tell the part of your mate's body you hurt before, gently stroking the short furred appendage.  Then you lean forward and repeatedly kiss it, running from the thick tuff on the tip, all the way up to the base where her spine meets the round cheeks of her ass.  When you reach the root, a quiver shoots through Marble's body, and she suddenly grabs you and forces her tail into your mouth.  You gasp in surprise and look up at your lover inquisitively." );
-	
+
 	outputText( "[pg]\"<i>Hmm, sorry sweetie, I just thought I'd try something.  It didn't feel the way I expect, but I really like the way you look with my tail in your mouth like that.  If you suck on it for a bit, I might be able to forgive you for yanking it before.</i>\"" );
-	
+
 	outputText( "[pg]You run your tongue around the sweaty fur and get an approving look from your bovine lover.  Then you shake your jaw back and forth a few times and slowly let her bush slide out of your mouth.  As the last of the hair slips out, you give a small kiss to the tip." );
-	
+
 	outputText( "[pg]\"<i>Did you like that sweetie?" );
 	if( silly() ) outputText( "  Want to brush your teeth with my tail next time?" );
 	outputText( "</i>\"  She nods and considers you for a moment.  \"<i>Well, I think I'm feeling a lot better now.  I think I can forgive you for what you did.  In fact, you did such a good job that I think I'll give you a reward!</i>\"" );
-	
+
 	outputText( "[pg]With a smile, you ask her what she's got planned for you." );
-	
+
 	outputText( "[pg]She repositions herself overtop of your waist and eyes your male member.  \"<i>Obviously this thing here is in need of some treatment, since you were so eager to try and take charge with it before.</i>\"  She drops down and brings the flaps of her womanhood into contact with the front of your shaft and runs them over it a couple of times.  \"<i>Look how hard you are.  You really want me to take you inside me, don't you?  You want so much to give complete control of your long, hard, dick, to me to use as I see fit.</i>\"" );
-	
+
 	outputText( "[pg]She doesn't let you respond.  She's already decided what is going to happen, and that's for you to go inside her and be used by her as she sees fit.  She strokes your " + cockDescript(x) + " with one finger, then pushes it into her waiting cunt.  You slip easily into her very well lubricated passage and groan as it clamps down on you.  Every part of your shaft is being tightly wrapped in the ring of her vaginal muscles, and you can't help but groan in pleasure." );
-	
+
 	outputText( "[pg]She shakes her hips side to side a few times, spinning your shaft around her interior, then stops and considers you.  \"<i>You know, I was thinking that maybe I'm giving you too much of a reward, or maybe not enough of one?</i>\"  The same wicked look when she first knocked you over crosses her eyes once more.  \"<i>Let's try something new...</i>\"  She turns away from you and puts her hand somewhere behind her, outside of your view." );
-	
+
 	outputText( "[pg]After a moment, you suddenly feel something pushing up against the entrance to your [vagOrAss]!  You try to ask what Marble has planned, but the pressure forces something bushy into your hole.  She just stuck her tail into your [vagOrAss]!" );
-	
+
 	outputText( "[pg]\"<i>Well sweetie, what do you think?</i>\"  It quivers a few times as Marble resumes the rocking of her wide womanly hips.  \"<i>Never mind, if you don't like it, well you can just try and end this as soon as possible.  If you do like it, then I guess...</i>\"  She leans forward as she switches from a swinging movement to a bounce on your " + cockDescript(x) + ", and her furry tufft of a backend appendage starts to push its way in deeper sliding easily thanks to your saliva on it.  \"<i>You'll just have to bear it as long as you can!</i>\"" );
-	
+
 	outputText( "[pg]You've never seen Marble this aggressive before, but the cause is rather obvious: the whirring milking machine that's currently attached to her breasts.  Obviously giving milk is triggering some kind of dominance instinct, and it's incredibly sexy!" );
-	
+
 	outputText( "[pg]Your lover laughs uproariously as she continues to ride you hard and fast, bringing up the pleasure in your lower body just as hard and fast.  Whether or not you want it, you can feel an orgasm rapidly building up within you, easily detectable to your rider from the increased rate of your gasps and cries of pleasure.  For her part, Marble is rapidly approaching her peak as well, and with a practiced rhythm, the two of you cum in unison as your lover's tail pops out of your [vagOrAss]." );
-	
+
 	outputText( "[pg]The bovine woman gasps a few times above you in exhaustion, her great breasts heaving with each breath.  She then reaches down and pulls your head up and cradles it to her chest, smiling very happily.  \"<i>Well sweetie, if you ever want me to play rough again, you know what to do.  I'm looking forward to any other adventures the two of us have in the bedroom, are you?</i>\"" );
-	
+
 	outputText( "[pg]You snuggle up to her bosom, thinking something very similar.  Things certainly haven't been dull while you've been in Marble's milking stall, that's for certain." );
 
 	player.sexReward("milk");
@@ -4218,11 +4218,11 @@ private function milkMarbleBarPullTail():void
 private function milkMarbleLeaveAfterBar():void
 {
 	clearOutput();
-	
+
 	outputText( "You don't answer Marble and instead continue to finger her womanhood until she cries out in orgasm.  You tell her you'd be happy to help her out again whenever she'd like someone to accompany her to get milked." );
-	
+
 	outputText( "[pg]She is a bit disappointed that you didn't go further after getting her on the bar, but doesn't have a problem with you leaving.  She does tell you that she's looking forward to having you in her milker again some time." );
-	
+
 	var pLust:int = int( 5 + player.lib / 20 );
 	dynStats( "lus", pLust );
 	flags[kFLAGS.MARBLE_LUST] += 5;
@@ -4234,9 +4234,9 @@ private function milkMarbleNoMilking():void
 {
 	clearOutput();
 	outputText( "You shake your head and say that you think you'll be fine." );
-	
+
 	outputText( "[pg]\"<i>Oh, alright then sweetie, I'll see you later.</i>\"  She takes a seat in the chair in the middle of the room and picks up where she left off in her book.  You excuse yourself and return back to camp." );
-	
+
 	doNext(camp.returnToCampUseTwoHours);
 }
 }

--- a/classes/classes/Scenes/NPCs/Michiko.as
+++ b/classes/classes/Scenes/NPCs/Michiko.as
@@ -12,10 +12,10 @@ import coc.view.ButtonDataList;
 
 public class Michiko extends NPCAwareContent
 	{
-		
+
 		public function Michiko()
 		{}
-		
+
 public function firstMeetingMichiko():void {
 	clearOutput();
 	outputText("Entering the humble eastern establishment exposes you to the confounding scents of a foreign land. Your confusion only draws you in, wanting to experience these foods for yourself, your feet moving in step with your mind towards the origin of the mystifying aromas.\n\n");
@@ -95,7 +95,7 @@ public function campMichikoMainMenu():void {
 			menu();
 			submenu(buttons, camp.campFollowers, 0, false);
 		}
-		
+
 		public function identifyItem(item:ItemSlotClass):void {
 			clearOutput();
 			var oldItem:ItemType = item.itype;
@@ -174,7 +174,7 @@ public function campMichikoTalkRegionWasteland():void {
 	outputText("You inquire about the Mareth wasteland. The endless expanse of nothingness that spans most of the area.\n\n");
 	outputText("\"<i>Mareth is a big place, [name], but just because it appears empty, does not mean it is. Several people have been spotted wandering the area, including that weirdo merchant Giacomo. There's also rumors that  a goblin trader has set up shop there somewhere, that is if you can find her of course. It's also possible one or more of the cave systems in the area could be inhabited.</i>\"\n\n");
 	doNext(campMichikoTalkRegion);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalkRegionForest():void {
 	clearOutput();
@@ -182,7 +182,7 @@ public function campMichikoTalkRegionForest():void {
 	outputText("\"<i>The woods are both one of the purest areas of Mareth and one of the most corrupt. Depending on your luck you could either run across a bee girl or a Tentacle beast. The bees, despite using hypnosis and such to lull victims into accepting their eggs, are actually pure of soul and intentions. I've heard several rumors about the area such as that a monk in exile wanders the place trying to cleanse the corruption ");
 	outputText("or that a weird hybrid between a plant and cow wanders about. There’s even rumors that somewhere in the woods is a hidden pure grove guarded by a unicorn, for all I know the race is almost extinct. Should you seek the unicorn out I would advise you come to it as a virgin, they are more trustful of virgins, never knew why.</i>\"\n\n");
 	doNext(campMichikoTalkRegion);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalkRegionDeepwood():void {
 	clearOutput();
@@ -190,7 +190,7 @@ public function campMichikoTalkRegionDeepwood():void {
 	outputText("\"<i>Yea I kind of do, the place is nasty as it's pretty much the source of all the corruption in the forest. At first you would think it’s just that sealed demon Akhbal but truth be told it goes way deeper than that, it's like the deepwoods became a refuge for fiends ranging from the infamous Erlking’s Wyld hunt to the dark mistress of the twilight grove. Speaking of grove watch out for tentacle beast and more then anything watch out for alraunes, ");
 	outputText("they just seem to grow all over the place. Amidst all this corruption the kitsunes somehow still manage to thrive in secrecy while the fairies flutter around. Be wary of who you trust in those woods.</i>\"\n\n");
 	doNext(campMichikoTalkRegion);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalkRegionLake():void {
 	clearOutput();
@@ -198,7 +198,7 @@ public function campMichikoTalkRegionLake():void {
 	outputText("\"<i>Well aside from old Whitney’s farm, there's the ruins of an old mousefolk town, they say it’s haunted. On the side of the locals though a large community of shark girls reside in the lake and you may run across a slime girl or two, also from the lake. I highly advise against swimming there unless you would favor getting stung by an anemone. Now that’s the nicer locales, amongst the nasties are the Ooze, ");
 	outputText("always at war with the slimes, and the cultist of the fetish, a faction of sex crazed lunatics worshiping demonised ex gods. There's a rumor Marae might still live somewhere on an island at the center of the lake, might be worth investigating.</i>\"\n\n");
 	doNext(campMichikoTalkRegion);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalkRegionDesert():void {
 	clearOutput();
@@ -206,7 +206,7 @@ public function campMichikoTalkRegionDesert():void {
 	outputText("\"<i>Ain't much to see there, the place is almost as empty as the wasteland, at least at a first glance. Empty is a very suggestive word because several things hints at the presence of a hidden city somewhere in the desert aside from the many ant fortresses. If you are the adventuring sort you may run into Sand witches across the desert, they may or may not be helpful. Aside from them there has been spottings of a Naga or two living in there. ");
 	outputText("I recommend you keep watch for traps and most of all sand traps when wandering around there, these bugs live for a chance to stick their eggs down someone’s butt. Demons like almost everywhere else also have been spotted partying in the desert.</i>\"\n\n");
 	doNext(campMichikoTalkRegion);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalkRegionMountains():void {
 	clearOutput();
@@ -214,7 +214,7 @@ public function campMichikoTalkRegionMountains():void {
 	outputText("\"<i>It’s minotaur territory, if you plan on heading there avoid them best you can. The demons also have a strong presence there due to a local factory, expect to run into one or two. I heard there's an old castle somewhere around there, an old ruin of the old days though I don't know if anyone lives there. Last but not least avoid entering caves and watch out for anything that sounds like thunder, ");
 	outputText("raiju's tend to live in area closer to the clouds and they will jump on whatever can sate their uncontrollable need to discharge.</i>\"\n\n");
 	doNext(campMichikoTalkRegion);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalkRegionHighMountains():void {
 	clearOutput();
@@ -222,7 +222,7 @@ public function campMichikoTalkRegionHighMountains():void {
 	outputText("\"<i>Well for one the minotaurs don't thread there, thank Marae for that. This said the harpies who nest up there are not really that fond of strangers and the basilisks that constantly steal their eggs only makes them more prone to attack anything that closes in on them. Aside from that, There’s an oni who apparently took residence up there, you also have good odds of finding what remains of the old temple of the divine ");
 	outputText("that used to once be Mareth’s greatest holy site until the demons damaged it. If the demons do have a fortress it’s likely located somewhere up there.</i>\"\n\n");
 	doNext(campMichikoTalkRegion);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalkRegionPlains():void {
 	clearOutput();
@@ -230,7 +230,7 @@ public function campMichikoTalkRegionPlains():void {
 	outputText("The plains of Mareth are home to many tribes both good and bad. I know there's at least one remaining village of sheep morphs and several kangaroo morphs hunting there though odds are good, you will never find their burrows as they hide underground at night. Of all the tribes though avoid the gnolls, they are highly territorial and enjoy dominating males above anything else. \"<i>");
 	outputText("Finally there's also a demonic camp somewhere which acts as a trade hub for people of questionable morality.</i>\"\n\n");
 	doNext(campMichikoTalkRegion);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalkRegionSwamp():void {
 	clearOutput();
@@ -238,7 +238,7 @@ public function campMichikoTalkRegionSwamp():void {
 	outputText("\"<i>The swamps of Mareth are old [name]. The dragon tribes used to reside there until they became extinct or so I think. No one has seen a dragon in years but if an artefact of the dragon does exist it’s likely hidden somewhere in the swamp away from the gaze of the lesser races. The spider morphs and driders are the local nuisances there and they are as random as a coin. ");
 	outputText("Either they attack you or they talk to you. I generally prefer to flee rather then find out.</i>\"\n\n");
 	doNext(campMichikoTalkRegion);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalkMarriage():void {
 	clearOutput();
@@ -249,56 +249,56 @@ public function campMichikoTalkMarriage():void {
 	outputText("\"<i>That you do but a fair bit of warning, weddings attracts a lot of people and are handled in public churches dedicated to Marae thus it also tends to drag the attention of troublemakers. Your foes will be well aware of the wedding going on just as well as if you would have screamed it out loud, they simply will know. Be prepared to defend your happy day at any time, I've yet to see one going well from start to finish.</i>\"\n\n");
 	if (flags[kFLAGS.MICHIKO_TALK_MARRIAGE] == 0) flags[kFLAGS.MICHIKO_TALK_MARRIAGE] = 1;
 	doNext(campMichikoTalkMM);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalk7():void {
 	clearOutput();
 	outputText("\n\n");
 	outputText("\"<i></i>\"\n\n");
 	doNext(campMichikoTalkMM);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalk6():void {
 	clearOutput();
 	outputText("\n\n");
 	outputText("\"<i></i>\"\n\n");
 	doNext(campMichikoTalkMM);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalk5():void {
 	clearOutput();
 	outputText("\n\n");
 	outputText("\"<i></i>\"\n\n");
 	doNext(campMichikoTalkMM);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalk4():void {
 	clearOutput();
 	outputText("\n\n");
 	outputText("\"<i></i>\"\n\n");
 	doNext(campMichikoTalkMM);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalk3():void {
 	clearOutput();
 	outputText("\n\n");
 	outputText("\"<i></i>\"\n\n");
 	doNext(campMichikoTalkMM);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalk2():void {
 	clearOutput();
 	outputText("\n\n");
 	outputText("\"<i></i>\"\n\n");
 	doNext(campMichikoTalkMM);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 public function campMichikoTalk1():void {
 	clearOutput();
 	outputText("\n\n");
 	outputText("\"<i></i>\"\n\n");
 	doNext(campMichikoTalkMM);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 }
 	}
 }

--- a/classes/classes/Scenes/NPCs/NeisaFollower.as
+++ b/classes/classes/Scenes/NPCs/NeisaFollower.as
@@ -2,21 +2,21 @@
  * ...
  * @author Ormael, Liadri
  */
-package classes.Scenes.NPCs 
+package classes.Scenes.NPCs
 {
 	import classes.*;
 	import classes.GlobalFlags.kFLAGS;
-	
+
 	public class NeisaFollower extends NPCAwareContent implements TimeAwareInterface
 	{
-		
-		public function NeisaFollower() 
+
+		public function NeisaFollower()
 		{
 			EventParser.timeAwareClassAdd(this);
 		}//between 6 and 15 she get her counter go up by 1 each night and if it hit 15 she leave at the morning xD
 		//neisa follower flag: 1-3 - first exploring river dungeon, 4 i 5 - after first exploring, 6 - left camp due to not paid weekly paycheck (to make her return to camp req. to pay her that mercenary fee with all costs for delay so 10 days of fee not 7 - also her affection should drop to 0/pretty low after leaving camp due to not paid weekly paycheck),
 		//7 to 16 - hired and staying in camp (7 to 13 - with PC having not yet paid her weekly paycheck - up to 3 days after deadline stays this way, 14 to 16 - when she's paid in time), 18 - after her affection rise high enough and she move from mercenary to camp member
-	
+
 //Implementation of TimeAwareInterface
 public function timeChange():Boolean
 {
@@ -111,7 +111,7 @@ public function neisaMorningPaycheckCall():void {
 			outputText("\"<i>Heh, I don't mind if you are paying late, mistakes happen. Just make sure you got my pay for tomorrow as well as the missing spirit stones of today.</i>\"\n\n");
 		}
 	}
-	eachMinuteCount(5);
+	advanceMinutes(5);
 	doNext(playerMenu);
 }
 
@@ -236,7 +236,7 @@ public function neisaHenchmanOption():void {
 		addButtonDisabled(6, "Team (2)", "Req. Intermediate Leadership.");
 	}
 	addButton(14, "Back", neisaCampMenu);
-	
+
 }
 public function neisaHenchmanOption2(slot:Number = 1):void {
 	clearOutput();

--- a/classes/classes/Scenes/NPCs/Rathazul.as
+++ b/classes/classes/Scenes/NPCs/Rathazul.as
@@ -17,7 +17,7 @@ public class Rathazul extends NPCAwareContent implements TimeAwareInterface {
 		{
 			EventParser.timeAwareClassAdd(this);
 		}
-		
+
 		//Implementation of TimeAwareInterface
 		public function timeChange():Boolean
 		{
@@ -32,12 +32,12 @@ public class Rathazul extends NPCAwareContent implements TimeAwareInterface {
 			}
 			return false;
 		}
-	
+
 		public function timeChangeLarge():Boolean {
 			return false;
 		}
 		//End of Interface Implementation
-		
+
 		public function returnToRathazulMenu():void {
 			if (player.hasStatusEffect(StatusEffects.CampRathazul))
 				campRathazul();
@@ -151,7 +151,7 @@ public function campRathazul():void {
 	outputText(images.showImage("rathazul-camp"));
 	outputText("Rathazul looks up from his equipment and gives you an uncertain smile.\n\n\"<i>Oh, don't mind me,</i>\" he says, \"<i>I'm just running some tests here.  Was there something you needed, [name]?</i>\"\n\n");
 	//player.createStatusEffect(StatusEffects.metRathazul,0,0,0,0);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 	offered = rathazulWorkOffer();
 	if (!offered) {
 		outputText("He sighs dejectedly, \"<i>I don't think there is.  Why don't you leave me be for a time, and I will see if I can find something to aid you.</i>\"");
@@ -345,10 +345,10 @@ private function rathazulWorkOffer():Boolean {
 	}
 	return false;
 }
-	
+
 	private function askForTools():void {
 		clearOutput();
-		
+
 		outputText("<i>(todo writeme)</i> ");
 		outputText("Having an interest in doing alchemy yourself, you ask Rathazul if you can borrow some of his tools. ");
 		// high int or HistoryAlchemist: free
@@ -401,7 +401,7 @@ private function oneTimeOptions():void {
 	}
 	if (player.hasItem(consumables.PURHONY, 1) && player.hasItem(consumables.C__MINT, 1) && player.hasItem(consumables.PURPEAC, 1) && player.hasKeyItem("Rathazul's Purity Potion") < 0 &&(flags[kFLAGS.MINERVA_PURIFICATION_RATHAZUL_TALKED] == 2 && flags[kFLAGS.MINERVA_PURIFICATION_PROGRESS] < 10)) {
 		addButton(6, "Pure Potion", rathazulMakesPurifyPotion).hint("Ask him to brew a purification potion for Minerva.");
-	
+
 	}
 	if (flags[kFLAGS.MITZI_RECRUITED] == 2) {
 		if (player.hasItem(consumables.SMART_T, 5) && player.hasItem(consumables.VITAL_T, 5) && player.hasItem(consumables.S_WATER, 1) && player.hasItem(consumables.PURHONY, 1)) addButton(7, "Mitzi", cureMitzi).hint("Ask him to help Mitzi. \n\nNeeds five scholar teas, five vitality tinctures, one bottle of pure spring water, and one vial of pure honey");
@@ -419,7 +419,7 @@ private function TyrantiaEggQuestRathazul():void {
 	outputText("You bring Ralthazul back to Tyrantia, and you ask him to fill her in. The old mouse puts a hand on Tyrantia’s leg, telling her what he told you. Your giantess looks at you, eyes gleaming, and both hands in front of her mouth.\n\n");
 	outputText("\"<i>Really?!</i>\" She pats the alchemist’s head, somewhat dazed. \"<i>...I...Okay.</i>\" She turns to you, inhaling nervously. \"<i>...I trust you. If you think Ralthzul can stop me from ruining our podlings, then...I’ll do it.</i>\"\n\n");
 	TyrantiaFollower.TyrantiaFollowerStage = 6;
-	eachMinuteCount(15);
+	advanceMinutes(15);
 	doNext(playerMenu);
 }
 

--- a/classes/classes/Scenes/NPCs/SamirahScene.as
+++ b/classes/classes/Scenes/NPCs/SamirahScene.as
@@ -272,7 +272,7 @@ public function samirahTalkHer():void {
 		outputText("\"<i>Actually, yes. Albeit uncommon, it can happens to very gifted individuals. The few born within this rare breed have a gaze so strong it turns prey to stone. I guess the snake hair is just a symptom of it.</i>\"\n\n");
 	}*/
 	outputText("You thank Samirah for her time and go back to your things.\n\n");
-	eachMinuteCount(10);
+	advanceMinutes(10);
 	doNext(samirahMainTalkMenu);
 }
 public function samirahTalkHomeworld():void {
@@ -281,7 +281,7 @@ public function samirahTalkHomeworld():void {
 	outputText("\"<i>I’m from Gobis, a world of sun and sand. Well it’s a large land of sandy dunes with an oasis every now and then. We travel between sandstorms for sustenance and resources, as not to despoil the land of everything. Even then, a naga can survive alone in the Gobis desert for several weeks before running out of water or food.</i>\"\n\n");
 	outputText("So, wait, they never experienced any cold weather there?\n\n");
 	outputText("\"<i>Of course not! Else we would spend our days hibernating. Nights in the world of Gobis are cold and us naga spend all of it sleeping, otherwise, we would be hunting night and day.</i>\"\n\n");
-	eachMinuteCount(10);
+	advanceMinutes(10);
 	doNext(samirahMainTalkMenu);
 }
 public function samirahTalkHypnosis():void {
@@ -294,11 +294,11 @@ public function samirahTalkHypnosis():void {
 		outputText("Samirah gives you the ABC of proper hypnosis, starting with the gaze."+(player.isFemale() ? " You never thought a proper belly dance would help maintain an opponent captive of your gaze either, is the whole thing just about capturing the target attention?" : "")+"\n\n");
 		outputText("\"<i>The point is to give a show the target wants to see so to force its gaze toward you and capture it. Once its attention is caught it should be easy for you to maintain it for as long as you want. Once that is done you can do tons of things to your prey and even go so far as to have it do things to you.</i>\"\n\n");
 		flags[kFLAGS.SAMIRAH_HYPNOSIS] = 1;
-		eachMinuteCount(20);
+		advanceMinutes(20);
 	}
 	else {
 		outputText("You nod, thanking her for the information.\n\n");
-		eachMinuteCount(10);
+		advanceMinutes(10);
 	}
 	doNext(samirahMainTalkMenu);
 }
@@ -330,12 +330,12 @@ public function samirahTalkClothes():void {
 		}
 		else {
 			outputText(" Of course, despite how nice it would look on you, it was made with a snake tail in mind and your current body simply won’t allow you to wear it.");
-			eachMinuteCount(60);
+			advanceMinutes(60);
 			doNext(samirahMainTalkMenu);
 		}
 	}
 	else {
-		eachMinuteCount(60);
+		advanceMinutes(60);
 		doNext(samirahMainTalkMenu);
 	}
 }

--- a/classes/classes/Scenes/NPCs/SiegweirdFollower.as
+++ b/classes/classes/Scenes/NPCs/SiegweirdFollower.as
@@ -12,7 +12,7 @@ import classes.display.SpriteDb;
 
 public class SiegweirdFollower extends NPCAwareContent
 	{
-		
+
 		public function SiegweirdFollower()
 		{}
 
@@ -237,7 +237,7 @@ public function addIngredientText():void {
 	outputText("Siegweird gives you a suspicious glance before redirecting his attention to the item in your grasp, \"<i>I… Um… Okay… Go ahead, [name]. I don’t really see an issue with that ingredient. </i>\"");
 	outputText("You drop it in the soup as Siegweird scratches the back of his head nervously, \"<i>I’m sure the magic within will make the soup a little stronger.</i>\"\n\n");
 	doNext(siegweirdMainCampMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 
 //adds the 'val' value of 'effect' and consumes the 'item'
@@ -291,7 +291,7 @@ public function siegweirdCampSoup():void
 		HPChange(Math.round(player.maxHP() * recoveryV), true);
 		EngineCore.changeFatigue(-(Math.round(player.maxFatigue() * recoveryV)));
 		doNext(camp.campFollowers);
-		eachMinuteCount(15);
+		advanceMinutes(15);
 	}
 	else {
 		outputText("The smell of Siegwierd’s soup is amazing. He did offer to share it with you, so perhaps now isn’t a bad time?\n\nYou decide to approach him.\n\n");
@@ -319,7 +319,7 @@ public function siegweirdCampStudy():void
 		outputText("Siegweird eyes you narrowly, \"<i>I’m sorry, [name]... but I cannot teach someone who cannot learn. Please, if you seek to study then you must purge yourself from excess corruption. </i>\"\n\n");
 		outputText("You nod your head, you shouldn’t be surprised a paladin can’t teach the impure.")
 		doNext(camp.campFollowers);
-		eachMinuteCount(5);
+		advanceMinutes(5);
 	}
 	else {
 		outputText("Seigweird eyes you narrowly, \"<i>Yes, you are ready to learn, we shall work together. </i>\"\n\n");
@@ -378,7 +378,7 @@ public function siegweirdAdvancedStudy_0():void {
         player.createStatusEffect(StatusEffects.SiegweirdTraining2, 0, 0, 0, 0);
     }
     doNext(camp.campFollowers);
-    eachMinuteCount(5);
+    advanceMinutes(5);
 }
 
 public function siegweirdAdvancedStudy_1_choose():void {
@@ -414,7 +414,7 @@ public function siegweirdAdvancedStudy_1(usePearl:Boolean):void {
 	}
     player.addStatusValue(StatusEffects.SiegweirdTraining2, 1, 1);
     doNext(camp.campFollowers);
-    eachMinuteCount(5);
+    advanceMinutes(5);
 }
 
 //Holy symbol
@@ -428,7 +428,7 @@ public function siegweirdAdvancedStudy_2():void {
     player.createKeyItem("Holy Symbol", 0, 0, 0, 0);
     player.addStatusValue(StatusEffects.SiegweirdTraining2, 1, 1);
     doNext(camp.campFollowers);
-    eachMinuteCount(5);
+    advanceMinutes(5);
 }
 
 //Alvina reward
@@ -446,7 +446,7 @@ public function siegweirdAdvancedStudy_3():void {
     outputText("<b>You gained a tome of Meteor Shower.</b>\n\n");
     player.addStatusValue(StatusEffects.SiegweirdTraining2, 1, 1);
     inventory.takeItem(consumables.MET_SHO, camp.campFollowers);
-    eachMinuteCount(5);
+    advanceMinutes(5);
 }
 
 	}

--- a/classes/classes/Scenes/NPCs/TyrantiaFollower.as
+++ b/classes/classes/Scenes/NPCs/TyrantiaFollower.as
@@ -434,7 +434,7 @@ public function repeatEncounterBattlefieldTalkHerHowUDoing():void {
 		outputText("\"<i>...Our kids are happy and safe.</i>\" She gives you a big hug, a single tear going down her face. \"<i>I might be corrupt, but they…They’re not. This meadow formed nearby, and they…Every time I visit them, play with our kids, I feel…Cleaner. I don’t think it’ll cure me, not by a long shot…But they’re counteracting my corrupt aura. As they grow, they’ll only get stronger…</i>\" She looks down at your children, playing in their meadow. \"<i>...Even if I can’t be cured, they’ll make up for my corruption…Just by existing.</i>\" You assure your giantess that she doesn’t need to ‘make up’ for anything. That her corruption aura isn’t her fault.\n\n");
 		outputText("\"<i>I know…</i>\" She lets you go, gently shoving you back towards camp. \"<i>Go on, my champion. Make the world a better place, eh?</i>\"\n\n");
 	}
-	eachMinuteCount(15);
+	advanceMinutes(15);
 	doNext(repeatEncounterBattlefieldTalkHer);
 }
 public function repeatEncounterBattlefieldTalkHerLifeBeforeDemons():void {
@@ -474,7 +474,7 @@ public function repeatEncounterBattlefieldTalkHerLifeBeforeDemonsNo():void {
 	outputText("She takes a moment to breathe. \"<i>They tied me down, slathered me in their juices, and made me beg for it...But I never fell all the way, like some of the others. That got some of them thinking. They wanted to turn me into a war machine, wind me up and unleash me onto the world...They got some of that right.</i>\"\n\n");
 	if (TyrantiaFollowerStage > 1) {
 		outputText("Tyrantia shakes herself, armor pieces clattering loudly. \"<i>But anyways, that’s in the past. Now I’m here…With you.</i>\" She gives you a grin.\n\n");
-		eachMinuteCount(15);
+		advanceMinutes(15);
 		endEncounter();
 	}
 	else {
@@ -546,7 +546,7 @@ public function talkHerKids():void {
 	if (player.hasStatusEffect(StatusEffects.PureCampJojo) && flags[kFLAGS.JOJO_BIMBO_STATE] != 3) outputText("Jojo could be of some assistance, perhaps.\n\n");
 	if (arianScene.arianFollower()) outputText("Arian has purification powers.\n\n");
 	tyraniaAffection(5);
-	eachMinuteCount(15);
+	advanceMinutes(15);
 	doNext(repeatEncounterBattlefieldTalk);
 }
 public function talkThePhalluspear():void {
@@ -558,7 +558,7 @@ public function talkThePhalluspear():void {
 	outputText("She explains that this isn’t a social call, and that the two of you had been looking for a way to recreate her Phalluspear. Konstantine holds his hand out, and your giant lover hands him the weapon.\n\n");
 	outputText("\"<i>Ah. This weapon is quite interesting!</i>\" Konstantine declares. \"<i>Yes, I can make it for you…But I’ll need some materials and assistance to do so.</i>\" He ponders for a moment. \"<i>I’ll need 5 LustDrafts, to start. The basis of this weapon’s poison is the same.</i>\" He flicks the weapon’s head, and he nods. \"<i>Two…No…Three metal plates, and some tough silk to make the mechanism. I’ll also need a base to work with. A simple spear should do the trick.</i>\"\n\n");
 	TyraniaThePhalluspear = true;
-	eachMinuteCount(15);
+	advanceMinutes(15);
 	doNext(playerMenu);
 }
 public function TyraniaAndFlitzyScene():void {
@@ -1289,7 +1289,7 @@ public function TyrantiaHenchmanOption():void {
 		addButtonDisabled(6, "JoinMe (2)", "Req. Intermediate Leadership.");
 	}
 	addButton(14, "Back", TyrantiaAtCamp);
-	
+
 }
 public function TyrantiaHenchmanOption2(slot:Number = 1):void {
 	clearOutput();
@@ -1332,7 +1332,7 @@ public function unlockingCorruptLegendariesOption():void {
 	outputText("You ask if she’d be willing to upgrade your weapons, and she nods. \"<i>But I can’t do much with it right now. Give me some time to figure it out.</i>\"\n\n");
 	TyraniaCorrupteedLegendaries = 1;
 	doNext(playerMenu);
-	eachMinuteCount(5);
+	advanceMinutes(5);
 }
 public function itemImproveMenuCorrupt():void {
 	var improvableItems:Array = [
@@ -1389,7 +1389,7 @@ public function itemImproveMenuCorrupt():void {
 		}
 	}
 	submenu(selectMenu, TyrantiaAtCamp);
-	
+
 	function improveItem(item:ItemType, from:ItemType):void {
 		clearOutput();
 		outputText("\"<i>You sure about this?”</i>\" Tyrantia asks, hesitant. You nod, and she sighs, relieved. \"<i>Okay, just making sure.</i>\" You hand her the base item, and she takes it in her meaty hands, turning it over. Tyrantia closes her eyes, a black aura growing from her horns. It focuses, darkening further, until with a grunt, Tyrantia’s horns fire twin beams of black energy, converging on the item in her hands.\n\n");

--- a/classes/classes/Scenes/NPCs/ZenjiScenes.as
+++ b/classes/classes/Scenes/NPCs/ZenjiScenes.as
@@ -91,7 +91,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 		{
 			Saves.registerSaveableState(this);
 		}
-	
+
 		public function zenjiPerspectiveOnPlayer(changes:Number = 0):Number
 		{
 			if (flags[kFLAGS.ZENJI_PROGRESS] < 7) flags[kFLAGS.ZENJI_PERSPECTIVE_ON_PLAYER] += changes;
@@ -99,11 +99,11 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			if (flags[kFLAGS.ZENJI_PERSPECTIVE_ON_PLAYER] < 0) flags[kFLAGS.ZENJI_PERSPECTIVE_ON_PLAYER] = 0;
 			return flags[kFLAGS.ZENJI_PERSPECTIVE_ON_PLAYER];
 		}
-		
+
 		private var spellBookButtons:ButtonDataList = new ButtonDataList();
-		
+
 		//PART 1
-		
+
 		public function part1TrollEncounter():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -137,14 +137,14 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			addButton(3, "Fight", part1TrollEncounterFight);
 			addButton(4, "Leave", part1TrollEncounterLeave);
 		}
-		
+
 		public function part1TrollEncounterLeave():void {
 			outputText("You decide that it's not worth paying whatever he's demanding to venture into who knows where.\n\n");
 			outputText("\"<i>Eh? You’re just gonna leave me like dat? You don' want ta even try to fight me?</i>\" he chuckles, \"<i>Your loss.</i>\"\n\n");
 			outputText("You return back to your camp following the path that you made along your way.\n\n");
 			endEncounter();
 		}
-		
+
 		public function part1TrollEncounterFight():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -154,7 +154,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			startCombat(new Zenji());
 			doNext(playerMenu);
 		}
-		
+
 		public function part1TrollEncounterFightPCDefeated():void {
 			clearOutput();
 			zenjiPerspectiveOnPlayer(-4);
@@ -169,7 +169,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			cleanupAfterCombat();
 		}
-		
+
 		public function part1TrollEncounterFightZenjiDefeated():void {
 			clearOutput();
 			outputText("The troll staggers backward, unable to fight anymore. \"<i>Heh... ya bested me...</i>\" he coughs, \"<i>Go on, ya can enter... I jus need a break...</i>\"\n\n");
@@ -180,7 +180,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			else addButtonDisabled(1, "???", "Need 50+ corruption.");
 			addButton(3, "Leave", cleanupAfterCombat);
 		}
-		
+
 		public function part1TrollEncounterFightZenjiDefeatedHuntHim():void {
 			if (player.spe < 180 && player.wis < 180) {
 				outputText("You chase after the troll, unwilling to let your prey elude you. Afterall, what’s the point in a little combat if you can’t claim your spoils by slaying your foe?\n\n");
@@ -203,7 +203,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			startCombat(new Zenji());
 			doNext(playerMenu);
 		}
-		
+
 		public function part1TrollEncounterFightTOTHEDEATHPCDefeated():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -226,7 +226,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				EventParser.gameOver();
 			}
 		}
-		
+
 		public function part1TrollEncounterFightTOTHEDEATHZenjiDefeated():void {
 			clearOutput();
 			outputText("The troll falls to the ground, severely wounded, unable to fight any longer. He struggles to regain his footing, desperately clinging onto the spear he has impaled to the ground.\n\n");
@@ -265,7 +265,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("\"<i>I… will neva die..! I will hunt you down! I… I will…</i>\" His voice rings through the thicket before dying out slowly. Words are meaningless when it comes from the dirt beneath you anyway.\n\n");
 			cleanupAfterCombat();
 		}
-		
+
 		public function part1TrollEncounterChallange():void {
 			outputText("You look up to him and ask just what did he mean by 'challenge'?\n\n");
 			outputText("He hops down from the tree, standing just over a foot away from you. \"<i>Heheh, I challenge you to a battle of skill, if you can beat me at ma own game, den I’ll let you pass.</i>\"\n\n");
@@ -507,7 +507,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			zenjiPerspectiveOnPlayer(-6);
 			endEncounter();
 		}
-		
+
 		public function part1TrollEncounterSex():void {
 			outputText("You eye him once more, he's tall, easily standing over 8 feet, he's only dressed in a loin cloth and some fur bracers as the rest of his muscular body is covered in light green fuzz. It could be worse, his chiseled face definitely is rather handsome.\n\n");
 			outputText("You take him on his offer and decide that you're willing to pay his toll with your body.\n\n");
@@ -518,14 +518,14 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			addButton(1, "Challenge?", part1TrollEncounterChallange);
 			addButton(3, "Leave", part1TrollEncounterLeave);
 		}
-		
+
 		public function part1TrollEncounterPayWithGems():void {
 			player.gems -= 25;
 			outputText("You pull out 25 gems from your gem pouch as you do so he hops down from the tree. He holds out a four-fingered palm, awaiting your payment and you fork the gems over. The entire time he looks directly into your eyes, but at the same time there seems to be a tinge of disappointment within his.\n\n");
 			outputText("As you enter the opening in the bog you search around the area and wonder what makes it so special that he wanted to guard it against you.\n\n");
 			part1TrollEncounterRewards();
 		}
-		
+
 		public function part1TrollEncounterRewards():void {
 			var event:Number = rand(10);
 			var itype:ItemType;
@@ -538,9 +538,9 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You decide to head back home afterwards as there doesn't appear to be anything else of interest right now.\n\n");
 			inventory.takeItem(itype, explorer.done);
 		}
-		
+
 		//PART 2
-		
+
 		public function part2TrollEncounterFirst():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -567,20 +567,20 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				addButton(3, "Leave", part2TrollEncounterLeave);
 			}
 		}
-		
+
 		public function part2TrollEncounterFirstDecline():void {
 			flags[kFLAGS.ZENJI_PROGRESS] = -1;
 			outputText("\"<i>Ah, so be it den, I shall go somewhere else for a real challenge, all I see here are cowards.</i>\" Zenji leans back and climbs on top of a nearby tree, he quickly vanishes into the canopy where you can't see him anymore.\n\n");
 			endEncounter();
 		}
-		
+
 		public function part2TrollEncounterFirstFight():void {
 			if (flags[kFLAGS.ZENJI_PROGRESS] < 5) flags[kFLAGS.ZENJI_PROGRESS] = 5;
 			outputText("If he really wants a fight, then so be it, who knows, it could be fun after all.\n\n");
 			startCombat(new Zenji());
 			doNext(playerMenu);
 		}
-		
+
 		public function part2TrollEncounterFirstFightPCDefeated():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -589,7 +589,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("\"<i>Ahah... So... dat's why ya didn' want ta fight? Perhap I shouldn’ta fought so hard on ya... Forgive me, I just didn' expect someone out here in de bog to be so weak.</i>\" He shakes his head, \"<i>Ya be safe now, I don' want ya ta get hurt out dere.</i>\"\n\n");
 			cleanupAfterCombat();
 		}
-		
+
 		public function part2TrollEncounterFirstFightZenjiDefeated():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -599,7 +599,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You make your way back to camp as the troll takes a moment to rest.\n\n");
 			cleanupAfterCombat();
 		}
-		
+
 		public function part2TrollEncounterRepeat():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -615,13 +615,13 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			if (flags[kFLAGS.ZENJI_PERSPECTIVE_ON_PLAYER] <= 30) addButton(3, "Talk", part2TrollEncounterTalk);
 			addButton(4, "Leave", part2TrollEncounterLeave);
 		}
-		
+
 		public function part2TrollEncounterLeave():void {
 			outputText("You tell Zenji that you are not in the mood for sticking around with him at the moment.\n\n");
 			outputText("\"<i>Eh? Then whatcha here for? Go on den, no reason to stay if ya don' wanna be here.</i>\"\n\n");
 			endEncounter();
 		}
-		
+
 		public function part2TrollEncounterTalk():void {
 			outputText("Zenji seems hesitant while near you, perhaps there’s something he wants to talk about?\n\n");
 			outputText("You continue to eye him, causing his stoic exterior to collapse again. \"<i>[name], is everything alright? I just…</i>\"\n\n");
@@ -635,7 +635,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			zenjiPerspectiveOnPlayer(-3);
 			endEncounter();
 		}
-		
+
 		public function part2TrollEncounterRepeatFight():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -643,7 +643,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			startCombat(new Zenji());
 			doNext(playerMenu);
 		}
-		
+
 		public function part2TrollEncounterRepeatFightPCDefeated():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -663,7 +663,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			cleanupAfterCombat();
 		}
-		
+
 		public function part2TrollEncounterRepeatFightZenjiDefeated():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -672,7 +672,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji leans back against a tree and sits down, he rubs his hands along his tusks as if they were sore from combat.\n\n");
 			cleanupAfterCombat();
 		}
-		
+
 		public function part2TrollEncounterTrain():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -682,7 +682,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			addButton(2, "Toughness", part2TrollEncounterTrainToughness);
 			addButton(3, "Speed", part2TrollEncounterTrainSpeed);
 		}
-		
+
 		public function part2TrollEncounterTrainStrength():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -705,7 +705,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			endEncounter();
 		}
-		
+
 		public function part2TrollEncounterTrainToughness():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -728,7 +728,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			endEncounter();
 		}
-		
+
 		public function part2TrollEncounterTrainSpeed():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -753,9 +753,9 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			endEncounter();
 		}
-		
+
 		//ZENJI FOLLOWER
-		
+
 		public function followerZenjiFirstTimeOffer():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -766,7 +766,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			addButton(1, "Yes", followerZenjiOfferYes);
 			addButton(3, "No", followerZenjiOfferNo);
 		}
-		
+
 		public function followerZenjiRepeatOffer():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -777,14 +777,14 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			addButton(4, "Leave", part2TrollEncounterLeave);
 			addButton(7, "Yes", followerZenjiOfferYes);
 		}
-		
+
 		public function followerZenjiOfferNo():void {
 			outputText("You tell Zenji that you don't want him to hang out around your camp.\n\n");
 			outputText("\"<i>Ah, dat is a shame, if ya don't want ta, I undastand, I still got all dis land to maself at least.</i>\"\n\n");
 			flags[kFLAGS.ZENJI_PROGRESS]++;
 			endEncounter();
 		}
-		
+
 		public function followerZenjiOfferYes():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -797,7 +797,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			flags[kFLAGS.ZENJI_PROGRESS] = 8;
 			endEncounter();
 		}
-		
+
 		public function followerZenjiMainCampMenu():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -812,7 +812,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			else addButtonDisabled(5, "Spar", "You can spar with him, but you need to build a sparring ring first!");
 			addButton(14, "Leave", followerZenjiMainCampMenuLeave);
 		}
-		
+
 		public function followerZenjiMainCampMenuAppearance():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -825,7 +825,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			menu();
 			addButton(14, "Back", followerZenjiMainCampMenu);
 		}
-		
+
 		public function followerZenjiMainCampMenuTraining():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -845,7 +845,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				addButton(4, "Wisdom", followerZenjiMainCampMenuTrainingWisdom);
 			}
 		}
-		
+
 		public function followerZenjiMainCampMenuTrainingStrength():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -862,7 +862,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			followerZenjiMainCampMenuTrainingPerks();
 			endEncounter();
 		}
-		
+
 		public function followerZenjiMainCampMenuTrainingToughness():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -881,7 +881,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			followerZenjiMainCampMenuTrainingPerks();
 			endEncounter();
 		}
-		
+
 		public function followerZenjiMainCampMenuTrainingSpeed():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -899,7 +899,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			followerZenjiMainCampMenuTrainingPerks();
 			endEncounter();
 		}
-		
+
 		public function followerZenjiMainCampMenuTrainingIntelligence():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -922,7 +922,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			followerZenjiMainCampMenuTrainingPerks();
 			endEncounter();
 		}
-		
+
 		public function followerZenjiMainCampMenuTrainingWisdom():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -944,7 +944,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			followerZenjiMainCampMenuTrainingPerks();
 			endEncounter();
 		}
-		
+
 		public function followerZenjiMainCampMenuTrainingPerks():void {
 			if (player.statusEffectv3(StatusEffects.ZenjiTrainingsCounters2) < 30) player.addStatusValue(StatusEffects.ZenjiTrainingsCounters2, 3, 1);
 			if (player.statusEffectv3(StatusEffects.ZenjiTrainingsCounters2) == 5 || player.statusEffectv3(StatusEffects.ZenjiTrainingsCounters2) == 15 || player.statusEffectv3(StatusEffects.ZenjiTrainingsCounters2) == 30) outputText("After you're done training, you feel different, you can't explain it, but something has surely changed, almost as if the training you've done with Zenji is really speaking to you.\n\n");
@@ -961,7 +961,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				player.createPerk(PerkLib.ZenjisInfluence3,0,0,0,0);
 			}
 		}
-		
+
 		public function followerZenjiSpar():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -969,7 +969,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			startCombat(new Zenji());
 			doNext(playerMenu);
 		}
-		
+
 		public function followerZenjiSparPCDefeated():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -983,7 +983,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			cleanupAfterCombat();
 		}
-		
+
 		public function followerZenjiSparZenjiDefeated():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -991,7 +991,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You tell Zenji you'd need a moment before you could consider fighting him again.\n\n");
 			cleanupAfterCombat();
 		}
-		
+
 		public function followerZenjiTalks():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1008,7 +1008,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 
 			addButton(14, "Back", followerZenjiMainCampMenu);
 		}
-		
+
 		public function followerZenjiTalksHimself():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1019,7 +1019,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji spends the rest of the hour talking about new experiences in the camp and other things about himself that he can recall.\n\n");
 			endEncounter();
 		}
-		
+
 		public function followerZenjiTalksTrolls():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1029,7 +1029,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji spends the rest of the hour talking about trolls and other nuances about his kind from the other trolls.\n\n");
 			endEncounter();
 		}
-		
+
 		public function followerZenjiTalksYourself():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1041,7 +1041,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You spend the rest of the hour talking about yourself and sharing old stories back in Ingnam with Zenji.\n\n");
 			endEncounter();
 		}
-		
+
 		public function followerZenjiSex():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1059,7 +1059,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			doNext(followerZenjiMainCampMenu);
 		}
-		
+
 		public function followerZenjiGlades():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1075,15 +1075,15 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			doNext(followerZenjiMainCampMenu);
 		}
-		
+
 		public function followerZenjiMainCampMenuLeave():void {
 			outputText("You realize that you don’t have anything you need from him at this moment, you apologize and take your leave.\n\n");
 			outputText("Zenji gives you a small nod as he dismisses you.\n\n");
 			doNext(camp.campFollowers);
 		}
-		
+
 		//ZENJI LOVER
-		
+
 		public function loverZenjiFirstTimeOffer():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1096,7 +1096,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			addButton(1, "Yes", loverZenjiOfferYes);
 			addButton(3, "No", loverZenjiOfferNo);
 		}
-		
+
 		public function loverZenjiRepeatOffer():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1107,13 +1107,13 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			addButton(4, "Leave", part2TrollEncounterLeave);
 			addButton(7, "Yes", loverZenjiOfferYes);
 		}
-		
+
 		public function loverZenjiOfferNo():void {
 			outputText("Zenji's eyes grow watery, \"<i>You are a brave soul, I tell ya dat.</i>\" He slowly moves closer to you and puts his hands on your shoulders. \"<i>Stay safe out dere, I will remain here if ya need me.</i>\"\n\n");
 			flags[kFLAGS.ZENJI_PROGRESS] = 10;
 			endEncounter();
 		}
-		
+
 		public function loverZenjiOfferYes():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1130,7 +1130,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			flags[kFLAGS.ZENJI_PROGRESS] = 11;
 			endEncounter();
 		}
-		
+
 		public function loverZenjiMainCampMenu2():void {
 			if (!player.hasStatusEffect(StatusEffects.LunaOff) && !player.hasStatusEffect(StatusEffects.LunaWasWarned)) {
 				if ((flags[kFLAGS.LUNA_JEALOUSY] > 200 && rand(10) < 4) || (flags[kFLAGS.LUNA_JEALOUSY] > 300 && rand(10) < 8)) mishapsLunaZenji();
@@ -1138,7 +1138,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			else loverZenjiMainCampMenu();
 		}
-		
+
 		public function loverZenjiMainCampMenu():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1182,7 +1182,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			else addButton(7, "Sleep Alone", zenjiSleepToggle).hint("Stop sleeping with Zenji.");
 			addButton(14, "Leave", loverZenjiMainCampMenuLeave);
 		}
-		
+
 		public function loverZenjiMainCampMenuAppearance():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1200,7 +1200,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			menu();
 			addButton(14, "Back", loverZenjiMainCampMenu);
 		}
-		
+
 		public function loverZenjiTalks():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1232,7 +1232,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			addButton(14, "Back", loverZenjiMainCampMenu);
 		}
-		
+
 		public function loverZenjiTalksHimself():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1245,7 +1245,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			ZenjiTalkCount++;
 			endEncounter();
 		}
-		
+
 		public function loverZenjiTalksTrolls():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1257,7 +1257,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			ZenjiTalkCount++;
 			endEncounter();
 		}
-		
+
 		public function loverZenjiTalksYourself():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1271,7 +1271,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			ZenjiTalkCount++;
 			endEncounter();
 		}
-		
+
 		public function loverZenjiTalksChildren():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1285,7 +1285,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			ZenjiTalkCount++;
 			endEncounter();
 		}
-		
+
 		public function loverZenjiShowoff():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1450,7 +1450,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("\n\n");
 			endEncounter();
 		}
-		
+
 		public function loverZenjiComfort():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1480,9 +1480,9 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			if (player.statusEffectv1(StatusEffects.ZenjiPreparationsList) < 15) player.addStatusValue(StatusEffects.ZenjiPreparationsList, 1, 1);
 			ZenjiTalkCount++;
 			doNext(loverZenjiTalks);
-			eachMinuteCount(5);
+			advanceMinutes(5);
 		}
-		
+
 		public function loverZenjiFood():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1495,9 +1495,9 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			ZenjiFood = true;
 			inventory.takeItem(consumables.ZENJI_H, loverZenjiTalks);
 			ZenjiTalkCount++;
-			eachMinuteCount(5);
+			advanceMinutes(5);
 		}
-		
+
 		public function loverZenjiGiveItem():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1515,7 +1515,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			else addButtonDisabled(3, "TrollFig", "You do not have this item to offer");
 			addButton(4, "Back", loverZenjiGiveItemBack);
 		}
-		
+
 		public function loverZenjiGiveItemLotion():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1566,7 +1566,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Alright, alright, jus' tell me when ya want ta do someting later, Dere's someting I need ta check up on. \"\n\n");
 			doNext(loverZenjiGiveItem);
 		}
-		
+
 		public function loverZenjiGiveItemGroPlus():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1629,7 +1629,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji nods respectfully.\n\n");
 			doNext(loverZenjiGiveItem);
 		}
-		
+
 		public function loverZenjiGiveItemReducto():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1692,7 +1692,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji nods respectfully.\n\n");
 			doNext(loverZenjiGiveItem);
 		}
-		
+
 		public function loverZenjiGiveItemBack():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1700,7 +1700,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("Zenji gives you a sideways glance, \"<i>Alright den, if ya change your mind or find someting special fa me, I'll be here.</i>\" He pulls you in for a hug, \"<i>I'll always be here for you...</i>\" He whispers before releasing you.\n\n");
 			doNext(loverZenjiMainCampMenu);
 		}
-		
+
 		public function loverZenjiGiveItemTrollFig():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1736,7 +1736,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			else outputText("As he pulls away, Zenji looks down at his groin, \"<i>Aha, I didn’t expect someting like dis from you, [name]. Dat’s one of de weird, wild figs…</i>\" He chuckles softly before looking back at you, \"<i>Let’s just say you’ll be in for a little surprise later…</i>\"\n\n");
 			doNext(loverZenjiGiveItem);
 		}
-		
+
 		public function loverZenjiSex():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1803,7 +1803,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				addButtonDisabled(10, "Get Blown", "You aren't turned on enough to consider this.");
 			}
 		}
-		
+
 		public function loverZenjiTakeAnal():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1847,7 +1847,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.sexReward("cum","Anal");
 			endEncounter();
 		}
-		
+
 		public function loverZenjiTakeVaginal():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1889,7 +1889,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			else player.knockUp(PregnancyStore.PREGNANCY_ZENJI, PregnancyStore.INCUBATION_ZENJI);
 			endEncounter();
 		}
-		
+
 		public function loverZenjiPitchAnal():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1927,7 +1927,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.sexReward("no", "Dick");
 			endEncounter();
 		}
-		
+
 		public function loverZenjiSexBlowHim():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -1977,7 +1977,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			dynStats("lust", 25);
 			endEncounter();
 		}
-		
+
 		public function loverZenjiSexCuddle():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2017,7 +2017,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			dynStats("cor", -0.25);
 			endEncounter();
 		}
-		
+
 		public function loverZenjiPregnantSex():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2071,7 +2071,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.sexReward("cum", "Vaginal");
 			endEncounter();
 		}
-		
+
 		public function loverZenjiHotSpring():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2169,7 +2169,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			else player.knockUp(PregnancyStore.PREGNANCY_ZENJI, PregnancyStore.INCUBATION_ZENJI);
 			endEncounter();
 		}
-		
+
 		public function loverZenjiSexGetFingered():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2190,7 +2190,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.sexReward("no", "Vaginal");
 			endEncounter();
 		}
-		
+
 		public function loverZenjiSexGetHandjob():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2209,7 +2209,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.sexReward("no", "Dick");
 			endEncounter();
 		}
-		
+
 		public function loverZenjiSexGetLicked():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2228,7 +2228,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.sexReward("no", "Vaginal");
 			endEncounter();
 		}
-		
+
 		public function loverZenjiSexGetBlown():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2260,7 +2260,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.sexReward("no", "Dick");
 			endEncounter();
 		}
-		
+
 		public function loverZenjiSexTease():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2320,7 +2320,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.addStatusValue(StatusEffects.ZenjiZList, 3, 1);
 			endEncounter();
 		}
-		
+
 		public function loverZenjiSexNevermind():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2338,7 +2338,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			doNext(loverZenjiMainCampMenu);
 		}
-		
+
 		private function zenjiSleepToggle():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2355,7 +2355,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			menu();
 			addButton(0,"Next", loverZenjiMainCampMenu);
 		}
-		
+
 		public function loverZenjiSleepWithMorning():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2529,7 +2529,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			ZenjiSleepCount += 1;
 			doNext(playerMenu);
 		}
-		
+
 		public function loverZenjiGlades():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2545,7 +2545,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			doNext(loverZenjiMainCampMenu);
 		}
-		
+
 		public function loverZenjiNightWatch():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2561,7 +2561,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			doNext(loverZenjiMainCampMenu);
 		}
-		
+
 		public function zenjiHenchmanOption():void {
 			menu();
 			if (flags[kFLAGS.PLAYER_COMPANION_1] == "") {
@@ -2626,13 +2626,13 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			doNext(loverZenjiMainCampMenu);
 			cheatTime(1/12);
 		}
-		
+
 		public function loverZenjiMainCampMenuLeave():void {
 			outputText("You realize that you don’t have anything you need from him at this moment, you apologize and take your leave.\n\n");
 			outputText("Zenji gives you a small nod as he dismisses you.\n\n");
 			doNext(camp.campLoversMenu);
 		}
-		
+
 		public function loverZenjiHalloweenEvent():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2730,7 +2730,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			player.addStatusValue(StatusEffects.ZenjiZList, 4, -2);
 			endEncounter();
 		}
-		
+
 		public function birthScene():void {
 			spriteSelect(SpriteDb.s_zenji);
 			clearOutput();
@@ -2790,8 +2790,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			clearOutput();
 			outputText("\"<i>"+(Z2ndKid ? ""+Z2ndKid+"":""+Z1stKid+"")+"... I like dat name…'</i>\" he states with a smile.\n\n");
 			outputText("Zenji relaxes by your side as you drift off to sleep within his protection, exhausted from giving birth.");
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 		}
 		private function applyZenjikidName2():void {
 			spriteSelect(SpriteDb.s_zenji);
@@ -2799,8 +2798,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			flags[kFLAGS.ZENJI_KIDS]++;
 			outputText("Zenji gives you a gentle stare as he gently caresses your child, \"<i>Actually, Ya know... I was thinkin’, and I thought I should name dem dis time.</i>\"\n\n");
 			outputText("He scoops up your baby once they detach from your breast. \"<i>What will daddy name you?</i>\" he croons, taking his child to his nest.\n\n");
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 		}
 		private function applyZenjikidName3():void {
 			spriteSelect(SpriteDb.s_zenji);
@@ -2811,10 +2809,9 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			outputText("You groan in pain as you spread your legs, ready to give birth, hoping for a healthy child.\n\n");
 			outputText("After an hour of pain and screaming, you successfully give birth to your child. She is doing just fine, taking her first breath as she cries.\n\n");
 			outputText("Maternal pride overwhelms you. You manage to collect yourself enough to bring your baby to your breast to comfort her. She latches on reflexively as you take a moment to rest.\n\n");
-			explorer.stopExploring();
-			doNext(camp.returnToCampUseTwoHours);
+			endEncounter(120);
 		}
-		
+
 		public function mishapsLunaZenji():void {
 			clearOutput();
 			outputText("You notice Zenji surveying the camp for potential danger. As he hops off the tree he usually resides on top of, you notice a rope trap quickly close in on his ankle. Zenji is swept clean off his feet from the ground and hung upside down.\n\n");
@@ -2828,7 +2825,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			if (player.statusEffectv1(StatusEffects.LunaWasCaugh) == 3) outputText("<b>That's it, you're sure of it now, it's all Luna's doing!</b>\n\n");
 			doNext(playerMenu);
 		}
-		
+
 		public function zenjiVillageProblems():void{
 			clearOutput();
 			outputText("You ask Zenji if he’s ready to talk about his problems with you.\n" +
@@ -2865,12 +2862,12 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 					"He gives you a sincere grin, the sight warms you to your core. You feel like you can breathe a little easier as well knowing he's taken a weight off his chest.");
 			doNext(playerMenu);
 		}
-		
+
 		//ZENJI MARRIAGE
 		public function ZenjiMarriagePreCheck():Boolean{
 			return player.hasKeyItem("Jabala's Charm") > 0 && TrollVillage.ZenjiVillageStage > 0 && ZenjiSleepCount >= 5 && ZenjiTalkCount >= 15 && ZenjiLoverDays >= 20;
 		}
-		
+
 		public function ZenjiProposalScene():void{
 			if (!sceneHunter.canMarry()){
 				outputText("You call Zenji to you, to which he immediately approaches you with a stride in his step. His deep voice rings to you as he stands in front of you, \"<i>You called?</i>\"\n" +
@@ -2888,7 +2885,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 						"His rejection stings, but his words carry meaning.\n" +
 						"\n" +
 						"Zenji rests a hand on your shoulder, \"<i>Never disgrace love, [name],</i>\" he states before leaving you alone for the time being.");
-				eachMinuteCount(15);
+				advanceMinutes(15);
 				doNext(loverZenjiTalks);
 			}
 			else{
@@ -2931,7 +2928,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 				doNext(ZenjiMarriageSceneUno);
 			}
 		}
-	
+
 		private function ZenjiMarriageSceneUno():void{
 			clearOutput();
 			outputText("Zenji guides you back to the troll village, holding your hand tightly in a mix of love and anticipation. He guides you to his parent’s home, knocking on the door when he finally reaches the hut.\n" +
@@ -3565,7 +3562,7 @@ public class ZenjiScenes extends NPCAwareContent implements SaveableState
 			}
 			doNext(ZenjiMarriageSexTime3, options);
 		}
-		
+
 		private function ZenjiMarriageSexTime3(options:int):void{
 			clearOutput();
 			outputText("<b>Next Morning</b>");

--- a/classes/classes/Scenes/Places/Boat.as
+++ b/classes/classes/Scenes/Places/Boat.as
@@ -6,6 +6,7 @@ package classes.Scenes.Places
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.API.Encounters;
+import classes.Scenes.API.ExplorationEntry;
 import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Lake.*;
 import classes.Scenes.NPCs.BelisaFollower;
@@ -141,26 +142,31 @@ public class Boat extends AbstractLakeContent
 
 		public function boatExplore():void
 		{
-			SceneLib.exploration.counters.boat++;
-			clearOutput();
-			outputText("You reach the dock without any incident and board the small rowboat.  The water is calm and placid, perfect for rowing.  ");
+			explorer.prepareArea(boatEncounter);
+			explorer.setTags("boat", "lakeBoat", "water");
+			explorer.prompt = "You explore the lake.";
 			if (flags[kFLAGS.FACTORY_SHUTDOWN] == 2) {
-				outputText("The water appears somewhat muddy and has a faint pungent odor.  ");
-				if (player.inte > 40) outputText("You realize what it smells like – sex.  ");
+				explorer.prompt += "The water appears somewhat muddy and has a faint pungent odor.  ";
+				if (player.inte > 40) explorer.prompt += "You realize what it smells like – sex.  ";
 			}
-			outputText("You set out, wondering if you'll find any strange islands or creatures in the lake.\n\n");
-			boatEncounter.execEncounter();
+			explorer.onEncounter = function(e:ExplorationEntry):void {
+				SceneLib.exploration.counters.boat++;
+			}
+			explorer.leave.hint("Return to the shore");
+			explorer.skillBasedReveal(areaLevel, timesExplored());
+			explorer.doExplore();
 		}
 
 		private function fishing():void {
 			outputText("This is a calm day at the lake, you managed to hold your boat in place and, while you found nothing of note, couldn’t help yourself but to enjoy a few hour using your newly acquired fishing pole. You even spotted Calu in the distance doing the same thing from her usual sitting spot.\n\n");
 			outputText("<b>You got a fish!</b>");
-			inventory.takeItem(consumables.FREFISH, camp.returnToCampUseOneHour);
+			inventory.takeItem(consumables.FREFISH, explorer.done);
 		}
 
 		private function rowBoat():void {
 			if (rand(2) == 0) outputText("You row for nearly an hour, until your arms practically burn with exhaustion from all the rowing.");
 			else outputText("You give up on finding anything interesting, and decide to go check up on your camp.");
+			endEncounter(60);
 		}
 	}
 }

--- a/classes/classes/Scenes/Places/Boat.as
+++ b/classes/classes/Scenes/Places/Boat.as
@@ -5,6 +5,8 @@ package classes.Scenes.Places
 {
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.API.Encounters;
+import classes.Scenes.API.GroupEncounter;
 import classes.Scenes.Areas.Lake.*;
 import classes.Scenes.NPCs.BelisaFollower;
 import classes.Scenes.NPCs.EtnaFollower;
@@ -17,8 +19,10 @@ public class Boat extends AbstractLakeContent
 		public var marae:MaraeScene = new MaraeScene();
 		public var kaiju:Kaiju = new Kaiju();
 		public var anemoneScene:AnemoneScene = new AnemoneScene();
-		public function Boat() {}
-		
+		public function Boat() {
+			onGameInit(init);
+		}
+
 		public const discoverLevel:int = 0;
 		public const areaLevel:int = 1;
 		public function isDiscovered():Boolean {
@@ -41,109 +45,122 @@ public class Boat extends AbstractLakeContent
 			explorer.stopExploring();
 			doNext(camp.returnToCampUseOneHour);
 		}
+		private var _boatEncounter:GroupEncounter = null;
+		public function get boatEncounter():GroupEncounter {
+			return _boatEncounter;
+		}
+		private function init():void {
+			_boatEncounter = Encounters.group("boat", {
+				name: "Belisa",
+				label: "Belisa",
+				kind: 'npc',
+				unique: true,
+				when: function ():Boolean {
+					return BelisaFollower.BelisaInGame && BelisaFollower.BelisaEncounternum == 1;
+				},
+				call: SceneLib.belisa.secondEncounter,
+				chance: 20
+			}, {
+				name: "Etna",
+				label: "Etna",
+				kind: 'npc',
+				unique: true,
+				when: function():Boolean {
+					return (flags[kFLAGS.ETNA_FOLLOWER] < 1 || EtnaFollower.EtnaInfidelity == 2) && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2 && !player.hasStatusEffect(StatusEffects.EtnaOff) && (player.level >= 20);
+				},
+				call: SceneLib.etnaScene.repeatYandereEnc
+			}, {
+				name: "izmaKids",
+				label: "Lost daughter",
+				kind: 'event',
+				unique: true,
+				chance: 0.3,
+				when: function():Boolean {
+					return flags[kFLAGS.IZMA_KIDS_IN_THE_WILD] > 0 && SceneLib.izmaScene.izmaFollower();
+				},
+				call: SceneLib.izmaScene.findLostIzmaKids
+			}, {
+				name: "Marae",
+				label: "Marae",
+				kind: 'npc',
+				unique: true,
+				chance: 3,
+				when: function():Boolean {
+					return flags[kFLAGS.MARAE_ISLAND];
+				},
+				night: false,
+				call: marae.encounterMarae
+			}, {
+				name: "Walk",
+				label: "Row",
+				kind: 'walk',
+				chance: 0.25,
+				call: rowBoat
+			}, {
+				name: "sharkgirl",
+				label : "Shark girl",
+				kind  : 'monster',
+				call: sharkGirlScene.sharkGirlEncounter
+			}, {
+				name: 'anemone',
+				label : "Anemone",
+				kind  : 'monster',
+				call: function():void {
+					flags[kFLAGS.ANEMONE_OR_SEA_ANEMONE] = 1;
+					anemoneScene.mortalAnemoneeeeee();
+				}
+			}, {
+				name: 'zealot',
+				label: "Fetish Zealot",
+				kind: 'monster',
+				night: false,
+				when: function():Boolean {
+					return flags[kFLAGS.FACTORY_SHUTDOWN] > 0 && player.level > 2 && player.hasStatusEffect(StatusEffects.FetishOn)
+				},
+				call: lake.fetishZealotScene.zealotBoat
+			}, {
+				name : "Fishing",
+				label : "Fishing",
+				kind  : 'event',
+				unique: true,
+				when: function():Boolean {
+					return player.hasKeyItem("Fishing Pole") >= 0;
+				},
+				call: fishing
+			}, {
+				name: "Venus",
+				label : "Venus",
+				kind  : 'npc',
+				unique: true,
+				when: function():Boolean {
+					return player.level >= 5 && flags[kFLAGS.KAIJU_DISABLED] == 0 && !player.hasStatusEffect(StatusEffects.VenusOff);
+				},
+				call: kaiju.kaijuMeeting
+			})
+		}
+
 		public function boatExplore():void
 		{
 			SceneLib.exploration.counters.boat++;
-			//Belisa
-			if (BelisaFollower.BelisaInGame && BelisaFollower.BelisaEncounternum == 1) {
-				SceneLib.belisa.secondEncounter();
-				//label : "Belisa",
-				//kind  : 'npc',
-				//unique: true,
-				return;
-			}
-			//Etna
-			if ((flags[kFLAGS.ETNA_FOLLOWER] < 1 || EtnaFollower.EtnaInfidelity == 2) && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2 && !player.hasStatusEffect(StatusEffects.EtnaOff) && rand(5) == 0 && (player.level >= 20)) {
-				SceneLib.etnaScene.repeatYandereEnc();
-				//label : "Etna",
-				//kind  : 'npc',
-				//unique: true,
-				return;
-			}
 			clearOutput();
 			outputText("You reach the dock without any incident and board the small rowboat.  The water is calm and placid, perfect for rowing.  ");
 			if (flags[kFLAGS.FACTORY_SHUTDOWN] == 2) {
 				outputText("The water appears somewhat muddy and has a faint pungent odor.  ");
 				if (player.inte > 40) outputText("You realize what it smells like – sex.  ");
 			}
-			//3% chance of finding lost daughters
-			if (rand(100) <= 3 && flags[kFLAGS.IZMA_KIDS_IN_THE_WILD] > 0 && SceneLib.izmaScene.izmaFollower()) {
-				SceneLib.izmaScene.findLostIzmaKids();
-				//label : "Lost daughter",
-				//kind  : 'event',
-				//unique: true,
-				return;
-			}
 			outputText("You set out, wondering if you'll find any strange islands or creatures in the lake.\n\n");
-			//Marae
-			if (rand(3) == 0 && flags[kFLAGS.MARAE_ISLAND] < 1 && !isNightTime) {
-				marae.encounterMarae();
-				//label : "Marae",
-				//kind  : 'npc',
-				//unique: true,
-				return;
-			}
-			
-			//BUILD LIST OF CHOICES
-			var choice:Array = [0, 1, 2, 3, 4];
-			if (player.hasKeyItem("Fishing Pole") >= 0) choice[choice.length] = 5;
-			if (player.level >= 5 && flags[kFLAGS.KAIJU_DISABLED] == 0 && !player.hasStatusEffect(StatusEffects.VenusOff)) choice[choice.length] = 6; //moved kaiju here
-			//MAKE YOUR CHOICE
-			var selector:Number = choice[rand(choice.length)];
-			//RUN CHOSEN EVENT
-			switch (selector) {
-				case 0:
-					if (rand(2) == 0) outputText("You row for nearly an hour, until your arms practically burn with exhaustion from all the rowing.");
-					else outputText("You give up on finding anything interesting, and decide to go check up on your camp.");
-					//if (rand(2) == 0 && player.str < 100) {
-					//	outputText("Despite the exaustion, you feel like you have become stronger.");
-					//	dynStats("str", .5);
-					//}
-					//chance:  0.25,
-					//label:'Walk',
-					//kind:'walk'
-					doNext(camp.returnToCampUseOneHour);
-					return;
-				case 1:
-					sharkGirlScene.sharkGirlEncounter();
-					//label : "Shark girl",
-					//kind  : 'monster',
-					return;
-				case 2:
-					flags[kFLAGS.ANEMONE_OR_SEA_ANEMONE] = 1;
-					anemoneScene.mortalAnemoneeeeee();
-					//label : "Anemone",
-					//kind  : 'monster',
-					return;
-				case 3:
-				case 4:
-					if (flags[kFLAGS.FACTORY_SHUTDOWN] > 0 && player.level > 2 && player.hasStatusEffect(StatusEffects.FetishOn) && !isNightTime) {
-					lake.fetishZealotScene.zealotBoat();
-					//label : "Fetish Zealot",
-					//kind  : 'monster',
-					//night : false,
-					}
-					else {
-					sharkGirlScene.sharkGirlEncounter();
-					//label : "Shark girl",
-					//kind  : 'monster',
-					}
-					return;
-				case 5:
-					outputText("This is a calm day at the lake, you managed to hold your boat in place and, while you found nothing of note, couldn’t help yourself but to enjoy a few hour using your newly acquired fishing pole. You even spotted Calu in the distance doing the same thing from her usual sitting spot.\n\n");
-					outputText("<b>You got a fish!</b>");
-					inventory.takeItem(consumables.FREFISH, camp.returnToCampUseOneHour);
-					//label : "Fishing",
-					//kind  : 'event',
-					//unique: true,
-					return;
-				case 6:
-					kaiju.kaijuMeeting();
-					//label : "Venus",
-					//kind  : 'npc',
-					//unique: true,
-					return;
-			}
+			boatEncounter.execEncounter();
+		}
+
+		private function fishing():void {
+			outputText("This is a calm day at the lake, you managed to hold your boat in place and, while you found nothing of note, couldn’t help yourself but to enjoy a few hour using your newly acquired fishing pole. You even spotted Calu in the distance doing the same thing from her usual sitting spot.\n\n");
+			outputText("<b>You got a fish!</b>");
+			inventory.takeItem(consumables.FREFISH, camp.returnToCampUseOneHour);
+		}
+
+		private function rowBoat():void {
+			if (rand(2) == 0) outputText("You row for nearly an hour, until your arms practically burn with exhaustion from all the rowing.");
+			else outputText("You give up on finding anything interesting, and decide to go check up on your camp.");
 		}
 	}
 }

--- a/classes/classes/Scenes/Places/Boat/Kaiju.as
+++ b/classes/classes/Scenes/Places/Boat/Kaiju.as
@@ -542,7 +542,7 @@ public class Kaiju extends AbstractLakeContent {
 		clearOutput();
 		kaijuSprite();
 		outputText("You shake your head no, politely responding that you do not want to get her off right now.  \"<i>Oh, okay. I understand,</i>\" the giantess states, looking somewhat crestfallen.  You row away, leaving her and her new addition to themselves for the time being.");
-		doNext(recalling ? recallWakeUp : camp.returnToCampUseOneHour);
+		doNext(recalling ? recallWakeUp : explorer.done);
 	}
 
 	//[If Mock]

--- a/classes/classes/Scenes/Places/Boat/MaraeScene.as
+++ b/classes/classes/Scenes/Places/Boat/MaraeScene.as
@@ -114,11 +114,11 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
                     outputText("You nod, understanding.  She commands, \"<i>Now go, there is nothing to be gained by your presence here.  Return if you manage to close that vile place.</i>\"\n\n");
                     if (player.lib + player.cor > 80) {
                         outputText("You could leave, but the desire to feel her breast will not go away.  What do you do?");
-                        simpleChoices("Boob", grabHerBoob, "", null, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
-                    } else doNext(camp.returnToCampUseOneHour);
+                        simpleChoices("Boob", grabHerBoob, "", null, "", null, "", null, "Leave", explorer.done);
+                    } else endEncounter();
                     return;
                 }
-                doNext(camp.returnToCampUseOneHour);
+                endEncounter();
             }
             //Second meeting
             else {
@@ -126,12 +126,12 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
                 if (player.cor > 66 + player.corruptionTolerance) {
                     outputText("She bellows in rage, \"<i>I told you, begone!</i>\"\n\nYou turn tail and head back to your boat, knowing you cannot compete with her power directly.");
                     if (player.level >= 130) outputText(" Of course, you could probably try to overthrow her.");
-					doNext(camp.returnToCampUseOneHour);
+					endEncounter();
                 } else {
                     //If youve taken her quest already
                     if (flags[kFLAGS.MARAE_QUEST_START] >= 1) {
                         outputText("Marae reminds you, \"<i>You need to disable the demonic factory!  It's located in the foothills of the mountain.  Please, I do not know how long I can resist.</i>\"");
-                        doNext(camp.returnToCampUseOneHour);
+                        endEncounter();
                     }
                     //If not
                     else {
@@ -149,8 +149,8 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
                         outputText("You nod, understanding.  She commands, \"<i>Now go, there is nothing to be gained by your presence here.  Return if you manage to close that vile place.</i>\"\n\n");
                         if (player.lib + player.cor > 80) {
                             outputText("You could leave, but the desire to feel her breast will not go away.  What do you do?");
-                            simpleChoices("Boob", grabHerBoob, "", null, "", null, "", null, "Leave", camp.returnToCampUseOneHour);
-                        } else doNext(camp.returnToCampUseOneHour);
+                            simpleChoices("Boob", grabHerBoob, "", null, "", null, "", null, "Leave", explorer.done);
+                        } else endEncounter();
                     }
                 }
             }
@@ -163,7 +163,7 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
                 outputText("\"<i>Thank you,</i>\" she says, breaking the hug and turning back to her tree, \"<i>The onslaught has lessened, and I feel more myself already.  Let me thank you for your heroic deeds.</i>\"\n\n");
                 outputText("She plunges a hand inside the tree and pulls out a small pearl.  \"<i>This is a pearl from the very depths of the lake, infused with my purity.  If you eat it, it will grant you my aid in resisting the lust and corruption of this land.</i>\"\n\n");
                 outputText("Marae pushes the pearl into your hand, and closes your fingers over it gently.  \"<i>Go now, there is still much to be done.  With luck, we will not need each other again but I will leave something in your camp for you to remember about your good deed,</i>\" commands the goddess as she slips back into her tree.  ");
-                inventory.takeItem(consumables.P_PEARL, camp.returnToCampUseOneHour);
+                inventory.takeItem(consumables.P_PEARL, explorer.done);
                 flags[kFLAGS.MARAE_QUEST_COMPLETE] = 1;
             }
             //Corrupt!
@@ -241,7 +241,7 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
     private function alraunezeMeNo():void {
         clearOutput();
         outputText("\n\nYou politely decline, telling her that you only wanted to pay a visit. Still, it is a tempting offer, one you will consider while you head back to camp. Such decisions are not to be taken in the heat of the moment. You tell her as much, which she accepts with a smile and a nod.");
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     private function alraunezeMeYes():void {
@@ -318,7 +318,7 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
         player.vaginaType(VaginaClass.ALRAUNE);
 		Metamorph.unlockMetamorphEx(VaginaMem.getMemory(VaginaMem.ALRAUNE));
         CoC.instance.mainViewManager.updateCharviewIfNeeded();
-        doNext(camp.returnToCampUseTwoHours);
+        explorer.done(120);
     }
 
     //Prompts
@@ -337,7 +337,7 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
     private function promptFightMarae3():void {
         clearOutput();
         outputText("Are you sure you want to fight Marae? She is the life-goddess of Mareth. This is going to be extremely difficult battle.");
-        doYesNo(initiateFightMarae, camp.returnToCampUseOneHour);
+        doYesNo(initiateFightMarae, explorer.done);
     }
 
     //FIGHT!
@@ -392,7 +392,7 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
             awardAchievement("Godslayer", kACHIEVEMENTS.GENERAL_GODSLAYER, true, true);
             flags[kFLAGS.CORRUPTED_MARAE_KILLED] = 1;
             cleanupAfterCombat();
-            inventory.takeItem(useables.TBAPLAT, camp.returnToCampUseOneHour);
+            inventory.takeItem(useables.TBAPLAT, explorer.done);
         } else {
             if (monster.HP <= 0) outputText("Marae reels back from the incredible amount of damage you've dealt to her.");
             else outputText("Marae clearly shows signs of her overwhelming arousal and reels back.");
@@ -402,7 +402,7 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
             awardAchievement("Godslayer", kACHIEVEMENTS.GENERAL_GODSLAYER, true, true);
             flags[kFLAGS.PURE_MARAE_ENDGAME] = 2;
             cleanupAfterCombat();
-            inventory.takeItem(useables.DBAPLAT, camp.returnToCampUseOneHour);
+            inventory.takeItem(useables.DBAPLAT, explorer.done);
         }
     }
 
@@ -445,7 +445,7 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
             outputText("You dart to the side, diving into a roll that brings you up behind the tree.  You evade the gauntlet of grabbing tentacles that hang from the branches, snatch the large gem in both arms and run for the beach.  You do not hear the sounds of pursuit, only a disappointed sigh.");
             outputText("\n<b>(Key Item Acquired: Marae's Lethicite!)</b>");
             if (!recalling) player.createKeyItem("Marae's Lethicite", 3, 0, 0, 0);
-            doNext(recalling ? recallWakeUp : camp.returnToCampUseOneHour);
+            doNext(recalling ? recallWakeUp : explorer.done);
         }
         //(FAIL)
         else {
@@ -494,7 +494,7 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
                     player.createPerk(PerkLib.MaraesGiftStud, 0, 0, 0, 0);
                     player.sexReward("no", "Dick");
 					if (!WoodElves.WoodElfMagicTranerGetLaid) WoodElves.WoodElfMagicTranerGetLaid = true;
-                    doNext(camp.returnToCampUseTwoHours);
+                    explorer.done(120);
                 } else doNext(recallWakeUp);
             }
 
@@ -518,7 +518,7 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
                     }
                     player.sexReward("no", "Vaginal");
 					if (!WoodElves.WoodElfMagicTranerGetLaid) WoodElves.WoodElfMagicTranerGetLaid = true;
-                    doNext(camp.returnToCampUseOneHour);
+                    endEncounter();
                 } else doNext(recallWakeUp);
             }
         }
@@ -839,14 +839,14 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
                 }
             }
         }
-        doNext(recalling ? recallWakeUp : camp.returnToCampUseTwoHours);
+        doNext(recalling ? recallWakeUp : curry(explorer.done,120));
     }
 
     private function MaraeIIFlyAway():void {
         spriteSelect(SpriteDb.s_marae);
         clearOutput();
         outputText("You launch into the air and beat your wings, taking to the skies.  The tentacle-tree lashes at you, but comes up short.  You've escaped!  Something large whooshes by, and you glance up to see your boat sailing past you.  She must have hurled it at you!  It lands with a splash near the mooring, somehow surviving the impact.  You dive down and drag it back to the dock before you return to camp.  That was close!");
-        doNext(recalling ? recallWakeUp : camp.returnToCampUseOneHour);
+        doNext(recalling ? recallWakeUp : explorer.done);
     }
 
     //Only procs when you have both perks. Rare.
@@ -857,20 +857,20 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
         menu();
         addButton(0, "Fight Her", promptFightMarae3).hint("Fight Marae the corrupted goddess!");
         addButton(1, "Stay With Her", maraeBadEnd).hint("Stay with Marae and end your adventures?");
-        addButton(4, "Leave", camp.returnToCampUseOneHour);
+        addButton(4, "Leave", explorer.done);
     }
 
     private function grabHerBoob():void {
         clearOutput();
         outputText("You reach forward to cop a feel. The goddess' eyes go wide with fury as a massive branch swings down, catching you in the sternum. It hits you hard enough that you land in your boat and float back a few feet into the water. Nothing to do but leave and hope for another chance at her breasts...");
         player.takePhysDamage(player.HP - 1);
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     private function runFromPervertedGoddess():void {
         clearOutput();
         outputText("You turn and run for the boat, leaving the corrupt goddess behind. High-pitched laugher seems to chase you as you row away from the island.");
-        doNext(recalling ? recallWakeUp : camp.returnToCampUseOneHour);
+        doNext(recalling ? recallWakeUp : explorer.done);
     }
 
     public function talkToMaraeAboutMinervaPurification():void {
@@ -890,7 +890,7 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
         player.createKeyItem("Marae's Seed", 0, 0, 0, 0);
         flags[kFLAGS.MINERVA_PURIFICATION_PROGRESS] = 3;
         flags[kFLAGS.MINERVA_PURIFICATION_MARAE_TALKED] = 2;
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 
     public function encounterPureMaraeEndgame():void {
@@ -907,7 +907,7 @@ public class MaraeScene extends AbstractBoatContent implements TimeAwareInterfac
         flags[kFLAGS.PURE_MARAE_ENDGAME] = 1;
         menu();
         addButton(0, "Bring it on!", initiateFightMarae).hint("Challenge Marae to a fight. This is going to be an extremely HARD boss fight! \n\nRecommended level: 60+");
-        addButton(1, "Not yet!", camp.returnToCampUseOneHour);
+        addButton(1, "Not yet!", explorer.done);
     }
 }
 }

--- a/classes/classes/Scenes/Places/HeXinDao.as
+++ b/classes/classes/Scenes/Places/HeXinDao.as
@@ -29,7 +29,7 @@ public class HeXinDao extends BaseContent
 	public var eraendirorsbulg:EraendirAndOrsbulg = new EraendirAndOrsbulg();
 
     public function HeXinDao() {}
-	
+
 	public function riverislandVillageStuff0():void {
 		spriteSelect(null);
         clearOutput();
@@ -77,7 +77,7 @@ public class HeXinDao extends BaseContent
 		clearOutput();
 		outputText("The local restaurant seems to be offering some local specialties, and best of all; it's free! Some " + flags[kFLAGS.LUNAR_NEW_YEAR_ANIMAL] + "-morphs are serving the meal. You proceed to grab a plate of these strange ravioli the people calls jiǎozi, taking the rice dessert they call niángāo right after. The meal is comforting. For a moment, you could believe everything in Mareth was going fine... Until you look up, into the red sky, clouds roiling above the festival.");
 		player.refillHunger(50);
-		eachMinuteCount(30);
+		advanceMinutes(30);
 		doNext(riverislandVillageStuffLunar);
 	}
 	public function riverislandVillageStuffLunarClothing():void {
@@ -300,7 +300,7 @@ public class HeXinDao extends BaseContent
 			}
 			outputText(" in your camp.</b>")
 		}
-		
+
 		function buyAlembic(tier:int, priceGems:int):void {
 			Crafting.alembicLevel = tier;
 			player.gems -= priceGems;
@@ -315,7 +315,7 @@ public class HeXinDao extends BaseContent
 			statScreenRefresh();
 			doNext(alchemyTools);
 		}
-		
+
 		menu();
 		button(0).show("Alembic I", curry(buyAlembic, Crafting.ALEMBIC_LEVEL_SIMPLE, Crafting.ALEMBIC_LEVELS[Crafting.ALEMBIC_LEVEL_SIMPLE].value))
 				 .hint("Buy a simple alembic to refine substances from ingredients.\n\nCost: "+Crafting.ALEMBIC_LEVELS[Crafting.ALEMBIC_LEVEL_SIMPLE].value+" gems.")
@@ -810,7 +810,7 @@ public class HeXinDao extends BaseContent
         statScreenRefresh();
         inventory.takeItem(itype, soulequipmentshelf5);
     }
-	
+
 	public function entranceToRiverDungeon():void {
 		clearOutput();
 		if (flags[kFLAGS.NEISA_FOLLOWER] == 0) {
@@ -866,7 +866,7 @@ public class HeXinDao extends BaseContent
         addButton(7, weaponsrange.SHURIKE.shortName, weaponrangeBuy2, weaponsrange.SHURIKE);
         addButton(14, "Back", ermaswiftarrowmerchant);
     }
-	
+
     private function weaponrangeBuy1(itype:ItemType):void {
         clearOutput();
         outputText("The centauress nods at your purchase and replies: \"<i>That'll be " + itype.value / 10 + " spirit stones.</i>\"");
@@ -903,7 +903,7 @@ public class HeXinDao extends BaseContent
         statScreenRefresh();
         inventory.takeItem(itype, ermaswiftarrowmerchantshelf2);
     }
-	
+
 	public function ermaswiftarrowmerchantarcherytraining():void {
 		clearOutput();
 		if (flags[kFLAGS.ERMA_ARCHERY_TRAINING] > 0) outputText("\"<i>Need more training? Sure, but it's 10 spirit stones, paid up front, if you would.</i>\"");
@@ -940,7 +940,7 @@ public class HeXinDao extends BaseContent
 			}
 		}
 	}
-	
+
 	public function qimerchant():void {
         clearOutput();
         outputText("After entering the shop with a sign saying 'Flying Swords are always with you!' over the doors you see a few shelves filled with various flying swords. ");
@@ -958,7 +958,7 @@ public class HeXinDao extends BaseContent
         addButton(14, "Back", riverislandVillageStuff);
         statScreenRefresh();
     }
-	
+
     private function flyingswordBuy(itype:ItemType):void {
         clearOutput();
         outputText("The flesh golem nods at your purchase and replies: \"<i>That'll be " + itype.value / 10 + " spirit stones.</i>\"");
@@ -1425,7 +1425,7 @@ public function soularena():void {
 		player.createKeyItem("Heavenly Tribulation: Myths and Facts", 0, 0, 0, 0);
 		doNext(camp.returnToCampUseTwoHours);
 	}
- 
+
 	public function mrsShigureLecturesFourth():void {
 		clearOutput();
 		flags[kFLAGS.SPIRIT_STONES] -= 20;
@@ -1486,7 +1486,7 @@ public function soularena():void {
 		player.createKeyItem("Cultivation Manual: Heart-shaped Eyed She-Devil", 0, 0, 0, 0);
 		doNext(missAkemiManualsShop);
 	}
-	
+
 	private function golemancershop():void {
 		clearOutput();
 		if (player.hasStatusEffect(StatusEffects.GolemancerShop)) {
@@ -1621,7 +1621,7 @@ public function soularena():void {
 		outputText("\"<i>Always happy to do business: Anything else you want to buy?</i>\"\n\n");
 		inventory.takeItem(odd, golemancershopRepeat);
 	}
-	
+
     public function restaurantShiraOfTheEast():void {
         clearOutput();
         outputText("You arrive at the exotic food restaurant, ‘Shira of the east’ and look at the menu posted on the outside. Would you like get something to eat?");

--- a/classes/classes/Scenes/Places/HeXinDao/JourneyToTheEast.as
+++ b/classes/classes/Scenes/Places/HeXinDao/JourneyToTheEast.as
@@ -229,7 +229,7 @@ public class JourneyToTheEast extends HeXinDaoAbstractContent implements Saveabl
 				player.statPoints -= 5;
 				player.perkPoints += 1;
 				doNext(enteringInn,false);
-				eachMinuteCount(30);
+				advanceMinutes(30);
 			}
 		}
 		private function workHoursTemptress():Boolean {
@@ -276,7 +276,7 @@ public class JourneyToTheEast extends HeXinDaoAbstractContent implements Saveabl
 				player.statPoints += 5;
 				player.perkPoints -= 1;
 				doNext(enteringInn,false);
-				eachMinuteCount(30);
+				advanceMinutes(30);
 			}
 		}
 

--- a/classes/classes/Scenes/Places/Ingnam.as
+++ b/classes/classes/Scenes/Places/Ingnam.as
@@ -16,13 +16,13 @@ public class Ingnam extends BaseContent
 		public var ingnamFarm:IngnamFarm = new IngnamFarm();
 		public var thiefScene:ThiefScene = new ThiefScene();
 		public var soulforce:Soulforce = new Soulforce();
-		
+
 		public function get inIngnam():Boolean { return flags[kFLAGS.IN_INGNAM]; }
-		
+
 		public function Ingnam()
 		{
 		}
-		
+
 		//Main Ingnam menu.
 		public function menuIngnam():void {
 			//Force autosave
@@ -87,7 +87,7 @@ public class Ingnam extends BaseContent
             }
 			if (player.hasPerk(PerkLib.JobSoulCultivator)) addButton(10, "Soulforce", soulforce.accessSoulforceMenu).hint("Spend some time on the cultivation or spend some of the soulforce.");
 		}
-		
+
 		//The end of prologue, starts the game.
 		public function getBanishedToMareth():void {
 			var hasWeapon:Boolean = false;
@@ -98,33 +98,33 @@ public class Ingnam extends BaseContent
 			flags[kFLAGS.INGNAM_PROLOGUE_COMPLETE] = 1;
 			doNext(CoC.instance.charCreation.arrival);
 		}
-		
+
 		public function returnToMareth():void {
 			clearOutput();
 			outputText("You make your journey to Mount Ilgast, walk through the portal back to Mareth and return to your camp.");
 			flags[kFLAGS.IN_INGNAM] = 0;
 			doNext(camp.returnToCampUseOneHour);
 		}
-		
+
 		public function returnToIngnam():void {
 			clearOutput();
 			outputText("You enter the portal and make your return to Ingnam, thanks to the debug powers.");
 			flags[kFLAGS.IN_INGNAM] = 1;
 			doNext(camp.returnToCampUseOneHour);
 		}
-		
+
 		//Explore Ingnam
 		public function exploreIngnam():void {
 			hideMenus();
 			clearOutput();
 			if (rand(4) == 0) {
 				outputText("You explore the village of Ingnam for a while but you don't find anything interesting.");
-				eachMinuteCount(15);
+				advanceMinutes(15);
 				doNext(camp.doCamp);
 			}
 			else thiefScene.encounterThief();
 		}
-		
+
 		//Shopping time!
 		public function menuShops():void {
 			hideMenus();
@@ -138,7 +138,7 @@ public class Ingnam extends BaseContent
 			addButton(4, "Black Market", shopBlackMarket);
 			addButton(14, "Back", menuIngnam);
 		}
-		
+
 		public function shopBlacksmith():void {
 			clearOutput();
 			outputText("You enter the armor shop, noting the sign depicting armors. Some armor is proudly displayed on racks. You can hear the sound of hammering although it stops shortly after you enter. The local blacksmith, Ben, comes from the rear door, stepping up to the counter as he wipes the sweat from his brow, face red from the heat of his forge. \"<i>Welcome to my shop. Are you in need of protection? Or something sharp?</i>\"");
@@ -177,7 +177,7 @@ public class Ingnam extends BaseContent
 			addShopItem(weapons.A_WAND, 225, 2);
 			addButton(14, "Leave", menuShops);
 		}
-		
+
 		public function shopTailor():void {
 			clearOutput();
 			outputText("You enter the tailor’s. The interior is laden with mannequins wearing half-finished works. Clothes are displayed on racks without obvious flaws. A fastidious, well-groomed young man with an immaculate blue three-piece suit topped with a measuring tape draping around his collar stands behind the counter and smiles at you with deference.");
@@ -195,7 +195,7 @@ public class Ingnam extends BaseContent
 			addShopItem(armors.T_BSUIT, 75, 3);
 			addButton(14, "Leave", menuShops);
 		}
-		
+
 		public function shopAlchemist():void {
 			clearOutput();
 			if (flags[kFLAGS.INGNAM_ALCHEMIST_TALKED] <= 0) {
@@ -228,7 +228,7 @@ public class Ingnam extends BaseContent
 			}
 			addButton(14, "Leave", menuShops);
 		}
-		
+
 		public function shopTradingPost():void {
 			clearOutput();
 			outputText("The trading post is one of the larger buildings in the village, with its porch covered in barrels filled with pickled goods, preserved delicacies and dried goods, from the humble local farm to exotic faraway lands. The interior is packed with crowded shelves that boast a variety of goods, all arranged neatly on shelves.");
@@ -355,7 +355,7 @@ public class Ingnam extends BaseContent
 			statScreenRefresh();
 			doNext(sellAtTradingPost);
 		}
-		
+
 		public function shopBlackMarket():void {
 			clearOutput();
 			if (flags[kFLAGS.INGNAM_BLACKMARKET_TALKED] <= 0) {
@@ -380,7 +380,7 @@ public class Ingnam extends BaseContent
 			addShopItem(consumables.RINGFIG, 75, 6);
 			addButton(14, "Leave", menuShops);
 		}
-		
+
 		//Transaction for buying items.
 		public function transactionItemConfirmation(item:ItemType, price:int, shop:int):void {
 			clearOutput();
@@ -430,7 +430,7 @@ public class Ingnam extends BaseContent
 			else if (shop == 6) shopBlackMarket();
 			else shopBlackMarket();
 		}
-		
+
 		public function addShopItem(item:ItemType, price:int, shop:int):void {
 			outputText("\n" + capitalizeFirstLetter(item.longName) + " - " + price + " gems");
 			var button:int = 0;
@@ -439,7 +439,7 @@ public class Ingnam extends BaseContent
 			}
 			addButton(button, item.shortName, transactionItemConfirmation, item, price, shop);
 		}
-		
+
 		//Temple
 		public function menuTemple():void {
 			hideMenus();
@@ -452,7 +452,7 @@ public class Ingnam extends BaseContent
 			addButton(0, "Meditate", SceneLib.masturbation.meditate);
 			addButton(14, "Leave", menuIngnam);
 		}
-		
+
 		//Tavern
 		public function menuTavern():void {
 			hideMenus();
@@ -473,7 +473,7 @@ public class Ingnam extends BaseContent
 			//if (player.hasPerk(PerkLib.HistoryWhore)) addButton(5, "Prostitute", whoreForGems).hint("Seek someone who's willing to have sex with you for profit.");
 			addButton(14, "Leave", menuIngnam);
 		}
-		
+
 		public function welcomeBack():void {
 			clearOutput();
 			outputText("The innkeeper looks at you and says, \"<i>Welcome back! I've missed you! How did your adventures go?</i>\"");
@@ -496,7 +496,7 @@ public class Ingnam extends BaseContent
 			flags[kFLAGS.INGNAM_GREETED_AFTER_LONGTIME] = 1;
 			doNext(menuTavern);
 		}
-		
+
 		public function appearanceFreakout():void {
 			clearOutput();
 			outputText("The innkeeper stands up to see that there's something unusual with your appearance.");
@@ -525,7 +525,7 @@ public class Ingnam extends BaseContent
 			doNext(menuTavern);
 		}
 
-		
+
 		public function orderDrink():void {
 			clearOutput();
 			outputText("What kind of drink would you like?");
@@ -540,7 +540,7 @@ public class Ingnam extends BaseContent
 			addButton(2, "Root Beer", buyRootBeer);
 			addButton(14, "Back", menuTavern);
 		}
-		
+
 		public function buyBeer():void {
 			clearOutput();
 			if (player.gems < 5) {
@@ -613,7 +613,7 @@ public class Ingnam extends BaseContent
 			cheatTime(1/12);
 			doNext(menuTavern);
 		}
-		
+
 		public function orderFood():void { //Order food, because you need to be able to fill hunger.
 			clearOutput();
 			outputText("You take a seat and look at the menu. What would you like?");
@@ -629,7 +629,7 @@ public class Ingnam extends BaseContent
 			addButton(3, "Trail Mix", buyTrailMix);
 			addButton(14, "Back", menuTavern);
 		}
-		
+
 		public function buySandwich():void { //Eat sandwich, refill hunger. The reason it's ambiguous is to let you imagine what sandwich you're eating.
 			clearOutput();
 			if (player.gems < 5) {
@@ -645,7 +645,7 @@ public class Ingnam extends BaseContent
 			cheatTime(1/12);
 			doNext(menuTavern);
 		}
-		
+
 		public function buySoup():void { //Eat soup. Again, it's vague to let you imagine what soup you're eating.
 			clearOutput();
 			if (player.gems < 3) {
@@ -661,7 +661,7 @@ public class Ingnam extends BaseContent
 			cheatTime(1/12);
 			doNext(menuTavern);
 		}
-		
+
 		private function buyHardBiscuits():void {
 			clearOutput();
 			if(player.gems < 5) {
@@ -687,7 +687,7 @@ public class Ingnam extends BaseContent
 			statScreenRefresh();
 			inventory.takeItem(consumables.TRAILMX, orderFood);
 		}
-		
+
 		public function hearRumors():void { //Hear rumors. Will be altered after defeating Lethice so he will say "Welcome back".
 			clearOutput();
 			var rumor:int = rand(4);
@@ -712,7 +712,7 @@ public class Ingnam extends BaseContent
 			}
 			doNext(camp.returnToCampUseOneHour);
 		}
-		
+
 	}
 
 }

--- a/classes/classes/Scenes/Places/Ingnam/ThiefScene.as
+++ b/classes/classes/Scenes/Places/Ingnam/ThiefScene.as
@@ -3,14 +3,14 @@ package classes.Scenes.Places.Ingnam
 	import classes.*;
 	import classes.GlobalFlags.*;
 	import classes.Items.*;
-	
+
 	public class ThiefScene extends BaseContent
 	{
-		
+
 		public function ThiefScene()
 		{
 		}
-		
+
 		public function encounterThief():void {
 			clearOutput();
 			outputText("You wander the village of Ingnam until you feel something pressing against your shoulder and you look around to see the thief. \"<i>Your money or your life,</i>\" he demands.");
@@ -18,7 +18,7 @@ package classes.Scenes.Places.Ingnam
 			addButton(0, "Fight", startCombatImmediate, new Thief);
 			addButton(1, "Give Gems", giveGems);
 		}
-		
+
 		private function giveGems():void {
 			clearOutput();
 			outputText("You reach into your gem pouch");
@@ -34,10 +34,10 @@ package classes.Scenes.Places.Ingnam
 				player.gems -= 5;
 			}
 			statScreenRefresh();
-			eachMinuteCount(15);
+			advanceMinutes(15);
 			doNext(camp.doCamp);
 		}
-		
+
 		public function winAgainstThief():void {
 			clearOutput();
 			outputText("The thief collapses from his " + (monster.lust >= monster.maxOverLust() ? "overwhelming desires": "injuries") + ". You smile in satisfaction as you rummage through his gem pouch");
@@ -60,10 +60,10 @@ package classes.Scenes.Places.Ingnam
 		}
 		private function thiefEncEnd():void {
 			cleanupAfterCombat();
-			eachMinuteCount(15);
+			advanceMinutes(15);
 			doNext(camp.doCamp);
 		}
-		
+
 		private function rapeThiefAnally():void {
 			var x:int = player.cockThatFits(monster.analCapacity());
 			clearOutput();
@@ -74,10 +74,10 @@ package classes.Scenes.Places.Ingnam
 			player.orgasm();
 			cleanupAfterCombat();
 			statScreenRefresh();
-			eachMinuteCount(15);
+			advanceMinutes(15);
 			doNext(camp.doCamp);
 		}
-		
+
 		private function getLicked():void {
 			clearOutput();
 			outputText("You drag the unconscious thief into one of the alleys. The thief wakes up and realize what you're going to do. You " + (!player.armor.isNothing || !player.lowerGarment.isNothing ? "remove the bottom half of your [armor]" : "") + " to reveal your [vagina]" + (player.hasCock() ? " and " + player.cockDescript(): "") + ".");
@@ -88,7 +88,7 @@ package classes.Scenes.Places.Ingnam
 			player.orgasm();
 			cleanupAfterCombat();
 			statScreenRefresh();
-			eachMinuteCount(15);
+			advanceMinutes(15);
 			doNext(camp.doCamp);
 		}
 	}

--- a/classes/classes/Scenes/Places/TrollVillage/Kuru.as
+++ b/classes/classes/Scenes/Places/TrollVillage/Kuru.as
@@ -95,7 +95,7 @@ public class Kuru extends TrollVillageAbstractContent{
         else{
             outputText("You decide to head home for the time being\n");
         }
-        doNext(camp.returnToCampUseOneHour);
+        endEncounter();
     }
 }
 }


### PR DESCRIPTION
Updates:
* Encounters take time during map exploration.
* Mining and other similar events do not return you to camp.
* Character doll is updated when doing map exploration.
* Converted Boat area.
Bugfixes:
* Fixed invalid alchemical reagents. They should not appear and will be silently deleted if found in a save file.
* Fixed multiple encounters not finished properly.
Code changes:
* endEncounter() and explorer.done() can take optional argument - how many minutes passed
* eachMinuteCount renamed to advanceMinutes