### PR TITLE
Soulskill revamp

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -7208,14 +7208,28 @@ use namespace CoC;
 		public function knownAbilities():/*CombatAbility*/Array {
 			return CombatAbilities.ALL.filter(
 					function(ability:CombatAbility,index:int,array:Array):Boolean {
-						return ability.isKnown
+						return ability.isKnown;
 					}
 			)
 		}
 		public function knownAbilitiesOfClass(klass:Class):/*CombatAbility*/Array {
 			return CombatAbilities.ALL.filter(
 					function(ability:CombatAbility,index:int,array:Array):Boolean {
-						return ability is klass && ability.isKnown
+						return ability is klass && ability.isKnown;
+					}
+			)
+		}
+		public function hasknownAbilities():Boolean {
+			return CombatAbilities.ALL.some(
+					function(ability:CombatAbility,index:int,array:Array):Boolean {
+						return ability.isKnown;
+					}
+			)
+		}
+		public function hasknownAbilitiesOfClass(klass:Class):Boolean {
+			return CombatAbilities.ALL.some(
+					function(ability:CombatAbility,index:int,array:Array):Boolean {
+						return ability is klass && ability.isKnown;
 					}
 			)
 		}

--- a/classes/classes/PlayerInfo.as
+++ b/classes/classes/PlayerInfo.as
@@ -3,6 +3,8 @@ import classes.BodyParts.Tail;
 import classes.GlobalFlags.*;
 import classes.IMutations.IMutationsLib;
 import classes.Scenes.Combat.CombatAbility;
+import classes.Scenes.Combat.AbstractSpell;
+import classes.Scenes.Combat.AbstractSoulSkill;
 import classes.Scenes.Crafting;
 import classes.Scenes.NPCs.BelisaFollower;
 import classes.Scenes.NPCs.CharybdisFollower;
@@ -37,7 +39,7 @@ public class PlayerInfo extends BaseContent {
 	private function statsMenu(currentButton:int):void {
 		menu();
 		addButton(0, "Next", playerMenu);
-		if (player.knownAbilities().length > 0) {
+		if (player.hasknownAbilities()) {
 			addButton(4, "Abilities", displayStatsAbilities);
 		}
 		addButton(5, "General", displayStats);
@@ -47,6 +49,20 @@ public class PlayerInfo extends BaseContent {
 		addButton(9, "Mastery", displayStatsmastery);
 		if (currentButton >= 4 && currentButton <= 9) {
 			button(currentButton).disable("You are currently at this stats page.");
+		}
+		if (currentButton == 4 || (currentButton >= 10 && currentButton <= 13)) {
+			button(4).disable("You are currently at this stats page.");
+			if (currentButton == 4) {
+				//Should show all abilities by default
+				currentButton = 10;
+			}
+			addButton(10, "All", displayStatsAbilities);
+			addButtonIfTrue(11, "Spells", curry(displayStatsAbilities, AbstractSpell, 11), "You currently have no spells", player.hasknownAbilitiesOfClass(AbstractSpell));
+			addButtonIfTrue(12, "SoulSkills", curry(displayStatsAbilities, AbstractSoulSkill, 12), "You currently have no soulskills", player.hasknownAbilitiesOfClass(AbstractSoulSkill));
+
+			if (currentButton != 4){
+				button(currentButton).disable("You are currently viewing this category.");
+			}
 		}
 	}
 	//------------
@@ -404,15 +420,20 @@ public class PlayerInfo extends BaseContent {
 			addButton(1, "Stat Up", attributeMenu);
 		}
 		}
-	public function displayStatsAbilities():void {
+	public function displayStatsAbilities(kLass:Class = null, currentButton:int = 4):void {
 		clearOutput();
-		for each (var ability:CombatAbility in player.knownAbilities()) {
+		var abilities:/*CombatAbility*/Array = [];
+		if (!kLass)
+			abilities = player.knownAbilities();
+		else
+			abilities = player.knownAbilitiesOfClass(kLass);
+		for each (var ability:CombatAbility in abilities) {
 			outputText("<font size=\"24\" face=\"Georgia\"><u><b>"+ability.name+"</b></u></font>");
 			outputText(" "+ability.catObject.name+"\n");
 			outputText(ability.fullDescription(null));
 			outputText("\n\n");
 		}
-		statsMenu(4);
+		statsMenu(currentButton);
 	}
 	public function displayStatsCombat():void {
 		spriteSelect(null);

--- a/classes/classes/Scenes/Combat/AbstractBloodSoulSkill.as
+++ b/classes/classes/Scenes/Combat/AbstractBloodSoulSkill.as
@@ -20,6 +20,10 @@ public class AbstractBloodSoulSkill extends AbstractSoulSkill {
         this.sfInfusion = sfInfusion;
     }
 
+    override public function get category():int {
+        return CAT_BLOOD_SOULSKILL;
+    }
+
     override protected function usabilityCheck():String {
         //Soulforce check will be handled in this class instead of AbstractSoulForce
         var uc:String =  super.usabilityCheck();
@@ -53,7 +57,7 @@ public class AbstractBloodSoulSkill extends AbstractSoulSkill {
         //Remove addition from Abstract soulSkill Implementation
         if (sfCost() > 0) {
             costs.pop();
-            if (sfInfusion) costs.push("Soulforce Cost: "+sfCost());
+            if (sfInfusion) costs.push("Soulforce Cost: "+super.sfCost());
             costs.push("Blood Cost: "+sfCost());
         }
         return costs;

--- a/classes/classes/Scenes/Combat/AbstractBloodSoulSkill.as
+++ b/classes/classes/Scenes/Combat/AbstractBloodSoulSkill.as
@@ -1,0 +1,85 @@
+package classes.Scenes.Combat {
+
+import classes.StatusEffectType;
+import classes.StatusEffects;
+
+public class AbstractBloodSoulSkill extends AbstractSoulSkill {
+    protected var sfInfusion:Boolean;
+    
+    public function AbstractBloodSoulSkill(
+        name:String,
+        desc:String,
+        targetType:int,
+        timingType:int,
+        tags:/*int*/Array,
+        statusEffect:StatusEffectType,
+        canUseBlood:Boolean = true,
+        sfInfusion:Boolean= false
+    ) {
+        super(name, desc, targetType, timingType, tags, statusEffect, canUseBlood);
+        this.sfInfusion = sfInfusion;
+    }
+
+    override protected function usabilityCheck():String {
+        //Soulforce check will be handled in this class instead of AbstractSoulForce
+        var uc:String =  super.usabilityCheck();
+        if (uc && uc != "Your current soulforce is too low.") return uc;
+
+        if (monster.hasStatusEffect(StatusEffects.Dig)) {
+            return "You can only use buff soulskills while underground.";
+        }
+
+        if (sfInfusion && (player.soulforce < sfCost()) && (!player.hasStatusEffect(StatusEffects.BloodCultivator) || !canUseBlood)) {
+            return "Your current soulforce is too low."
+        }
+
+        if (combat.isEnemyInvisible) {
+            return "You cannot use offensive soulskills against an opponent you cannot see or target.";
+        }
+
+        if (player.isGargoyle()) {
+            return "You cannot use blood soulskills if you don't have blood at all."
+        }
+        
+        return "";
+    }
+
+    override public function sfCost():int {
+        return spellCostBlood(baseSFCost);
+    }
+
+    override public function costDescription():Array {
+        var costs:/*String*/Array = super.costDescription().concat();
+        //Remove addition from Abstract soulSkill Implementation
+        if (sfCost() > 0) {
+            costs.pop();
+            if (sfInfusion) costs.push("Soulforce Cost: "+sfCost());
+            costs.push("Blood Cost: "+sfCost());
+        }
+        return costs;
+    }
+
+    override public function useResources():void {
+        HPChange(sfCost(), false);
+
+        if (sfInfusion) {
+            player.soulforce -= super.sfCost();
+        }
+    }
+
+    //Used to specifiy the base name of the blood soulskill, which will be a suffix added for the SF version
+    protected function baseName():String {
+        return "";
+    }
+
+    override public function get buttonName():String {
+        return baseName() + (sfInfusion? " (SF)" : "");
+    }
+
+    protected function bloodSoulSkillCoolDown(baseCooldown:int):int {
+        var cooldown:int = baseCooldown;
+        if (sfInfusion) cooldown += 1;
+        return cooldown;
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/AbstractSoulSkill.as
+++ b/classes/classes/Scenes/Combat/AbstractSoulSkill.as
@@ -2,13 +2,13 @@ package classes.Scenes.Combat {
 import classes.GlobalFlags.kFLAGS;
 import classes.StatusEffectType;
 import classes.StatusEffects;
-import classes.Monster;
 import classes.PerkLib;
 import classes.IMutations.IMutationsLib;
 
 public class AbstractSoulSkill extends CombatAbility {
     protected var statusEffect:StatusEffectType;
     public var baseSFCost:Number = 0;
+    protected var canUseBlood:Boolean;
 
     public function AbstractSoulSkill (
             name:String,
@@ -16,10 +16,12 @@ public class AbstractSoulSkill extends CombatAbility {
             targetType:int,
             timingType:int,
             tags:/*int*/Array,
-            statusEffect:StatusEffectType
+            statusEffect:StatusEffectType,
+            canUseBlood:Boolean = true
     ) {
         super(name, desc, targetType, timingType, tags);
         this.statusEffect = statusEffect;
+        this.canUseBlood = canUseBlood;
     }
 
     override public function get category():int {
@@ -38,11 +40,11 @@ public class AbstractSoulSkill extends CombatAbility {
         var uc:String =  super.usabilityCheck();
         if (uc) return uc;
 
-        if ((player.soulforce < sfCost()) && !player.hasStatusEffect(StatusEffects.BloodCultivator)) {
+        if ((player.soulforce < sfCost()) && (!player.hasStatusEffect(StatusEffects.BloodCultivator) || !canUseBlood)) {
             return "Your current soulforce is too low."
         }
 
-        if (player.hasStatusEffect(StatusEffects.BloodCultivator) && ((player.HP - player.minHP()) - 1) < (sfCost())) {
+        if (canUseBlood && player.hasStatusEffect(StatusEffects.BloodCultivator) && ((player.HP - player.minHP()) - 1) < (sfCost())) {
             return "Your hp is too low to use this soulskill."
         }
 

--- a/classes/classes/Scenes/Combat/AbstractSoulSkill.as
+++ b/classes/classes/Scenes/Combat/AbstractSoulSkill.as
@@ -1,0 +1,131 @@
+package classes.Scenes.Combat {
+import classes.GlobalFlags.kFLAGS;
+import classes.StatusEffectType;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.PerkLib;
+import classes.IMutations.IMutationsLib;
+
+public class AbstractSoulSkill extends CombatAbility {
+    protected var statusEffect:StatusEffectType;
+    public var baseSFCost:Number = 0;
+
+    public function AbstractSoulSkill (
+            name:String,
+            desc:String,
+            targetType:int,
+            timingType:int,
+            tags:/*int*/Array,
+            statusEffect:StatusEffectType
+    ) {
+        super(name, desc, targetType, timingType, tags);
+        this.statusEffect = statusEffect;
+    }
+
+    override public function get category():int {
+        return CAT_SOULSKILL;
+    }
+
+    override public function costDescription():Array {
+        var costs:/*String*/Array = super.costDescription().concat();
+        if (sfCost() > 0) {
+            costs.push("Soulforce Cost: "+sfCost());
+        }
+        return costs;
+    }
+
+    override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+        if ((player.soulforce < sfCost()) && !player.hasStatusEffect(StatusEffects.BloodCultivator)) {
+            return "Your current soulforce is too low."
+        }
+
+        if (player.hasStatusEffect(StatusEffects.BloodCultivator) && ((player.HP - player.minHP()) - 1) < (sfCost())) {
+            return "Your hp is too low to use this soulskill."
+        }
+
+        return "";
+    }  
+
+    public function sfCost():int {
+        var soulforcecost:Number = baseSFCost * soulskillCost() * soulskillcostmulti();
+        return Math.round(soulforcecost);
+    }
+
+    override public function get isKnown():Boolean {
+        return player.hasStatusEffect(statusEffect);
+    }
+
+    override public function useResources():void {
+        if (player.hasStatusEffect(StatusEffects.BloodCultivator)) {
+            player.takePhysDamage(sfCost());
+        } 
+        else {
+            player.soulforce -= sfCost();
+        }
+    }
+
+    protected function display():String {
+        return "";
+    }  
+
+
+    protected function anubiHeartLeeching(dmg:Number):void {
+		flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] = 1;
+		var leech:Number = dmg;
+		var leechCap:Number = 0.1;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) {
+			leechCap *= 2;
+			leech *= 0.2;
+		}
+		else leech *= 0.1;
+		leech = Math.round(leech);
+		if (leech > Math.round(player.maxHP() * leechCap)) leech = Math.round(player.maxHP() * leechCap);
+		HPChange(leech, false);
+	}
+
+	protected function monsterDodgeSkill(skillName:String, display:Boolean):Boolean {
+		if (((player.playerIsBlinded() && rand(2) == 0) || ((monster.getEvasionRoll(false, player.spe) && !monster.hasPerk(PerkLib.NoDodges)))) && !monster.monsterIsStunned()) {
+			if ((monster.spe - player.spe < 8) && display) outputText("[Themonster] narrowly avoids your " + skillName + "!");
+			else if ((monster.spe-player.spe < 20) && display) outputText("[Themonster] dodges your " + skillName + " with superior quickness!");
+			else if (display) outputText("[Themonster] deftly avoids your slow " + skillName + ".");
+			enemyAI();
+			return true;
+		}
+		return false;
+	}
+
+    protected function endTurnBySpecialHit(damage:Number, display: Boolean = true):void {
+		checkAchievementDamage(damage);
+		if (display) outputText("\n\n");
+		combat.WrathGenerationPerHit2(5);
+		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(damage);
+		combat.heroBaneProc(damage);
+		combat.EruptingRiposte();
+	}
+
+	protected function endTurnByBloodSkillUse(damage:Number, display:Boolean = true):void {
+		if (rand(20) < 4) {
+			if (monster.hasStatusEffect(StatusEffects.Hemorrhage)) monster.removeStatusEffect(StatusEffects.Hemorrhage);
+			monster.createStatusEffect(StatusEffects.Hemorrhage, 2, 0.05, 0, 0);
+			if (display) outputText(" The attack leaves many bloody gashes.");
+		}
+		if (display) outputText("\n\n");
+		checkAchievementDamage(damage);
+		combat.WrathGenerationPerHit2(15);
+		combat.heroBaneProc(damage);
+	}
+
+    protected function advanceDuration(statusEffect:StatusEffectType, display:Boolean, endMessage:String = ""):void {
+        if (player.hasStatusEffect(statusEffect)) {
+            if (player.statusEffectv1(statusEffect) <= 0) {
+                player.removeStatusEffect(statusEffect);
+                if (endMessage && display)
+                    outputText(endMessage);
+            } else player.addStatusValue(statusEffect, 1, -1);
+        }
+    }    
+}
+}

--- a/classes/classes/Scenes/Combat/AbstractSoulSkill.as
+++ b/classes/classes/Scenes/Combat/AbstractSoulSkill.as
@@ -91,7 +91,6 @@ public class AbstractSoulSkill extends CombatAbility {
 			if ((monster.spe - player.spe < 8) && display) outputText("[Themonster] narrowly avoids your " + skillName + "!");
 			else if ((monster.spe-player.spe < 20) && display) outputText("[Themonster] dodges your " + skillName + " with superior quickness!");
 			else if (display) outputText("[Themonster] deftly avoids your slow " + skillName + ".");
-			enemyAI();
 			return true;
 		}
 		return false;

--- a/classes/classes/Scenes/Combat/AbstractSoulSkill.as
+++ b/classes/classes/Scenes/Combat/AbstractSoulSkill.as
@@ -113,16 +113,6 @@ public class AbstractSoulSkill extends CombatAbility {
 		checkAchievementDamage(damage);
 		combat.WrathGenerationPerHit2(15);
 		combat.heroBaneProc(damage);
-	}
-
-    protected function advanceDuration(statusEffect:StatusEffectType, display:Boolean, endMessage:String = ""):void {
-        if (player.hasStatusEffect(statusEffect)) {
-            if (player.statusEffectv1(statusEffect) <= 0) {
-                player.removeStatusEffect(statusEffect);
-                if (endMessage && display)
-                    outputText(endMessage);
-            } else player.addStatusValue(statusEffect, 1, -1);
-        }
-    }    
+	}    
 }
 }

--- a/classes/classes/Scenes/Combat/AbstractSoulSkill.as
+++ b/classes/classes/Scenes/Combat/AbstractSoulSkill.as
@@ -88,9 +88,9 @@ public class AbstractSoulSkill extends CombatAbility {
 
 	protected function monsterDodgeSkill(skillName:String, display:Boolean):Boolean {
 		if (((player.playerIsBlinded() && rand(2) == 0) || ((monster.getEvasionRoll(false, player.spe) && !monster.hasPerk(PerkLib.NoDodges)))) && !monster.monsterIsStunned()) {
-			if ((monster.spe - player.spe < 8) && display) outputText("[Themonster] narrowly avoids your " + skillName + "!");
-			else if ((monster.spe-player.spe < 20) && display) outputText("[Themonster] dodges your " + skillName + " with superior quickness!");
-			else if (display) outputText("[Themonster] deftly avoids your slow " + skillName + ".");
+			if ((monster.spe - player.spe < 8) && display) outputText("[Themonster] narrowly avoids your " + skillName + "!\n\n");
+			else if ((monster.spe-player.spe < 20) && display) outputText("[Themonster] dodges your " + skillName + " with superior quickness!\n\n");
+			else if (display) outputText("[Themonster] deftly avoids your slow " + skillName + ".\n\n");
 			return true;
 		}
 		return false;

--- a/classes/classes/Scenes/Combat/AbstractSoulSkill.as
+++ b/classes/classes/Scenes/Combat/AbstractSoulSkill.as
@@ -4,10 +4,10 @@ import classes.StatusEffectType;
 import classes.StatusEffects;
 import classes.PerkLib;
 import classes.IMutations.IMutationsLib;
+import classes.PerkType;
 
 public class AbstractSoulSkill extends CombatAbility {
-    protected var statusEffect:StatusEffectType;
-    public var baseSFCost:Number = 0;
+    protected var knownCondition:*;
     protected var canUseBlood:Boolean;
 
     public function AbstractSoulSkill (
@@ -16,24 +16,16 @@ public class AbstractSoulSkill extends CombatAbility {
             targetType:int,
             timingType:int,
             tags:/*int*/Array,
-            statusEffect:StatusEffectType,
+            knownCondition:*,
             canUseBlood:Boolean = true
     ) {
         super(name, desc, targetType, timingType, tags);
-        this.statusEffect = statusEffect;
+        this.knownCondition = knownCondition;
         this.canUseBlood = canUseBlood;
     }
 
     override public function get category():int {
         return CAT_SOULSKILL;
-    }
-
-    override public function costDescription():Array {
-        var costs:/*String*/Array = super.costDescription().concat();
-        if (sfCost() > 0) {
-            costs.push("Soulforce Cost: "+sfCost());
-        }
-        return costs;
     }
 
     override protected function usabilityCheck():String {
@@ -51,17 +43,21 @@ public class AbstractSoulSkill extends CombatAbility {
         return "";
     }  
 
-    public function sfCost():int {
+    override public function sfCost():int {
         var soulforcecost:Number = baseSFCost * soulskillCost() * soulskillcostmulti();
         return Math.round(soulforcecost);
     }
 
     override public function get isKnown():Boolean {
-        return player.hasStatusEffect(statusEffect);
+        if (knownCondition is StatusEffectType)
+            return player.hasStatusEffect(knownCondition);
+        if (knownCondition is PerkType)
+            return player.hasPerk(knownCondition);
+        return false;
     }
 
     override public function useResources():void {
-        if (player.hasStatusEffect(StatusEffects.BloodCultivator)) {
+        if (player.hasStatusEffect(StatusEffects.BloodCultivator) && canUseBlood) {
             player.takePhysDamage(sfCost());
         } 
         else {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -67,7 +67,6 @@ public class Combat extends BaseContent {
     public var mspecials:MagicSpecials = new MagicSpecials();
     public var magic:CombatMagic = new CombatMagic();
     public var teases:CombatTeases = new CombatTeases();
-    public var soulskills:CombatSoulskills = new CombatSoulskills();
     public var comfoll:CombatFollowersActions = new CombatFollowersActions();
     public var ui:CombatUI = new CombatUI();
 	public var meleeDamageNoLag:Number = 0;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -11025,7 +11025,7 @@ public class Combat extends BaseContent {
                 player.addStatusValue(StatusEffects.CooldownSpectralScream, 1, -1);
             }
         }
-        //Hurricane Dance
+        /*//Hurricane Dance
         if (player.hasStatusEffect(StatusEffects.CooldownHurricaneDance)) {
             if (player.statusEffectv1(StatusEffects.CooldownHurricaneDance) <= 0) {
                 player.removeStatusEffect(StatusEffects.CooldownHurricaneDance);
@@ -11052,7 +11052,7 @@ public class Combat extends BaseContent {
                 player.removeStatusEffect(StatusEffects.EarthStance);
                 outputText("<b>Earth Stance effect wore off!</b>\n\n");
             } else player.addStatusValue(StatusEffects.EarthStance, 1, -1);
-        }
+        } */
         //Punishing Kick
         if (player.hasStatusEffect(StatusEffects.CooldownPunishingKick)) {
             if (player.statusEffectv1(StatusEffects.CooldownPunishingKick) <= 0) {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -872,43 +872,20 @@ public class Combat extends BaseContent {
 			if (player.statusEffectv2(StatusEffects.Flying) == 2) buttons.add("Land", landAfterUsingSoulforce);
             buttons.add("Great Dive", greatDive).hint("Make a Great Dive to deal TONS of damage!");
         }
-        if (player.hasStatusEffect(StatusEffects.KnowsFlamesOfLove)) {
-            bd = buttons.add("Flames of Love", flamesOfLove).hint("Turn your burning lust into literal flames of passion. Can your enemies take your heat?  \n\nWould go into cooldown after use for: "+Math.round(player.statusEffectv1(StatusEffects.KnowsFlamesOfLove))+" round  \n\nLust cost: "+flamesOfLoveLC()+"% of current lust");
-            if (player.hasStatusEffect(StatusEffects.CooldownFlamesOfLove)) {
-                bd.disable("You need more time before you can use Flames of Love again.");
-            } else if (player.lust < 50) {
-                bd.disable("Your current lust is too low.");
-            }
+        if (CombatAbilities.FlamesOfLove.isKnown) {
+            buttons.append(CombatAbilities.FlamesOfLove.createButton(monster));
         }
-        if (player.hasStatusEffect(StatusEffects.KnowsIciclesOfLove)) {
-            bd = buttons.add("Icicles of Love", iciclesOfLove).hint("Crystalise your lust into cold spikes. Impale your foes with love!  \n\nWould go into cooldown after use for: "+Math.round(player.statusEffectv1(StatusEffects.KnowsIciclesOfLove))+" round  \n\nLust cost: "+iciclesOfLoveLC()+"% of current lust");
-            if (player.hasStatusEffect(StatusEffects.CooldownIciclesOfLove)) {
-                bd.disable("You need more time before you can use Icicles of Love again.");
-            } else if (player.lust < 50) {
-                bd.disable("Your current lust is too low.");
-            }
+        if (CombatAbilities.IciclesOfLove.isKnown) {
+            buttons.append(CombatAbilities.IciclesOfLove.createButton(monster));
         }
-		if (player.hasStatusEffect(StatusEffects.KnowsStormOfSisterhood)) {
-			bd = buttons.add("Storm of Sisterhood", stormOfSisterhood).hint("Focus your wrath into the storm of sisterhood.  \n\nWould go into cooldown after use for: "+Math.round(player.statusEffectv1(StatusEffects.KnowsStormOfSisterhood))+" round  \n\nWrath cost: "+stormOfSisterhoodWC()+"% of current wrath");
-			if (player.hasStatusEffect(StatusEffects.CooldownStormOfSisterhood)) {
-				bd.disable("You need more time before you can use Storm of Sisterhood again.");
-			} else if (player.wrath < 50) {
-				bd.disable("Your current wrath is too low.");
-			}
+		if (CombatAbilities.StormOfSisterhood.isKnown) {
+            buttons.append(CombatAbilities.StormOfSisterhood.createButton(monster));
 		}
-		if (player.hasStatusEffect(StatusEffects.KnowsNightOfBrotherhood)) {
-			bd = buttons.add("Night of Brotherhood", nightOfBrotherhood).hint("Condense your wrath into a wreath of shadows, filled with the hate of your brotherhood.  \n\nWould go into cooldown after use for: "+Math.round(player.statusEffectv1(StatusEffects.KnowsNightOfBrotherhood))+" round  \n\nWrath cost: "+nightOfBrotherhoodWC()+"% of current wrath");
-			if (player.hasStatusEffect(StatusEffects.CooldownNightOfBrotherhood)) {
-				bd.disable("You need more time before you can use Night of Brotherhood again.");
-			} else if (player.wrath < 50) {
-				bd.disable("Your current wrath is too low.");
-			}
+		if (CombatAbilities.NightOfBrotherhood.isKnown) {
+            buttons.append(CombatAbilities.NightOfBrotherhood.createButton(monster));
 		}
-        if (player.hasStatusEffect(StatusEffects.KnowsHeavensDevourer)) {
-            bd = buttons.add("Devourer", heavensDevourer).hint("Form a small sphere inscribed by symbols to drain from enemy a bit of lust and/or wrath.  \n\nWould go into cooldown after use for: 3 rounds");
-            if (player.hasStatusEffect(StatusEffects.CooldownHeavensDevourer)) {
-                bd.disable("You need more time before you can use Devourer again.");
-            }
+        if (CombatAbilities.Devourer.isKnown) {
+            buttons.append(CombatAbilities.Devourer.createButton(monster));
         }
 		if ((monster.hasStatusEffect(StatusEffects.Stunned) || monster.hasStatusEffect(StatusEffects.StunnedTornado) || monster.hasStatusEffect(StatusEffects.Polymorphed) || monster.hasStatusEffect(StatusEffects.Sleep) || monster.hasStatusEffect(StatusEffects.Fascinated)) && (player.fatigueLeft() > combat.physicalCost(20)) && player.perkv1(IMutationsLib.HollowFangsIM) >= 2) {
 			bd = buttons.add("Bite", VampiricBite).hint("Suck on the blood of an opponent. \n\nFatigue Cost: " + physicalCost(20) + "");

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -274,6 +274,15 @@ public class CombatAbilities {
 	public static const Trance:TranceSkill											= new TranceSkill();
 	public static const VioletPupilTransformation:VioletPupilTransformationSkill	= new VioletPupilTransformationSkill();
 	public static const FingerOfDeath:FingerOfDeathSkill							= new FingerOfDeathSkill();
+	public static const BloodSwipe:BloodSwipeSkill									= new BloodSwipeSkill();
+	public static const BloodSwipeSF:BloodSwipeSkill								= new BloodSwipeSkill(true);
+	public static const BloodDewdrops:BloodDewdropsSkill							= new BloodDewdropsSkill();
+	public static const BloodDewdropsSF:BloodDewdropsSkill							= new BloodDewdropsSkill(true);
+	public static const HeartSeeker:HeartSeekerSkill								= new HeartSeekerSkill();
+	public static const HeartSeekerSF:HeartSeekerSkill								= new HeartSeekerSkill(true);
+	public static const BloodRequiem:BloodReqiuemSkill								= new BloodReqiuemSkill();
+	public static const BloodRequiemSF:BloodReqiuemSkill							= new BloodReqiuemSkill(true);
+	public static const ScarletSpiritCharge:ScarletSpiritChargeSkill				= new ScarletSpiritChargeSkill();
 
 
 
@@ -314,7 +323,16 @@ public class CombatAbilities {
 		SoulDrain,
 		Trance,
 		VioletPupilTransformation,
-		FingerOfDeath
+		FingerOfDeath,
+		BloodSwipe,
+		BloodSwipeSF,
+		BloodDewdrops,
+		BloodDewdropsSF,
+		HeartSeeker,
+		HeartSeekerSF,
+		BloodRequiem,
+		BloodRequiemSF,
+		ScarletSpiritCharge
 	]
 	
 	/*

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -237,32 +237,44 @@ public class CombatAbilities {
 			.concat(ALL_GREEN_SPELLS)
 	;
 
-	public static const CleansingPalm:CleansingPalmSkill 			= new CleansingPalmSkill();
-	public static const IceFist:IceFistSkill						= new IceFistSkill()
-	public static const FirePunch:FirePunchSkill					= new FirePunchSkill();
-	public static const HurricaneDance:HurricaneDanceSkill			= new HurricaneDanceSkill();
-	public static const EarthStance:EarthStanceSkill				= new EarthStanceSkill();
-	public static const PunishingKick:PunishingKickSkill			= new PunishingKickSkill();
-	public static const SoulBlast:SoulBlastSkill					= new SoulBlastSkill();
-	public static const Overlimit:OverlimitSkill					= new OverlimitSkill();
-	public static const TripleThrust:MultiThrustSkill				= new MultiThrustSkill(1);
-	public static const SextupleThrust:MultiThrustSkill				= new MultiThrustSkill(2);
-	public static const NonupleThrust:MultiThrustSkill				= new MultiThrustSkill(3);
-	public static const DracoSweep:DracoSweepSkill					= new DracoSweepSkill();
-	public static const FlamesOfLove:FlamesOfLoveSkill				= new FlamesOfLoveSkill();
-	public static const IciclesOfLove:IciclesOfLoveSkill			= new IciclesOfLoveSkill();
-	public static const StormOfSisterhood:StormOfSisterhoodSkill	= new StormOfSisterhoodSkill();
-	public static const NightOfBrotherhood:NightOfBrotherhoodSkill	= new NightOfBrotherhoodSkill();
-	public static const Devourer:DevourerSkill						= new DevourerSkill();
-	public static const ManyBirds:ManyBirdsSkill					= new ManyBirdsSkill();
-	public static const ResonanceVolley:ResonanceVolleySkill		= new ResonanceVolleySkill();
-	public static const AvatarOfTheSong:AvatarOfTheSongSkill		= new AvatarOfTheSongSkill();
-	public static const BeatOfWar:BeatOfWarSkill					= new BeatOfWarSkill();
-	public static const Comet:CometSkill							= new CometSkill();
-	public static const BladeDance:BladeDanceSkill					= new BladeDanceSkill();
-	public static const HailOfBlades:BladeHailSkill					= new BladeHailSkill(1);
-	public static const GrandioseHailOfBlades:BladeHailSkill		= new BladeHailSkill(2);
-	public static const GrandioseHailOfMoonBlades:BladeHailSkill	= new BladeHailSkill(3);
+	public static const CleansingPalm:CleansingPalmSkill 							= new CleansingPalmSkill();
+	public static const IceFist:IceFistSkill										= new IceFistSkill()
+	public static const FirePunch:FirePunchSkill									= new FirePunchSkill();
+	public static const HurricaneDance:HurricaneDanceSkill							= new HurricaneDanceSkill();
+	public static const EarthStance:EarthStanceSkill								= new EarthStanceSkill();
+	public static const PunishingKick:PunishingKickSkill							= new PunishingKickSkill();
+	public static const SoulBlast:SoulBlastSkill									= new SoulBlastSkill();
+	public static const Overlimit:OverlimitSkill									= new OverlimitSkill();
+	public static const TripleThrust:MultiThrustSkill								= new MultiThrustSkill(1);
+	public static const SextupleThrust:MultiThrustSkill								= new MultiThrustSkill(2);
+	public static const NonupleThrust:MultiThrustSkill								= new MultiThrustSkill(3);
+	public static const DracoSweep:DracoSweepSkill									= new DracoSweepSkill();
+	public static const FlamesOfLove:FlamesOfLoveSkill								= new FlamesOfLoveSkill();
+	public static const IciclesOfLove:IciclesOfLoveSkill							= new IciclesOfLoveSkill();
+	public static const StormOfSisterhood:StormOfSisterhoodSkill					= new StormOfSisterhoodSkill();
+	public static const NightOfBrotherhood:NightOfBrotherhoodSkill					= new NightOfBrotherhoodSkill();
+	public static const Devourer:DevourerSkill										= new DevourerSkill();
+	public static const ManyBirds:ManyBirdsSkill									= new ManyBirdsSkill();
+	public static const ResonanceVolley:ResonanceVolleySkill						= new ResonanceVolleySkill();
+	public static const AvatarOfTheSong:AvatarOfTheSongSkill						= new AvatarOfTheSongSkill();
+	public static const BeatOfWar:BeatOfWarSkill									= new BeatOfWarSkill();
+	public static const Comet:CometSkill											= new CometSkill();
+	public static const BladeDance:BladeDanceSkill									= new BladeDanceSkill();
+	public static const HailOfBlades:BladeHailSkill									= new BladeHailSkill(1);
+	public static const GrandioseHailOfBlades:BladeHailSkill						= new BladeHailSkill(2);
+	public static const GrandioseHailOfMoonBlades:BladeHailSkill					= new BladeHailSkill(3);
+	public static const ElementAir:CreateElementSkill								= new CreateElementSkill("Air", 1);
+	public static const ElementEarth:CreateElementSkill								= new CreateElementSkill("Earth", 1);
+	public static const ElementFire:CreateElementSkill								= new CreateElementSkill("Fire", 1);
+	public static const ElementWater:CreateElementSkill								= new CreateElementSkill("Water", 1);
+	public static const ElementIce:CreateElementSkill								= new CreateElementSkill("Ice", 2);
+	public static const ElementLightning:CreateElementSkill							= new CreateElementSkill("Lightning", 2);
+	public static const ElementDarkness:CreateElementSkill							= new CreateElementSkill("Darkness", 2);
+	public static const SoulDrain:SoulDrainSkill									= new SoulDrainSkill();
+	public static const Trance:TranceSkill											= new TranceSkill();
+	public static const VioletPupilTransformation:VioletPupilTransformationSkill	= new VioletPupilTransformationSkill();
+	public static const FingerOfDeath:FingerOfDeathSkill							= new FingerOfDeathSkill();
+
 
 
 	public static const ALL_SOULSKILLS:/*CombatAbility*/Array = [
@@ -291,7 +303,18 @@ public class CombatAbilities {
 		BladeDance,
 		HailOfBlades,
 		GrandioseHailOfBlades,
-		GrandioseHailOfMoonBlades
+		GrandioseHailOfMoonBlades,
+		ElementAir,
+		ElementDarkness,
+		ElementEarth,
+		ElementFire,
+		ElementIce,
+		ElementLightning,
+		ElementWater,
+		SoulDrain,
+		Trance,
+		VioletPupilTransformation,
+		FingerOfDeath
 	]
 	
 	/*

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -254,6 +254,15 @@ public class CombatAbilities {
 	public static const StormOfSisterhood:StormOfSisterhoodSkill	= new StormOfSisterhoodSkill();
 	public static const NightOfBrotherhood:NightOfBrotherhoodSkill	= new NightOfBrotherhoodSkill();
 	public static const Devourer:DevourerSkill						= new DevourerSkill();
+	public static const ManyBirds:ManyBirdsSkill					= new ManyBirdsSkill();
+	public static const ResonanceVolley:ResonanceVolleySkill		= new ResonanceVolleySkill();
+	public static const AvatarOfTheSong:AvatarOfTheSongSkill		= new AvatarOfTheSongSkill();
+	public static const BeatOfWar:BeatOfWarSkill					= new BeatOfWarSkill();
+	public static const Comet:CometSkill							= new CometSkill();
+	public static const BladeDance:BladeDanceSkill					= new BladeDanceSkill();
+	public static const HailOfBlades:BladeHailSkill					= new BladeHailSkill(1);
+	public static const GrandioseHailOfBlades:BladeHailSkill		= new BladeHailSkill(2);
+	public static const GrandioseHailOfMoonBlades:BladeHailSkill	= new BladeHailSkill(3);
 
 
 	public static const ALL_SOULSKILLS:/*CombatAbility*/Array = [
@@ -273,7 +282,16 @@ public class CombatAbilities {
 		IciclesOfLove,
 		StormOfSisterhood,
 		NightOfBrotherhood,
-		Devourer
+		Devourer,
+		ManyBirds,
+		ResonanceVolley,
+		AvatarOfTheSong,
+		BeatOfWar,
+		Comet,
+		BladeDance,
+		HailOfBlades,
+		GrandioseHailOfBlades,
+		GrandioseHailOfMoonBlades
 	]
 	
 	/*

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -7,6 +7,7 @@ import classes.Scenes.Combat.SpellsDivine.*;
 import classes.Scenes.Combat.SpellsNecro.*;
 import classes.Scenes.Combat.SpellsGrey.*;
 import classes.Scenes.Combat.SpellsBlood.*;
+import classes.Scenes.Combat.Soulskills.*;
 
 public class CombatAbilities {
 	
@@ -235,6 +236,26 @@ public class CombatAbilities {
 			.concat(ALL_BLOOD_SPELLS)
 			.concat(ALL_GREEN_SPELLS)
 	;
+
+	public static const CleansingPalm:CleansingPalmSkill 		= new CleansingPalmSkill();
+	public static const IceFist:IceFistSkill					= new IceFistSkill()
+	public static const FirePunch:FirePunchSkill				= new FirePunchSkill();
+	public static const HurricaneDance:HurricaneDanceSkill		= new HurricaneDanceSkill();
+	public static const EarthStance:EarthStanceSkill			= new EarthStanceSkill();
+	public static const PunishingKick:PunishingKickSkill		= new PunishingKickSkill();
+	public static const SoulBlast:SoulBlastSkill				= new SoulBlastSkill();
+	public static const Overlimit:OverlimitSkill				= new OverlimitSkill();
+
+	public static const ALL_SOULSKILLS:/*CombatAbility*/Array = [
+		CleansingPalm,
+		IceFist,
+		FirePunch,
+		HurricaneDance,
+		EarthStance,
+		PunishingKick,
+		SoulBlast,
+		Overlimit
+	]
 	
 	/*
 	 * Difference from CombatAbility.Registry:
@@ -243,6 +264,7 @@ public class CombatAbilities {
 	 */
 	public static const ALL:/*CombatAbility*/Array = []
 			.concat(ALL_SPELLS)
+			.concat(ALL_SOULSKILLS)
 	;
 	
 	function CombatAbilities() {

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -237,14 +237,24 @@ public class CombatAbilities {
 			.concat(ALL_GREEN_SPELLS)
 	;
 
-	public static const CleansingPalm:CleansingPalmSkill 		= new CleansingPalmSkill();
-	public static const IceFist:IceFistSkill					= new IceFistSkill()
-	public static const FirePunch:FirePunchSkill				= new FirePunchSkill();
-	public static const HurricaneDance:HurricaneDanceSkill		= new HurricaneDanceSkill();
-	public static const EarthStance:EarthStanceSkill			= new EarthStanceSkill();
-	public static const PunishingKick:PunishingKickSkill		= new PunishingKickSkill();
-	public static const SoulBlast:SoulBlastSkill				= new SoulBlastSkill();
-	public static const Overlimit:OverlimitSkill				= new OverlimitSkill();
+	public static const CleansingPalm:CleansingPalmSkill 			= new CleansingPalmSkill();
+	public static const IceFist:IceFistSkill						= new IceFistSkill()
+	public static const FirePunch:FirePunchSkill					= new FirePunchSkill();
+	public static const HurricaneDance:HurricaneDanceSkill			= new HurricaneDanceSkill();
+	public static const EarthStance:EarthStanceSkill				= new EarthStanceSkill();
+	public static const PunishingKick:PunishingKickSkill			= new PunishingKickSkill();
+	public static const SoulBlast:SoulBlastSkill					= new SoulBlastSkill();
+	public static const Overlimit:OverlimitSkill					= new OverlimitSkill();
+	public static const TripleThrust:MultiThrustSkill				= new MultiThrustSkill(1);
+	public static const SextupleThrust:MultiThrustSkill				= new MultiThrustSkill(2);
+	public static const NonupleThrust:MultiThrustSkill				= new MultiThrustSkill(3);
+	public static const DracoSweep:DracoSweepSkill					= new DracoSweepSkill();
+	public static const FlamesOfLove:FlamesOfLoveSkill				= new FlamesOfLoveSkill();
+	public static const IciclesOfLove:IciclesOfLoveSkill			= new IciclesOfLoveSkill();
+	public static const StormOfSisterhood:StormOfSisterhoodSkill	= new StormOfSisterhoodSkill();
+	public static const NightOfBrotherhood:NightOfBrotherhoodSkill	= new NightOfBrotherhoodSkill();
+	public static const Devourer:DevourerSkill						= new DevourerSkill();
+
 
 	public static const ALL_SOULSKILLS:/*CombatAbility*/Array = [
 		CleansingPalm,
@@ -254,7 +264,16 @@ public class CombatAbilities {
 		EarthStance,
 		PunishingKick,
 		SoulBlast,
-		Overlimit
+		Overlimit,
+		TripleThrust,
+		SextupleThrust,
+		NonupleThrust,
+		DracoSweep,
+		FlamesOfLove,
+		IciclesOfLove,
+		StormOfSisterhood,
+		NightOfBrotherhood,
+		Devourer
 	]
 	
 	/*

--- a/classes/classes/Scenes/Combat/CombatAbility.as
+++ b/classes/classes/Scenes/Combat/CombatAbility.as
@@ -1,6 +1,7 @@
 package classes.Scenes.Combat {
 import classes.Monster;
 import classes.internals.EnumValue;
+import classes.StatusEffectType;
 
 import coc.view.ButtonData;
 
@@ -527,5 +528,22 @@ public class CombatAbility extends BaseCombatContent {
 	protected function toggleOffUsabilityCheck():String {
 		return "";
 	}
+
+	/**
+	 * Function to be used within the advance() function to handle the statuseffect associated with an ability's duration
+	 * @param statusEffect - StatusEffectType responsible for ability effect duration
+	 * @param endFunction - Function that will be called when the ability's duration ends. Function signature must be of the format
+	 * "function endFunction(ability:CombatAbility, display:Boolean):void"
+	 * @param display - To be passed to the endFunction parameter to determine if text should be displayed to the user
+	 */
+	protected function advanceDuration(statusEffect:StatusEffectType, endFunction:Function = null, display:Boolean = true):void {
+        if (player.hasStatusEffect(statusEffect)) {
+            if (player.statusEffectv1(statusEffect) <= 0) {
+                player.removeStatusEffect(statusEffect);
+                if (endFunction != null)
+                    endFunction(this, display);
+            } else player.addStatusValue(statusEffect, 1, -1);
+        }
+    }
 }
 }

--- a/classes/classes/Scenes/Combat/CombatAbility.as
+++ b/classes/classes/Scenes/Combat/CombatAbility.as
@@ -89,7 +89,7 @@ public class CombatAbility extends BaseCombatContent {
 	});
 	public static const CAT_SOULSKILL:int   = EnumValue.add(AllCategories, 3, "SOULSKILL", {
 		name:"Soulskill",
-		group:"spell"
+		group:"soulskill"
 	});
 	public static const CAT_SPELL_WHITE:int = EnumValue.add(AllCategories, 4, "SPELL_WHITE", {
 		name:"White Spell",
@@ -123,6 +123,10 @@ public class CombatAbility extends BaseCombatContent {
 		name:"Green Spell",
 		group:"spell"
 	});
+	public static const CAT_BLOOD_SOULSKILL:int   = EnumValue.add(AllCategories, 12, "BLOOD_SOULSKILL", {
+		name:"Blood Soulskill",
+		group:"soulskill"
+	});
 	
 	public static var AllTags:/*EnumValue*/Array = [];
 	public static const TAG_DAMAGING:int = EnumValue.add(AllTags, 0, 'DAMAGING', {
@@ -143,19 +147,19 @@ public class CombatAbility extends BaseCombatContent {
 	});
 	public static const TAG_FIRE:int = EnumValue.add(AllTags, 4, 'FIRE', {
 		name: 'Fire',
-		desc: "This ability primary element is Fire"
+		desc: "This ability's primary element is Fire"
 	});
 	public static const TAG_LIGHTNING:int = EnumValue.add(AllTags, 5, 'LIGHTNING', {
 		name: 'Lightning',
-		desc: "This ability primary element is Lightning"
+		desc: "This ability's primary element is Lightning"
 	});
 	public static const TAG_ICE:int = EnumValue.add(AllTags, 6, 'ICE', {
 		name: 'Ice',
-		desc: "This ability primary element is Ice"
+		desc: "This ability's primary element is Ice"
 	});
 	public static const TAG_DARKNESS:int = EnumValue.add(AllTags, 7, 'DARKNESS', {
 		name: 'Darkness',
-		desc: "This ability primary element is Darkness"
+		desc: "This ability's primary element is Darkness"
 	});
 	public static const TAG_HEALING:int = EnumValue.add(AllTags, 8, 'HEALING', {
 		name: 'Healing',
@@ -171,19 +175,19 @@ public class CombatAbility extends BaseCombatContent {
 	});
 	public static const TAG_WATER:int = EnumValue.add(AllTags, 11, 'WATER', {
 		name: 'Water',
-		desc: "This ability primary element is Water"
+		desc: "This ability's primary element is Water"
 	});
 	public static const TAG_WIND:int = EnumValue.add(AllTags, 12, 'WIND', {
 		name: 'Wind',
-		desc: "This ability primary element is Wind"
+		desc: "This ability's primary element is Wind"
 	});
 	public static const TAG_EARTH:int = EnumValue.add(AllTags, 13, 'EARTH', {
 		name: 'Earth',
-		desc: "This ability primary element is Earth"
+		desc: "This ability's primary element is Earth"
 	});
 	public static const TAG_ACID:int = EnumValue.add(AllTags, 14, 'ACID', {
 		name: 'Acid',
-		desc: "This ability primary element is Acid"
+		desc: "This ability's primary element is Acid"
 	});
 	public static const TAG_TIER1:int = EnumValue.add(AllTags, 15, 'TIER1', {
 		name: 'Tier1',
@@ -197,6 +201,14 @@ public class CombatAbility extends BaseCombatContent {
 		name: 'Tier3',
 		desc: "This ability is tier 3"
 	});
+	public static const TAG_PHYSICAL:int = EnumValue.add(AllTags, 18, 'PHYSICAL', {
+		name: 'Physical',
+		desc: "This ability deals physical damage"
+	});
+	public static const TAG_MAGICAL:int = EnumValue.add(AllTags, 19, 'MAGICAL', {
+		name: 'Magical',
+		desc: "This ability deals magical damage"
+	});
 	
 	/**
 	 * Unique id of this ability.
@@ -209,6 +221,9 @@ public class CombatAbility extends BaseCombatContent {
 	private var _tags:/*Boolean*/Array;
 	public var baseManaCost:Number = 0;
 	public var baseWrathCost:Number = 0;
+	public var baseSFCost:Number = 0;
+	public var baseFatigueCost:Number = 0;
+	public var processPostCallback:Boolean = true;
 	
 	public function CombatAbility(
 			name:String,
@@ -308,6 +323,12 @@ public class CombatAbility extends BaseCombatContent {
 		if (hpCost() > 0) {
 			costs.push("HP Cost: " + hpCost());
 		}
+		if (fatigueCost() > 0) {
+			costs.push("Fatigue Cost: " + fatigueCost());
+		}
+		if (sfCost() > 0) {
+            costs.push("Soulforce Cost: "+sfCost());
+        }
 		var cd:int = calcCooldown();
 		if (cd > 0) {
 			costs.push("Cooldown: "+cd);
@@ -394,7 +415,8 @@ public class CombatAbility extends BaseCombatContent {
 		} else {
 			perform();
 		}
-		combat.callbackAfterAbility(this);
+		//Allows for some abilities to handle post-ability handling in their own "doeffect()" function - e.g. if the ability calls the standard physical attack function
+		if (processPostCallback) combat.callbackAfterAbility(this);
 	}
 	
 	/**
@@ -458,6 +480,14 @@ public class CombatAbility extends BaseCombatContent {
 	
 	public function hpCost():Number {
 		return 0;
+	}
+
+	public function sfCost():int {
+        return baseSFCost;
+    }
+
+	public function fatigueCost():int {
+		return baseFatigueCost;
 	}
 	
 	/**

--- a/classes/classes/Scenes/Combat/CombatUI.as
+++ b/classes/classes/Scenes/Combat/CombatUI.as
@@ -236,7 +236,8 @@ public class CombatUI extends BaseCombatContent {
 			btnMagic.disable("You are too angry to think straight. Smash your puny opponents first and think later.\n\n").icon("A_Magic")
 		} else if (!combat.canUseMagic()) btnMagic.disable().icon("A_Magic")
 		// Submenu - Soulskills
-		combat.soulskills.buildMenu(soulforceButtons);
+		//combat.soulskills.buildMenu(soulforceButtons);
+		buildAbilityMenu(CombatAbilities.ALL_SOULSKILLS, soulforceButtons);
 		if (soulforceButtons.length > 0) btnSoulskills.show("Soulforce", submenuSoulforce, "Soulforce attacks menu.", "Soulforce Specials");
 		// Submenu - Other
 		combat.buildOtherActions(otherButtons);

--- a/classes/classes/Scenes/Combat/Soulskills/AvatarOfTheSongSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/AvatarOfTheSongSkill.as
@@ -11,7 +11,8 @@ public class AvatarOfTheSongSkill extends AbstractSoulSkill {
             TARGET_SELF,
             TIMING_INSTANT,
             [TAG_BUFF, TAG_HEALING],
-            null
+            null,
+			false
         )
 		baseSFCost = 200;
     }

--- a/classes/classes/Scenes/Combat/Soulskills/AvatarOfTheSongSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/AvatarOfTheSongSkill.as
@@ -1,0 +1,69 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Scenes.Combat.CombatAbilities;
+
+public class AvatarOfTheSongSkill extends AbstractSoulSkill {
+    public function AvatarOfTheSongSkill() {
+        super(
+            "Avatar Of The Song",
+            "Doublecast Charged Weapon and Might. Casts blind if charged weapon is already active. Casts Heal if Might is already active.",
+            TARGET_SELF,
+            TIMING_INSTANT,
+            [TAG_BUFF, TAG_HEALING],
+            null
+        )
+		baseSFCost = 200;
+    }
+
+	override public function get buttonName():String {
+		return "AvatarOfTheSong";
+	}
+
+	override public function get isKnown():Boolean {
+		return player.weapon == weapons.WDSTAFF;
+	}
+
+	override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+		if (player.hasStatusEffect(StatusEffects.OniRampage) || player.wrath > player.maxSafeWrathMagicalAbilities()) {
+			return "You are too angry to think straight. Smash your puny opponents first and think later.";
+		}
+
+        return "";
+    }
+
+	override public function sfCost():int {
+		return baseSFCost;
+	}
+
+    override public function doEffect(display:Boolean = true):void {		
+		if (display) outputText("You feel the song of the mother tree all around you. Using your staff as a beacon, you unify it with the flow of magic through your body,");
+		if (!player.statStore.hasBuff("Might")) {
+			if (display) outputText("drawing strength from it");
+			CombatAbilities.Might.backfireEnabled = false;
+			CombatAbilities.Might.doEffect(false);
+			CombatAbilities.Might.backfireEnabled = true;
+		}
+		else {
+			if (display) outputText("feeling it mend your wounds");
+			CombatAbilities.Heal.doEffect(false);
+			spellPerkUnlock();
+		}
+		if (!monster.hasStatusEffect(StatusEffects.Blind)) {
+			if (display) outputText(". The residual power ");
+			if (!player.hasStatusEffect(StatusEffects.ChargeWeapon)) {
+				if (display) outputText("makes your staff glow with barely contained energy");
+				CombatAbilities.ChargeWeapon.doEffect(false);
+			}
+			else {
+				if (display) outputText("makes your staff flare up, as the energy escapes in a radiant flash");
+				CombatAbilities.Blind.doEffect(false);
+			}
+		}
+		if (display) outputText(".\n\n");
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/AvatarOfTheSongSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/AvatarOfTheSongSkill.as
@@ -12,7 +12,7 @@ public class AvatarOfTheSongSkill extends AbstractSoulSkill {
             TARGET_SELF,
             TIMING_INSTANT,
             [TAG_BUFF, TAG_HEALING],
-            null,
+            PerkLib.MageWarden,
 			false
         )
 		baseSFCost = 200;
@@ -20,10 +20,6 @@ public class AvatarOfTheSongSkill extends AbstractSoulSkill {
 
 	override public function get buttonName():String {
 		return "AvatarOfTheSong";
-	}
-
-	override public function get isKnown():Boolean {
-		return player.hasPerk(PerkLib.MageWarden);
 	}
 
 	override protected function usabilityCheck():String {

--- a/classes/classes/Scenes/Combat/Soulskills/AvatarOfTheSongSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/AvatarOfTheSongSkill.as
@@ -2,6 +2,7 @@ package classes.Scenes.Combat.Soulskills {
 import classes.Scenes.Combat.AbstractSoulSkill;
 import classes.StatusEffects;
 import classes.Scenes.Combat.CombatAbilities;
+import classes.PerkLib;
 
 public class AvatarOfTheSongSkill extends AbstractSoulSkill {
     public function AvatarOfTheSongSkill() {
@@ -22,7 +23,7 @@ public class AvatarOfTheSongSkill extends AbstractSoulSkill {
 	}
 
 	override public function get isKnown():Boolean {
-		return player.weapon == weapons.WDSTAFF;
+		return player.hasPerk(PerkLib.MageWarden);
 	}
 
 	override protected function usabilityCheck():String {

--- a/classes/classes/Scenes/Combat/Soulskills/BeatOfWarSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/BeatOfWarSkill.as
@@ -1,12 +1,13 @@
 package classes.Scenes.Combat.Soulskills {
 import classes.Scenes.Combat.AbstractSoulSkill;
 import classes.Monster;
+import classes.PerkLib;
 
 public class BeatOfWarSkill extends AbstractSoulSkill {
     public function BeatOfWarSkill() {
         super(
             "Beat of War",
-            "Form a small sphere inscribed by symbols to drain from enemy a bit of lust and/or wrath.",
+            "Attack with low-moderate additional soul damage, gain strength equal to 15% your base strength until end of battle. This effect stacks.",
             TARGET_ENEMY,
             TIMING_INSTANT,
             [TAG_DAMAGING, TAG_BUFF],
@@ -20,7 +21,7 @@ public class BeatOfWarSkill extends AbstractSoulSkill {
 	}
 
 	override public function get isKnown():Boolean {
-		return player.weapon == weapons.WGSWORD;
+		return player.hasPerk(PerkLib.StrifeWarden);
 	}
 
 	override public function describeEffectVs(target:Monster):String {

--- a/classes/classes/Scenes/Combat/Soulskills/BeatOfWarSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/BeatOfWarSkill.as
@@ -1,0 +1,48 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.Monster;
+
+public class BeatOfWarSkill extends AbstractSoulSkill {
+    public function BeatOfWarSkill() {
+        super(
+            "Beat of War",
+            "Form a small sphere inscribed by symbols to drain from enemy a bit of lust and/or wrath.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_BUFF],
+            null
+        )
+		baseSFCost = 50;
+    }
+
+	override public function get buttonName():String {
+		return "Beat of War";
+	}
+
+	override public function get isKnown():Boolean {
+		return player.weapon == weapons.WGSWORD;
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "Deals physical damage and raises strength by 15% of base value"
+	}
+
+    override public function doEffect(display:Boolean = true):void {		
+		if (!player.statStore.hasBuff("BeatOfWar"))
+		mainView.statsView.showStatUp('str');
+		player.buff("BeatOfWar").addStats({"str.mult":0.15}).withText("Beat of War").combatPermanent();
+		if (display) outputText("You momentarily attune yourself to the song of the mother tree, and prepare to add a note of your own to it’s rhythm. You feel the beat shift the song’s tempo slightly, taking a twist towards the ominous. This attunement augments your strength.\n\n");
+		combat.basemeleeattacks();
+    }
+
+	//Prevent default enemyAI function call, since post ability cleanup will be handled by combat.basemeleeattacks()
+	override public function buttonCallback():void {
+		combat.callbackBeforeAbility(this);
+		if (timingType == TIMING_TOGGLE && isActive()) {
+			toggleOff();
+		} else {
+			perform();
+		}
+	}
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/BeatOfWarSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/BeatOfWarSkill.as
@@ -11,17 +11,14 @@ public class BeatOfWarSkill extends AbstractSoulSkill {
             TARGET_ENEMY,
             TIMING_INSTANT,
             [TAG_DAMAGING, TAG_BUFF],
-            null
+            PerkLib.StrifeWarden
         )
 		baseSFCost = 50;
+		processPostCallback = false;
     }
 
 	override public function get buttonName():String {
 		return "Beat of War";
-	}
-
-	override public function get isKnown():Boolean {
-		return player.hasPerk(PerkLib.StrifeWarden);
 	}
 
 	override public function describeEffectVs(target:Monster):String {
@@ -30,20 +27,11 @@ public class BeatOfWarSkill extends AbstractSoulSkill {
 
     override public function doEffect(display:Boolean = true):void {		
 		if (!player.statStore.hasBuff("BeatOfWar"))
-		mainView.statsView.showStatUp('str');
+			mainView.statsView.showStatUp('str');
 		player.buff("BeatOfWar").addStats({"str.mult":0.15}).withText("Beat of War").combatPermanent();
-		if (display) outputText("You momentarily attune yourself to the song of the mother tree, and prepare to add a note of your own to it’s rhythm. You feel the beat shift the song’s tempo slightly, taking a twist towards the ominous. This attunement augments your strength.\n\n");
+		if (display) 
+			outputText("You momentarily attune yourself to the song of the mother tree, and prepare to add a note of your own to it’s rhythm. You feel the beat shift the song’s tempo slightly, taking a twist towards the ominous. This attunement augments your strength.\n\n");
 		combat.basemeleeattacks();
     }
-
-	//Prevent default enemyAI function call, since post ability cleanup will be handled by combat.basemeleeattacks()
-	override public function buttonCallback():void {
-		combat.callbackBeforeAbility(this);
-		if (timingType == TIMING_TOGGLE && isActive()) {
-			toggleOff();
-		} else {
-			perform();
-		}
-	}
 }
 }

--- a/classes/classes/Scenes/Combat/Soulskills/BladeDanceSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/BladeDanceSkill.as
@@ -13,17 +13,14 @@ public class BladeDanceSkill extends AbstractSoulSkill {
             TARGET_ENEMY,
             TIMING_INSTANT,
             [TAG_DAMAGING],
-            null
+            PerkLib.BladeWarden
         )
 		baseSFCost = 50;
+		processPostCallback = false;
     }
 
 	override public function get buttonName():String {
 		return "Blade Dance";
-	}
-
-	override public function get isKnown():Boolean {
-		return player.hasPerk(PerkLib.BladeWarden);
 	}
 
 	override public function describeEffectVs(target:Monster):String {
@@ -40,15 +37,5 @@ public class BladeDanceSkill extends AbstractSoulSkill {
 		player.createStatusEffect(StatusEffects.BladeDance,0,0,0,0);
 		combat.basemeleeattacks();
     }
-
-	//Prevent default enemyAI function call, since post ability cleanup will be handled by combat.basemeleeattacks()
-	override public function buttonCallback():void {
-		combat.callbackBeforeAbility(this);
-		if (timingType == TIMING_TOGGLE && isActive()) {
-			toggleOff();
-		} else {
-			perform();
-		}
-	}
 }
 }

--- a/classes/classes/Scenes/Combat/Soulskills/BladeDanceSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/BladeDanceSkill.as
@@ -1,0 +1,53 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+
+public class BladeDanceSkill extends AbstractSoulSkill {
+    public function BladeDanceSkill() {
+        super(
+            "Blade Dance",
+            "Attack twice (four times if double attack is active, six times if triple attack is active and etc.).",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            null
+        )
+		baseSFCost = 50;
+    }
+
+	override public function get buttonName():String {
+		return "Blade Dance";
+	}
+
+	override public function get isKnown():Boolean {
+		return player.weapon == weapons.WDBLADE;
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "Deals 2 sets of physical damage attacks"
+	}
+
+	override public function sfCost():int {
+		var soulforcecost:Number = baseSFCost * soulskillCost() * (1 + flags[kFLAGS.MULTIATTACK_STYLE]);
+        return Math.round(soulforcecost);
+	}
+
+    override public function doEffect(display:Boolean = true):void {		
+		if (display) outputText("You momentarily attune yourself to the song of the mother tree, and dance forward, darting around your enemy, your blade slicing the air and foe alike.\n\n");
+		player.createStatusEffect(StatusEffects.BladeDance,0,0,0,0);
+		combat.basemeleeattacks();
+    }
+
+	//Prevent default enemyAI function call, since post ability cleanup will be handled by combat.basemeleeattacks()
+	override public function buttonCallback():void {
+		combat.callbackBeforeAbility(this);
+		if (timingType == TIMING_TOGGLE && isActive()) {
+			toggleOff();
+		} else {
+			perform();
+		}
+	}
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/BladeDanceSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/BladeDanceSkill.as
@@ -3,6 +3,7 @@ import classes.Scenes.Combat.AbstractSoulSkill;
 import classes.StatusEffects;
 import classes.Monster;
 import classes.GlobalFlags.kFLAGS;
+import classes.PerkLib;
 
 public class BladeDanceSkill extends AbstractSoulSkill {
     public function BladeDanceSkill() {
@@ -22,7 +23,7 @@ public class BladeDanceSkill extends AbstractSoulSkill {
 	}
 
 	override public function get isKnown():Boolean {
-		return player.weapon == weapons.WDBLADE;
+		return player.hasPerk(PerkLib.BladeWarden);
 	}
 
 	override public function describeEffectVs(target:Monster):String {

--- a/classes/classes/Scenes/Combat/Soulskills/BladeHailSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/BladeHailSkill.as
@@ -122,23 +122,23 @@ public class BladeHailSkill extends AbstractSoulSkill {
 		damage *= d2;
 
 		if (display) outputText(" ");
-		doMagicDamage(damage, true, true);
+		doMagicDamage(damage, true, display);
 		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
 		if (hits == 2) {
 			if (display) outputText(" ");
-			doMagicDamage(damage, true, true);
+			doMagicDamage(damage, true, display);
 			if (crit && display) outputText(" <b>*Critical Hit!*</b>");
 			damage *= 2;
 		}
 		if (hits == 4) {
 			if (display) outputText(" ");
-			doMagicDamage(damage, true, true);
+			doMagicDamage(damage, true, display);
 			if (crit && display) outputText(" <b>*Critical Hit!*</b>");
 			if (display) outputText(" ");
-			doMagicDamage(damage, true, true);
+			doMagicDamage(damage, true, display);
 			if (crit && display) outputText(" <b>*Critical Hit!*</b>");
 			if (display) outputText(" ");
-			doMagicDamage(damage, true, true);
+			doMagicDamage(damage, true, display);
 			if (crit && display) outputText(" <b>*Critical Hit!*</b>");
 			damage *= 4;
 		}

--- a/classes/classes/Scenes/Combat/Soulskills/BladeHailSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/BladeHailSkill.as
@@ -1,0 +1,170 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Races;
+import classes.Scenes.Combat.Combat;
+import classes.Items.Weapons.Tidarion;
+
+public class BladeHailSkill extends AbstractSoulSkill {
+	//Skill name, number of attacks, status effect to sjow knowledge of skill, base SF cost, cooldown, number of attack rounds, hits per attack round
+	private var hailArray:Array = [
+		["Hail of Blades", "six", StatusEffects.KnowsHailOfBlades, 50, 0, 6, 1],
+		["Grandiose Hail Of Blades", "eighteen", StatusEffects.KnowsGrandioseHailOfBlades, 200, 3, 9, 2],
+		["Grandiose Hail Of Moon Blades", "fifty-six", StatusEffects.KnowsGrandioseHailOfMoonBlades, 800, 9, 19, 4]
+	];
+	private var hailSelection:int;
+	private var count:int;
+
+    public function BladeHailSkill(count: int) {
+        super(
+            count < 4 && count > 0? hailArray[count - 1][0]: "Thrust",
+            "Form " + hailArray[count - 1][1] + " weapons from your soulforce traveling at extreme speeds.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            count < 4 && count > 0? hailArray[count - 1][2]: null
+        )
+		hailSelection = count - 1;
+		baseSFCost = hailArray[hailSelection][3];
+    }
+
+	override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+		if (player.hasStatusEffect(StatusEffects.OniRampage) || player.wrath > player.maxSafeWrathMagicalAbilities()) {
+			return "You are too angry to think straight. Smash your puny opponents first and think later.";
+		}
+
+        return "";
+    }
+
+	override public function get buttonName():String {
+		switch (hailSelection) {
+			case 0: return "Hail of Blades";
+			case 1: return "G.Hail of Blades";
+			case 2: return "G.Hail of M.Blades";
+			default: return "";
+		}
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		var attackRounds:int = hailArray[hailSelection][6];
+		var attacksPerRound:int = hailArray[hailSelection][5]
+		return "~" + Math.round(calcHailDamage() * attacksPerRound * attackRounds) + " magical damage" 
+	}
+
+	override public function calcCooldown():int {
+		return hailArray[hailSelection][4];
+	}
+
+	//Calculate dodge chance for each version of skill
+	private function didDodge(display:Boolean):Boolean {
+		switch (hailSelection + 1) {
+			case 0: return monsterDodgeSkill("weapons", display);
+			case 1:
+				if ((player.playerIsBlinded() && rand(2) == 0) || (monster.spe - player.spe > 10 && int(Math.random() * (((monster.spe - player.spe) / 5) + 70)) > 80)) {
+					if (display) {
+						if (monster.spe - player.spe < 8) outputText("[Themonster] narrowly avoids weapons!\n\n");
+						else if (monster.spe-player.spe < 20) outputText("[Themonster] dodges weapons with superior quickness!\n\n");
+						else outputText("[Themonster] deftly avoids weapons.\n\n");
+					}
+					return true;
+				} else
+					return false;
+			case 2:
+				if ((player.playerIsBlinded() && rand(2) == 0) || (monster.spe - player.spe > 20 && int(Math.random() * (((monster.spe - player.spe) / 6) + 60)) > 80)) {
+					if (display) {
+						if (monster.spe - player.spe < 8) outputText("[Themonster] narrowly avoids weapons!\n\n");
+						else if (monster.spe-player.spe < 20) outputText("[Themonster] dodges weapons with superior quickness!\n\n");
+						else outputText("[Themonster] deftly avoids weapons.\n\n");
+					}
+					return true;
+				} else
+					return false;
+			default: return false;
+		}
+	}
+
+	private function calcHailDamage():Number {
+		var damage:Number = player.wis * 0.5;
+		damage += scalingBonusWisdom() * 0.5;
+		if (damage < 10) damage = 10;
+
+		//soulskill mod effect
+		damage *= combat.soulskillMagicalMod();
+
+		//other bonuses
+		if (player.hasPerk(PerkLib.Heroism) && (monster && (monster.hasPerk(PerkLib.EnemyBossType) || monster.hasPerk(PerkLib.EnemyHugeType)))) damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+		return damage;
+	}
+
+	private function fireHail(hits:int = 1, display:Boolean = true):void {
+		var damage:Number = calcHailDamage();
+
+		//Determine if critical hit!
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatMagicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+
+		var d2:Number = 0.9;
+		d2 += (rand(21) * 0.01);
+		damage *= d2;
+
+		if (display) outputText(" ");
+		doMagicDamage(damage, true, true);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		if (hits == 2) {
+			if (display) outputText(" ");
+			doMagicDamage(damage, true, true);
+			if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+			damage *= 2;
+		}
+		if (hits == 4) {
+			if (display) outputText(" ");
+			doMagicDamage(damage, true, true);
+			if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+			if (display) outputText(" ");
+			doMagicDamage(damage, true, true);
+			if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+			if (display) outputText(" ");
+			doMagicDamage(damage, true, true);
+			if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+			damage *= 4;
+		}
+
+		checkAchievementDamage(damage);
+		if (player.hasStatusEffect(StatusEffects.HeroBane)) flags[kFLAGS.HERO_BANE_DAMAGE_BANK] += damage;
+		if (player.hasStatusEffect(StatusEffects.EruptingRiposte)) flags[kFLAGS.ERUPTING_RIPOSTE_DAMAGE_BANK] += monster.tou + monster.inte + monster.wis;
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+
+		if (display) outputText("Letting soulforce leak out around you, you form " + hailArray[hailSelection][1] +
+			" ethereal two meter long weapons in four rows. You thrust your hand outwards and in the blink of an eye, weapons shoot forwards [themonster].  ");
+
+		if (didDodge(display)) return;
+
+		if (display) outputText("Weapons hits [themonster], dealing ");
+
+		var rounds:Number = hailArray[hailSelection][5];
+		while (rounds-->0) fireHail(hailArray[hailSelection][6], display);
+		if (display) outputText(" damage!\n\n");
+
+		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(flags[kFLAGS.HERO_BANE_DAMAGE_BANK]);
+		combat.heroBaneProc2();
+		combat.EruptingRiposte2();
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/BloodDewdropsSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/BloodDewdropsSkill.as
@@ -1,0 +1,94 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractBloodSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class BloodDewdropsSkill extends AbstractBloodSoulSkill {
+    public function BloodDewdropsSkill(sfInfusion: Boolean = false) {
+        super(
+            "Blood Dewdrops",
+            sfInfusion? "(Soulforce infused) Blood Dewdrops, infused by a small amount of soulforce. Blood Dewdrops will fire many blood droplets from your hand.  "
+			: "Blood Dewdrops will fire many bloody droplets from your hand.  ",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            sfInfusion? StatusEffects.KnowsBloodDewdropsSF: StatusEffects.KnowsBloodDewdrops,
+			true,
+			sfInfusion
+        )
+		baseSFCost = 240;
+    }
+
+	override protected function baseName():String {
+		return "Blood Dewdrops";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + Math.round(calcDamage(target) * 4) + " blood damage"
+	}
+
+	override public function calcCooldown():int {
+		return bloodSoulSkillCoolDown(2);
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = scalingBonusWisdom() * spellModBlood() * 0.5;
+		var damageFloor:Number = 10;
+
+		if (sfInfusion) {
+			damage *= 3;
+			damageFloor *= 3;
+		}
+
+		if (damage < damageFloor) damage = damageFloor;
+		if (monster && monster.plural) damage *= 5;
+		if (player.hasPerk(PerkLib.BloodAffinity)) damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+
+		if (sfInfusion) {
+			//soulskill mod effect
+			damage *= soulskillPhysicalMod();
+		}
+
+		return Math.round(damage);
+
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_PHYS;
+		var additionalSFLine: String = sfInfusion? "You close your eyes for a moment, sending soulforce into the pellets. " : "";
+		if (display) outputText("You concentrate, focusing on the power of your blood before opening your hand and pointing it toward the enem"+(monster.plural?"ies":"y")
+			+". Blood spurts from your fingertips, beads of crimson darkening as they harden. " + additionalSFLine
+			+ "You flick your wrist, sending the blood pellets flying towards [themonster].\n\n");
+		
+		var damage:Number = calcDamage(monster);
+
+		//Determine if critical hit!
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatPhysicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+		if (player.hasPerk(PerkLib.BloodMastery)) damage *= 2;
+		damage = Math.round(damage * combat.bloodDamageBoostedByDao());
+		if (display && display) outputText("[Themonster] takes ");
+		doDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		doDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		doDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		doDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		if (display) outputText(" damage.");
+		endTurnByBloodSkillUse(damage);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/BloodReqiuemSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/BloodReqiuemSkill.as
@@ -1,0 +1,83 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractBloodSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class BloodReqiuemSkill extends AbstractBloodSoulSkill {
+    public function BloodReqiuemSkill(sfInfusion: Boolean = false) {
+        super(
+            "Blood Requiem",
+            sfInfusion? "(Soulforce infused) Blood Requiem, infused by a small amount of soulforce to enhance its power, will create pillars of blood that would deal damage and reduce the recovery rate of enemies for a short time.  "
+			: "Blood Requiem will create pillars of blood, dealing damage and reducing the recovery rate of enemies for a short time.  ",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            sfInfusion? StatusEffects.KnowsBloodRequiemSF: StatusEffects.KnowsBloodRequiem,
+			true,
+			sfInfusion
+        )
+		baseSFCost = 150;
+    }
+
+	override protected function baseName():String {
+		return "Blood Requiem";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + calcDamage(target) + " blood damage, inflicts Bleed for 4 rounds"
+	}
+
+	override public function calcCooldown():int {
+		return bloodSoulSkillCoolDown(4);
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = scalingBonusWisdom() * spellModBlood() * 2;
+		var damageFloor:Number = 10;
+
+		if (sfInfusion) {
+			damage *= 3;
+			damageFloor *= 3;
+		}
+
+		if (damage < damageFloor) damage = damageFloor;
+		if (player.hasPerk(PerkLib.BloodAffinity)) damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+
+		return Math.round(damage);
+
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_PHYS;
+		var additionalSFLine: String = sfInfusion? "You pour Soulforce into your hands, and they glow blue with each gesture, power pulsing with your heartbeat. " : "";
+		if (display) outputText("You concentrate, focusing on the power of your blood before starting making gestures with your hands, precise movements sending power blazing through your body. " + 
+			additionalSFLine + 
+			"Within an instant, large, blood dripping pillars form above [themonster]. The pillars begin to fall, and [themonster] looks up in shock, too late to dodge such a large projectile. \n\n");
+		var damage:Number = calcDamage(monster);
+
+		//Determine if critical hit!
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatPhysicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+		if (player.hasPerk(PerkLib.BloodMastery)) damage *= 2;
+		damage = Math.round(damage * combat.bloodDamageBoostedByDao());
+		if (display) outputText("[Themonster] takes ");
+		doDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		if (display) outputText(" damage.");
+		if (monster.hasStatusEffect(StatusEffects.BloodRequiem)) monster.addStatusValue(StatusEffects.BloodRequiem, 1, 4);
+		else monster.createStatusEffect(StatusEffects.BloodRequiem,4,0,0,0);
+		endTurnByBloodSkillUse(damage, display);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/BloodSwipeSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/BloodSwipeSkill.as
@@ -1,0 +1,90 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractBloodSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class BloodSwipeSkill extends AbstractBloodSoulSkill {
+    public function BloodSwipeSkill(sfInfusion: Boolean = false) {
+        super(
+            "Blood Swipe",
+            sfInfusion? "(Soulforce infused) Blood Swipe, infused by a small amount of soulforce. This skill will fire three red lines of blood energy from your hand.  "
+			: "Blood Swipe will fire three red lines of blood energy from your hand.  ",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            sfInfusion? StatusEffects.KnowsBloodSwipeSF: StatusEffects.KnowsBloodSwipe,
+			true,
+			sfInfusion
+        )
+		baseSFCost = 60;
+    }
+
+	override protected function baseName():String {
+		return "Blood Swipe";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + Math.round(calcDamage(target) * 3) + " blood damage"
+	}
+
+	override public function calcCooldown():int {
+		return bloodSoulSkillCoolDown(2);
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = scalingBonusWisdom() * spellModBlood();
+		var damageFloor:Number = 10;
+
+		if (sfInfusion) {
+			damage *= 3;
+			damageFloor *= 3;
+		}
+
+		if (damage < damageFloor) damage = damageFloor;
+		if (player.hasPerk(PerkLib.BloodAffinity)) damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+
+		if (sfInfusion) {
+			//soulskill mod effect
+			damage *= soulskillPhysicalMod();
+		}
+
+		return Math.round(damage);
+
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_PHYS;
+		var additionalSFLine: String = sfInfusion? "You infuse a bit of soulforce into the blood, before swiping your hand across your chest. " : "You swipe your hand across your chest. ";
+		if (display) outputText("You concentrate, focusing on the power of your blood. " + additionalSFLine
+			+ "Three trails of blood pour from your fingertips, condensing into thin crimson blades. You point your clawlike blades at your foe, and they detach with a small crunch, flying toward [themonster].\n\n");
+		
+		var damage:Number = calcDamage(monster);
+
+		//Determine if critical hit!
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatPhysicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+		if (player.hasPerk(PerkLib.BloodMastery)) damage *= 2;
+		damage = Math.round(damage * combat.bloodDamageBoostedByDao());
+		if (display) outputText("[Themonster] takes ");
+		doDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		doDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		doDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		if (display) outputText(" damage.");
+		endTurnByBloodSkillUse(damage, display);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/CleansingPalmSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/CleansingPalmSkill.as
@@ -19,7 +19,7 @@ public class CleansingPalmSkill extends AbstractSoulSkill {
             TARGET_ENEMY,
             TIMING_INSTANT,
             [TAG_DAMAGING],
-            null //Skill uses a perk rather than a status effect to determine knowledge
+            PerkLib.CleansingPalm
         )
 		baseSFCost = 30;
     }
@@ -38,10 +38,6 @@ public class CleansingPalmSkill extends AbstractSoulSkill {
 	override public function get buttonName():String {
 		return "C.Palm";
 	}
-
-    override public function get isKnown():Boolean {
-        return player.hasPerk(PerkLib.CleansingPalm);
-    }
 
 	override public function describeEffectVs(target:Monster):String {
 		return "~" + calcDamage(target) + " magical damage"

--- a/classes/classes/Scenes/Combat/Soulskills/CleansingPalmSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/CleansingPalmSkill.as
@@ -1,0 +1,154 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.Scenes.NPCs.Jojo;
+import classes.Scenes.NPCs.JojoScene;
+import classes.Scenes.Dungeons.D3.LivingStatue;
+import classes.Races;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class CleansingPalmSkill extends AbstractSoulSkill {
+    public function CleansingPalmSkill() {
+        super(
+            "Cleansing Palm",
+            "Unleash the power of your cleansing aura! More effective against corrupted opponents. Doesn't work on the pure.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            null //Skill uses a perk rather than a status effect to determine knowledge
+        )
+		baseSFCost = 30;
+    }
+
+    override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+        if (player.cor >= (10 + player.corruptionTolerance)) {
+				return "You are too corrupt to use this ability!";
+		}
+
+        return "";
+    }
+
+	override public function get buttonName():String {
+		return "C.Palm";
+	}
+
+    override public function get isKnown():Boolean {
+        return player.hasPerk(PerkLib.CleansingPalm);
+    }
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + calcDamage(target) + " magical damage"
+	}
+
+	private function calcCorruptionMulti(monster:Monster):Number {
+		var corruptionMulti:Number = (monster.cor - 20) / 25;
+		if (corruptionMulti > 1.5) {
+			corruptionMulti = 1.5;
+			corruptionMulti += ((monster.cor - 57.5) / 100); //The increase to multiplier is diminished.
+		}
+		return corruptionMulti;
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = int(10 + (player.wis / 3 + rand(player.wis / 2)));
+		damage += combat.meleeUnarmedDamageNoLagSingle();
+		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.BlazingBattleSpirit)) {
+			if (player.isRaceCached(Races.MOUSE, 2) && (player.jewelryName == "Infernal Mouse ring" || player.jewelryName2 == "Infernal Mouse ring" || player.jewelryName3 == "Infernal Mouse ring" || player.jewelryName4 == "Infernal Mouse ring")) damage *= 2.2;
+			else damage *= 2;
+			damage = combat.FireTypeDamageBonusLarge(damage);
+		}
+		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
+			damage = combat.FireTypeDamageBonus(damage);
+			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
+			damage *= 1.1;
+		}
+		damage *= soulskillMod();
+		if (monster) {
+			damage *= calcCorruptionMulti(monster);
+			if (player.hasPerk(PerkLib.PerfectStrike) && monster.monsterIsStunned()) damage *= 1.5;
+		}
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+		return Math.round(damage);
+
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+        if (monster is Jojo) {
+			// Not a completely corrupted monkmouse
+			if (JojoScene.monk < 2) {
+				if (display) {
+					outputText("You thrust your palm forward, sending a blast of pure energy towards Jojo. At the last second he sends a blast of his own against yours canceling it out\n\n");
+				}
+				enemyAI();
+				return;
+			}
+		}
+		if (monster is LivingStatue) {
+			if (display) {
+				outputText("You thrust your palm forward, causing a blast of pure energy to slam against the giant stone statue- to no effect!");		
+			}
+			enemyAI();
+			return;
+		}
+
+		var damage:Number = calcDamage(monster);
+		if (damage > 0) {
+			if (display) {
+				outputText("You thrust your palm forward, creating a blast of pure energy that erupts from your palm, slamming into [themonster], tossing");
+				if ((monster as Monster).plural) {
+					outputText(" them");
+				} else {
+					outputText((monster as Monster).mfn(" him", " her", " it"));
+				}
+				outputText(" back a few feet.\n\n");
+				if (silly() && calcCorruptionMulti(monster) >= 1.75) outputText("It's super effective!  ");
+			}
+			
+			//Determine if critical hit!
+			var crit:Boolean = false;
+			var critChance:int = 5;
+			critChance += combat.combatPhysicalCritical();
+			if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+			if (rand(100) < critChance) {
+				crit = true;
+				damage *= 1.75;
+			}
+			
+			if (display) {
+				outputText("[Themonster] takes ");
+			}
+
+			doMagicDamage(damage, true, display);
+			if (player.hasPerk(PerkLib.FlurryOfBlows)) {
+				doMagicDamage(damage, true, display);
+				doMagicDamage(damage, true, display);
+				damage *= 3;
+			}
+
+			if (display) {
+				if (crit) 
+					outputText(" <b>*Critical Hit!*</b>");
+				outputText("damage \n\n");
+			}
+			
+		}
+		else {
+			if (display) {
+				outputText("You thrust your palm forward, causing a blast of pure energy to slam against [themonster], which they ignore. It is probably best you don’t use this technique against the pure.\n\n");
+			}
+		} 
+		combat.WrathGenerationPerHit2(5);
+		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) this.anubiHeartLeeching(damage);
+		combat.heroBaneProc(damage);
+		combat.EruptingRiposte();
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/CometSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/CometSkill.as
@@ -80,7 +80,7 @@ public class CometSkill extends AbstractSoulSkill {
 
 		//final touches
 		if (display) outputText("Comet fragments hits [themonster], dealing ");
-		doMagicDamage(damage, true, true);
+		doMagicDamage(damage, true, display);
 		if (display) outputText(" damage! ");
 		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
 		checkAchievementDamage(damage);

--- a/classes/classes/Scenes/Combat/Soulskills/CometSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/CometSkill.as
@@ -1,0 +1,92 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class CometSkill extends AbstractSoulSkill {
+    public function CometSkill() {
+        super(
+            "Comet",
+            "Project a shard of soulforce, which will come crashing down upon your opponent as a crystalline comet.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_AOE],
+            StatusEffects.KnowsComet
+        )
+		baseSFCost = 60;
+    }
+
+    override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+		if (player.hasStatusEffect(StatusEffects.OniRampage) || player.wrath > player.maxSafeWrathMagicalAbilities()) {
+			return "You are too angry to think straight. Smash your puny opponents first and think later.";
+		}
+
+        return "";
+    }
+
+	override public function get buttonName():String {
+		return "Comet";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + calcDamage(target) + " magical damage"
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = scalingBonusWisdom();
+		if (damage < 10) damage = 10;
+
+		//soulskill mod effect
+		damage *= combat.soulskillMagicalMod();
+
+		//group enemies bonus
+		if (monster && monster.plural) damage *= 5;
+
+		//other bonuses
+		if (player.hasPerk(PerkLib.Heroism) && (monster && (monster.hasPerk(PerkLib.EnemyBossType) || monster.hasPerk(PerkLib.EnemyHugeType)))) damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+
+		return Math.round(damage);
+
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+
+		if (display) {
+			outputText("You focus for a moment, projecting a fragment of your soulforce above you.  A moment later, a prismatic comet crashes down on your opponents [themonster].  ");
+			if (monster.plural) outputText("Shattering into thousands of fragments that shower anything and everything around you.  ");
+		}
+		if (monsterDodgeSkill("comet fragments", display)) return;
+
+		var damage:Number = calcDamage(monster);
+
+		//Determine if critical hit!
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatMagicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+
+		//final touches
+		if (display) outputText("Comet fragments hits [themonster], dealing ");
+		doMagicDamage(damage, true, true);
+		if (display) outputText(" damage! ");
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		checkAchievementDamage(damage);
+		if (display) outputText("\n\n");
+		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(damage);
+		combat.heroBaneProc(damage);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/CreateElementSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/CreateElementSkill.as
@@ -1,0 +1,159 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class CreateElementSkill extends AbstractSoulSkill {
+	private var rank:int;
+	private var element:String;
+    public function CreateElementSkill(element:String, rank:int) {
+        super(
+            "Create Element (" + element + ")",
+            "Form ball of " + element.toLowerCase() + " elemental energy to toss at the enemy.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            buildTagList(element),
+            rank == 1? StatusEffects.KnowsCreateElementBasic: StatusEffects.KnowsCreateElementAdvanced
+        )
+		baseSFCost = 10;
+		this.rank = rank;
+		this.element = element;
+    }
+
+	private function buildTagList(element:String):Array {
+		var tagArr:Array = [TAG_DAMAGING];
+
+		var tagToAdd:int;
+		switch(element.toLowerCase()) {
+			case "fire":
+				tagToAdd = TAG_FIRE
+				break;
+			case "water":
+				tagToAdd = TAG_WATER
+				break;
+			case "air":
+				tagToAdd = TAG_WIND
+				break;
+			case "earth":
+				tagToAdd = TAG_EARTH
+				break;
+			case "ice":
+				tagToAdd = TAG_ICE
+				break;
+			case "lightning":
+				tagToAdd = TAG_LIGHTNING
+				break;
+			case "darkness":
+				tagToAdd = TAG_DARKNESS
+				break;
+			default:
+				break;
+		}
+
+		if (tagToAdd) {
+			tagArr.push(tagToAdd)
+		}
+
+		return tagArr;
+	}
+
+    override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+		if (player.hasStatusEffect(StatusEffects.OniRampage) || player.wrath > player.maxSafeWrathMagicalAbilities()) {
+			return "You are too angry to think straight. Smash your puny opponents first and think later.";
+		}
+
+        return "";
+    }
+
+	override public function get buttonName():String {
+		return "Create E. (" + element + ")";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + calcDamage(target) + " " + this.element.toLowerCase() + " damage";
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = scalingBonusWisdom();
+		if (damage < 10) damage = 10;
+
+		//soulskill mod effect
+		damage *= combat.soulskillMagicalMod();
+
+		//other bonuses
+		if (player.hasPerk(PerkLib.Heroism) && (monster && (monster.hasPerk(PerkLib.EnemyBossType) || monster.hasPerk(PerkLib.EnemyHugeType)))) damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+
+		return Math.round(damage);
+
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+
+		if (display) outputText("You concentrate, focusing on the power of your soul. You infuse a bit of soulforce into a finger, " + 
+			"bright blue energy covering the tip. You draw a simple rune in the air, the energy from your finger dissipating into it. A moment later, the rune swells, energy forming into a small ball of "
+		 	+ element.toLowerCase() +". You motion, sending the ball flying toward [themonster].  ");
+		if (monsterDodgeSkill("ball", display)) return;
+
+		var damage:Number = calcDamage(monster);
+
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatMagicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+		if (display) outputText("The tossed projectile hits [themonster], dealing ");
+		switch (element) {
+			case "Fire":
+				damage = Math.round(damage*combat.fireDamageBoostedByDao());
+				doFireDamage(damage, true, display);
+				break;
+			case "Water":
+				damage = Math.round(damage*combat.waterDamageBoostedByDao());
+				doWaterDamage(damage, true, display);
+				break;
+			case "Air":
+				damage = Math.round(damage*combat.windDamageBoostedByDao());
+				doWindDamage(damage, true, display);
+				break;
+			case "Earth":
+				damage = Math.round(damage*combat.earthDamageBoostedByDao());
+				doEarthDamage(damage, true, display);
+				break;
+			case "Ice":
+				damage = Math.round(damage*combat.iceDamageBoostedByDao());
+				doIceDamage(damage, true, display);
+				break;
+			case "Lightning":
+				damage = Math.round(damage*combat.lightningDamageBoostedByDao());
+				doLightingDamage(damage, true, display);
+				break;
+			case "Darkness":
+				damage = Math.round(damage*combat.darknessDamageBoostedByDao());
+				doDarknessDamage(damage, true, display);
+				break;
+			default:
+				damage = Math.round(damage*combat.fireDamageBoostedByDao());
+				doFireDamage(damage, true, display);
+				break;
+		}
+		if (display) outputText(" damage! ");
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		checkAchievementDamage(damage);
+		if (display) outputText("\n\n");
+		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(damage);
+		combat.heroBaneProc(damage);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/DevourerSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/DevourerSkill.as
@@ -32,6 +32,8 @@ public class DevourerSkill extends AbstractSoulSkill {
 	private function calcLustDrain(monster:Monster, apply:Boolean):Number {
 		var drainAmount:Number = 0;
 
+		if (!monster) return drainAmount;
+
 		if (monster.lust > 400) {
         	if (apply) monster.lust -= 400;
         	drainAmount += 200;
@@ -45,6 +47,9 @@ public class DevourerSkill extends AbstractSoulSkill {
 
 	private function calcWrathDrain(monster:Monster, apply:Boolean):Number {
 		var drainAmount:Number = 0;
+
+		if (!monster) return drainAmount;
+
 		if (monster.wrath > 400) {
         	if (apply) monster.wrath -= 400;
         	drainAmount += 200;

--- a/classes/classes/Scenes/Combat/Soulskills/DevourerSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/DevourerSkill.as
@@ -1,0 +1,82 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class DevourerSkill extends AbstractSoulSkill {
+    public function DevourerSkill() {
+        super(
+            "Devourer",
+            "Form a small sphere inscribed by symbols to drain from enemy a bit of lust and/or wrath.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DEBUFF],
+            StatusEffects.KnowsHeavensDevourer
+        )
+    }
+
+	override public function get buttonName():String {
+		return "Devourer";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "Drains ~" + calcLustDrain(target, false) + "lust and ~" + calcWrathDrain(target, false) + " wrath";
+	}
+
+	override public function calcCooldown():int {
+		return 4;
+	}
+
+	private function calcLustDrain(monster:Monster, apply:Boolean):Number {
+		var drainAmount:Number = 0;
+
+		if (monster.lust > 400) {
+        	if (apply) monster.lust -= 400;
+        	drainAmount += 200;
+    	} else {
+			var devouredLust:Number = monster.lust;
+			if (apply) monster.lust = 0;
+			drainAmount += Math.round(devouredLust / 2);
+    	}
+		return drainAmount;
+	}
+
+	private function calcWrathDrain(monster:Monster, apply:Boolean):Number {
+		var drainAmount:Number = 0;
+		if (monster.wrath > 400) {
+        	if (apply) monster.wrath -= 400;
+        	drainAmount += 200;
+    	} else {
+			var devouredWrath:Number = monster.wrath;
+			if (apply) monster.wrath = 0;
+			drainAmount += Math.round(devouredWrath / 2);
+    	}
+		return drainAmount;
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+
+		if (display) {
+			outputText("You start to concentrate and between your hands forms small black sphere inscribed with many tiny symbols. With a simple flick of hand you send it toward [themonster], which preparing to defend. But sphere stops a round twenty centimiters before [monster his]. ");
+    		outputText("And then it starts greedy sucking our any bit of lust or wrath it can find in [themonster] trasmiting part of it back to you.");
+		}
+		var transferedWrath:Number = calcLustDrain(monster, true);
+		var transferedLust:Number = calcWrathDrain(monster, true);
+
+		
+		if (transferedLust > 0) {
+			if (display) outputText("(+" + transferedLust + " lust)");
+			player.lust += transferedLust;
+		}
+		if (transferedWrath > 0) {
+			if (display) outputText("(+" + transferedWrath + " wrath)");
+			player.wrath += transferedWrath;
+		}
+		if (display) outputText("\n\n");
+		
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/DracoSweepSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/DracoSweepSkill.as
@@ -40,7 +40,7 @@ public class DracoSweepSkill extends AbstractSoulSkill {
 			if (player.isMeetingNaturalJousterReq()) damage *= 3;
 			if (player.isMeetingNaturalJousterMasterGradeReq()) damage *= 5;
 		}
-		if (player.weapon == weapons.L_WHIP || player.weapon == weapons.DL_WHIP || player.weapon == weapons.TIDAR) {
+		if ((player.weapon == weapons.L_WHIP || player.weapon == weapons.DL_WHIP || player.weapon == weapons.TIDAR) && monster) {
 			if (monster.hasPerk(PerkLib.IceNature)) damage *= 5;
 			if (monster.hasPerk(PerkLib.FireVulnerability)) damage *= 2;
 			if (monster.hasPerk(PerkLib.IceVulnerability)) damage *= 0.5;
@@ -55,7 +55,7 @@ public class DracoSweepSkill extends AbstractSoulSkill {
 		//soulskill mod effect
 		damage *= soulskillPhysicalMod();
 		//group enemies bonus
-		if (monster.plural) damage *= 5;
+		if (monster && monster.plural) damage *= 5;
 		//other bonuses
 		if (player.armor.name == "some taur paladin armor" || player.armor.name == "some taur blackguard armor") damage *= 2;
 		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;

--- a/classes/classes/Scenes/Combat/Soulskills/DracoSweepSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/DracoSweepSkill.as
@@ -1,0 +1,131 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+import classes.Items.Weapons.Tidarion;
+
+public class DracoSweepSkill extends AbstractSoulSkill {
+    public function DracoSweepSkill() {
+        super(
+            "Drace Sweep",
+            "Use a little bit of soulforce to empower your weapon, then sweep ahead hitting as many enemies as possible.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            StatusEffects.KnowsDracoSweep
+        )
+		baseSFCost = 50;
+    }
+
+	override public function get buttonName():String {
+		return "Draco Sweep";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + calcDamage(target) + " damage"
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = 0;
+		damage += combat.meleeDamageNoLagSingle();
+		damage *= 1.75;
+		//All special weapon effects like...fire/ice
+		if (player.haveWeaponForJouster()) {
+			if (player.isPolearmTypeWeapon()) damage *= 0.75;
+			if (player.isTaur() || player.isDrider()) damage *= 2;
+			if (player.isMeetingNaturalJousterReq()) damage *= 3;
+			if (player.isMeetingNaturalJousterMasterGradeReq()) damage *= 5;
+		}
+		if (player.weapon == weapons.L_WHIP || player.weapon == weapons.DL_WHIP || player.weapon == weapons.TIDAR) {
+			if (monster.hasPerk(PerkLib.IceNature)) damage *= 5;
+			if (monster.hasPerk(PerkLib.FireVulnerability)) damage *= 2;
+			if (monster.hasPerk(PerkLib.IceVulnerability)) damage *= 0.5;
+			if (monster.hasPerk(PerkLib.FireNature)) damage *= 0.2;
+		}
+		if (player.weapon == weapons.TIDAR) (player.weapon as Tidarion).afterStrike();
+		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
+			damage = combat.FireTypeDamageBonus(damage);
+			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
+			damage *= 1.1;
+		}
+		//soulskill mod effect
+		damage *= soulskillPhysicalMod();
+		//group enemies bonus
+		if (monster.plural) damage *= 5;
+		//other bonuses
+		if (player.armor.name == "some taur paladin armor" || player.armor.name == "some taur blackguard armor") damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+		return Math.round(damage);
+
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_PHYS;
+		if (display) outputText("You ready your [weapon] and prepare to sweep it towards [themonster].  ");
+		if (monsterDodgeSkill("attack", display)) return;
+
+		var damage:Number = calcDamage(monster);
+
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		if (player.isSwordTypeWeapon()) critChance += 10;
+		if (player.isDuelingTypeWeapon()) critChance += 20;
+		critChance += combat.combatPhysicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			var buffMultiplier:Number = 0;
+			buffMultiplier += combat.bonusCriticalDamageFromMissingHP();
+			if (player.hasPerk(PerkLib.Impale) && player.spe >= 100 && player.haveWeaponForJouster()) damage *= ((1.75 + buffMultiplier) * combat.impaleMultiplier());
+			else damage *= (1.75 + buffMultiplier);
+		}
+
+		if (display) outputText("Your [weapon] sweeps against [themonster], dealing ");
+		if (((player.weapon == weapons.RCLAYMO || player.weapon == weapons.RDAGGER) && player.hasStatusEffect(StatusEffects.ChargeWeapon)) || (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.BlazingBattleSpirit)) || (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) || player.flameBladeActive()) {
+			if (player.flameBladeActive()) damage += scalingBonusLibido() * 0.20;
+			damage = Math.round(damage * combat.fireDamageBoostedByDao());
+			doFireDamage(damage, true, true);
+		}
+		else if (combat.isIceTypeWeapon()) {
+			damage = Math.round(damage * combat.iceDamageBoostedByDao());
+			doIceDamage(damage, true, true);
+		}
+		else if (combat.isLightningTypeWeapon()) {
+			damage = Math.round(damage * combat.lightningDamageBoostedByDao());
+			doLightingDamage(damage, true, true);
+		}
+		else if (combat.isDarknessTypeWeapon()) {
+			damage = Math.round(damage * combat.darknessDamageBoostedByDao());
+			doDarknessDamage(damage, true, true);
+		}
+		else if (player.weapon == weapons.MGSWORD) doMagicDamage(damage, true, true);
+		else if (player.weapon == weapons.MCLAWS) doMagicDamage(damage, true, true);
+		else {
+			doDamage(damage, true, true);
+			if (player.weapon == weapons.DAISHO) doDamage(Math.round(damage * 0.5), true, true);
+			if (player.hasPerk(PerkLib.FlurryOfBlows) && player.isFistOrFistWeapon()) {
+				doDamage(damage, true, true);
+				doDamage(damage, true, true);
+				damage *= 3;
+			}
+		}
+		if (display) outputText(" damage! ");
+		
+		if (crit) {
+			if (display) outputText(" <b>*Critical Hit!*</b>");
+			if (player.hasStatusEffect(StatusEffects.Rage)) player.removeStatusEffect(StatusEffects.Rage);
+		}
+		if (!crit && player.hasPerk(PerkLib.Rage) && (player.hasStatusEffect(StatusEffects.Berzerking) || player.hasStatusEffect(StatusEffects.Lustzerking))) {
+			if (player.hasStatusEffect(StatusEffects.Rage) && player.statusEffectv1(StatusEffects.Rage) > 5 && player.statusEffectv1(StatusEffects.Rage) < 70) player.addStatusValue(StatusEffects.Rage, 1, 10);
+			else player.createStatusEffect(StatusEffects.Rage, 10, 0, 0, 0);
+		}
+		endTurnBySpecialHit(damage);
+
+
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/DracoSweepSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/DracoSweepSkill.as
@@ -88,28 +88,28 @@ public class DracoSweepSkill extends AbstractSoulSkill {
 		if (((player.weapon == weapons.RCLAYMO || player.weapon == weapons.RDAGGER) && player.hasStatusEffect(StatusEffects.ChargeWeapon)) || (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.BlazingBattleSpirit)) || (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) || player.flameBladeActive()) {
 			if (player.flameBladeActive()) damage += scalingBonusLibido() * 0.20;
 			damage = Math.round(damage * combat.fireDamageBoostedByDao());
-			doFireDamage(damage, true, true);
+			doFireDamage(damage, true, display);
 		}
 		else if (combat.isIceTypeWeapon()) {
 			damage = Math.round(damage * combat.iceDamageBoostedByDao());
-			doIceDamage(damage, true, true);
+			doIceDamage(damage, true, display);
 		}
 		else if (combat.isLightningTypeWeapon()) {
 			damage = Math.round(damage * combat.lightningDamageBoostedByDao());
-			doLightingDamage(damage, true, true);
+			doLightingDamage(damage, true, display);
 		}
 		else if (combat.isDarknessTypeWeapon()) {
 			damage = Math.round(damage * combat.darknessDamageBoostedByDao());
-			doDarknessDamage(damage, true, true);
+			doDarknessDamage(damage, true, display);
 		}
-		else if (player.weapon == weapons.MGSWORD) doMagicDamage(damage, true, true);
-		else if (player.weapon == weapons.MCLAWS) doMagicDamage(damage, true, true);
+		else if (player.weapon == weapons.MGSWORD) doMagicDamage(damage, true, display);
+		else if (player.weapon == weapons.MCLAWS) doMagicDamage(damage, true, display);
 		else {
-			doDamage(damage, true, true);
-			if (player.weapon == weapons.DAISHO) doDamage(Math.round(damage * 0.5), true, true);
+			doDamage(damage, true, display);
+			if (player.weapon == weapons.DAISHO) doDamage(Math.round(damage * 0.5), true, display);
 			if (player.hasPerk(PerkLib.FlurryOfBlows) && player.isFistOrFistWeapon()) {
-				doDamage(damage, true, true);
-				doDamage(damage, true, true);
+				doDamage(damage, true, display);
+				doDamage(damage, true, display);
 				damage *= 3;
 			}
 		}

--- a/classes/classes/Scenes/Combat/Soulskills/EarthStanceSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/EarthStanceSkill.as
@@ -1,0 +1,50 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Monster;
+
+public class EarthStanceSkill extends AbstractSoulSkill {
+    public function EarthStanceSkill() {
+        super(
+            "Earth Stance",
+            "Take on the stability and strength of the earth, gaining temporary damage reduction",
+            TARGET_SELF,
+            TIMING_LASTING,
+            [TAG_BUFF],
+            StatusEffects.KnowsEarthStance
+        )
+		baseSFCost = 30;
+    }
+
+	override public function get buttonName():String {
+		return "Earth Stance";
+	}
+
+	override public function isActive():Boolean {
+		return player.hasStatusEffect(StatusEffects.EarthStance);
+	}
+
+    override public function advance(display:Boolean):void {
+        advanceDuration(StatusEffects.EarthStance, display, "<b>Earth Stance effect wore off!</b>\n\n");
+    }
+
+    override public function calcCooldown():int {
+        return 10;
+    }
+
+    public function calcDuration():int {
+        return 3;
+    }
+
+    override public function describeEffectVs(target:Monster):String {
+		return "Gains 30% damage reduction for the next " + calcDuration() + " rounds"; 
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		if (display)
+			outputText("Your body suddenly hardens like rock. You will be way harder to damage for a while.\n\n");
+		
+		player.createStatusEffect(StatusEffects.EarthStance, calcDuration(), 0, 0, 0);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/EarthStanceSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/EarthStanceSkill.as
@@ -1,5 +1,6 @@
 package classes.Scenes.Combat.Soulskills {
 import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.Scenes.Combat.CombatAbility;
 import classes.StatusEffects;
 import classes.Monster;
 
@@ -25,7 +26,10 @@ public class EarthStanceSkill extends AbstractSoulSkill {
 	}
 
     override public function advance(display:Boolean):void {
-        advanceDuration(StatusEffects.EarthStance, display, "<b>Earth Stance effect wore off!</b>\n\n");
+        function endFunction(ability:CombatAbility, display:Boolean):void {
+            if (display) outputText("<b>Earth Stance effect wore off!</b>\n\n");
+        }
+        advanceDuration(StatusEffects.EarthStance, endFunction, display);
     }
 
     override public function calcCooldown():int {

--- a/classes/classes/Scenes/Combat/Soulskills/FingerOfDeathSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/FingerOfDeathSkill.as
@@ -1,0 +1,106 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+import classes.Races;
+
+public class FingerOfDeathSkill extends AbstractSoulSkill {
+    public function FingerOfDeathSkill() {
+        super(
+            "Finger Of Death",
+            "Inflict massive dark damage. Also damage the opponent's toughness and strength by 10 percent. Ineffective on foes who lack a soul.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_DARKNESS, TAG_DEBUFF],
+            null
+        )
+		baseSFCost = 200;
+    }
+
+    override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+		if (monster && monster.hasPerk(PerkLib.EnemyTrueDemon)) {
+			return "You can't use this soulskill on somoene truly souless.";
+		}
+		if (player.hasStatusEffect(StatusEffects.OniRampage) || player.wrath > player.maxSafeWrathMagicalAbilities()) {
+			return "You are too angry to think straight. Smash your puny opponents first and think later.";
+		}
+
+        return "";
+    }
+
+	override public function get buttonName():String {
+		return "Finger Of Death";
+	}
+
+	override public function get isKnown():Boolean {
+		return player.racialScore(Races.ANUBIS) >= 20;
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + calcDamage(target) + " magical damage";
+	}
+
+	override public function calcCooldown():int {
+		var cooldown:int = 6;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4) cooldown -= 2;
+			
+		return cooldown;
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = (scalingBonusWisdom() * 1.5) + (scalingBonusIntelligence() * 1.5);
+		if (damage < 15) damage = 15;
+
+		//soulskill mod effect
+		damage *= spellMod();
+		damage *= soulskillMagicalMod();
+		damage = calcEclypseMod(damage, true);
+
+		//other bonuses
+		if (player.hasPerk(PerkLib.Heroism) && (monster.hasPerk(PerkLib.EnemyBossType) || monster.hasPerk(PerkLib.EnemyHugeType))) damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+		if (player.armor == armors.DEATHPGA) damage *= 1.5;
+		return Math.round(damage * combat.darknessDamageBoostedByDao());
+		
+	}
+
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+
+		if (display) outputText("You point a finger at your opponent condemning [monster his] soul as you call on to the power of death to claim a part of [monster him] early!"
+			+ " A ghastly claw appears and pierce through [themonster] body tearing [monster his] soul appart.  ");
+		combat.darkRitualCheckDamage();
+
+		var damage:Number = calcDamage(monster);
+
+		//Determine if critical hit!
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatMagicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+		if (display) outputText(" ");
+
+		doDarknessDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		monster.statStore.addBuffObject({str:-10*(monster.str/100),tou:-10*(monster.tou/100)}, "Finger of death",{text:"Finger of death"});
+
+		checkAchievementDamage(damage);
+		if (display) outputText("\n\n");
+		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(damage);
+		combat.heroBaneProc2();
+		combat.EruptingRiposte2();
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/FirePunchSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/FirePunchSkill.as
@@ -1,0 +1,106 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Races;
+import classes.Scenes.Combat.Combat;
+
+public class FirePunchSkill extends AbstractSoulSkill {
+    public function FirePunchSkill() {
+        super(
+            "Fire Punch",
+            "Ignite your opponents dealing fire damage and setting them ablaze.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_FIRE],
+            StatusEffects.KnowsFirePunch
+        )
+		baseSFCost = 30;
+    }
+
+    override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+		if ((player.hasPerk(PerkLib.ColdMastery) || player.hasPerk(PerkLib.ColdAffinity)) && (player.hasPerk(PerkLib.FireAffinity) || player.hasPerk(PerkLib.AffinityIgnis))) {
+			return "You call upon the power of flame...and you begin to sweat. You aren't built for the heat, and your body knows it.";
+		}
+		if (!player.isFistOrFistWeapon()) {
+			return "<b>Your [weapon] can't be used with this soulskill.</b>";
+		}
+
+        return "";
+    }
+
+	override public function get buttonName():String {
+		return "Fire Punch";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + calcDamage(target) + " fire damage"
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = 0;
+		damage += combat.meleeUnarmedDamageNoLagSingle();
+		if (player.hasPerk(PerkLib.SuperStrength) || player.hasPerk(PerkLib.BigHandAndFeet)) {
+			damage += player.str;
+			damage += scalingBonusStrength();
+		}
+		damage += player.wis;
+		damage += scalingBonusWisdom();
+		if (player.hasStatusEffect(StatusEffects.BlazingBattleSpirit)) {
+			if (player.isRaceCached(Races.MOUSE, 2) && (player.jewelryName == "Infernal Mouse ring" || player.jewelryName2 == "Infernal Mouse ring" || player.jewelryName3 == "Infernal Mouse ring" || player.jewelryName4 == "Infernal Mouse ring")) damage *= 2.2;
+			else damage *= 2;
+		}
+		//other bonuses
+		if (player.hasPerk(PerkLib.PerfectStrike) && monster.monsterIsStunned()) damage *= 1.5;
+		if (player.hasPerk(PerkLib.Heroism) && (monster.hasPerk(PerkLib.EnemyBossType) || monster.hasPerk(PerkLib.EnemyHugeType))) damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+		return Math.round(damage);
+
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_PHYS;
+		var damage:Number = calcDamage(monster);
+
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combat.combatPhysicalCritical();
+		if (player.hasPerk(PerkLib.ElvenSense) && player.inte >= 50) critChance += 5;
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+		monster.createStatusEffect(StatusEffects.FirePunchBurnDoT,16,0,0,0);
+		if (display) outputText("Setting your fist ablaze, you rush at [themonster] and scorch [monster him] with your searing flames. ");
+		damage = Math.round(damage * combat.fireDamageBoostedByDao());
+		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
+			damage += Math.round(damage * 0.1);
+			doFireDamage(damage, true, display);
+			if (player.hasPerk(PerkLib.FlurryOfBlows)) {
+				doFireDamage(damage, true, display);
+				doFireDamage(damage, true, display);
+				damage *= 3;
+			}
+			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
+			damage = Math.round(damage * 1.1);
+		}
+		else {
+			doFireDamage(damage, true, display);
+			if (player.hasPerk(PerkLib.FlurryOfBlows)) {
+				doFireDamage(damage, true, display);
+				doFireDamage(damage, true, display);
+				damage *= 3;
+			}
+		}
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		endTurnBySpecialHit(damage, display);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/FlamesOfLoveSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/FlamesOfLoveSkill.as
@@ -1,0 +1,80 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class FlamesOfLoveSkill extends AbstractSoulSkill {
+    public function FlamesOfLoveSkill() {
+        super(
+            "Flames of Love",
+            "Enfuse your magic with your burning lust, transfering it to your enemy as a barrage of flames.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_FIRE, TAG_RECOVERY],
+            StatusEffects.KnowsFlamesOfLove
+        )
+    }
+
+	override public function get buttonName():String {
+		return "Flames of Love";
+	}
+
+	override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+        if (player.lust < 50) {
+			return "Your current lust is too low.";
+		}
+
+        return "";
+    }  
+
+	override public function describeEffectVs(target:Monster):String {
+		var lustRestore: Number = calcLustRestore();
+		return "~" + calcDamage(target, lustRestore) + " fire damage, restores " + lustRestore + " lust";
+	}
+
+	override public function calcCooldown():int {
+		return  Math.round(player.statusEffectv1(StatusEffects.KnowsFlamesOfLove));
+	}
+
+	public function flamesOfLoveLC():Number {
+    	var follc:Number = 10;
+    	return follc;
+	}
+
+	private function calcLustRestore():Number {
+		var restoreAmount:Number = 0;
+		restoreAmount += Math.round(player.lust * (flamesOfLoveLC() * 0.01));
+		return restoreAmount;
+	}
+
+	public function calcDamage(monster:Monster, baseDamage: Number):Number {
+		var damage:Number = baseDamage * (5 * player.statusEffectv1(StatusEffects.KnowsFlamesOfLove));
+		if (monster.plural) damage *= 2;
+		damage *= combat.fireDamageBoostedByDao();
+		return Math.round(damage);
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+
+		var lustRestore:Number = calcLustRestore();
+		player.lust -= lustRestore;
+
+		var damage:Number = calcDamage(monster, lustRestore);
+
+		if (display) {
+			outputText("You concentrate on the lust flowing in your body, your veins heating up rapidly. With every beat of your heart, the heat rises, the heat in your groin transfering to the palm of your hands. \n\n");
+			outputText("With almost orgasmic joy, you send a wave of flames toward [themonster]. ");
+		}
+		doFireDamage(damage, true, display);
+		if (display) outputText("\n\n");
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/FlamesOfLoveSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/FlamesOfLoveSkill.as
@@ -56,7 +56,7 @@ public class FlamesOfLoveSkill extends AbstractSoulSkill {
 
 	public function calcDamage(monster:Monster, baseDamage: Number):Number {
 		var damage:Number = baseDamage * (5 * player.statusEffectv1(StatusEffects.KnowsFlamesOfLove));
-		if (monster.plural) damage *= 2;
+		if (monster && monster.plural) damage *= 2;
 		damage *= combat.fireDamageBoostedByDao();
 		return Math.round(damage);
 	}

--- a/classes/classes/Scenes/Combat/Soulskills/HeartSeekerSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/HeartSeekerSkill.as
@@ -1,0 +1,81 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractBloodSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class HeartSeekerSkill extends AbstractBloodSoulSkill {
+    public function HeartSeekerSkill(sfInfusion: Boolean = false) {
+        super(
+            "Heart Seeker",
+            sfInfusion? "(Soulforce infused) Heart Seeker, infused by a small amount of soulforce. This skill will hit the vital points of your foe.  "
+			: "Heart Seeker will strike the vital points of your enemy, dealing true damage.  ",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            sfInfusion? StatusEffects.KnowsHeartSeekerSF: StatusEffects.KnowsHeartSeeker,
+			true,
+			sfInfusion
+        )
+		baseSFCost = 120;
+    }
+
+	override protected function baseName():String {
+		return "Heart Seeker";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + calcDamage(target) + " true damage"
+	}
+
+	override public function calcCooldown():int {
+		return bloodSoulSkillCoolDown(3);
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = scalingBonusWisdom() * spellModBlood();
+		var damageFloor:Number = 10;
+
+		if (sfInfusion) {
+			damage *= 2;
+			damageFloor *= 3;
+		}
+
+		if (damage < damageFloor) damage = damageFloor;
+		if (player.hasPerk(PerkLib.BloodAffinity)) damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+
+		return Math.round(damage);
+
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_PHYS;
+		var additionalSFLine: String = sfInfusion? "You infuse a bit of soulforce into the blood, spreading your fingers wide. " : "";
+		if (display) outputText("You concentrate, focusing on the power of your blood. " + additionalSFLine 
+		+ "Within an instant, a large blood dripping spear forms in your hand. You motion, sending the spear flying toward [themonster]'s vitals.\n\n");
+		
+		var damage:Number = calcDamage(monster);
+
+		//Determine if critical hit!
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatPhysicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+		if (player.hasPerk(PerkLib.BloodMastery)) damage *= 2;
+		damage = Math.round(damage * combat.bloodDamageBoostedByDao());
+		if (display) outputText("[Themonster] takes ");
+		doTrueDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		if (display) outputText(" damage.");
+		endTurnByBloodSkillUse(damage);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/HurricaneDanceSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/HurricaneDanceSkill.as
@@ -1,5 +1,6 @@
 package classes.Scenes.Combat.Soulskills {
 import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.Scenes.Combat.CombatAbility;
 import classes.StatusEffects;
 import classes.Monster;
 
@@ -25,7 +26,10 @@ public class HurricaneDanceSkill extends AbstractSoulSkill {
 	}
 
     override public function advance(display:Boolean):void {
-        advanceDuration(StatusEffects.HurricaneDance, display, "<b>Hurricane Dance effect wore off!</b>\n\n");
+        function endFunction(ability:CombatAbility, display:Boolean):void {
+            if (display) outputText("<b>Hurricane Dance effect wore off!</b>\n\n");
+        }
+        advanceDuration(StatusEffects.HurricaneDance, endFunction, display);
     }
 
     override public function calcCooldown():int {

--- a/classes/classes/Scenes/Combat/Soulskills/HurricaneDanceSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/HurricaneDanceSkill.as
@@ -1,0 +1,50 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Monster;
+
+public class HurricaneDanceSkill extends AbstractSoulSkill {
+    public function HurricaneDanceSkill() {
+        super(
+            "Hurricane Dance",
+            "Take on the aspect of the wind, dodging attacks like a leaf in the wind.",
+            TARGET_SELF,
+            TIMING_LASTING,
+            [TAG_BUFF],
+            StatusEffects.KnowsHurricaneDance
+        )
+		baseSFCost = 30;
+    }
+
+	override public function get buttonName():String {
+		return "Hurricane Dance";
+	}
+
+	override public function isActive():Boolean {
+		return player.hasStatusEffect(StatusEffects.HurricaneDance);
+	}
+
+    override public function advance(display:Boolean):void {
+        advanceDuration(StatusEffects.HurricaneDance, display, "<b>Hurricane Dance effect wore off!</b>\n\n");
+    }
+
+    override public function calcCooldown():int {
+        return 10;
+    }
+
+    public function calcDuration():int {
+        return 5;
+    }
+
+    override public function describeEffectVs(target:Monster):String {
+		return "Increases speed and evasion for " + calcDuration() + " rounds";
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		if (display)
+			outputText("Your movement becomes more fluid and precise, increasing your speed and evasion.\n\n");
+		
+		player.createStatusEffect(StatusEffects.HurricaneDance, calcDuration(), 0, 0, 0);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/IceFistSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/IceFistSkill.as
@@ -1,0 +1,109 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class IceFistSkill extends AbstractSoulSkill {
+    public function IceFistSkill() {
+        super(
+            "Ice Fist",
+            "A chilling strike that can freeze an opponent solid, leaving it vulnerable to shattering soul art and hindering its movement.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_ICE],
+            StatusEffects.KnowsIceFist
+        )
+		baseSFCost = 30;
+    }
+
+    override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+		if ((player.hasPerk(PerkLib.FireAffinity) || player.hasPerk(PerkLib.AffinityIgnis)) && (player.hasPerk(PerkLib.ColdMastery) || player.hasPerk(PerkLib.ColdAffinity))) {
+			return "When you try to use this technique, you shudder in revulsion. Ice, that close to your body? You're a creature of fire!";
+		}
+		if (!player.isFistOrFistWeapon()) {
+			return "<b>Your [weapon] can't be used with this soulskill.</b>";
+		}
+
+        return "";
+    }
+
+	override public function get buttonName():String {
+		return "Ice Fist";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + calcDamage(target) + " ice damage"
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = 0;
+		damage += combat.meleeUnarmedDamageNoLagSingle()
+		if (player.hasPerk(PerkLib.SuperStrength) || player.hasPerk(PerkLib.BigHandAndFeet)) {
+			damage += player.str;
+			damage += scalingBonusStrength();
+		}
+		damage += player.wis;
+		damage += scalingBonusWisdom();
+		//other bonuses
+		if (player.hasPerk(PerkLib.PerfectStrike) && monster.monsterIsStunned()) damage *= 1.5;
+		if (player.hasPerk(PerkLib.Heroism) && (monster.hasPerk(PerkLib.EnemyBossType) || monster.hasPerk(PerkLib.EnemyHugeType))) damage *= 2;
+		if (combat.wearingWinterScarf()) damage *= 1.2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+		return Math.round(damage);
+
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_PHYS;
+		var damage:Number = calcDamage(monster);
+
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combat.combatPhysicalCritical();
+		if (player.hasPerk(PerkLib.ElvenSense) && player.inte >= 50) critChance += 5;
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+		monster.buff("FrozenSolid").addStats({spe:-20}).withText("Frozen Solid").combatTemporary(1);
+		if (display) outputText("The air around your fist seems to lose all heat as you dash at [themonster]. You place your palm on [monster him], [monster his] body suddenly is frozen solid, encased in a thick block of ice! ");
+		damage = Math.round(damage * combat.iceDamageBoostedByDao());
+		doIceDamage(damage, true, display);
+		if (player.hasPerk(PerkLib.FlurryOfBlows)) {
+			doIceDamage(damage, true, display);
+			doIceDamage(damage, true, display);
+			damage *= 3;
+		}
+
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		//stun
+		if (monster.hasPerk(PerkLib.Resolute)) {
+			if (display) {
+				outputText("  <b>[Themonster] ");
+				if(!monster.plural) outputText("is ");
+				else outputText("are ");
+				outputText("too sturdy to be frozen by your attack.</b>");
+			}
+		}
+		else if (monster.hasStatusEffect(StatusEffects.FrozenSolid)) monster.addStatusValue(StatusEffects.FrozenSolid, 1, 2);
+		else monster.createStatusEffect(StatusEffects.FrozenSolid, 2, 0, 0, 0);
+		//speed debuff
+		if (monster.buff("FrozenSolid").isPresent()) monster.buff("FrozenSolid").addStats({spe: -20}).addDuration(2);
+		else monster.buff("FrozenSolid").addStats({spe: -20}).withText("Frozen Solid").combatTemporary(2);
+		checkAchievementDamage(damage);
+		combat.WrathGenerationPerHit2(5);
+		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(damage);
+		combat.heroBaneProc(damage);
+		combat.EruptingRiposte();
+		if (display) outputText("\n\n");
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/IciclesOfLoveSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/IciclesOfLoveSkill.as
@@ -54,7 +54,7 @@ public class IciclesOfLoveSkill extends AbstractSoulSkill {
 
 	public function calcDamage(monster:Monster, baseDamage: Number):Number {
 		var damage:Number = baseDamage * (5 * player.statusEffectv1(StatusEffects.KnowsIciclesOfLove));
-		if (monster.plural) damage *= 2;
+		if (monster && monster.plural) damage *= 2;
 		damage *= combat.iceDamageBoostedByDao();
 		return Math.round(damage);
 	}

--- a/classes/classes/Scenes/Combat/Soulskills/IciclesOfLoveSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/IciclesOfLoveSkill.as
@@ -1,0 +1,78 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class IciclesOfLoveSkill extends AbstractSoulSkill {
+    public function IciclesOfLoveSkill() {
+        super(
+            "Icicles of Love",
+            "Weaponize your lust, crystalizing it into cold, sharp icicles.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_ICE, TAG_RECOVERY],
+            StatusEffects.KnowsIciclesOfLove
+        )
+    }
+
+	override public function get buttonName():String {
+		return "Icicles of Love";
+	}
+
+	override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+        if (player.lust < 50) {
+			return "Your current lust is too low.";
+		}
+
+        return "";
+    }  
+
+	override public function describeEffectVs(target:Monster):String {
+		var lustRestore: Number = calcLustRestore();
+		return "~" + calcDamage(target, lustRestore) + " ice damage, restores " + lustRestore + " lust";
+	}
+
+	override public function calcCooldown():int {
+		return  Math.round(player.statusEffectv1(StatusEffects.KnowsIciclesOfLove));
+	}
+
+	public function iciclesOfLoveLC():Number {
+    	var follc:Number = 10;
+    	return follc;
+	}
+
+	private function calcLustRestore():Number {
+		var restoreAmount:Number = 0;
+		restoreAmount += Math.round(player.lust * (iciclesOfLoveLC() * 0.01));
+		return restoreAmount;
+	}
+
+	public function calcDamage(monster:Monster, baseDamage: Number):Number {
+		var damage:Number = baseDamage * (5 * player.statusEffectv1(StatusEffects.KnowsIciclesOfLove));
+		if (monster.plural) damage *= 2;
+		damage *= combat.iceDamageBoostedByDao();
+		return Math.round(damage);
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+
+		var lustRestore:Number = calcLustRestore();
+		player.lust -= lustRestore;
+
+		var damage:Number = calcDamage(monster, lustRestore);
+
+		if (display) {
+			outputText("You start concentrate on the lust flowing in your body, your veins while imaging a joy of sharing icicles of love with enemy. Shortly after that lust starts to gather around your hands getting colder and colder till it envelop your hands in icicles.\n\n");
+    		outputText("And with almost orgasmic joy, you sends a wave of ice shards toward [themonster] while mumbling about 'sharing the icicles of love'. ");
+		}
+		doIceDamage(damage, true, display);
+		if (display) outputText("\n\n");
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/ManyBirdsSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/ManyBirdsSkill.as
@@ -1,0 +1,95 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class ManyBirdsSkill extends AbstractSoulSkill {
+    public function ManyBirdsSkill() {
+        super(
+            "Many Birds",
+            "Project a figment of your soulforce as a crystal traveling at extreme speeds.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            StatusEffects.KnowsManyBirds
+        )
+		baseSFCost = 10;
+    }
+
+    override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+		if (player.hasStatusEffect(StatusEffects.OniRampage) || player.wrath > player.maxSafeWrathMagicalAbilities()) {
+			return "You are too angry to think straight. Smash your puny opponents first and think later.";
+		}
+
+        return "";
+    }
+
+	override public function get buttonName():String {
+		return "Many Birds";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + calcDamage(target) + " magical damage"
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = scalingBonusWisdom();
+		if (damage < 10) damage = 10;
+		//soulskill mod effect
+		damage *= combat.soulskillMagicalMod();
+		//other bonuses
+		if (player.hasPerk(PerkLib.Heroism) && (monster && (monster.hasPerk(PerkLib.EnemyBossType) || monster.hasPerk(PerkLib.EnemyHugeType)))) damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+
+		return Math.round(damage);
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+
+		if (silly()) 
+			if (display) outputText("You focus your soulforce, projecting it as an aura around you.  As you concentrate, dozens, hundreds, thousands of tiny, ethereal birds shimmer into existence.  As you raise your hand up, more and more appear, until the area around you and [themonster]  is drowned in spectral flappy shapes.  ");
+		else {
+			outputText("You thrust your hand outwards with deadly intent, and in the blink of an eye a crystal shoots towards [themonster].  ");
+			if (monsterDodgeSkill("crystal", display)) return;
+		}
+
+		var damage:Number = calcDamage(monster);
+
+		//Determine if critical hit!
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatMagicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+		if (silly ()) {
+			if (display) {
+				outputText("You snap your fingers, and at once every bird lends their high pitched voice to a unified, glass shattering cry:");
+				outputText("\n\n\"<i>AAAAAAAAAAAAAAAAAAAAAAAAAAAAA</i>\" ([themonster] takes ");
+			}
+			doMagicDamage(damage, true, display);
+			if (display) outputText(" damage) ");
+		}
+		else {
+			if (display) outputText("Crystal hits [themonster], dealing ");
+			doMagicDamage(damage, true, display);
+			if (display) outputText(" damage! ");
+		}
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		checkAchievementDamage(damage);
+		if (display) outputText("\n\n");
+		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(damage);
+		combat.heroBaneProc(damage);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/MultiThrustSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/MultiThrustSkill.as
@@ -1,0 +1,166 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Races;
+import classes.Scenes.Combat.Combat;
+import classes.Items.Weapons.Tidarion;
+
+public class MultiThrustSkill extends AbstractSoulSkill {
+	private var thrustArray:Array = [
+		["Triple Thrust", "three", StatusEffects.KnowsTripleThrust, 30, "thrice"],
+		["Sextuple Thrust", "six", StatusEffects.KnowsSextupleThrust, 70, "sixfold"],
+		["Nonuple Thrust", "nine", StatusEffects.KnowsNonupleThrust, 150, "ninefold"]
+	];
+	private var thrustSelection:int;
+	private var multiTrustDNLag:Number = 0;
+	private var count:int;
+
+    public function MultiThrustSkill(count: int) {
+        super(
+            count < 4 && count > 0? thrustArray[count - 1][0]: "Thrust",
+            "Use a little bit of soulforce to infuse your weapon with power, striking your foe " + thrustArray[count - 1][1] + " times.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            count < 4 && count > 0? thrustArray[count - 1][2]: null
+        )
+		thrustSelection = count - 1;
+		baseSFCost = thrustArray[thrustSelection][3];
+    }
+
+	override public function get buttonName():String {
+		return thrustArray[thrustSelection][0];
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		multiTrustDNLag = 0;
+		return "~" + Math.round(MultiThrustDSingle(target) * ((thrustSelection + 1) * 3)) + " damage ";
+	}
+
+	override public function calcCooldown():int {
+		return thrustSelection;
+	}
+
+	private function MultiThrustDSingle(monster: Monster):Number {
+		var damage:Number = 0;
+		damage += combat.meleeDamageNoLagSingle();
+		damage *= 1.75;
+
+		//All special weapon effects like...fire/ice
+		if (player.weapon == weapons.TIDAR) (player.weapon as Tidarion).afterStrike();
+		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
+			var damage1:Number = damage;
+			damage = combat.FireTypeDamageBonus(damage);
+			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
+			damage += damage1;
+			damage *= 1.1;
+		}
+
+		//soulskill mod effect
+		damage *= soulskillPhysicalMod();
+
+		//other bonuses
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+		if (monster.hasStatusEffect(StatusEffects.FrozenSolid)) damage *= 2;
+		return damage;
+	}
+
+	private function MultiThrustD(monster:Monster, display:Boolean):void {
+		var damage:Number = 0;
+		if (multiTrustDNLag != 0) damage += multiTrustDNLag;
+		else {
+			multiTrustDNLag += MultiThrustDSingle(monster);
+			damage += MultiThrustDSingle(monster);
+		}
+
+		var d2:Number = 0.9;
+		d2 += (rand(21) * 0.01);
+		damage *= d2;
+
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		if (player.isSwordTypeWeapon()) critChance += 10;
+		if (player.isDuelingTypeWeapon()) critChance += 20;
+		critChance += combat.combatPhysicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			var buffMultiplier:Number = 0;
+			buffMultiplier += combat.bonusCriticalDamageFromMissingHP();
+			if (player.hasPerk(PerkLib.Impale) && player.spe >= 100 && player.haveWeaponForJouster()) damage *= ((1.75 + buffMultiplier) * combat.impaleMultiplier());
+			else damage *= (1.75 + buffMultiplier);
+		}
+		if (display) outputText(" ");
+		if (combat.isFireTypeWeapon()) {
+			if (player.flameBladeActive()) damage += scalingBonusLibido() * 0.20;
+			damage = Math.round(damage * combat.fireDamageBoostedByDao());
+			doFireDamage(damage, true, display);
+		}
+		else if (combat.isIceTypeWeapon()) {
+			damage = Math.round(damage * combat.iceDamageBoostedByDao());
+			doIceDamage(damage, true, display);
+		}
+		else if (combat.isLightningTypeWeapon()) {
+			damage = Math.round(damage * combat.lightningDamageBoostedByDao());
+			doLightingDamage(damage, true, display);
+		}
+		else if (combat.isDarknessTypeWeapon()) {
+			damage = Math.round(damage * combat.darknessDamageBoostedByDao());
+			doDarknessDamage(damage, true, display);
+		}
+		else if (player.weapon == weapons.MGSWORD) doMagicDamage(damage, true, display);
+		else if (player.weapon == weapons.MCLAWS) doMagicDamage(damage, true, display);
+		else {
+			doDamage(damage, true, display);
+			if (player.weapon == weapons.DAISHO) doDamage(Math.round(damage * 0.5), true, display);
+		}
+
+		if (crit) {
+			if (display) outputText(" <b>*Critical Hit!*</b>");
+			if (player.hasStatusEffect(StatusEffects.Rage)) player.removeStatusEffect(StatusEffects.Rage);
+		}
+		if (!crit && player.hasPerk(PerkLib.Rage) && (player.hasStatusEffect(StatusEffects.Berzerking) || player.hasStatusEffect(StatusEffects.Lustzerking))) {
+			if (player.hasStatusEffect(StatusEffects.Rage) && player.statusEffectv1(StatusEffects.Rage) > 5 && player.statusEffectv1(StatusEffects.Rage) < 70) player.addStatusValue(StatusEffects.Rage, 1, 10);
+			else player.createStatusEffect(StatusEffects.Rage, 10, 0, 0, 0);
+		}
+
+		checkAchievementDamage(damage);
+		combat.WrathGenerationPerHit2(5);
+		if (player.hasStatusEffect(StatusEffects.HeroBane)) flags[kFLAGS.HERO_BANE_DAMAGE_BANK] += damage;
+		if (player.hasStatusEffect(StatusEffects.EruptingRiposte)) flags[kFLAGS.ERUPTING_RIPOSTE_DAMAGE_BANK] += monster.tou + monster.inte + monster.wis;
+
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_PHYS;
+		if (display) outputText("You ready your [weapon] and prepare to thrust it towards [themonster].");
+		if (monsterDodgeSkill("attack", display)) return;
+
+		multiTrustDNLag = 0;
+		var thrustCount:Number = (thrustSelection + 1) * 3;
+		if (player.hasPerk(PerkLib.FlurryOfBlows) && player.isFistOrFistWeapon()) thrustCount *= 3;
+
+		if (monster.hasStatusEffect(StatusEffects.FrozenSolid)) {
+			if (display) outputText("Your [weapon] hits the ice in three specific points, making it explode along with your frozen adversary!");
+			while (thrustCount-->0) MultiThrustD(monster, display);
+			monster.statStore.removeBuffs("FrozenSolid");
+			monster.removeStatusEffect(StatusEffects.FrozenSolid);
+			if (display) outputText(" damage!");
+		}
+		else {
+			if (display) outputText("Your [weapon] hits " + thrustArray[thrustSelection][4] + " against [themonster],");
+			while (thrustCount-->0) MultiThrustD(monster, display);
+			if (display) outputText(" damage!");
+		}
+
+		if (display) outputText("\n\n");
+		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(flags[kFLAGS.HERO_BANE_DAMAGE_BANK]);
+		combat.heroBaneProc2();
+		combat.EruptingRiposte2();
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/MultiThrustSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/MultiThrustSkill.as
@@ -65,7 +65,7 @@ public class MultiThrustSkill extends AbstractSoulSkill {
 
 		//other bonuses
 		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
-		if (monster.hasStatusEffect(StatusEffects.FrozenSolid)) damage *= 2;
+		if (monster) if (monster.hasStatusEffect(StatusEffects.FrozenSolid)) damage *= 2;
 		return damage;
 	}
 

--- a/classes/classes/Scenes/Combat/Soulskills/NightOfBrotherhoodSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/NightOfBrotherhoodSkill.as
@@ -54,7 +54,7 @@ public class NightOfBrotherhoodSkill extends AbstractSoulSkill {
 
 	public function calcDamage(monster:Monster, baseDamage: Number):Number {
 		var damage:Number = baseDamage * (5 * player.statusEffectv1(StatusEffects.KnowsNightOfBrotherhood));
-		if (monster.plural) damage *= 2;
+		if (monster && monster.plural) damage *= 2;
 		damage *= combat.darknessDamageBoostedByDao();
 		return Math.round(damage);
 	}

--- a/classes/classes/Scenes/Combat/Soulskills/NightOfBrotherhoodSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/NightOfBrotherhoodSkill.as
@@ -1,0 +1,78 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class NightOfBrotherhoodSkill extends AbstractSoulSkill {
+    public function NightOfBrotherhoodSkill() {
+        super(
+            "Night of Brotherhood",
+            "Condense your wrath into a wreath of shadows, filled with the hate of your brotherhood.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, , TAG_RECOVERY],
+            StatusEffects.KnowsNightOfBrotherhood
+        )
+    }
+
+	override public function get buttonName():String {
+		return "Night of Brotherhood";
+	}
+
+	override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+        if (player.wrath < 50) {
+			return "Your current wrath is too low.";
+		}
+
+        return "";
+    }  
+
+	override public function describeEffectVs(target:Monster):String {
+		var wrathRestore: Number = calcWrathRestore();
+		return "~" + calcDamage(target, wrathRestore) + " darkness damage, restores " + wrathRestore + " wrath";
+	}
+
+	override public function calcCooldown():int {
+		return  Math.round(player.statusEffectv1(StatusEffects.KnowsNightOfBrotherhood));
+	}
+
+	public function nightOfBrotherhoodWC():Number {
+    	var soswc:Number = 10;
+    	return soswc;
+	}
+
+	private function calcWrathRestore():Number {
+		var restoreAmount:Number = 0;
+		restoreAmount += Math.round(player.wrath * (nightOfBrotherhoodWC() * 0.01));
+		return restoreAmount;
+	}
+
+	public function calcDamage(monster:Monster, baseDamage: Number):Number {
+		var damage:Number = baseDamage * (5 * player.statusEffectv1(StatusEffects.KnowsNightOfBrotherhood));
+		if (monster.plural) damage *= 2;
+		damage *= combat.darknessDamageBoostedByDao();
+		return Math.round(damage);
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+
+		var wrathRestore:Number = calcWrathRestore();
+		player.wrath -= wrathRestore;
+
+		var damage:Number = calcDamage(monster, wrathRestore);
+
+		if (display) {
+			outputText("You start concentrate on the wrath flowing in your body, your veins while imaging a joy of sharing storm of sisterhood with enemy. Shortly after that wrath starts to gather around your hands till it envelop your hands in ligthing.\n\n");
+    		outputText("With joy, you sends a mass of ligthing toward [themonster] while mumbling about 'sharing the storm of sisterhood'. ");
+		}
+		doDarknessDamage(damage, true, display);
+		if (display) outputText("\n\n");
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/OverlimitSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/OverlimitSkill.as
@@ -1,0 +1,44 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Monster;
+
+public class OverlimitSkill extends AbstractSoulSkill {
+    public function OverlimitSkill() {
+        super(
+            "Overlimit",
+            "Double your melee damage for a time, by ignoring your body's limits, pushing past them.",
+            TARGET_SELF,
+            TIMING_TOGGLE,
+            [TAG_BUFF],
+            StatusEffects.KnowsOverlimit
+        )
+		baseSFCost = 0;
+    }
+
+	override public function get buttonName():String {
+		if (isActive())
+			return "Overlimit(Off)";
+		else
+			return "Overlimit(On)";
+	}
+
+	override public function isActive():Boolean {
+		return player.hasStatusEffect(StatusEffects.Overlimit);
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "Increases melee damage by 100%, and lust resistance by 10%. Reduces Health by 10% per turn";
+	}
+
+	override public function toggleOff(display:Boolean = true):void {
+		if (display) outputText("You let your rage fade, your red aura and manic strength vanishing along with it. You wince, feeling the strain you put your body through. You \n\n");
+		player.removeStatusEffect(StatusEffects.Overlimit);
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		if (display) outputText("You let out a primal roar of pain and fury, as you push your body beyond its normal capacity, a blood red aura cloaking your form.\n\n");
+		player.createStatusEffect(StatusEffects.Overlimit, 0, 0, 0, 0);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/ResonanceVolleySkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/ResonanceVolleySkill.as
@@ -1,0 +1,46 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+
+public class ResonanceVolleySkill extends AbstractSoulSkill {
+    public function ResonanceVolleySkill() {
+        super(
+            "Resonance Volley",
+            "Perform a ranged attack where each arrow after the first gets an additional 10% accuracy for every arrow before it.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            null
+        )
+		baseSFCost = 150;
+    }
+
+	override public function get buttonName():String {
+		return "Resonance Volley";
+	}
+
+	override public function get isKnown():Boolean {
+		return player.weaponRangeName == "Warden’s bow";
+	}
+
+	override public function sfCost():int {
+		return baseSFCost;
+	}
+
+    override public function doEffect(display:Boolean = true):void {		
+		if (display) outputText("You ready your bow, infusing it with a figment of soulforce. The energy awakens the wood’s connection to the world tree, causing the bow to pulse beneath your fingers.\n\n");
+		player.createStatusEffect(StatusEffects.ResonanceVolley,0,0,0,0);
+		combat.fireBow();
+    }
+
+	//Prevent default enemyAI function call, since post ability cleanup will be handled by combat.basemeleeattacks()
+	override public function buttonCallback():void {
+		combat.callbackBeforeAbility(this);
+		if (timingType == TIMING_TOGGLE && isActive()) {
+			toggleOff();
+		} else {
+			perform();
+		}
+	}
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/ResonanceVolleySkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/ResonanceVolleySkill.as
@@ -11,18 +11,15 @@ public class ResonanceVolleySkill extends AbstractSoulSkill {
             TARGET_ENEMY,
             TIMING_INSTANT,
             [TAG_DAMAGING],
-            null,
+            PerkLib.WildWarden,
 			false
         )
 		baseSFCost = 150;
+		processPostCallback = false;
     }
 
 	override public function get buttonName():String {
 		return "Resonance Volley";
-	}
-
-	override public function get isKnown():Boolean {
-		return player.hasPerk(PerkLib.WildWarden);
 	}
 
 	override public function sfCost():int {
@@ -34,15 +31,5 @@ public class ResonanceVolleySkill extends AbstractSoulSkill {
 		player.createStatusEffect(StatusEffects.ResonanceVolley,0,0,0,0);
 		combat.fireBow();
     }
-
-	//Prevent default enemyAI function call, since post ability cleanup will be handled by combat.basemeleeattacks()
-	override public function buttonCallback():void {
-		combat.callbackBeforeAbility(this);
-		if (timingType == TIMING_TOGGLE && isActive()) {
-			toggleOff();
-		} else {
-			perform();
-		}
-	}
 }
 }

--- a/classes/classes/Scenes/Combat/Soulskills/ResonanceVolleySkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/ResonanceVolleySkill.as
@@ -10,7 +10,8 @@ public class ResonanceVolleySkill extends AbstractSoulSkill {
             TARGET_ENEMY,
             TIMING_INSTANT,
             [TAG_DAMAGING],
-            null
+            null,
+			false
         )
 		baseSFCost = 150;
     }

--- a/classes/classes/Scenes/Combat/Soulskills/ResonanceVolleySkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/ResonanceVolleySkill.as
@@ -1,6 +1,7 @@
 package classes.Scenes.Combat.Soulskills {
 import classes.Scenes.Combat.AbstractSoulSkill;
 import classes.StatusEffects;
+import classes.PerkLib;
 
 public class ResonanceVolleySkill extends AbstractSoulSkill {
     public function ResonanceVolleySkill() {
@@ -21,7 +22,7 @@ public class ResonanceVolleySkill extends AbstractSoulSkill {
 	}
 
 	override public function get isKnown():Boolean {
-		return player.weaponRangeName == "Warden’s bow";
+		return player.hasPerk(PerkLib.WildWarden);
 	}
 
 	override public function sfCost():int {

--- a/classes/classes/Scenes/Combat/Soulskills/ScarletSpiritChargeSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/ScarletSpiritChargeSkill.as
@@ -1,0 +1,67 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.Races;
+import classes.Scenes.API.FnHelpers;
+
+public class ScarletSpiritChargeSkill extends AbstractSoulSkill {
+	private static const ScarletSpiritChargeABC:Object = FnHelpers.FN.buildLogScaleABC(10,100,1000,10,100);
+    public function ScarletSpiritChargeSkill() {
+        super(
+            "Scarlet Spirit Charge",
+            "Activate Scarlet Spirit Charge state, which enhances your physical and mental abilities.  Allow to use during it Charge action.",
+            TARGET_SELF,
+            TIMING_TOGGLE,
+            [TAG_BUFF],
+            StatusEffects.KnowsScarletSpiritCharge
+        )
+		baseSFCost = 0;
+    }
+
+	override public function get buttonName():String {
+		if (isActive())
+			return "DeActSSCharge";
+		else
+			return "ScarletSpiritCharge";
+	}
+
+	override public function isActive():Boolean {
+		return player.statStore.hasBuff("ScarletSpiritCharge");
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "Increases all stats, reduces health by 5% per round";
+	}
+
+	override public function toggleOff(display:Boolean = true):void {
+		if (display) outputText("You disrupt the flow of blood within you, your body slumps as the glow radiating from your [skin] dissipates back into your natural hue.");
+		player.statStore.removeBuffs("ScarletSpiritCharge");
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		var tempStrTouSpe:Number = 0;
+		if (display) outputText("You focus the power of your blood and soul, allowing the scarlet energy fill your being." + 
+			" Your [skin] begins to glow as the power within you coalesces, whirling within you with the force of a tsunami.\n");
+
+		var ScarletSpiritChargeBoost:Number = 10;
+		ScarletSpiritChargeBoost += player.wisStat.core.value;
+		ScarletSpiritChargeBoost *= spellModBlood();
+		if (ScarletSpiritChargeBoost < 10) ScarletSpiritChargeBoost = 10;
+		ScarletSpiritChargeBoost = FnHelpers.FN.logScale(ScarletSpiritChargeBoost,ScarletSpiritChargeABC,10);
+		ScarletSpiritChargeBoost = Math.round(ScarletSpiritChargeBoost);
+		tempStrTouSpe = ScarletSpiritChargeBoost;
+		mainView.statsView.showStatUp('str');
+		mainView.statsView.showStatUp('tou');
+		mainView.statsView.showStatUp('spe');
+		mainView.statsView.showStatUp('inte');
+		mainView.statsView.showStatUp('wis');
+		player.buff("ScarletSpiritCharge").addStats({
+			"str.mult":(ScarletSpiritChargeBoost*0.02),
+			"tou.mult":(ScarletSpiritChargeBoost*0.02),
+			"spe.mult":(ScarletSpiritChargeBoost*0.02),
+			"int.mult":(ScarletSpiritChargeBoost*0.01),
+			"wis.mult":(ScarletSpiritChargeBoost*0.01)}).withText("Scarlet Spirit Charge").combatPermanent();
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/ScarletSpiritChargeSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/ScarletSpiritChargeSkill.as
@@ -1,11 +1,11 @@
 package classes.Scenes.Combat.Soulskills {
-import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.Scenes.Combat.AbstractBloodSoulSkill;
 import classes.StatusEffects;
 import classes.Monster;
 import classes.Races;
 import classes.Scenes.API.FnHelpers;
 
-public class ScarletSpiritChargeSkill extends AbstractSoulSkill {
+public class ScarletSpiritChargeSkill extends AbstractBloodSoulSkill {
 	private static const ScarletSpiritChargeABC:Object = FnHelpers.FN.buildLogScaleABC(10,100,1000,10,100);
     public function ScarletSpiritChargeSkill() {
         super(
@@ -33,6 +33,10 @@ public class ScarletSpiritChargeSkill extends AbstractSoulSkill {
 	override public function describeEffectVs(target:Monster):String {
 		return "Increases all stats, reduces health by 5% per round";
 	}
+
+	override public function sfCost():int {
+        return baseSFCost;
+    }
 
 	override public function toggleOff(display:Boolean = true):void {
 		if (display) outputText("You disrupt the flow of blood within you, your body slumps as the glow radiating from your [skin] dissipates back into your natural hue.");

--- a/classes/classes/Scenes/Combat/Soulskills/SoulBlastSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/SoulBlastSkill.as
@@ -1,0 +1,86 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class SoulBlastSkill extends AbstractSoulSkill {
+    public function SoulBlastSkill() {
+        super(
+            "Soul Blast",
+            "Focus your reserves of soul force to unleash a torrent of devastating energy and obliterate your opponent.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING],
+            StatusEffects.KnowsSoulBlast
+        )
+		baseSFCost = 100;
+    }
+
+	override public function get buttonName():String {
+		return "Soul Blast";
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + calcDamage(target) + " magical damage, Stuns for 3 rounds"
+	}
+
+	override public function calcCooldown():int {
+        return 15;
+    }
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = player.str;
+		damage += scalingBonusStrength() * 1.8;
+		damage += player.inte;
+		damage += scalingBonusIntelligence() * 1.8;
+		damage += player.wis;
+		damage += scalingBonusWisdom() * 1.8;
+		if (damage < 10) damage = 10;
+		damage *= spellMod();
+		//soulskill mod effect
+		damage *= combat.soulskillMagicalMod();
+		//other bonuses
+		if (monster) {
+			if (player.hasPerk(PerkLib.PerfectStrike) && monster.monsterIsStunned()) damage *= 1.5;
+			if (player.hasPerk(PerkLib.Heroism) && (monster.hasPerk(PerkLib.EnemyBossType) || monster.hasPerk(PerkLib.EnemyHugeType))) damage *= 2;
+		}
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+		return Math.round(damage);
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+		var damage:Number = calcDamage(monster);
+
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatMagicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+
+		if (display) outputText("You wave the sign of the gate, tiger and serpent as you unlock all of your soulforce for an attack. [Themonster] can’t figure out what you are doing until a small sphere of energy explodes at the end of your fist in a massive beam of condensed soulforce. ");
+		doMagicDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.Stunned, 3, 0, 0, 0);
+		else {
+			if (display) {
+				outputText("  <b>[Themonster] ");
+				if(!monster.plural) outputText("is ");
+				else outputText("are ");
+				outputText("too resolute to be stunned by your attack.</b>");
+			}
+		}
+		checkAchievementDamage(damage);
+		if (display) outputText("\n\n");
+		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(damage);
+		combat.heroBaneProc(damage);
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/SoulDrainSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/SoulDrainSkill.as
@@ -1,0 +1,109 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.IMutations.IMutationsLib;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+import classes.Races;
+
+public class SoulDrainSkill extends AbstractSoulSkill {
+    public function SoulDrainSkill() {
+        super(
+            "Soul Drain",
+            "Damage victim’s soul force directly, inflicting suffering both physical and spiritual in the form of heavy dark damage." + 
+			"Ineffective on foes who lack a soul. Gain Healing as a percentage of the soul force stolen.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_HEALING],
+            null,
+			false
+        )
+		baseSFCost = 100;
+    }
+
+    override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+		if (monster && monster.hasPerk(PerkLib.EnemyTrueDemon)) {
+			return "You can't use this soulskill on somoene truly souless.";
+		}
+		if (player.hasStatusEffect(StatusEffects.OniRampage) || player.wrath > player.maxSafeWrathMagicalAbilities()) {
+			return "You are too angry to think straight. Smash your puny opponents first and think later.";
+		}
+
+        return "";
+    }
+
+	override public function get buttonName():String {
+		return "Soul Drain";
+	}
+
+	override public function get isKnown():Boolean {
+		return player.racialScore(Races.ANUBIS) >= 20;
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		var monsterDrain: String;
+		if (target)
+			monsterDrain = "health and drains " + calcSoulforceDrain(target) + " soulforce from the enemy";
+		else
+			monsterDrain = "";
+
+		return "~" + calcDamage(target) + " magical damage, heals " + calcHealAmount() + monsterDrain;
+	}
+
+	public function calcDamage(monster:Monster):Number {
+		var damage:Number = scalingBonusWisdom() + scalingBonusIntelligence();
+		if (damage < 10) damage = 10;
+
+		//soulspell mod effect
+		damage *= spellMod();
+		damage *= soulskillMagicalMod();
+		damage = calcEclypseMod(damage, true);
+
+		//other bonuses
+		if (player.hasPerk(PerkLib.Heroism) && (monster && (monster.hasPerk(PerkLib.EnemyBossType) || monster.hasPerk(PerkLib.EnemyHugeType)))) damage *= 2;
+		if (player.perkv1(IMutationsLib.AnubiHeartIM) >= 4 && player.HP < Math.round(player.maxHP() * 0.5)) damage *= 1.5;
+		if (player.armor == armors.DEATHPGA) damage *= 1.5;
+		return Math.round(damage * combat.darknessDamageBoostedByDao());
+	}
+
+	private function calcHealAmount():int {
+		return Math.round(player.maxHP() * 0.2);
+	}
+
+	private function calcSoulforceDrain(monster: Monster):int {
+		return Math.round(monster.maxSoulforce() * 0.2);
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+
+		if (display) outputText("You reach out with your magic and attempt to tear a part of your opponent soul. [monster his] scream in pain and horror as you attack [monster his] very essence!  ");
+		combat.darkRitualCheckDamage();
+
+		var damage:Number = calcDamage(monster);
+
+		//Determine if critical hit!
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatMagicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+		doDarknessDamage(damage, true, display);
+		if (crit && display) outputText(" <b>*Critical Hit!*</b>");
+		checkAchievementDamage(damage);
+		HPChange(calcHealAmount(), display);
+		monster.addSoulforce(-calcSoulforceDrain(monster)); 
+		if (display) outputText("\n\n");
+		anubiHeartLeeching(damage);
+		combat.heroBaneProc(damage);	
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/StormOfSisterhoodSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/StormOfSisterhoodSkill.as
@@ -1,0 +1,78 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.Combat;
+
+public class StormOfSisterhoodSkill extends AbstractSoulSkill {
+    public function StormOfSisterhoodSkill() {
+        super(
+            "Storm of Sisterhood",
+            "Transform your wrath into an electric storm, empowered by sisterhood.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_LIGHTNING, TAG_RECOVERY],
+            StatusEffects.KnowsStormOfSisterhood
+        )
+    }
+
+	override public function get buttonName():String {
+		return "Storm of Sisterhood";
+	}
+
+	override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+        if (player.wrath < 50) {
+			return "Your current wrath is too low.";
+		}
+
+        return "";
+    }  
+
+	override public function describeEffectVs(target:Monster):String {
+		var wrathRestore: Number = calcWrathRestore();
+		return "~" + calcDamage(target, wrathRestore) + " lightning damage, restores " + wrathRestore + " wrath";
+	}
+
+	override public function calcCooldown():int {
+		return  Math.round(player.statusEffectv1(StatusEffects.KnowsStormOfSisterhood));
+	}
+
+	public function stormOfSisterhoodWC():Number {
+    	var soswc:Number = 10;
+    	return soswc;
+	}
+
+	private function calcWrathRestore():Number {
+		var restoreAmount:Number = 0;
+		restoreAmount += Math.round(player.wrath * (stormOfSisterhoodWC() * 0.01));
+		return restoreAmount;
+	}
+
+	public function calcDamage(monster:Monster, baseDamage: Number):Number {
+		var damage:Number = baseDamage * (5 * player.statusEffectv1(StatusEffects.KnowsStormOfSisterhood));
+		if (monster.plural) damage *= 2;
+		damage *= combat.lightningDamageBoostedByDao();
+		return Math.round(damage);
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
+
+		var wrathRestore:Number = calcWrathRestore();
+		player.wrath -= wrathRestore;
+
+		var damage:Number = calcDamage(monster, wrathRestore);
+
+		if (display) {
+			outputText("You start concentrate on the wrath flowing in your body, your veins while imaging a joy of sharing storm of sisterhood with enemy. Shortly after that wrath starts to gather around your hands till it envelop your hands in ligthing.\n\n");
+    		outputText("With joy, you sends a mass of ligthing toward [themonster] while mumbling about 'sharing the storm of sisterhood'. ");
+		}
+		doLightingDamage(damage, true, display);
+		if (display) outputText("\n\n");
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/StormOfSisterhoodSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/StormOfSisterhoodSkill.as
@@ -54,7 +54,7 @@ public class StormOfSisterhoodSkill extends AbstractSoulSkill {
 
 	public function calcDamage(monster:Monster, baseDamage: Number):Number {
 		var damage:Number = baseDamage * (5 * player.statusEffectv1(StatusEffects.KnowsStormOfSisterhood));
-		if (monster.plural) damage *= 2;
+		if (monster && monster.plural) damage *= 2;
 		damage *= combat.lightningDamageBoostedByDao();
 		return Math.round(damage);
 	}

--- a/classes/classes/Scenes/Combat/Soulskills/TranceSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/TranceSkill.as
@@ -14,7 +14,7 @@ public class TranceSkill extends AbstractSoulSkill {
             TARGET_SELF,
             TIMING_TOGGLE,
             [TAG_RECOVERY],
-            null,
+            PerkLib.Trance,
 			false
         )
 		baseSFCost = 100;
@@ -37,10 +37,6 @@ public class TranceSkill extends AbstractSoulSkill {
 
         return "";
     }
-
-	override public function get isKnown():Boolean {
-		return player.hasPerk(PerkLib.Trance);
-	}
 
 	override public function sfCost():int {
 		return baseSFCost;

--- a/classes/classes/Scenes/Combat/Soulskills/TranceSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/TranceSkill.as
@@ -1,0 +1,112 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.PerkLib;
+import classes.Scenes.API.FnHelpers;
+
+public class TranceSkill extends AbstractSoulSkill {
+	private static const TranceABC:Object = FnHelpers.FN.buildLogScaleABC(10,100,1000,10,100);
+    public function TranceSkill() {
+        super(
+            "Trance",
+            "Activate Trance state, which enhances your physical and mental abilities.",
+            TARGET_SELF,
+            TIMING_TOGGLE,
+            [TAG_RECOVERY],
+            null,
+			false
+        )
+		baseSFCost = 100;
+    }
+
+	override public function get buttonName():String {
+		if (isActive())
+			return "Deactiv VPT";
+		else
+			return "V P Trans";
+	}
+
+	override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+		if (player.hasStatusEffect(StatusEffects.OniRampage) || player.wrath > player.maxSafeWrathMagicalAbilities()) {
+			return "You are too angry to think straight. Smash your puny opponents first and think later.";
+		}
+
+        return "";
+    }
+
+	override public function get isKnown():Boolean {
+		return player.hasPerk(PerkLib.Trance);
+	}
+
+	override public function sfCost():int {
+		return baseSFCost;
+	}
+
+	override public function isActive():Boolean {
+		return player.statStore.hasBuff("TranceTransformation");
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "Increases physical and mental damage for 50 soulforce per turn";
+	}
+
+	override public function toggleOff(display:Boolean = true):void {
+		if (display) outputText("You disrupt the flow of power within you, softly falling to the ground as the crystal sheathing your [skin] dissipates into nothingness.");
+		player.statStore.removeBuffs("TranceTransformation");
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		var tempStrTou:Number = 0;
+		if (display) outputText("You focus the power of your mind and soul, letting the mystic energy fill you. Your [skin] begins to crystalize as the power within you takes form. The power whirls within you like a hurricane, the force of it lifting you off your feet. This power...  You will use it to reach victory!\n");
+		
+		var TranceBoost:Number = 10;
+		if (player.hasPerk(PerkLib.JobSorcerer) && player.inte >= 25) TranceBoost += 5;
+		if (player.hasPerk(PerkLib.Spellpower) && player.inte >= 50) TranceBoost += 5;
+		if (player.hasPerk(PerkLib.Mage) && player.inte >= 50) TranceBoost += 10;
+		if (player.hasPerk(PerkLib.FocusedMind) && player.inte >= 50) TranceBoost += 10;
+		if (player.hasPerk(PerkLib.Channeling) && player.inte >= 60) TranceBoost += 10;
+		if (player.hasPerk(PerkLib.Archmage) && player.inte >= 75) TranceBoost += 15;
+		if (player.hasPerk(PerkLib.GrandArchmage) && player.inte >= 100) TranceBoost += 20;
+		if (player.hasPerk(PerkLib.GreyMageApprentice) && player.inte >= 75) TranceBoost += 10;
+		if (player.hasPerk(PerkLib.GreyMage) && player.inte >= 125) TranceBoost += 15;
+		if (player.hasPerk(PerkLib.GreyArchmage) && player.inte >= 175) TranceBoost += 20;
+		if (player.hasPerk(PerkLib.GrandGreyArchmage) && player.inte >= 225) TranceBoost += 25;
+		if (player.hasPerk(PerkLib.GrandGreyArchmage2ndCircle) && player.inte >= 275) TranceBoost += 30;
+		if (player.hasPerk(PerkLib.JobEnchanter) && player.inte >= 50) TranceBoost += 5;
+		if (player.hasPerk(PerkLib.Battleflash) && player.inte >= 50) TranceBoost += 15;
+		if (player.hasPerk(PerkLib.JobSwordsman)) TranceBoost -= 10;
+		if (player.hasPerk(PerkLib.JobBrawler)) TranceBoost -= 10;
+		if (player.hasPerk(PerkLib.JobDervish)) TranceBoost -= 10;
+		if (player.hasPerk(PerkLib.IronFistsI)) TranceBoost -= 10;
+		if (player.hasPerk(PerkLib.JobMonk)) TranceBoost -= 15;
+		if (player.hasPerk(PerkLib.Berzerker)) TranceBoost -= 15;
+		if (player.hasPerk(PerkLib.Lustzerker)) TranceBoost -= 15;
+		if (player.hasPerk(PerkLib.WeaponMastery)) TranceBoost -= 15;
+		if (player.hasPerk(PerkLib.WeaponGrandMastery)) TranceBoost -= 25;
+		if (player.hasPerk(PerkLib.HeavyArmorProficiency)) TranceBoost -= 15;
+		if (player.hasPerk(PerkLib.AyoArmorProficiency)) TranceBoost -= 20;
+		if (player.hasPerk(PerkLib.Agility)) TranceBoost -= 10;
+		if (player.hasPerk(PerkLib.LightningStrikes)) TranceBoost -= 10;
+		if (player.hasPerk(PerkLib.StarlightStrikes)) TranceBoost -= 10;
+		if (player.hasPerk(PerkLib.FleshBodyApprenticeStage)) TranceBoost -= 5;
+		//	TranceBoost += player.inte / 10;player.inte * 0.1 - może tylko jak bedzie mieć perk z prestige job: magus/warock/inny związany z spells
+		if (TranceBoost < 10) TranceBoost = 10;
+		//	if (player.hasPerk(PerkLib.JobEnchanter)) TranceBoost *= 1.2;
+		//	TranceBoost *= spellModBlack();
+		TranceBoost = FnHelpers.FN.logScale(TranceBoost,TranceABC,10);
+		TranceBoost = Math.round(TranceBoost);
+		tempStrTou = TranceBoost;
+		mainView.statsView.showStatUp('str');
+		// strUp.visible = true;
+		// strDown.visible = false;
+		mainView.statsView.showStatUp('tou');
+		// touUp.visible = true;
+		// touDown.visible = false;
+		player.buff("TranceTransformation").addStats({str:TranceBoost,tou:TranceBoost}).withText("Trance Transformation").combatPermanent();
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/Soulskills/VioletPupilTransformationSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/VioletPupilTransformationSkill.as
@@ -1,0 +1,61 @@
+package classes.Scenes.Combat.Soulskills {
+import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.Races;
+
+public class VioletPupilTransformationSkill extends AbstractSoulSkill {
+    public function VioletPupilTransformationSkill() {
+        super(
+            "Violet Pupil Transformation",
+            "Violet Pupil Transformation is a regenerating oriented soul art. While it drains your SoulForce constantly, it allows one to rapidly heal their injuries.",
+            TARGET_SELF,
+            TIMING_TOGGLE,
+            [TAG_RECOVERY],
+            StatusEffects.KnowsVioletPupilTransformation
+        )
+		baseSFCost = 0;
+    }
+
+	override public function get buttonName():String {
+		if (isActive())
+			return "Deactiv VPT";
+		else
+			return "V P Trans";
+	}
+
+	override protected function usabilityCheck():String {
+        var uc:String =  super.usabilityCheck();
+        if (uc) return uc;
+
+		var cm1:Number = 0.05;
+		if (player.isRaceCached(Races.UNICORN, 2)) cm1 -= 0.01;
+		if (player.isRaceCached(Races.ALICORN, 2)) cm1 -= 0.01;
+		var cost1:Number = Math.round(player.maxSoulforce()*cm1);
+		if (player.soulforce < cost1) {
+			return "<b>Your current soulforce is too low.</b>";
+		}
+
+        return "";
+    }
+
+	override public function isActive():Boolean {
+		return player.hasStatusEffect(StatusEffects.VioletPupilTransformation);
+	}
+
+	override public function describeEffectVs(target:Monster):String {
+		return "Regenerates 5% of health per turn, for a cost of 5% soulforce";
+	}
+
+	override public function toggleOff(display:Boolean = true):void {
+		if (display) outputText("Deciding you not need for now to constantly using Violet Pupil Transformation you concentrate and deactivating it.");
+		player.removeStatusEffect(StatusEffects.VioletPupilTransformation);
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+		if (display) outputText("Deciding you need additional regeneration during current fight you spend moment to concentrate and activate Violet Pupil Transformation."
+			+"  Your eyes starting to glow with a violet hua and you can feel refreshing feeling spreading all over your body.\n\n");
+		player.createStatusEffect(StatusEffects.VioletPupilTransformation,0,0,0,0);
+    }
+}
+}


### PR DESCRIPTION
Converted Soulskills so that they now inherit from the CombatAbility classes.
This allows Soulskills to benefit from that classes' functions, such as tagging, ability to be viewed in the "Stats ->Abilities" menu and number of turns before the move can be used again in battle.
Also added Fatigue and Soulfoce Costs to the parent "CombatAbility" classes in case Physical and Magical Specials are converted to use the "CombatAbility" class in the future