### PR TITLE
no more player.level handling of negative

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -229,16 +229,6 @@ use namespace CoC;
 		public var tempInt:Number = 0;
 		public var tempWis:Number = 0;
 		public var tempLib:Number = 0;
-
-		override public function get level():Number 
-		{
-			return super.level;
-		}
-		override public function set level(value:Number):void
-		{
-			if (value > CoC.instance.levelCap) value = CoC.instance.levelCap;
-			super.level = value;
-		}
 		
 		//Player pregnancy variables and functions
 		private var pregnancy:Pregnancy = new Pregnancy();

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -236,33 +236,8 @@ use namespace CoC;
 		}
 		override public function set level(value:Number):void
 		{
-			// Handle negativeLevels, and when more than 1 level is granted
-			// There is more elegant writing but this is more readable
-			
-			// 0 for Character creation
-			if (value == 0) super.level = 0;
-			// discard negative/fractions; use setLevelDirectly(x) for those poor choices
-			if (value < 1) return;
-			// If wanting to set player level directly, use setLevelDirectly(x)
-			value = value - super.level; // value will almost always be passed as level+1, so this will almost always be 1
-			if (value > 1) { // levels should be going through levelUp but if passed directly this will handle it
-				// TODO: (lvl) In theory supports custom characters out of the box, since they overwrite their stat/perk points after if non-default anyway; but double-check.
-				while (negativeLevel > 0 && value > 0) {
-					negativeLevel -= 1;
-					value -= 1;
-				}
-				while (value > 0) {
-					value -= 1;
-					CoC.instance.playerInfo.levelUp(true); // dancing around in circles until my little feet fall off
-				}
-			} else if (value == 1) {
-				// Everything below this line are what is usually run for any player level up
-				if (negativeLevel > 0) {
-					negativeLevel -= 1;
-				} else {
-					if (super.level < CoC.instance.levelCap) super.level = super.level + 1;
-				}
-			}
+			if (value > CoC.instance.levelCap) value = CoC.instance.levelCap;
+			super.level = value;
 		}
 		
 		//Player pregnancy variables and functions

--- a/classes/classes/PlayerInfo.as
+++ b/classes/classes/PlayerInfo.as
@@ -1522,6 +1522,12 @@ public class PlayerInfo extends BaseContent {
 		player.perkPoints += gainedPerks;
 		player.statPoints += gainedStats;
 	}
+	public function levelUpTo(value:int):void {
+		if (value > player.level) lUFSMM(value-player.level, true);
+	}
+	public function levelUpMultipleTimes(value:int):void {
+		lUFSMM(value, true);
+	}
 	
 	public function levelUpMenu():void {
 		clearOutput();
@@ -1595,13 +1601,13 @@ public class PlayerInfo extends BaseContent {
 		addButton(4, "LvlMax", lUFSMM, CoC.instance.levelCap);
 		addButton(14, "Done", lUFSMAP);
 	}
-	public function lUFSMM(incmax:int = CoC.instance.levelCap):void {
-		if (player.negativeLevel > 0 && player.XP >= player.requiredXP()) outputText("\n<b>Recovered negative levels.</b>");
+	public function lUFSMM(incmax:int = CoC.instance.levelCap, noxpcost:Boolean = false ):void {
+		if (player.negativeLevel > 0 && (player.XP >= player.requiredXP() || noxpcost)) outputText("\n<b>Recovered negative levels.</b>");
 		if (incmax == CoC.instance.levelCap) incmax += player.negativeLevel;
 		for (var i:int = 1; i <= incmax; i++) {
-			if (player.XP >= player.requiredXP() && (player.level < CoC.instance.levelCap || player.negativeLevel > 0)) levelUp();
+			if ((player.XP >= player.requiredXP() || noxpcost) && (player.level < CoC.instance.levelCap || player.negativeLevel > 0)) levelUp(noxpcost);
 		}
-		if (flags[kFLAGS.LVL_UP_FAST] == 1) levelUpFastMenu(true);
+		if (flags[kFLAGS.LVL_UP_FAST] == 1 && !noxpcost) levelUpFastMenu(true);
 	}
 	public function lUFSMAP():void {
 		if (player.statPoints > 0) {

--- a/classes/classes/PlayerInfo.as
+++ b/classes/classes/PlayerInfo.as
@@ -235,7 +235,7 @@ public class PlayerInfo extends BaseContent {
 		}
 		miscStats += "<b>Ebon Labyrinth:</b> Explored up to " + flags[kFLAGS.EBON_LABYRINTH_RECORD] + " room\n";
 		miscStats += "<b>Exp needed to lvl up:</b> ";
-		if (player.level < CoC.instance.levelCap) miscStats += "" + player.requiredXP() + "\n";
+		if (player.level < CoC.instance.levelCap || player.negativeLevel > 0) miscStats += "" + player.requiredXP() + "\n";
 		else miscStats += "N/A (You already at max lvl)\n";
 		miscStats += "<b>Ascension points (currently possessed):</b> " + player.ascensionPerkPoints + "\n";
 		miscStats += "<b>Ascension points (possible to gain during next ascension):</b> " + camp.possibleToGainAscensionPoints() + "\n";
@@ -1505,9 +1505,10 @@ public class PlayerInfo extends BaseContent {
 	public function levelUp(ignoreXPCost:Boolean = false):void {
 		if (!ignoreXPCost) player.XP -= player.requiredXP(); // Custom characters?
 		if (player.negativeLevel > 0) {
-			player.level += 1; // handles level cap and negative levels automatically in Player.as
+			player.negativeLevel -= 1;
 			return; // if player had negative, leave
 		}
+		if (player.level >= CoC.instance.levelCap) return;
 		player.level += 1; 
 		HPChange(player.maxHP(), false);
 		//if (player.level % 2 == 0) player.ascensionPerkPoints++;
@@ -1521,6 +1522,7 @@ public class PlayerInfo extends BaseContent {
 		player.perkPoints += gainedPerks;
 		player.statPoints += gainedStats;
 	}
+	
 	public function levelUpMenu():void {
 		clearOutput();
 		hideMenus();
@@ -1571,10 +1573,20 @@ public class PlayerInfo extends BaseContent {
 			doNext(playerMenu);
 		}
 	}
-	public function levelUpFastMenu():void {
+	public function levelUpFastMenu(leveled:Boolean=false):void {
 		spriteSelect(null);
-		outputText("Fast leveling, click the button repeatedly to level up that many times. Press LvlMax to instantly spend all experience.");
+		statScreenRefresh();
+		clearOutput();
+		outputText("\nFast leveling, click the button repeatedly to level up that many times. Press LvlMax to instantly spend all experience.");
 		outputText("\n\nPressing \"Done\" will bring you to stat/perk allocation.");		
+		if (leveled) {			
+			if (player.negativeLevel == 0) {
+				outputText("\n\n<b>You are now level " + num2Text(player.level) + "!</b>");
+				outputText("\n\nYou have " + num2Text(player.statPoints) + " attribute points and " + num2Text(player.perkPoints) + " perk point" + (player.perkPoints > 1 ? "s":"") + "!");
+			} else {
+				outputText("\n\n"+Num2Text(player.negativeLevel,100)+" negative level"+(player.negativeLevel > 1 ? "s" : "")+" remaining.");
+			}
+		}
 		menu();
 		addButton(0, "Lvl +1", lUFSMM, 1);
 		addButton(1, "Lvl +2", lUFSMM, 2);
@@ -1589,14 +1601,7 @@ public class PlayerInfo extends BaseContent {
 		for (var i:int = 1; i <= incmax; i++) {
 			if (player.XP >= player.requiredXP() && (player.level < CoC.instance.levelCap || player.negativeLevel > 0)) levelUp();
 		}
-		if (player.negativeLevel == 0) {
-			outputText("\n<b>You are now level " + num2Text(player.level) + "!</b>");
-			outputText("\n\nYou have " + num2Text(player.statPoints) + " attribute points and " + num2Text(player.perkPoints) + " perk point" + (player.perkPoints > 1 ? "s":"") + "!");
-		} else {
-			outputText("\n\n"+Num2Text(player.negativeLevel,100)+" negative level"+(player.negativeLevel > 1 ? "s" : "")+" remaining.");
-		}
-		statScreenRefresh();
-		if (flags[kFLAGS.LVL_UP_FAST] == 1) levelUpFastMenu();
+		if (flags[kFLAGS.LVL_UP_FAST] == 1) levelUpFastMenu(true);
 	}
 	public function lUFSMAP():void {
 		if (player.statPoints > 0) {

--- a/classes/classes/Scenes/TestMenu.as
+++ b/classes/classes/Scenes/TestMenu.as
@@ -2313,13 +2313,11 @@ public class TestMenu extends BaseContent
 	public function addsubLvl(type:String, cAmt:int):void{
 		clearOutput();
 		if (type == "Lvl"){
-			for (var i:int = 0; i < cAmt; i++){
-				CoC.instance.playerInfo.levelUp(true);
-			}
+			CoC.instance.playerInfo.levelUpMultipleTimes(cAmt);
 			outputText("\n\n<b>You now have " + player.level + " levels!</b>");
 		}
 		else if (type == "DLvl"){
-			player.setLevelDirectly(player.level-cAmt);
+			player.level -= cAmt;
 			outputText("\n\n<b>You have lost " + cAmt + " levels and are now " + player.level + "!</b>");
 		}
 		doNext(LevelDeLevel);

--- a/classes/coc/view/StatsView.as
+++ b/classes/coc/view/StatsView.as
@@ -343,7 +343,7 @@ public class StatsView extends Block {
 		corner.advancementText.htmlText = "<b>Advancement</b>";
 		corner.levelBar.value           = player.level;
 		if (player.negativeLevel) corner.levelBar.valueText = "(-" + player.negativeLevel + ") " + player.level;
-		if (player.level < CoC.instance.levelCap) {
+		if (player.level < CoC.instance.levelCap || player.negativeLevel > 0) {
 			corner.xpBar.maxValue = player.requiredXP();
 			corner.xpBar.value    = player.XP;
 		} else {


### PR DESCRIPTION
no more player.level handling of player.negativeLevel or level cap
~~forced to use for(){levelUp(true)} to properly up levels w/ perk/stat/neg~~ levelUpTo(x)/levelUpMultipleTimes(x)
do not "award" player.level without calling levelUp(true) or others, because perk/stat/neg rewards may change for balance
~~and player.level custom getter/setter reverted to cap only~~ cap only in levelUp()
~~can still set player above cap with setLevelDirectly(n), with no rewards~~ yes but /shrug, pointless, remains incase ever overriding Creature.level again I guess

Level +1, rewards+neg handling, no xp cost: levelUp(true)
Level +1, rewards+neg handling, xp cost: levelUp()
Level +x (including 1), rewards+neg handling, no xp cost: ~~for(x){levelUp(true)}~~ levelUpMultipleTimes(x)
Set level to x, rewards+neg handling, no xp cost: levelUpTo(x)
Level +x (including 1), rewards+neg handling, xp cost: for(x){levelUp()}
Level +1, no rewards, no neg handling: player.level++
Level +x (including 1), no rewards, no neg handling: player.level += x
~~All previous are capped to levelCap, setting player above requires setLevelDirectly(x) or setLevelDirectly(player.level+x)~~
player.negativeLevel:int is neg tracking for manual handling