### PR TITLE
Were Race Fixes

### DIFF
--- a/classes/classes/Races/WerefoxRace.as
+++ b/classes/classes/Races/WerefoxRace.as
@@ -6,6 +6,7 @@ import classes.GeneticMemories.RaceMem;
 import classes.IMutations.IMutationsLib;
 import classes.PerkLib;
 import classes.Race;
+import classes.internals.race.RaceUtils;
 
 public class WerefoxRace extends Race {
     public static const RaceBody:/*String*/Array = [
@@ -59,12 +60,13 @@ public class WerefoxRace extends Race {
 				.skinCoatType(Skin.FUR, +1)
 				.rearType(RearBody.WOLF_COLLAR, +1)
 				.noWings(+4)
-				.hasPerk(PerkLib.Vulpesthropy, +2, -11);
+				.hasAnyPerk([PerkLib.Vulpesthropy, PerkLib.VulpesthropyDormant], +2, -11);
 		
 		addMutation(IMutationsLib.WhiteFacedOneBirthrightIM);
 		
 		buildTier(12, "werefox cub")
-                .requirePerk(PerkLib.Vulpesthropy)
+				.require("Vulpesthropy or Dormant Vulpesthropy perk", 
+					RaceUtils.hasAnyPerkFn([PerkLib.Vulpesthropy, PerkLib.VulpesthropyDormant]))
 				.buffs({
 					"str.mult": +0.10,
 					"tou.mult": +1.00,

--- a/classes/classes/Races/WeresharkRace.as
+++ b/classes/classes/Races/WeresharkRace.as
@@ -8,6 +8,7 @@ import classes.IMutations.IMutationsLib;
 import classes.PerkLib;
 import classes.Race;
 import classes.VaginaClass;
+import classes.internals.race.RaceUtils;
 
 public class WeresharkRace extends Race {
     public static const WeresharkScaleColors:/*String*/Array = ["rough gray","dark gray","iridescent gray","ashen grayish-blue","gray"];
@@ -60,12 +61,14 @@ public class WeresharkRace extends Race {
 				.corruption(AT_LEAST(20), +1)
 				.corruption(AT_LEAST(50), +1)
 				.corruption(AT_LEAST(80), +1)
-				.hasPerk(PerkLib.Selachimorphanthropy, +2, -11);
+				.hasAnyPerk([PerkLib.Selachimorphanthropy, PerkLib.SelachimorphanthropyDormant], +2, -11);
 		
 		addMutation(IMutationsLib.FerasBirthrightIM);
 		addMutation(IMutationsLib.SharkOlfactorySystemIM);
 		
 		buildTier(12, "wereshark")
+				.require("Selachimorphanthropy or Dormant Selachimorphanthropy perk", 
+					RaceUtils.hasAnyPerkFn([PerkLib.Selachimorphanthropy, PerkLib.SelachimorphanthropyDormant]))
 				.buffs({
 					"str.mult": +0.90,
 					"tou.mult": +0.50,


### PR DESCRIPTION
Wereshark Race now takes Dormant Selachimorphanthropy into account for racial scores

Werefox Race now takes Dormant Vulpesthropy into account for racial scores