### PR TITLE
Enemy Temp Resolute Perk Implementation

### DIFF
--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -175,6 +175,9 @@ import flash.utils.getQualifiedClassName;
 		public var special2:Function = null;
 		public var special3:Function = null;
 
+		//Amount of turns an enemy may gain a temporary resolute perk coming out of stun
+		public var resoluteBuffDuration:int = 2; 
+
 		/**
 		 * Monster ability descriptors.
 		 * Structure:
@@ -2012,6 +2015,14 @@ import flash.utils.getQualifiedClassName;
 					addStatusValue(StatusEffects.AbilityCooldown4,1,-1);
 				}
 			}
+			if (hasTempResolute()) {
+				var currentDuration:int = getPerkValue(PerkLib.Resolute, 4);
+				if (currentDuration <= 0) {
+					clearTempResolute();
+				} else {
+					setPerkValue(PerkLib.Resolute, 4, currentDuration - 1);
+				}
+			}
 			if (hasStatusEffect(StatusEffects.Lustzerking)) {
 				this.wrath += 5;
 				if (statusEffectv1(StatusEffects.Lustzerking) > 1) addStatusValue(StatusEffects.Lustzerking, 1, -1);
@@ -2304,10 +2315,14 @@ import flash.utils.getQualifiedClassName;
 		protected function handleStun():Boolean
 		{
 			interruptAbility();
-			if (statusEffectv1(StatusEffects.Stunned) <= 0) removeStatusEffect(StatusEffects.Stunned);
+			if (statusEffectv1(StatusEffects.Stunned) <= 0) {
+				handleStunEnd(StatusEffects.Stunned);
+			} 
 			else addStatusValue(StatusEffects.Stunned, 1, -1);
 			if (hasPerk(PerkLib.EnemyResiliance)) addStatusValue(StatusEffects.Stunned,1,-5);
-			if (statusEffectv1(StatusEffects.StunnedTornado) <= 0) removeStatusEffect(StatusEffects.StunnedTornado);
+			if (statusEffectv1(StatusEffects.StunnedTornado) <= 0) {
+				handleStunEnd(StatusEffects.StunnedTornado);
+			}
 			else {
 				EngineCore.outputText("[Themonster] is still caught in the tornado.");
 				addStatusValue(StatusEffects.StunnedTornado, 1, -1);
@@ -2320,7 +2335,7 @@ import flash.utils.getQualifiedClassName;
 			if (hasStatusEffect(StatusEffects.Fascinated)) {
 				if (plural) EngineCore.outputText("Your opponents stares emptily in the space in front of [monster him] a dreamy expression on [monster his] face, totally entranced. A brief moment later [monster he] realises [monster he]'s been doing nothing for the past few seconds and snaps out of it.");
 				else EngineCore.outputText("Your opponent stares emptily in the space in front of [monster him] a dreamy expression on [monster his] face, totally entranced. A brief moment later [monster he] realises [monster he]'s been doing nothing for the past few seconds and snaps out of it.");
-				removeStatusEffect(StatusEffects.Fascinated);
+				handleStunEnd(StatusEffects.Fascinated);
 			}
 			else if (hasStatusEffect(StatusEffects.FrozenSolid)) {
 				if (plural) EngineCore.outputText("Your foes are too busy trying to break out of their icy prison to fight back.");
@@ -2347,6 +2362,29 @@ import flash.utils.getQualifiedClassName;
 				}
 			}
 			return false;
+		}
+
+		public function handleStunEnd(effect:StatusEffectType):void {
+			if (hasStatusEffect(effect) && canGainTempStunImmunity()) {
+				createPerk(PerkLib.Resolute, 0, 0, 1, resoluteBuffDuration);
+				outputText("<b>[Themonster] is now temporarily resistant to being stunned!</b>\n\n");
+			}
+			removeStatusEffect(effect);
+		}
+
+		public function canGainTempStunImmunity():Boolean {
+			return (hasPerk(PerkLib.EnemyBossType) || hasPerk(PerkLib.EnemyChampionType) || hasPerk(PerkLib.EnemyEliteType)) && !hasPerk(PerkLib.Resolute);
+		}
+
+		public function clearTempResolute(display:Boolean = true):void {
+			if (hasPerk(PerkLib.Resolute) && getPerkValue(PerkLib.Resolute, 3) == 1) {
+				removePerk(PerkLib.Resolute);
+				if (display) outputText("<b>[Themonster] is no longer resistant to being stunned!</b>\n\n");
+			}
+		}
+
+		public function hasTempResolute():Boolean {
+			return hasPerk(PerkLib.Resolute) && getPerkValue(PerkLib.Resolute, 3) == 1;
 		}
 
 		/**
@@ -2923,7 +2961,7 @@ import flash.utils.getQualifiedClassName;
 				if(statusEffectv1(StatusEffects.FrozenSolid) <= 0) {
 					outputText("<b>" + capitalA + short + (plural ? " are" : " is") + " no longer encased in the ice prison!</b>\n\n");
 					statStore.removeBuffs("FrozenSolid");
-					removeStatusEffect(StatusEffects.FrozenSolid);
+					handleStunEnd(StatusEffects.FrozenSolid);
 				}
 				else outputText("<b>" + capitalA + short + (plural ? " are" : " is") + " currently encased in the ice prison!</b>\n\n");
 			}
@@ -2932,7 +2970,7 @@ import flash.utils.getQualifiedClassName;
 				if (hasPerk(PerkLib.EnemyResiliance)) addStatusValue(StatusEffects.Polymorphed,1,-5);
 				if(statusEffectv1(StatusEffects.Polymorphed) <= 0) {
 					outputText("<b>[Themonster] has freed " + pronoun2 + "self from the curse!</b>\n\n");
-					removeStatusEffect(StatusEffects.Polymorphed);
+					handleStunEnd(StatusEffects.Polymorphed);
 				}
 				else outputText("<b>[Themonster] is fighting against the curse.</b>\n\n");
 			}
@@ -2941,7 +2979,7 @@ import flash.utils.getQualifiedClassName;
 				if (hasPerk(PerkLib.EnemyResiliance)) addStatusValue(StatusEffects.Sleep,1,-5);
 				if(statusEffectv1(StatusEffects.Sleep) <= 0) {
 					outputText("<b>" + capitalA + short + (plural ? " are" : " is") + " no longer asleep!</b>\n\n");
-					removeStatusEffect(StatusEffects.Sleep);
+					handleStunEnd(StatusEffects.Sleep);
 				}
 				else outputText("<b>" + capitalA + short + (plural ? " are" : " is") + " currently asleep!</b>\n\n");
 			}
@@ -2956,7 +2994,7 @@ import flash.utils.getQualifiedClassName;
 				else addStatusValue(StatusEffects.InvisibleOrStealth,1,-1);
 				if(statusEffectv1(StatusEffects.InvisibleOrStealth) <= 0) {
 					outputText("<b>" + capitalA + short + (plural ? " have" : " has") + " found you!</b>\n\n");
-					removeStatusEffect(StatusEffects.InvisibleOrStealth);
+					handleStunEnd(StatusEffects.InvisibleOrStealth);
 				}
 				else outputText("<b>" + capitalA + short + (plural ? " are" : " is") + " looking for you!</b>\n\n");
 			}
@@ -2974,7 +3012,7 @@ import flash.utils.getQualifiedClassName;
 				if (hasPerk(PerkLib.EnemyResiliance)) addStatusValue(StatusEffects.HypnosisNaga,1,-5);
 				if(statusEffectv1(StatusEffects.HypnosisNaga) <= 0) {
 					outputText("<b>You try to prolong the trance but [themonster] finally snaps out.</b>\n\n");
-					removeStatusEffect(StatusEffects.HypnosisNaga);
+					handleStunEnd(StatusEffects.HypnosisNaga);
 				}
 				else outputText("<b>[Themonster] is lost in your gaze unable to act.</b>\n\n");
 			}

--- a/classes/classes/Scenes/Areas/Forest/KitsuneScene.as
+++ b/classes/classes/Scenes/Areas/Forest/KitsuneScene.as
@@ -1114,11 +1114,11 @@ public class KitsuneScene extends BaseContent
 			addButtonIfTrue(4, "Tentacles...", kitsunesGetBonedBy3PlusTentacles, "Req. at least three 30-inch tentacle cocks", player.countCocksWithType(CockTypesEnum.TENTACLE, 30, -1, "length") >= 3);
 			//unique
 			if (monster.hairColor == "blonde") {
-				addButtonIfTrue(5, "FuckDraft", fuckDraftBlond, "Req. Fuck Draft", player.hasItem(consumables.F_DRAFT),
+				addButtonIfTrue(5, "FuckDraft", fuckDraftBlond, "Req. Fuck Draft and a cock", player.hasItem(consumables.F_DRAFT) && player.hasCock(),
 					"Feed her a bottle of FuckDraft and copulate with her like animals.");
-				addButtonIfTrue(6, "Lactaid", lactaidDoseAKitSune, "Req. Lactaid", player.hasItem(consumables.LACTAID),
+				addButtonIfTrue(6, "Lactaid", lactaidDoseAKitSune, "Req. Lactaid and a cock", player.hasItem(consumables.LACTAID) && player.hasCock(),
 					"Nourish her some Lactaid and play with her tits.");
-				addButtonIfTrue(7, "Ovi Elixir", doseAKitsuneWithOviElixirs, "Req. Ovi Elixir", player.hasItem(consumables.OVIELIX),
+				addButtonIfTrue(7, "Ovi Elixir", doseAKitsuneWithOviElixirs, "Req. Ovi Elixir and a cock", player.hasItem(consumables.OVIELIX) && player.hasCock(),
 					"Give her Oviposition Elixir and have some fum.");
 			}
 			if (monster.hairColor == "black") {

--- a/classes/classes/Scenes/Combat/CombatFollowersActions.as
+++ b/classes/classes/Scenes/Combat/CombatFollowersActions.as
@@ -95,12 +95,22 @@ import classes.StatusEffects.VampireThirstEffect;
 			player.createStatusEffect(StatusEffects.CompBoostingPCArmorValue, 0, 0, 0, 0);
 		}
 		public function neisaCombatActions3():void {
-			outputText("Neisa smashes her shield on [themonster]’s head, stunning it.\n\n");
-			monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
+			outputText("Neisa smashes her shield on [themonster]’s head, ");
+			if (!monster.hasPerk(PerkLib.Resolute)) {
+				monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
+				outputText("stunning it.\n\n");
+			} else {
+				outputText("but the enemy endured it.\n\n");
+			}
 		}
 		public function neisaCombatActions4():void {
-			outputText("Neisa viciously ram her shield on [themonster], dazing it.\n\n");
-			monster.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
+			outputText("Neisa viciously rams her shield on [themonster], ");
+			if (!monster.hasPerk(PerkLib.Resolute)) {
+				monster.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
+				outputText("dazing it.\n\n");
+			} else {
+				outputText("but the enemy endured it.\n\n");
+			}
 		}
 		
 		public function dianaCombatActions():void {
@@ -210,8 +220,13 @@ import classes.StatusEffects.VampireThirstEffect;
 			outputText("\n\n");
 		}
 		public function etnaCombatActions3():void {
-			outputText("Etna dives at [themonster] and crashes boob first into [monster his] face, staggering it before taking flight again.\n\n");
-			monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
+			outputText("Etna dives at [themonster] and crashes boob first into [monster his] face, ");
+			if (!monster.hasPerk(PerkLib.Resolute)) {
+				monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
+				outputText("staggering it before taking flight again.\n\n");
+			} else {
+				outputText("but the enemy shook off the blow.\n\n");
+			}
 		}
 		
 		public function auroraCombatActions():void {
@@ -291,8 +306,12 @@ import classes.StatusEffects.VampireThirstEffect;
 			dmg3a = Math.round(dmg3a * increasedEfficiencyOfAttacks());
 			outputText("Aurora flaps her huge bat wings at [themonster] trying to knock it down. ");
 			doDamage(dmg3a, true, true);
-			outputText("\n\n");
-			monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
+			if (!monster.hasPerk(PerkLib.Resolute)) {
+				monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
+				outputText("\n\n");
+			} else {
+				outputText("However, [themonster] was able to stand their ground.\n\n");
+			}
 		}
 		
 		public function ghoulishVampServCombatActions():void {
@@ -345,7 +364,11 @@ import classes.StatusEffects.VampireThirstEffect;
 				dmg03 = Math.round(dmg03 * increasedEfficiencyOfAttacks());
 				outputText("[Themonster] is pinned under your ghoulish partner's body!");
 				doDamage(dmg03, true, true);
-				monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
+				if (!monster.hasPerk(PerkLib.Resolute)) {
+					monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
+				} else {
+					outputText("\nHowever, [Themonster] was able to get free!");
+				}
 			}
 			else outputText("[Themonster] manages to shove your servant back!");
 			outputText("\n\n");
@@ -475,8 +498,12 @@ import classes.StatusEffects.VampireThirstEffect;
 			damage1 = Math.round(damage1 * increasedEfficiencyOfAttacks());
 			outputText("Alvina incants a spell and freezes the enemy solid, now's your chance! ");
 			doIceDamage(damage1, true, true);
+			if (!monster.hasPerk(PerkLib.Resolute)) {
+				monster.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
+			} else {
+				outputText("\nHowever, [Themonster] was able to break out of its prison!");
+			}
 			outputText("\n\n");
-			monster.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
 		}
 		public function alvinaCombatActions2():void {
 			var lustDmg:Number = Math.round(player.statusEffectv2(StatusEffects.CombatFollowerAlvina) / 3);
@@ -509,9 +536,13 @@ import classes.StatusEffects.VampireThirstEffect;
 			damage2 += scalingBonusIntelligenceCompanion() * 4;
 			damage2 = Math.round(damage2 * increasedEfficiencyOfAttacks());
 			if (monster.plural) damage2 *= 5;
+			outputText("Alvina sighs in annoyance and tosses a fireball which explodes on impact, setting "+(monster.plural ? "all ":"")+"the enem"+(monster.plural ? "ies ":"y")+" on fire!\n\n");
 			doFireDamage(damage2);
-			outputText("Alvina sighs in annoyance and tosses a fireball which explodes on impact, setting "+(monster.plural ? "all ":"")+"the enem"+(monster.plural ? "ies ":"y")+" on fire! (<b><font color=\"#800000\">" + String(damage2) + "</font></b>)\n\n");
-			monster.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
+			if (!monster.hasPerk(PerkLib.Resolute)) {
+				monster.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
+			} else {
+				outputText("However, [Themonster] quickly regains their bearings!\n\n");
+			}
 		}
 		public function alvinaCombatActions5():void {
 			var dmg:Number = player.statusEffectv2(StatusEffects.CombatFollowerAlvina);
@@ -897,10 +928,14 @@ import classes.StatusEffects.VampireThirstEffect;
 			else if (weaponZenji >= 151 && weaponZenji < 201) dmg13 *= (4.75 + ((weaponZenji - 150) * 0.015));
 			else dmg13 *= (5.5 + ((weaponZenji - 200) * 0.01));
 			dmg13 = Math.round(dmg13 * increasedEfficiencyOfAttacks());
-			monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
 			outputText("Zenji charges at [themonster], knocking them down and pinning them beneath him with his spear. ");
 			doDamage(dmg13, true, true);
-			outputText(" Zenji has [themonster] pinned beneath him. \"<i>And stay down!</i>\" Zenji shouts. [Themonster] struggles beneath him before finally shaking him off.\n\n");
+			if (!monster.hasPerk(PerkLib.Resolute)) {
+				outputText(" Zenji has [themonster] pinned beneath him. \"<i>And stay down!</i>\" Zenji shouts.\n\n");
+				monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
+			} else {
+				outputText(" Zenji has [themonster] pinned beneath him. \"<i>And stay down!</i>\" Zenji shouts. [Themonster] struggles beneath him before finally shaking him off.\n\n");
+			}
 		}
 		public function zenjiCombatActions5():void {
 			outputText("Seeing your injuries, Zenji quickly rushes to your side, \"<i>It’s okay [name]... I’m here for you…</i>\" he says, wrapping you within his arms, completely shielding you from your enemies. ");

--- a/classes/classes/Scenes/NPCs/Alvina.as
+++ b/classes/classes/Scenes/NPCs/Alvina.as
@@ -56,6 +56,7 @@ public class Alvina extends Monster
 				outputText("Alvina starts incanting a spell. While nothing visible happens, you feel a chill in the air.");
 				PolarMidnightSequance++;
 				createStatusEffect(StatusEffects.Uber, 0, 0,0,0);
+				clearTempResolute(false);
 			}
 			else {
 				if (PolarMidnightSequance == 1) {
@@ -105,6 +106,7 @@ public class Alvina extends Monster
 				outputText("Alvina weaves her scythe above her head tracing complicated arcane signs.");
 				MeteorStormSequence++;
 				createStatusEffect(StatusEffects.Uber, 0, 0,0,0);
+				clearTempResolute(false);
 			} else {
 				var damage:Number = 0;
 				damage += eBaseIntelligenceDamage() * 10;
@@ -147,6 +149,7 @@ public class Alvina extends Monster
 				outputText("\"<i>Most demons steal souls through sex. I have a more academic approach to it. Do not worry, you will still writhe in pleasure and reach orgasm as I tear it out of your chest!</i>\"\n\n");
 				outputText("You see a set of dark tendrils of black magic surging around her body, like grasping claws, ready to bury themselves in you. You need to stop that incantation before she strikes you with it!\n\n");
 				SoulTearInitiated = true;
+				clearTempResolute(false);
 			}
 		}
 

--- a/classes/classes/Scenes/NPCs/AlvinaFollower.as
+++ b/classes/classes/Scenes/NPCs/AlvinaFollower.as
@@ -746,6 +746,8 @@ public function alvinaThirdEncounterTakeHer():void
 		outputText("<b>Alvina has joined you as a follower.</b>\n\n");
 		flags[kFLAGS.ALVINA_FOLLOWER] = 12;
 		awardAchievement("Dawn chasing away the night", kACHIEVEMENTS.GENERAL_DAWN_CHASING_AWAY_THE_NIGHT);
+		if (flags[kFLAGS.GAME_DIFFICULTY] >= 4)
+			awardAchievement("Beyond gods and mortals", kACHIEVEMENTS.GENERAL_BEYOND_GODS_AND_MORTALS);
 
 		alvinaMakeLovePure();
 	}


### PR DESCRIPTION
Followers can no longer stun resolute enemies
Boss/Elite/Champion Type enemies gain a temporary resistance to stuns for 2 rounds after coming out of stun, except for Alvina when preparing an ultimate attack
Alvina's "Beyond gods and mortals" achievement now activates when beating her in the pure route in Xianxia mode 
Blonde Kitsune sex scenes can no longer be done if the player doesn't have a cock, preventing errors