### PR TITLE
Lycanthropy Issue Fix

### DIFF
--- a/classes/classes/Races/WerewolfRace.as
+++ b/classes/classes/Races/WerewolfRace.as
@@ -5,6 +5,7 @@ import classes.IMutations.IMutationsLib;
 import classes.PerkLib;
 import classes.Race;
 import classes.VaginaClass;
+import classes.internals.race.RaceUtils;
 
 public class WerewolfRace extends Race {
     public static const RaceBody:/*String*/Array = [
@@ -55,13 +56,14 @@ public class WerewolfRace extends Race {
 				.corruption(AT_LEAST(20), +1)
 				.corruption(AT_LEAST(50), +1)
 				.corruption(AT_LEAST(80), +1)
-				.hasPerk(PerkLib.Lycanthropy, +2, -11);
+				.hasAnyPerk([PerkLib.Lycanthropy, PerkLib.LycanthropyDormant], +2, -11);
 		
 		addMutation(IMutationsLib.FerasBirthrightIM);
 		addMutation(IMutationsLib.AlphaHowlIM);
 		
 		buildTier(12, "werewolf")
-                .requirePerk(PerkLib.Lycanthropy)
+				.require("Lycanthropy or Dormant Lycanthropy perk", 
+					RaceUtils.hasAnyPerkFn([PerkLib.Lycanthropy, PerkLib.LycanthropyDormant]))
 				.buffs({
 					"str.mult": +1.00,
 					"tou.mult": +0.60,


### PR DESCRIPTION
A player whose werewolf score has gone under 12 while having the Dormant Lycanthropy perk can now become a werewolf again upon increasing their racial score once more.