### PR TITLE
CI - Add in discord notification for auto reporting build success/fail + direct link to the compiled apks

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -73,3 +73,10 @@ jobs:
         with:
           name: mobile-arm8-64bit-apk
           path: target/CoC-Mobile-armv8.apk
+
+      - name: Discord notification to channel
+        uses: sarisia/actions-status-discord@v1
+        if: always()
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+        continue-on-error: true


### PR DESCRIPTION
Requires 1 secret,for the specific discord channel webhook, to tell it where to send the message for success/fail + download link.

**_Make sure you set up the secrets before pulling this!_**