### PR TITLE
Warden Weapon Fixes

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -15990,7 +15990,7 @@ public final class Mutations extends MutationsHelper {
         if (!player.hasPerk(PerkLib.Insanity) && changes < changeLimit) {
             outputText("[pg]");
             outputText(" You begin to laugh uncontrollably. Wow how stupid have you been acting until now. Reality has unfolded before your eyes in a whole new manner and as the magic of wonderland begins to fully seep into your formerly logical, short sighted, desperately stubborn mind you open to a whole new perspective of the world you didn't have access to, the diagonal one. See most people look up down left or right but what about the area in between or the area behind? ");
-			outputText("People might say you make no sense, that you're crazy but at the end of the day they are just blind idiots trying to make sense of a reality they have no access to. You've seen it all and understand it all.  (<b>Gained Perk: Dragon lust poison breath!</b>)");
+			outputText("People might say you make no sense, that you're crazy but at the end of the day they are just blind idiots trying to make sense of a reality they have no access to. You've seen it all and understand it all.  (<b>Gained Perk: Insanity!</b>)");
             player.createPerk(PerkLib.Insanity,0,0,0,0);
             changes++;
         }

--- a/classes/classes/Items/WeaponRange.as
+++ b/classes/classes/Items/WeaponRange.as
@@ -41,24 +41,16 @@ public class WeaponRange extends Equipable
 		
 		public function get perk():String { return _perk; }
 		
-		override public function get description():String {
-			var desc:String = _description;
-			//Type
-			desc += "\n\nType: Range Weapon ";
-			if (perk == "Bow") desc += "(Bow)";
-			else if (perk == "Crossbow") desc += "(Crossbow)";
-			else if (perk == "Pistol") desc += "(Pistol)";
-			else if (perk == "Rifle") desc += "(Rifle)";
-			else if (perk == "2H Firearm") desc += "(2H Firearm)";
-			else if (perk == "Dual Firearms") desc += "(Dual Firearms)";
-			else if (perk == "Dual 2H Firearms") desc += "(Dual 2H Firearms)";
-			else if (perk == "Throwing") desc += "(Throwing)";
-			else if (perk == "Tome") desc += "(Tome)";
-			//Attack
-			desc += "\nRange Attack: " + String(attack);
-			//Value
-			desc += "\nBase value: " + String(value);
-			return desc;
+		override public function effectDescriptionParts():Array {
+			var list:Array = super.effectDescriptionParts();
+			// Type
+			list.push([10,"Type: Range Weapon"]);
+			if (perk != "") {
+				list.push([15, "Weapon Class: " + perk]);
+			}
+			// Attack
+			list.push([20,"Attack: "+attack]);
+			return list;
 		}
 		
 		override public function canEquip(doOutput:Boolean):Boolean {

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -3349,7 +3349,7 @@ public class PerkLib
 
 		// Melee & Range weapon perks
 		public static const BladeWarden:PerkType = mk("Blade-Warden", "Blade-Warden",
-				"Enables Resonance Volley soul skill while equipped: Perform a ranged attack where each arrow after the first gets an additional 10% accuracy for every arrow before it.",null,true);
+				"Enables Blade Dance soul skill while equipped: Attack twice (four times if double attack is active, six times if triple attack is active and etc.).",null,true);
 		public static const CowGunslingerOutfit:PerkType = mk("Cow Gunslinger Outfit", "Cow Gunslinger Outfit",
 			"Increase the damage of all gun attack and increase milk production by 50%.",null,true);
 		public static const CowGunslingerHat:PerkType = mk("Cow Gunslinger Hat", "Cow Gunslinger Hat",
@@ -3359,7 +3359,7 @@ public class PerkLib
 		public static const InariBlessedKimono:PerkType = mk("Inari Blessed Kimono", "Inari Blessed Kimono",
 				"Increase the potency of all spells and soulskills by up to 100% based on purity and empower all enlighted kitsunes abilities. Reduce spellcasting cost by 60%.",null,true);
 		public static const MageWarden:PerkType = mk("Mage-Warden", "Mage-Warden",
-				"Enables Resonance Volley soul skill while equipped: Perform a ranged attack where each arrow after the first gets an additional 10% accuracy for every arrow before it.",null,true);
+				"Enables Avatar Of the Song soul skill while equipped: Doublecast Charged Weapon and Might. Casts blind if Charged Weapon is already active. Casts Heal if Might is already active.",null,true);
 		public static const StrifeWarden:PerkType = mk("Strife-Warden", "Strife-Warden",
 				"Enables Beat of War soul skill while equipped: Attack with low-moderate additional soul damage, gain strength equal to 15% your base strength until end of battle. This effect stacks.",null,true);
 		public static const TamamoNoMaeCursedKimono:PerkType = mk("Tamamo no Mae Cursed Kimono", "Tamamo no Mae Cursed Kimono",

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -249,7 +249,7 @@ use namespace CoC;
 				return;
 			}
 			if (CoC.instance.inCombat) SceneLib.combat.combatMenu(false);
-			playerMenu();
+			else playerMenu();
 		}
 		
 		public function showItemTooltipLinkHandler(itemid:String):void {


### PR DESCRIPTION
[Warden Weapons now display their correct SoulSkill
Changed the description display function of Ranged Weapons so their format matches Melee Weapons