### PR TITLE
Master wip

### DIFF
--- a/classes/classes/Scenes/Areas/HighMountains/PhoenixScene.as
+++ b/classes/classes/Scenes/Areas/HighMountains/PhoenixScene.as
@@ -51,6 +51,7 @@ public class PhoenixScene extends BaseContent
 		
 		//VICTORY!
 		public function winAgainstPhoenix(many:Boolean = false):void {
+			clearOutput();
 			flags[kFLAGS.PHOENIX_HP_LOSS_COUNTER] = 0; //Reset counter if you win.
 			if (many) outputText("With one final grunt, the quasi-phoenixes collapses, barely able to support themself. The once-proud soldiers has been reduced to a " + (monster.lust >= monster.maxOverLust() ? "dazed, lust-crazed sluts, desperately pulling at their clothing in a mad attempt to expose themself": "a beaten, battered heap; completely unable to resist your advances") + ". Still most of them seems to have some strength left as all lift off leaving behind one of them pressumable the weakest one. ");
 			else outputText("With one final grunt, the quasi-phoenix collapses against a nearby rock, barely able to support herself. The once-proud soldier has been reduced to a " + (monster.lust >= monster.maxOverLust() ? "dazed, lust-crazed slut, desperately pulling at her clothing in a mad attempt to expose herself": "a beaten, battered heap; completely unable to resist your advances") + ". ");

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1750,6 +1750,7 @@ public class Combat extends BaseContent {
 
     public function baseelementalattacks(elementType:int = -1):void {
         if (elementType == -1) {
+            clearOutput();
             elementType = flags[kFLAGS.ATTACKING_ELEMENTAL_TYPE];
         } /*else {
             flags[kFLAGS.ATTACKING_ELEMENTAL_TYPE] = elementType;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -2020,6 +2020,8 @@ public class Combat extends BaseContent {
 				}
 			}
         } else {
+            //If monster is dead, prevent further elemental attack calls
+            flags[kFLAGS.IN_COMBAT_PLAYER_ELEMENTAL_ATTACKED] = 2;
             if (monster.HP <= monster.minHP()) doNext(endHpVictory);
             else doNext(endLustVictory);
         }


### PR DESCRIPTION
The menu for choosing an Elemental attack will now no longer appear is the enemy is already dead.
Using an attack helped by an Elemental will now properly clear previous text.
Defeating a Phoenix will now have their defeated scene properly clear previous text.