### PR TITLE
Ranged Multi Attack Perk To Dao Conversion

### DIFF
--- a/classes/classes/Items/ItemConstants.as
+++ b/classes/classes/Items/ItemConstants.as
@@ -202,13 +202,13 @@ public class ItemConstants extends Utils {
 	public static const WT_SPEAR:String         = "Spear";
 	public static const WT_STAFF:String         = "Staff";
 	public static const WT_SWORD:String         = "Sword";
-	public static const WT_THROWING:String      = "Throwing";
 	public static const WT_WHIP:String          = "Whip";
 	public static const WT_WAND:String         	= "Wand";
 	public static const WT_TOME:String         	= "Tome";
 	// Ranged weapon classes
 	public static const WT_BOW:String           = "Bow";
 	public static const WT_CROSSBOW:String      = "Crossbow";
+	public static const WT_THROWING:String      = "Throwing";
 	public static const WT_DUAL_FIREARMS:String = "Dual Firearms";
 	public static const WT_PISTOL:String        = "Pistol";
 	public static const WT_RIFLE:String         = "Rifle";

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -5505,7 +5505,7 @@ public class PerkLib
                     .requireSpe(80)
                     .requireLevel(24);
             //Tier 5 Speed Perks
-            Multishot.requirePerk(WildQuiver)
+            Multishot.requireAnyPerk(WildQuiver, LockAndLoad)
                     .requireSpe(150)
                     .requireLevel(30);
             PenetratingThrow.requirePerk(ImpactThrow)

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -5329,9 +5329,9 @@ public class PerkLib
             Agility.requireSpe(75)
                     .requirePerk(Runner)
                     .requireLevel(6);
-            WeaponRangeDoubleStrike.requirePerk(JobRanger)
+            /*WeaponRangeDoubleStrike.requirePerk(JobRanger)
                     .requireSpe(50)
-                    .requireLevel(6);
+                    .requireLevel(6);*/
             Unhindered.requireSpe(75)
                     .requirePerk(Evade)
                     .requireLevel(6);
@@ -5400,9 +5400,9 @@ public class PerkLib
                     .requireLib(50)
                     .requirePerk(Unhindered)
                     .requireLevel(12);
-            WeaponRangeTripleStrike.requirePerk(WeaponRangeDoubleStrike)
+            /*WeaponRangeTripleStrike.requirePerk(WeaponRangeDoubleStrike)
                     .requireSpe(75)
-                    .requireLevel(12);
+                    .requireLevel(12);*/
             JobHunter.requireAdvancedJobSlot()
 					.requirePerks(JobRanger, ArchersStaminaI)
                     .requireSpe(80)
@@ -5445,9 +5445,9 @@ public class PerkLib
                     .requireSpe(90)
                     .requireLevel(12);
             //Tier 3 Speed Perks
-            Manyshot.requirePerks(JobHunter, WeaponRangeTripleStrike)
+            /*Manyshot.requirePerks(JobHunter, WeaponRangeTripleStrike)
                     .requireSpe(100)
-                    .requireLevel(18);
+                    .requireLevel(18);*/
             EnvenomedBolt.requireLevel(18)
                     .requirePerk(JobHunter)
                     .requireCustomFunction(function (player:Player):Boolean {
@@ -5487,9 +5487,9 @@ public class PerkLib
 								|| player.perkv1(IMutationsLib.VenomGlandsIM) >= 1 || player.hasKeyItem("Sky Poison Pearl") >= 0;
                     }, "Venom-producing tail, abdomen, fangs or having Venom Glands mutation or possesing Sky Poison Pearl");
             //Tier 4 Speed Perks
-            WildQuiver.requirePerk(Manyshot)
+            /*WildQuiver.requirePerk(Manyshot)
                     .requireSpe(125)
-                    .requireLevel(24);
+                    .requireLevel(24);*/
             Slayer.requirePerk(DeadlySneaker)
                     .requireSpe(120)
                     .requireLevel(12);
@@ -5505,9 +5505,9 @@ public class PerkLib
                     .requireSpe(80)
                     .requireLevel(24);
             //Tier 5 Speed Perks
-            Multishot.requireAnyPerk(WildQuiver, LockAndLoad)
+            /*Multishot.requireAnyPerk(WildQuiver, LockAndLoad)
                     .requireSpe(150)
-                    .requireLevel(30);
+                    .requireLevel(30);*/
             PenetratingThrow.requirePerk(ImpactThrow)
                     .requireSpe(100)
                     .requireLevel(24);
@@ -6213,11 +6213,11 @@ public class PerkLib
 					.requireCustomFunction(function (player:Player):Boolean {
                         return (player.hasPerk(PerkLib.ElementalContractRank3) || (player.hasPerk(PerkLib.DaoOfTheElements) && player.perkv1(PerkLib.DaoOfTheElements) >= 1)) && !player.hasPerk(PerkLib.StrongElementalBond);
                     }, "Having Elemental Contract Rank 3 or Dao of the Elements (layer 1 or higher) perks");
-            AmateurGunslinger.requirePerk(JobGunslinger)
+            /*AmateurGunslinger.requirePerk(JobGunslinger)
 					.requireWis(35)
 					.requireTou(30)
                     .requireSpe(25)
-                    .requireLevel(12);
+                    .requireLevel(12);*/
             RapidReload.requirePerk(JobGunslinger)
 					.requireWis(35)
                     .requireTou(30)
@@ -6250,12 +6250,12 @@ public class PerkLib
 					.requireWis(95)
 					.requireSpe(60)
 					.requireLevel(20);
-			ExplosiveCartridge.requirePerk(AmateurGunslinger)
+			ExplosiveCartridge.requirePerk(JobGunslinger)
 					.requireWis(50)
                     .requireTou(45)
                     .requireSpe(40)
                     .requireLevel(18);
-			TaintedMagazine.requirePerk(AmateurGunslinger)
+			TaintedMagazine.requirePerk(JobGunslinger)
 					.requireWis(55)
                     .requireTou(50)
                     .requireSpe(45)
@@ -6296,17 +6296,17 @@ public class PerkLib
 					.requireCustomFunction(function (player:Player):Boolean {
                         return player.hasPerk(PerkLib.ElementalContractRank4) || (player.hasPerk(PerkLib.DaoOfTheElements) && player.perkv1(PerkLib.DaoOfTheElements) >= 1);
                     }, "Having Elemental Contract Rank 4 or Dao of the Elements (layer 1 or higher) perks");
-            ExpertGunslinger.requirePerk(AmateurGunslinger)
+            /*ExpertGunslinger.requirePerk(AmateurGunslinger)
 					.requireWis(65)
                     .requireTou(60)
                     .requireSpe(55)
-                    .requireLevel(24);
+                    .requireLevel(24);*/
             LightningReload.requirePerk(RapidReload)
 					.requireWis(65)
                     .requireTou(60)
                     .requireSpe(55)
                     .requireLevel(24);
-            SilverForMonsters.requirePerk(ExpertGunslinger)
+            SilverForMonsters.requirePerk(JobGunslinger)
 					.requireWis(70)
                     .requireTou(65)
                     .requireSpe(60)
@@ -6331,12 +6331,12 @@ public class PerkLib
 					.requireCustomFunction(function (player:Player):Boolean {
                         return player.hasPerk(PerkLib.ElementalContractRank4) || (player.hasPerk(PerkLib.DaoOfTheElements) && player.perkv1(PerkLib.DaoOfTheElements) >= 1);
                     }, "Having Elemental Contract Rank 4 or Dao of the Elements (layer 1 or higher) perks");
-			NamedBullet.requirePerk(ExpertGunslinger)
+			NamedBullet.requirePerk(JobGunslinger)
 					.requireWis(80)
                     .requireTou(75)
                     .requireSpe(70)
                     .requireLevel(30);
-            LockAndLoad.requirePerk(ExpertGunslinger)
+            LockAndLoad.requirePerk(JobGunslinger)
 					.requireWis(80)
                     .requireTou(75)
                     .requireSpe(70)
@@ -6362,11 +6362,11 @@ public class PerkLib
             AdvancedMagiculesTheory.requirePerk(MagiculesTheory)
                     .requireWis(150)
                     .requireLevel(36);
-            MasterGunslinger.requirePerk(ExpertGunslinger)
+            /*MasterGunslinger.requirePerk(ExpertGunslinger)
 					.requireWis(95)
                     .requireTou(90)
                     .requireSpe(85)
-                    .requireLevel(36);
+                    .requireLevel(36);*/
 			PrimedClipWarp.requirePerk(TaintedMagazine)
 					.requireWis(100)
                     .requireTou(95)

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1639,7 +1639,7 @@ use namespace CoC;
         }
         public function isDualWieldRanged():Boolean
         {
-        	return weaponRangePerk == "Dual Firearms" || weaponRangePerk == "Dual 2H Firearms";
+        	return weaponRangePerk == ItemConstants.WT_DUAL_FIREARMS || weaponRangePerk == ItemConstants.WT_DUAL_2H_FIREARMS;
         }
         public function isDualWield():Boolean
         {
@@ -1663,7 +1663,7 @@ use namespace CoC;
 		//Is Thrown
 		public function isThrownTypeWeapon():Boolean
 		{
-			return weaponRangePerk == "Throwing";
+			return weaponRangePerk == ItemConstants.WT_THROWING;
 		}
 		//Using Firearms
 		public function isFirearmTypeWeapon():Boolean {
@@ -6145,7 +6145,7 @@ use namespace CoC;
 			var oldProgress:Number = experience/xpToLevel;
 			// for tracking bonus attack masteries
 			var grantsBonusAttacks:Boolean = Combat.bonusAttackMasteries.indexOf(index) != -1;
-			var maxAttacksOld:int = SceneLib.combat.maxCurrentAttacks();
+			var maxAttacksOld:int = melee? SceneLib.combat.maxCurrentAttacks(): SceneLib.combat.maxCurrentRangeAttacks();
 			// This loop does weapon types ( dagger, sword, fist, claws, ... )
 			while (xpLoop > 0) {
 				experience += xpLoop;	// incremeent the XP of the weapon mastery
@@ -6180,7 +6180,7 @@ use namespace CoC;
 			}
 			// Can we get any new attacks?
 			if (grantsBonusAttacks && levelUp) {// if it grants bonus attacks
-				var maxAttacksNew:int = SceneLib.combat.maxCurrentAttacks();
+				var maxAttacksNew:int = melee? SceneLib.combat.maxCurrentAttacks(): SceneLib.combat.maxCurrentRangeAttacks();
 				// remember the last value
 				var masteryArrays:Array = melee? masteryBonusAttacksMelee: masteryBonusAttacksRanged;
 				for each (var masteryArr:Array in masteryArrays) {

--- a/classes/classes/PlayerInfo.as
+++ b/classes/classes/PlayerInfo.as
@@ -516,7 +516,7 @@ public class PlayerInfo extends BaseContent {
 		combatStats += "<b>One Bullet Reload Cost (Fatigue): </b> " + combat.oneBulletReloadCost() + "\n";
 		
 		combatStats += "<b>Bow Accuracy (1st range attack):</b> " + (bAcc / 2) + "%\n";
-		var maxBowAttacks:int = player.calculateMaxAttacksForClass(false, 0);
+		var maxBowAttacks:int = combat.maxBowAttacks();
 		if (maxBowAttacks >= 2) combatStats += "<b>Bow Accuracy (2nd range attack):</b> " + ((bAcc / 2) - bAccPen) + "%\n";
 		if (maxBowAttacks >= 3) combatStats += "<b>Bow Accuracy (3rd range attack):</b> " + ((bAcc / 2) - (bAccPen * 2)) + "%\n";
 		if (maxBowAttacks >= 4) combatStats += "<b>Bow Accuracy (4th range attack):</b> " + ((bAcc / 2) - (bAccPen * 3)) + "%\n";
@@ -524,19 +524,19 @@ public class PlayerInfo extends BaseContent {
 		if (maxBowAttacks >= 6) combatStats += "<b>Bow Accuracy (6th range attack):</b> " + ((bAcc / 2) - (bAccPen * 5)) + "%\n";
 
 		combatStats += "<b>Crossbow Accuracy (1st range attack):</b> " + (bAcc / 2) + "%\n";
-		var maxCrossBowAttacks:int = player.calculateMaxAttacksForClass(false, 1);
+		var maxCrossBowAttacks:int = combat.maxCrossbowAttacks();
 		if (maxCrossBowAttacks >= 2) combatStats += "<b>Crossbow Accuracy (2nd range attack):</b> " + ((bAcc / 2) - bAccPen) + "%\n";
 		if (maxCrossBowAttacks >= 3) combatStats += "<b>Crossbow Accuracy (3rd range attack):</b> " + ((bAcc / 2) - (bAccPen * 2)) + "%\n";
 		combatStats += "<i>(All accuracy values above includes bonus to accuracy from Archery Mastery)</i>\n";
 		combatStats += "<b>Throwed Weapon Accuracy (1st range attack):</b> " + (combat.throwingAccuracy() / 2) + "%\n";
 		
-		var maxThrowAttacks:int = player.calculateMaxAttacksForClass(false, 2);
+		var maxThrowAttacks:int = combat.maxThrowingAttacks();
 		if (maxThrowAttacks >= 2) combatStats += "<b>Throwed Weapon Accuracy (2nd range attack):</b> " + ((combat.throwingAccuracy() / 2) - 15) + "%\n";
 		if (maxThrowAttacks >= 3) combatStats += "<b>Throwed Weapon Accuracy (3rd range attack):</b> " + ((combat.throwingAccuracy() / 2) - 30) + "%\n";
 		combatStats += "<i>(All accuracy values above includes bonus to accuracy from Throwing Weapons Mastery)</i>\n";
 		combatStats += "<b>Firearms Accuracy (1st range attack):</b> " + (fAcc / 2) + "%\n";
 		
-		var maxFirearmAttacks:int = player.calculateMaxAttacksForClass(false, 3);
+		var maxFirearmAttacks:int = combat.maxFirearmsAttacks();
 		if (maxFirearmAttacks >= 2) combatStats += "<b>Firearms Accuracy (2nd range attack):</b> " + ((fAcc / 2) - fAccPen) + "%\n";
 		if (maxFirearmAttacks >= 3) combatStats += "<b>Firearms Accuracy (3rd range attack):</b> " + ((fAcc / 2) - (fAccPen * 2)) + "%\n";
 		if (maxFirearmAttacks >= 4) combatStats += "<b>Firearms Accuracy (4th range attack):</b> " + ((fAcc / 2) - (fAccPen * 3)) + "%\n";

--- a/classes/classes/PlayerInfo.as
+++ b/classes/classes/PlayerInfo.as
@@ -470,15 +470,16 @@ public class PlayerInfo extends BaseContent {
 		combatStats += "\n";
 		combatStats += "<b>Melee Physical Attacks Multiplier:</b> " + Math.round(100 * combat.meleePhysicalForce()) + "%\n";
 		combatStats += "<b>Accuracy (1st melee attack):</b> " + (mAcc / 2) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponSmallDoubleAttack) || player.hasPerk(PerkLib.WeaponNormalDoubleAttack) || player.hasPerk(PerkLib.WeaponLargeDoubleAttack)) combatStats += "<b>Accuracy (2nd melee attack):</b> " + ((mAcc / 2) - mAccPen) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponSmallTripleAttack) || player.hasPerk(PerkLib.WeaponNormalTripleAttack) || player.hasPerk(PerkLib.WeaponLargeTripleAttack)) combatStats += "<b>Accuracy (3rd melee attack):</b> " + ((mAcc / 2) - (mAccPen * 2)) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponSmallQuadrupleAttack) || player.hasPerk(PerkLib.WeaponNormalQuadrupleAttack)) combatStats += "<b>Accuracy (4th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 3)) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponSmallPentaAttack) || player.hasPerk(PerkLib.WeaponNormalPentaAttack)) combatStats += "<b>Accuracy (5th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 4)) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponSmallHexaAttack) || player.hasPerk(PerkLib.WeaponNormalHexaAttack)) combatStats += "<b>Accuracy (6th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 5)) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponSmallHectaAttack)) combatStats += "<b>Accuracy (7th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 6)) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponSmallOctaAttack)) combatStats += "<b>Accuracy (8th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 7)) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponSmallNonaAttack)) combatStats += "<b>Accuracy (9th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 8)) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponSmallDecaAttack)) combatStats += "<b>Accuracy (10th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 9)) + "%\n";
+		var maxMeleeAttacks:int = player.calculateMultiAttacks();
+		if (maxMeleeAttacks >= 2) combatStats += "<b>Accuracy (2nd melee attack):</b> " + ((mAcc / 2) - mAccPen) + "%\n";
+		if (maxMeleeAttacks >= 3) combatStats += "<b>Accuracy (3rd melee attack):</b> " + ((mAcc / 2) - (mAccPen * 2)) + "%\n";
+		if (maxMeleeAttacks >= 4) combatStats += "<b>Accuracy (4th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 3)) + "%\n";
+		if (maxMeleeAttacks >= 5) combatStats += "<b>Accuracy (5th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 4)) + "%\n";
+		if (maxMeleeAttacks >= 6) combatStats += "<b>Accuracy (6th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 5)) + "%\n";
+		if (maxMeleeAttacks >= 7) combatStats += "<b>Accuracy (7th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 6)) + "%\n";
+		if (maxMeleeAttacks >= 8) combatStats += "<b>Accuracy (8th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 7)) + "%\n";
+		if (maxMeleeAttacks >= 9) combatStats += "<b>Accuracy (9th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 8)) + "%\n";
+		if (maxMeleeAttacks >= 10) combatStats += "<b>Accuracy (10th melee attack):</b> " + ((mAcc / 2) - (mAccPen * 9)) + "%\n";
 		combatStats += "<i>(All accuracy values above includes bonus to accuracy from Mastery for currently equipped type of melee weapon)\n(They not include penalty for using dual weapons that is "+combat.meleeDualWieldAccuracyPenalty()+"% (addictive) to each attack)</i>\n";
 		combatStats += "\n";
 		combatStats += "<b>Range Physical Attacks Multiplier:</b> " + Math.round(100 * combat.rangePhysicalForce()) + "%\n";
@@ -492,22 +493,33 @@ public class PlayerInfo extends BaseContent {
 		else combatStats += "<b>Bow Skill:</b> 0 / 100\n";
 		combatStats += "<b>Telekinesis Throw Cost (Fatigue): </b> " + combat.oneThrowTotalCost() + "\n";
 		combatStats += "<b>One Bullet Reload Cost (Fatigue): </b> " + combat.oneBulletReloadCost() + "\n";
-		combatStats += "<b>Bow/Crossbow Accuracy (1st range attack):</b> " + (bAcc / 2) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponRangeDoubleStrike)) combatStats += "<b>Bow/Crossbow Accuracy (2nd range attack):</b> " + ((bAcc / 2) - bAccPen) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponRangeTripleStrike)) combatStats += "<b>Bow/Crossbow Accuracy (3rd range attack):</b> " + ((bAcc / 2) - (bAccPen * 2)) + "%\n";
-		if (player.hasPerk(PerkLib.Manyshot)) combatStats += "<b>Bow/Crossbow Accuracy (4th range attack):</b> " + ((bAcc / 2) - (bAccPen * 3)) + "%\n";
-		if (player.hasPerk(PerkLib.WildQuiver)) combatStats += "<b>Bow/Crossbow Accuracy (5th range attack):</b> " + ((bAcc / 2) - (bAccPen * 4)) + "%\n";
-		if (player.hasPerk(PerkLib.Multishot)) combatStats += "<b>Bow/Crossbow Accuracy (6th range attack):</b> " + ((bAcc / 2) - (bAccPen * 5)) + "%\n";
+		
+		combatStats += "<b>Bow Accuracy (1st range attack):</b> " + (bAcc / 2) + "%\n";
+		var maxBowAttacks:int = player.calculateMaxAttacksForClass(false, 0);
+		if (maxBowAttacks >= 2) combatStats += "<b>Bow Accuracy (2nd range attack):</b> " + ((bAcc / 2) - bAccPen) + "%\n";
+		if (maxBowAttacks >= 3) combatStats += "<b>Bow Accuracy (3rd range attack):</b> " + ((bAcc / 2) - (bAccPen * 2)) + "%\n";
+		if (maxBowAttacks >= 4) combatStats += "<b>Bow Accuracy (4th range attack):</b> " + ((bAcc / 2) - (bAccPen * 3)) + "%\n";
+		if (maxBowAttacks >= 5) combatStats += "<b>Bow Accuracy (5th range attack):</b> " + ((bAcc / 2) - (bAccPen * 4)) + "%\n";
+		if (maxBowAttacks >= 6) combatStats += "<b>Bow Accuracy (6th range attack):</b> " + ((bAcc / 2) - (bAccPen * 5)) + "%\n";
+
+		combatStats += "<b>Crossbow Accuracy (1st range attack):</b> " + (bAcc / 2) + "%\n";
+		var maxCrossBowAttacks:int = player.calculateMaxAttacksForClass(false, 1);
+		if (maxCrossBowAttacks >= 2) combatStats += "<b>Crossbow Accuracy (2nd range attack):</b> " + ((bAcc / 2) - bAccPen) + "%\n";
+		if (maxCrossBowAttacks >= 3) combatStats += "<b>Crossbow Accuracy (3rd range attack):</b> " + ((bAcc / 2) - (bAccPen * 2)) + "%\n";
 		combatStats += "<i>(All accuracy values above includes bonus to accuracy from Archery Mastery)</i>\n";
 		combatStats += "<b>Throwed Weapon Accuracy (1st range attack):</b> " + (combat.throwingAccuracy() / 2) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponRangeDoubleStrike)) combatStats += "<b>Throwed Weapon Accuracy (2nd range attack):</b> " + ((combat.throwingAccuracy() / 2) - 15) + "%\n";
-		if (player.hasPerk(PerkLib.WeaponRangeTripleStrike)) combatStats += "<b>Throwed Weapon Accuracy (3rd range attack):</b> " + ((combat.throwingAccuracy() / 2) - 30) + "%\n";
+		
+		var maxThrowAttacks:int = player.calculateMaxAttacksForClass(false, 2);
+		if (maxThrowAttacks >= 2) combatStats += "<b>Throwed Weapon Accuracy (2nd range attack):</b> " + ((combat.throwingAccuracy() / 2) - 15) + "%\n";
+		if (maxThrowAttacks >= 3) combatStats += "<b>Throwed Weapon Accuracy (3rd range attack):</b> " + ((combat.throwingAccuracy() / 2) - 30) + "%\n";
 		combatStats += "<i>(All accuracy values above includes bonus to accuracy from Throwing Weapons Mastery)</i>\n";
 		combatStats += "<b>Firearms Accuracy (1st range attack):</b> " + (fAcc / 2) + "%\n";
-		if (player.hasPerk(PerkLib.AmateurGunslinger)) combatStats += "<b>Firearms Accuracy (2nd range attack):</b> " + ((fAcc / 2) - fAccPen) + "%\n";
-		if (player.hasPerk(PerkLib.ExpertGunslinger)) combatStats += "<b>Firearms Accuracy (3rd range attack):</b> " + ((fAcc / 2) - (fAccPen * 2)) + "%\n";
-		if (player.hasPerk(PerkLib.MasterGunslinger) || (player.hasPerk(PerkLib.ExpertGunslinger) && player.hasPerk(PerkLib.LockAndLoad))) combatStats += "<b>Firearms Accuracy (4th range attack):</b> " + ((fAcc / 2) - (fAccPen * 3)) + "%\n";
-		if (player.hasPerk(PerkLib.MasterGunslinger) && player.hasPerk(PerkLib.LockAndLoad)) {
+		
+		var maxFirearmAttacks:int = player.calculateMaxAttacksForClass(false, 3);
+		if (maxFirearmAttacks >= 2) combatStats += "<b>Firearms Accuracy (2nd range attack):</b> " + ((fAcc / 2) - fAccPen) + "%\n";
+		if (maxFirearmAttacks >= 3) combatStats += "<b>Firearms Accuracy (3rd range attack):</b> " + ((fAcc / 2) - (fAccPen * 2)) + "%\n";
+		if (maxFirearmAttacks >= 4) combatStats += "<b>Firearms Accuracy (4th range attack):</b> " + ((fAcc / 2) - (fAccPen * 3)) + "%\n";
+		if (maxFirearmAttacks >= 5) {
 			combatStats += "<b>Firearms Accuracy (5th range attack):</b> " + ((fAcc / 2) - (fAccPen * 4)) + "%\n";
 			combatStats += "<b>Firearms Accuracy (6th range attack):</b> " + ((fAcc / 2) - (fAccPen * 5)) + "%\n";
 		}

--- a/classes/classes/SaveUpdater.as
+++ b/classes/classes/SaveUpdater.as
@@ -2528,11 +2528,19 @@ public class SaveUpdater extends NPCAwareContent {
 				outputText("\n\nBeautiful items meant to be gathered not chosen one per game.");
 				if (player.hasStatusEffect(StatusEffects.BlessedItemAtTheLake)) player.addStatusValue(StatusEffects.BlessedItemAtTheLake, 1 , 1);
 				flags[kFLAGS.MOD_SAVE_VERSION] = 36.18;
-			}/*
-			if (flags[kFLAGS.MOD_SAVE_VERSION] < 36.19) {
-				
-				flags[kFLAGS.MOD_SAVE_VERSION] = 36.19;
 			}
+			if (flags[kFLAGS.MOD_SAVE_VERSION] < 36.19) {
+				outputText("\n\nPerks are no longer needed for ranged multi attacks");
+				refundPerk(PerkLib.Multishot);
+				refundPerk(PerkLib.WildQuiver);
+				refundPerk(PerkLib.Manyshot);
+				refundPerk(PerkLib.WeaponRangeTripleStrike);
+				refundPerk(PerkLib.WeaponRangeDoubleStrike);
+				refundPerk(PerkLib.MasterGunslinger);
+				refundPerk(PerkLib.ExpertGunslinger);
+				refundPerk(PerkLib.AmateurGunslinger);
+				flags[kFLAGS.MOD_SAVE_VERSION] = 36.19;
+			}/*
 			if (flags[kFLAGS.MOD_SAVE_VERSION] < 36.20) {
 				
 				flags[kFLAGS.MOD_SAVE_VERSION] = 36.20;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -382,7 +382,8 @@ public class Combat extends BaseContent {
         else if (player.hasPerk(PerkLib.WeaponRangeDoubleStrike)) baseHits = 2;
         else baseHits = 1;
         return (baseHits+extraHits) * (flags[kFLAGS.ELVEN_TWINSHOT_ENABLED] ? 2 : 1);*/
-        return player.calculateMaxAttacksForClass(false, 0);
+        return player.calculateMaxAttacksForClass(false, 0) + 
+            (player.isBowTypeWeapon() && player.hasPerk(PerkLib.ELFMasterShot))? 1: 0;
     }
 
     public function maxCrossbowAttacks():int {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -10,6 +10,7 @@ import classes.GlobalFlags.kFLAGS;
 import classes.IMutations.*;
 import classes.ItemType;
 import classes.Items.EnchantmentLib;
+import classes.Items.ItemConstants;
 import classes.Items.ItemTags;
 import classes.Items.JewelryLib;
 import classes.Items.Weapon;
@@ -409,11 +410,7 @@ public class Combat extends BaseContent {
     }
 
     public function maxCurrentRangeAttacks():int {
-        if (player.weaponRangePerk == "Pistol" || player.weaponRangePerk == "Rifle" || player.weaponRangePerk == "2H Firearm" || player.weaponRangePerk == "Dual Firearms" || player.weaponRangePerk == "Dual 2H Firearms") return maxFirearmsAttacks();
-        else if (player.weaponRangePerk == "Throwing") return maxThrowingAttacks();
-        else if (player.weaponRangePerk == "Crossbow") return maxCrossbowAttacks();
-        else if (player.weaponRangePerk == "Bow")return maxBowAttacks();
-        else return 1;
+        return player.calculateMultiAttacks(false);
     }
 
     public function endHpVictory():void {
@@ -823,7 +820,7 @@ public class Combat extends BaseContent {
             ((player.hasPerk(PerkLib.Berzerker) || (player.hasPerk(PerkLib.Lustzerker)) && player.perkv1(IMutationsLib.SalamanderAdrenalGlandsIM) >= 3)) || player.hasPerk(PerkLib.Poisoning) || player.hasPerk(PerkLib.SwiftCasting) || player.hasStatusEffect(StatusEffects.SoulDrill1) || player.hasStatusEffect(StatusEffects.ThePhalluspear1)) {
             buttons.add("Melee Opt", CoC.instance.perkMenu.meleeOptions, "You can adjust your melee attack settings.");
         }
-        if (player.hasPerk(PerkLib.WeaponRangeDoubleStrike) || player.hasPerk(PerkLib.ELFTwinShot) || player.hasPerk(PerkLib.ElementalArrows) || player.hasPerk(PerkLib.Cupid) || player.hasPerk(PerkLib.EnvenomedBolt) || player.hasPerk(PerkLib.ELFThornShot) || player.hasPerk(PerkLib.AmateurGunslinger)) {
+        if (player.hasPerk(PerkLib.ELFTwinShot) || player.hasPerk(PerkLib.ElementalArrows) || player.hasPerk(PerkLib.Cupid) || player.hasPerk(PerkLib.EnvenomedBolt) || player.hasPerk(PerkLib.ELFThornShot) || player.calculateMultiAttacks(false) > 1) {
             buttons.add("Range Opt", CoC.instance.perkMenu.rangedOptions, "You can adjust your range strike settings.");
         }
         if (player.hasPerk(PerkLib.JobLeader)) {
@@ -3043,6 +3040,8 @@ public class Combat extends BaseContent {
             return;
         }
         flags[kFLAGS.LAST_ATTACK_TYPE] = LAST_ATTACK_BOW;
+        var maxRangedAttacks:int = player.calculateMultiAttacks(false);
+
         if (player.vehicles == vehicles.HB_MECH) {
             if (player.hasKeyItem("HB Rapid Reload") >= 0) {
                 if (player.keyItemvX("HB Rapid Reload", 1) == 1) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 4;
@@ -3050,30 +3049,28 @@ public class Combat extends BaseContent {
             }
             else flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 2;
         }
-        else if (player.weaponRangePerk == "Bow" || player.weaponRangePerk == "Crossbow") {
-            if (player.weaponRangePerk == "Crossbow") flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = Math.min((flags[kFLAGS.MULTISHOT_STYLE] || 0) + 1, 3);
-            else flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = Math.min((flags[kFLAGS.MULTISHOT_STYLE] || 0) + 1, maxBowAttacks());
-			if (player.isElf() && player.hasPerk(PerkLib.ELFMasterShot) && player.weaponRangePerk == "Bow") flags[kFLAGS.MULTIPLE_ARROWS_STYLE] += 1;
-			if (player.isWoodElf() && player.hasPerk(PerkLib.ELFTwinShot) && player.weaponRangePerk == "Bow") flags[kFLAGS.MULTIPLE_ARROWS_STYLE] *= (flags[kFLAGS.ELVEN_TWINSHOT_ENABLED] ? 2 : 1);
-            if (player.weaponRangeName == "Avelynn") flags[kFLAGS.MULTIPLE_ARROWS_STYLE] *= 3;
+        else if (player.weaponRangePerk == ItemConstants.WT_BOW) {
+            flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = Math.min((flags[kFLAGS.MULTISHOT_STYLE] || 0) + 1, maxRangedAttacks);
+			if (player.isWoodElf() && player.hasPerk(PerkLib.ELFTwinShot)) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] *= (flags[kFLAGS.ELVEN_TWINSHOT_ENABLED] ? 2 : 1);
         }
-        else if (player.weaponRangePerk == "Throwing") {
-            if (flags[kFLAGS.MULTISHOT_STYLE] >= 2) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 3;
+        else if (player.weaponRangePerk == ItemConstants.WT_CROSSBOW) {
+            flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = Math.min((flags[kFLAGS.MULTISHOT_STYLE] || 0) + 1, maxRangedAttacks);
+            if (player.weaponRange == weaponsrange.AVELYNN) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] *= 3;
+        }
+        else if (player.weaponRangePerk == ItemConstants.WT_THROWING) {
+            flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = Math.min((flags[kFLAGS.MULTISHOT_STYLE] || 0) + 1, maxRangedAttacks);
+            /*if (flags[kFLAGS.MULTISHOT_STYLE] >= 2) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 3;
             else if (flags[kFLAGS.MULTISHOT_STYLE] == 1) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 2;
-            else flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 1;
+            else flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 1;*/
         }
-        else if (player.weaponRangePerk == "Pistol" || player.weaponRangePerk == "Rifle" || player.weaponRangePerk == "2H Firearm" || player.weaponRangePerk == "Dual Firearms" || player.weaponRangePerk == "Dual 2H Firearms") {
-            if (flags[kFLAGS.MULTISHOT_STYLE] >= 3) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 4;
+        else if (player.isFirearmTypeWeapon()) {
+            /*if (flags[kFLAGS.MULTISHOT_STYLE] >= 3) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 4;
             else if (flags[kFLAGS.MULTISHOT_STYLE] == 2) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 3;
             else if (flags[kFLAGS.MULTISHOT_STYLE] == 1) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 2;
-            else flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 1;
-			if (flags[kFLAGS.MULTISHOT_STYLE] >= 1 && player.hasPerk(PerkLib.LockAndLoad)) {
-				if (flags[kFLAGS.MULTISHOT_STYLE] >= 3) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] += 2;
-				else flags[kFLAGS.MULTIPLE_ARROWS_STYLE] += 1;
-			}
-			else if ((player.weaponRange == weaponsrange.M1CERBE || player.weaponRange == weaponsrange.TM1CERB || player.weaponRange == weaponsrange.SNIPPLE) && flags[kFLAGS.MULTIPLE_ARROWS_STYLE] > 1)
-                flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 1;
-			else if (player.weaponRange == weaponsrange.GOODSAM || player.weaponRange == weaponsrange.BADOMEN) {
+            else flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 1; */
+            flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = Math.min((flags[kFLAGS.MULTISHOT_STYLE] || 0) + 1, maxRangedAttacks);
+
+			if (player.weaponRange == weaponsrange.GOODSAM || player.weaponRange == weaponsrange.BADOMEN) {
 				var recoil:Number = 1;
 				if (player.str >= 50) recoil += 1;
 				if (player.str >= 100) recoil += 1;
@@ -3088,6 +3085,7 @@ public class Combat extends BaseContent {
 				else if (flags[kFLAGS.MULTISHOT_STYLE] >= 1 && player.hasPerk(PerkLib.TaintedMagazine)) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 2;
 				else flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 1;
 			}
+
             if ((player.weaponRange == weaponsrange.ADBSCAT || player.weaponRange == weaponsrange.ADBSHOT || player.weaponRange == weaponsrange.ALAKABL || player.weaponRange == weaponsrange.DALAKABL || player.weaponRange == weaponsrange.DBDRAGG) && flags[kFLAGS.MULTIPLE_ARROWS_STYLE] > 2) {
 				if (flags[kFLAGS.MULTISHOT_STYLE] >= 3 && player.hasPerk(PerkLib.PrimedClipWarp)) {
 					if (flags[kFLAGS.MULTISHOT_STYLE] >= 6) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 6;
@@ -3099,7 +3097,17 @@ public class Combat extends BaseContent {
 				}
 				else flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 2;
 			}
-            if (player.weaponRangePerk == "Dual Firearms" || player.weaponRangePerk == "Dual 2H Firearms") flags[kFLAGS.MULTIPLE_ARROWS_STYLE] *= 2;
+
+            if ((player.weaponRange == weaponsrange.M1CERBE || player.weaponRange == weaponsrange.TM1CERB || player.weaponRange == weaponsrange.SNIPPLE) && flags[kFLAGS.MULTIPLE_ARROWS_STYLE] > 1)
+                flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = 1;
+            
+            if (player.isDualWieldRanged()) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] *= 2;
+
+            if (flags[kFLAGS.MULTIPLE_ARROWS_STYLE] >= 2 && player.hasPerk(PerkLib.LockAndLoad)) {
+				/*if (flags[kFLAGS.MULTISHOT_STYLE] >= 3) flags[kFLAGS.MULTIPLE_ARROWS_STYLE] += 2;
+				else flags[kFLAGS.MULTIPLE_ARROWS_STYLE] += 1;*/
+                flags[kFLAGS.MULTIPLE_ARROWS_STYLE] += Math.floor(flags[kFLAGS.MULTIPLE_ARROWS_STYLE] / 2);
+			}         
         }
         if (flags[kFLAGS.ARROWS_ACCURACY] > 0) flags[kFLAGS.ARROWS_ACCURACY] = 0;
         var ammoWord:String = weaponRangeAmmo;
@@ -3151,7 +3159,7 @@ public class Combat extends BaseContent {
             if (player.hasStatusEffect(StatusEffects.ResonanceVolley)) outputText("Your bow nudges as you ready the next shot, helping you keep your aimed at [monster name].\n\n");
             multiArrowsStrike();
         }
-        if (player.weaponRangePerk == "Throwing"){
+        else if (player.weaponRangePerk == "Throwing"){
             if (player.hasPerk(PerkLib.Telekinesis)) {
                 outputText("Weapons begins to float around you as you draw several projectiles from your arsenal using your powers.\n\n");
                 TelekinesisThrow();
@@ -3159,8 +3167,7 @@ public class Combat extends BaseContent {
             }
             throwWeapon();
         }
-        if (player.weaponRangePerk == "Pistol" || player.weaponRangePerk == "Rifle" || player.weaponRangePerk == "2H Firearm" || player.weaponRangePerk == "Dual Firearms" || player.weaponRangePerk == "Dual 2H Firearms") shootWeapon();
-		if (player.vehicles == vehicles.HB_MECH) multiArrowsStrike();
+        else if (player.isFirearmTypeWeapon()) shootWeapon();
     }
 
     /**
@@ -3179,12 +3186,12 @@ public class Combat extends BaseContent {
         var accRange:Number = 0;
         accRange += (arrowsAccuracy() / 2);
         if (flags[kFLAGS.ARROWS_ACCURACY] > 0) accRange -= flags[kFLAGS.ARROWS_ACCURACY];
-        if (player.weaponRangeName == "Guided bow" || player.vehicles == vehicles.HB_MECH) accRange = 100;
+        if (player.weaponRange == weaponsrange.BOWGUID || player.vehicles == vehicles.HB_MECH) accRange = 100;
         var weaponRangePerk:String = player.weaponRangePerk;
         var ammoWord:String = weaponRangeAmmo;
         if (rand(100) < accRange) {
             var damage:Number = 0;
-			if (player.vehicles == vehicles.HB_MECH) {
+			/*if (player.vehicles == vehicles.HB_MECH) {
 				if (player.hasKeyItem("HB Rapid Reload") >= 0) {
 					if (player.inte < 201) player.weaponRangeAttack *= (1 + (player.inte / 200));
 					else player.weaponRangeAttack *= 2;
@@ -3200,9 +3207,12 @@ public class Combat extends BaseContent {
 				damage += scalingBonusSpeed() * 0.4;
 			}
 			else {
-				if (player.weaponRangePerk == "Bow") rangeDamageNoLagSingle(0);
-				if (player.weaponRangePerk == "Crossbow") rangeDamageNoLagSingle(1);
-			}
+				if (isBowTypeWeapon()) damage = rangeDamageNoLagSingle(0);
+				else if (isCrossbowTypeWeapon()) damage = rangeDamageNoLagSingle(1);
+			}*/
+            if (player.isBowTypeWeapon()) damage = rangeDamageNoLagSingle(0);
+			else if (player.isCrossbowTypeWeapon()) damage = rangeDamageNoLagSingle(1);
+
             if (damage == 0) {
                 if (monster.inte > 0) {
                     outputText("[Themonster] shrugs as the " + ammoWord + " bounces off them harmlessly.\n\n");
@@ -3210,6 +3220,7 @@ public class Combat extends BaseContent {
                     outputText("The " + ammoWord + " bounces harmlessly off [themonster].\n\n");
                 }
             }
+
             if (!MSGControll) {
                 if (monster is EncapsulationPod) {
                     outputText("The " + ammoWord + " lodges deep into the pod's fleshy wall");
@@ -3252,11 +3263,11 @@ public class Combat extends BaseContent {
                     if (player.lowerGarment == undergarments.HBSHORT) damage *= 1.05;
                 }
             }
-            if (weaponRangePerk == "Bow"){
+            if (player.isBowTypeWeapon()){
                 if (player.hasPerk(PerkLib.ElvenRangerArmor)) damage *= 1.5;
                 if (player.isElf() && player.hasPerk(PerkLib.ELFArcherCovenant) && player.isSpearTypeWeapon() && player.isNotHavingShieldCuzPerksNotWorkingOtherwise()) damage *= 1.25;
             }
-            if (weaponRangePerk == "Bow" && player.hasStatusEffect(StatusEffects.FletchingTable)) {
+            if (player.isBowTypeWeapon() && player.hasStatusEffect(StatusEffects.FletchingTable)) {
                 if (player.statusEffectv1(StatusEffects.FletchingTable) > 0) damage *= (1 + (0.1 * player.statusEffectv1(StatusEffects.FletchingTable)));
                 if (player.statusEffectv2(StatusEffects.FletchingTable) > 0) damage *= (1 + (0.1 * player.statusEffectv2(StatusEffects.FletchingTable)));
                 if (player.hasPerk(PerkLib.CraftedArrows)) {
@@ -3281,19 +3292,17 @@ public class Combat extends BaseContent {
             }
             //Section for item damage modifiers
             if (player.weaponRange is WildHunt && (player.level + playerLevelAdjustment()) > monster.level) damage *= 2;
-            if (player.weaponRangeName == "Hodr's bow" && monster.hasStatusEffect(StatusEffects.Blind)) damage *= 1.1;
+            if (player.weaponRange == weaponsrange.BOWHODR && monster.hasStatusEffect(StatusEffects.Blind)) damage *= 1.1;
             if (flags[kFLAGS.ELEMENTAL_ARROWS] > 0) damage = elementalArrowDamageMod(damage);
 			//Determine if critical hit!
             var crit:Boolean;
             var critChance:Number = 0;
 			var critDamage:Number = 0;
             if (player.isInNonGoblinMech() || player.isInGoblinMech()) {
-				damage *= firearmsForce();
 				critChance += calculateCritFirearms();
 				critDamage += calculateCritDamageFirearms();
 			}
 			else {
-				damage *= rangePhysicalForce();
 				critChance += calculateCritRange();
 				critDamage += calculateCritDamageRange();
 			}
@@ -3350,7 +3359,7 @@ public class Combat extends BaseContent {
 						if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.01;
 						HPChange(Math.round(player.maxHP() * 0.05), false);
 					}
-					if (monster.hasStatusEffect(StatusEffects.Rosethorn) && monster.statusEffectv1(StatusEffects.Rosethorn) < 6) monster.addStatusValue(StatusEffects.Rosethorn, 1, 1)
+					if (monster.hasStatusEffect(StatusEffects.Rosethorn) && monster.statusEffectv1(StatusEffects.Rosethorn) < 6) monster.addStatusValue(StatusEffects.Rosethorn, 1, 1);
 					else monster.createStatusEffect(StatusEffects.Rosethorn, 6, 0, 0, 0);
                 }
                 if (player.tailType == Tail.BEE_ABDOMEN) {
@@ -3975,17 +3984,20 @@ public class Combat extends BaseContent {
         accRange += (throwingAccuracy() / 2);
         if (flags[kFLAGS.ARROWS_ACCURACY] > 0) accRange -= flags[kFLAGS.ARROWS_ACCURACY];
         if (player.hasPerk(PerkLib.PhantomShooting)) {
-            if (player.weaponRange != weaponsrange.SHUNHAR && player.weaponRange != weaponsrange.KSLHARP && player.weaponRange != weaponsrange.LEVHARP) player.takePhysDamage(fc);
+            if (player.weaponRange != weaponsrange.SHUNHAR && player.weaponRange != weaponsrange.KSLHARP && player.weaponRange != weaponsrange.LEVHARP) {
+                player.takePhysDamage(fc);
+            }
         }
         else {
-            if (player.weaponRange != weaponsrange.SHUNHAR && player.weaponRange != weaponsrange.KSLHARP && player.weaponRange != weaponsrange.LEVHARP) player.ammo--;
+            if (player.weaponRange != weaponsrange.SHUNHAR && player.weaponRange != weaponsrange.KSLHARP && player.weaponRange != weaponsrange.LEVHARP) {
+                player.ammo--;
+            }
         }
         if (rand(100) < accRange) {
             var damage:Number = 0;
-			rangeDamageNoLagSingle(2);
+			damage += rangeDamageNoLagSingle(2);
 			damage *= 1.5;
             if ((MDOCount == maxCurrentRangeAttacks()) && (MSGControllForEvasion) && (!MSGControll)) {
-                //if (damage == 0) {
                 if (monster.inte > 0) {
                     outputText("[Themonster] shrugs as the [weaponrange] bounces off them harmlessly.\n\n");
                 } else {
@@ -4160,7 +4172,7 @@ public class Combat extends BaseContent {
                     else outputText("You casually fire an " + ammoWord + " at [themonster] with supreme skill");
                 }
             }
-			if (player.weaponRangePerk == "Dual Firearms" || player.weaponRangePerk == "Dual 2H Firearms") damage *= firearmsDualWieldDamagePenalty();
+			if (player.isDualWieldRanged()) damage *= firearmsDualWieldDamagePenalty();
             //any aoe effect from firearms
             if (monster.plural) {
                 if (player.weaponRange == weaponsrange.ADBSCAT || player.weaponRange == weaponsrange.DBDRAGG) damage *= 2;
@@ -4169,7 +4181,7 @@ public class Combat extends BaseContent {
             //other effects
             if (player.weaponRange == weaponsrange.M1CERBE || player.weaponRange == weaponsrange.TM1CERB) damage *= 6;
             if (player.weaponRange == weaponsrange.HARPGUN && player.hasStatusEffect(StatusEffects.UnderwaterCombatBoost)) damage *= 1.2;
-            if (player.weaponRangePerk == "Dual Firearms" || player.weaponRangePerk == "Dual 2H Firearms") damage *= (1 + (0.01 * dualWFLevel()));
+            if (player.isDualWieldRanged()) damage *= (1 + (0.01 * dualWFLevel()));
             if (player.armor == armors.GTECHC_ && !player.isInGoblinMech()) damage *= 1.2;
             if (player.hasKeyItem("Gun Scope") >= 0) damage *= 1.2;
             if (player.hasKeyItem("Gun Scope with Aim tech") >= 0) damage *= 1.4;
@@ -4276,8 +4288,11 @@ public class Combat extends BaseContent {
                 doNext(endHpVictory);
                 return;
             } else {
+                var maxFirearmAttacks:int = player.calculateMultiAttacks(false);
+                if (player.hasPerk(PerkLib.LockAndLoad)) maxFirearmAttacks += 1;
+
                 if (player.isInGoblinMech() && (player.hasKeyItem("Repeater Gun") >= 0 || player.hasKeyItem("Machine Gun MK1") >= 0 || player.hasKeyItem("Machine Gun MK2") >= 0 || player.hasKeyItem("Machine Gun MK3") >= 0)) {
-                    outputText(".  It's clearly very painful. ");
+                    outputText(".  It's clearly very painful. ");             
                     if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
 						doPhysicalDamage(damage, true, true);
 						doMagicDamage(Math.round(damage * 0.2), true, true);
@@ -4288,41 +4303,13 @@ public class Combat extends BaseContent {
 						dualWieldFirearmsXP(rangeMasteryEXPgained(crit));
 					}
 					if (player.weaponRange == weaponsrange.M1CERBE || player.weaponRange == weaponsrange.TM1CERB) {
-						if (player.hasPerk(PerkLib.AmateurGunslinger)) {
-							if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
+                        for (var attack:int = 1; attack < maxFirearmAttacks; attack++) {
+                            if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
 								doPhysicalDamage(damage, true, true);
 								doMagicDamage(Math.round(damage * 0.2), true, true);
 							}
 							else doPhysicalDamage(damage, true, true);
-						}
-						if (player.hasPerk(PerkLib.ExpertGunslinger)) {
-							if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
-								doPhysicalDamage(damage, true, true);
-								doMagicDamage(Math.round(damage * 0.2), true, true);
-							}
-							else doPhysicalDamage(damage, true, true);
-						}
-						if (player.hasPerk(PerkLib.MasterGunslinger)) {
-							if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
-								doPhysicalDamage(damage, true, true);
-								doMagicDamage(Math.round(damage * 0.2), true, true);
-							}
-							else doPhysicalDamage(damage, true, true);
-						}
-						if (player.hasPerk(PerkLib.LockAndLoad)) {
-							if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
-								doPhysicalDamage(damage, true, true);
-								doMagicDamage(Math.round(damage * 0.2), true, true);
-							}
-							else doPhysicalDamage(damage, true, true);
-						}
-						if (player.hasPerk(PerkLib.MasterGunslinger) && player.hasPerk(PerkLib.LockAndLoad)) {
-							if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
-								doPhysicalDamage(damage, true, true);
-								doMagicDamage(Math.round(damage * 0.2), true, true);
-							}
-							else doPhysicalDamage(damage, true, true);
-						}
+                        }
                         if (crit) outputText(" <b>*Critical Hit!*</b>");
 					}
                 } else {
@@ -4373,8 +4360,8 @@ public class Combat extends BaseContent {
 							}
 							else doPhysicalDamage(damage, true, true);
 							if (player.weaponRange == weaponsrange.M1CERBE || player.weaponRange == weaponsrange.TM1CERB) {
-								if (player.hasPerk(PerkLib.AmateurGunslinger)) {
-									if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
+                                for (var cerbAttack:int = 1; cerbAttack < maxFirearmAttacks; attack++) {
+                                    if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
 										doPhysicalDamage(damage, true, true);
 										doMagicDamage(Math.round(damage * 0.2), true, true);
 									}
@@ -4384,55 +4371,7 @@ public class Combat extends BaseContent {
 										monster.teased((monster.lustVuln * (10 + player.cor / 8)), false);
 									}
 									else doPhysicalDamage(damage, true, true);
-								}
-								if (player.hasPerk(PerkLib.ExpertGunslinger)) {
-									if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
-										doPhysicalDamage(damage, true, true);
-										doMagicDamage(Math.round(damage * 0.2), true, true);
-									}
-									else if (player.statStore.hasBuff("FoxflamePelt")) {
-										doFireDamage((damage * 2), true, true);
-										if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) doMagicDamage(Math.round(damage * 0.2), true, true);
-										monster.teased((monster.lustVuln * (10 + player.cor / 8)), false);
-									}
-									else doPhysicalDamage(damage, true, true);
-								}
-								if (player.hasPerk(PerkLib.MasterGunslinger)) {
-									if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
-										doPhysicalDamage(damage, true, true);
-										doMagicDamage(Math.round(damage * 0.2), true, true);
-									}
-									else if (player.statStore.hasBuff("FoxflamePelt")) {
-										doFireDamage((damage * 2), true, true);
-										if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) doMagicDamage(Math.round(damage * 0.2), true, true);
-										monster.teased((monster.lustVuln * (10 + player.cor / 8)), false);
-									}
-									else doPhysicalDamage(damage, true, true);
-								}
-								if (player.hasPerk(PerkLib.LockAndLoad)) {
-									if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
-										doPhysicalDamage(damage, true, true);
-										doMagicDamage(Math.round(damage * 0.2), true, true);
-									}
-									else if (player.statStore.hasBuff("FoxflamePelt")) {
-										doFireDamage((damage * 2), true, true);
-										if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) doMagicDamage(Math.round(damage * 0.2), true, true);
-										monster.teased((monster.lustVuln * (10 + player.cor / 8)), false);
-									}
-									else doPhysicalDamage(damage, true, true);
-								}
-								if (player.hasPerk(PerkLib.MasterGunslinger) && player.hasPerk(PerkLib.LockAndLoad)) {
-									if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) {
-										doPhysicalDamage(damage, true, true);
-										doMagicDamage(Math.round(damage * 0.2), true, true);
-									}
-									else if (player.statStore.hasBuff("FoxflamePelt")) {
-										doFireDamage((damage * 2), true, true);
-										if (player.hasStatusEffect(StatusEffects.ChargeRWeapon)) doMagicDamage(Math.round(damage * 0.2), true, true);
-										monster.teased((monster.lustVuln * (10 + player.cor / 8)), false);
-									}
-									else doPhysicalDamage(damage, true, true);
-								}
+                                }
 							}
 						}
 						firearmsXP(rangeMasteryEXPgained(crit));
@@ -4447,46 +4386,15 @@ public class Combat extends BaseContent {
 						outputText(" ");
                         doPhysicalDamage(damage, true, true);
 						if (crit) outputText(" <b>*Critical Hit!*</b>");
-						if (player.hasPerk(PerkLib.AmateurGunslinger)) {
-							outputText(" ");
+
+                        for (var touAttack:int = 1; touAttack < maxFirearmAttacks; attack++) {
+                            outputText(" ");
                             doPhysicalDamage(damage, true, true);
 							if (crit) outputText(" <b>*Critical Hit!*</b>");
 							outputText(" ");
                             doPhysicalDamage(damage, true, true);
 							if (crit) outputText(" <b>*Critical Hit!*</b>");
-						}
-						if (player.hasPerk(PerkLib.ExpertGunslinger)) {
-							outputText(" ");
-                            doPhysicalDamage(damage, true, true);
-							if (crit) outputText(" <b>*Critical Hit!*</b>");
-							outputText(" ");
-                            doPhysicalDamage(damage, true, true);
-							if (crit) outputText(" <b>*Critical Hit!*</b>");
-						}
-						if (player.hasPerk(PerkLib.MasterGunslinger)) {
-							outputText(" ");
-                            doPhysicalDamage(damage, true, true);
-							if (crit) outputText(" <b>*Critical Hit!*</b>");
-							outputText(" ");
-                            doPhysicalDamage(damage, true, true);
-							if (crit) outputText(" <b>*Critical Hit!*</b>");
-						}
-						if (player.hasPerk(PerkLib.LockAndLoad)) {
-							outputText(" ");
-                            doPhysicalDamage(damage, true, true);
-							if (crit) outputText(" <b>*Critical Hit!*</b>");
-							outputText(" ");
-                            doPhysicalDamage(damage, true, true);
-							if (crit) outputText(" <b>*Critical Hit!*</b>");
-						}
-						if (player.hasPerk(PerkLib.MasterGunslinger) && player.hasPerk(PerkLib.LockAndLoad)) {
-							outputText(" ");
-                            doPhysicalDamage(damage, true, true);
-							if (crit) outputText(" <b>*Critical Hit!*</b>");
-							outputText(" ");
-                            doPhysicalDamage(damage, true, true);
-							if (crit) outputText(" <b>*Critical Hit!*</b>");
-						}
+                        }
 					}
                 }
                 //Lust raising weapon bonuses
@@ -5814,7 +5722,7 @@ public class Combat extends BaseContent {
 		damage *= rangePhysicalForce();
 		return damage;
 	}
-	public function firearmsDamageNoLagSingle(subtype:Number = 0):Number {
+	public function firearmsDamageNoLagSingle():Number {
 		var damage:Number = 0;
 		damage += player.weaponRangeAttack * 2;
 		damage += player.speStat.core.value + player.intStat.core.value + player.wisStat.core.value;
@@ -11448,6 +11356,7 @@ public class Combat extends BaseContent {
 
     public function fatigueRecovery2():Number {
         var fatiguecombatrecovery:Number = 1;
+        var maxFirearmAttacks:int = player.calculateMaxAttacksForClass(false, 3);
         if (player.hasPerk(PerkLib.StarSphereMastery)) fatiguecombatrecovery += player.perkv1(PerkLib.StarSphereMastery);
         if (player.hasPerk(PerkLib.NinetailsKitsuneOfBalance)) fatiguecombatrecovery += 1;
         if (player.hasPerk(PerkLib.EnlightenedNinetails)) fatiguecombatrecovery += 1;
@@ -11463,9 +11372,9 @@ public class Combat extends BaseContent {
 		if (player.perkv1(IMutationsLib.HumanBloodstreamIM) >= 3 && player.racialScore(Races.HUMAN) > 17) fatiguecombatrecovery += 5;
         if (player.hasPerk(PerkLib.HydraRegeneration) && !player.hasStatusEffect(StatusEffects.HydraRegenerationDisabled)) fatiguecombatrecovery += 1 * player.statusEffectv1(StatusEffects.HydraTailsPlayer);
         if (player.hasPerk(PerkLib.JobGunslinger)) fatiguecombatrecovery += 1;
-		if (player.hasPerk(PerkLib.AmateurGunslinger)) fatiguecombatrecovery += 1;
-		if (player.hasPerk(PerkLib.ExpertGunslinger)) fatiguecombatrecovery += 1;
-		if (player.hasPerk(PerkLib.MasterGunslinger)) fatiguecombatrecovery += 1;
+		if (maxFirearmAttacks >= 2) fatiguecombatrecovery += 1;
+		if (maxFirearmAttacks >= 2) fatiguecombatrecovery += 1;
+		if (maxFirearmAttacks >= 2) fatiguecombatrecovery += 1;
 		if (player.hasPerk(PerkLib.AlchemicalCartridge)) fatiguecombatrecovery += 2;
 		if (player.hasPerk(PerkLib.ChurchOfTheGun)) fatiguecombatrecovery += 3;
 		if (player.hasPerk(PerkLib.SaintOfZariman)) fatiguecombatrecovery += 4;
@@ -16453,10 +16362,11 @@ public function rangePhysicalForce():Number {
 
 public function firearmsForce():Number {
 	var mod:Number = 0;
+    var maxFirearmAttacks:int = player.calculateMaxAttacksForClass(false, 3);
 	if (player.hasPerk(PerkLib.JobGunslinger)) mod += .1;
-	if (player.hasPerk(PerkLib.AmateurGunslinger)) mod += .05;
-	if (player.hasPerk(PerkLib.ExpertGunslinger)) mod += .1;
-	if (player.hasPerk(PerkLib.MasterGunslinger)) mod += .15;
+	if (maxFirearmAttacks >= 2) mod += .05;
+	if (maxFirearmAttacks >= 3) mod += .1;
+	if (maxFirearmAttacks >= 4) mod += .15;
     if (player.hasPerk(PerkLib.AlchemicalCartridge)) mod += .05;
     if (player.hasPerk(PerkLib.ChurchOfTheGun)) mod += .1;
     if (player.hasPerk(PerkLib.ExplosiveCartridge)) mod += .1;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -367,12 +367,12 @@ public class Combat extends BaseContent {
     }
 
     public function maxCurrentAttacks():int {
-        if (player.weaponSpecials("Staff") || player.weaponSpecials("Wand")) return 1;
+        if (player.isStaffTypeWeapon() || player.isWandTypeWeapon()) return 1;
         else return player.calculateMultiAttacks();
     }
 
     public function maxBowAttacks():int {
-        var extraHits:Number = 0;
+        /*var extraHits:Number = 0;
         var baseHits:Number;
         if (player.isElf() && player.hasPerk(PerkLib.ELFMasterShot)) extraHits = 1;
         if (player.hasPerk(PerkLib.Multishot)) baseHits = 6;
@@ -381,23 +381,26 @@ public class Combat extends BaseContent {
         else if (player.hasPerk(PerkLib.WeaponRangeTripleStrike)) baseHits = 3;
         else if (player.hasPerk(PerkLib.WeaponRangeDoubleStrike)) baseHits = 2;
         else baseHits = 1;
-        return (baseHits+extraHits) * (flags[kFLAGS.ELVEN_TWINSHOT_ENABLED] ? 2 : 1);
+        return (baseHits+extraHits) * (flags[kFLAGS.ELVEN_TWINSHOT_ENABLED] ? 2 : 1);*/
+        return player.calculateMaxAttacksForClass(false, 0);
     }
 
     public function maxCrossbowAttacks():int {
-        if (player.hasPerk(PerkLib.WeaponRangeTripleStrike)) return 3;
+        /*if (player.hasPerk(PerkLib.WeaponRangeTripleStrike)) return 3;
         else if (player.hasPerk(PerkLib.WeaponRangeDoubleStrike)) return 2;
-        else return 1;
+        else return 1;*/
+        return player.calculateMaxAttacksForClass(false, 1);
     }
 
     public function maxThrowingAttacks():int {
-        if (player.hasPerk(PerkLib.WeaponRangeTripleStrike)) return 3;
+        /*if (player.hasPerk(PerkLib.WeaponRangeTripleStrike)) return 3;
         else if (player.hasPerk(PerkLib.WeaponRangeDoubleStrike)) return 2;
-        else return 1;
+        else return 1;*/
+        return player.calculateMaxAttacksForClass(false, 2);
     }
 
     public function maxFirearmsAttacks():int {
-		var bonusShots:Number = 0;
+		/*var bonusShots:Number = 0;
 		if (player.hasPerk(PerkLib.LockAndLoad)) {
 			if (player.hasPerk(PerkLib.Multishot)) bonusShots = 2;
 			bonusShots = 1;
@@ -405,7 +408,8 @@ public class Combat extends BaseContent {
         if (player.hasPerk(PerkLib.MasterGunslinger)) return 4+bonusShots;
         else if (player.hasPerk(PerkLib.ExpertGunslinger)) return 3+bonusShots;
         else if (player.hasPerk(PerkLib.AmateurGunslinger)) return 2+bonusShots;
-        else return 1;
+        else return 1;*/
+        return player.calculateMaxAttacksForClass(false, 3);
     }
 
     public function maxCurrentRangeAttacks():int {
@@ -3127,11 +3131,11 @@ public class Combat extends BaseContent {
             enemyAI();
             return;
         }
-        if (player.weaponRangePerk == "Bow" || player.weaponRangePerk == "Crossbow") {
+        if (player.isBowTypeWeapon() || player.isCrossbowTypeWeapon()) {
             if (player.hasStatusEffect(StatusEffects.ResonanceVolley)) outputText("Your bow nudges as you ready the next shot, helping you keep your aimed at [monster name].\n\n");
             multiArrowsStrike(0);
         }
-        else if (player.weaponRangePerk == "Throwing"){
+        else if (player.isThrownTypeWeapon()){
             if (player.hasPerk(PerkLib.Telekinesis)) {
                 outputText("Weapons begins to float around you as you draw several projectiles from your arsenal using your powers.\n\n");
                 TelekinesisThrow();
@@ -11330,7 +11334,7 @@ public class Combat extends BaseContent {
 
     public function fatigueRecovery2():Number {
         var fatiguecombatrecovery:Number = 1;
-        var maxFirearmAttacks:int = player.calculateMaxAttacksForClass(false, 3);
+        var maxFirearmAttacks:int = maxFirearmsAttacks();
         if (player.hasPerk(PerkLib.StarSphereMastery)) fatiguecombatrecovery += player.perkv1(PerkLib.StarSphereMastery);
         if (player.hasPerk(PerkLib.NinetailsKitsuneOfBalance)) fatiguecombatrecovery += 1;
         if (player.hasPerk(PerkLib.EnlightenedNinetails)) fatiguecombatrecovery += 1;
@@ -12350,7 +12354,10 @@ public static const bonusAttackMasteries:Array = [
     MASTERY_LARGE,
     MASTERY_MASSIVE,
     MASTERY_RANGED,
-    MASTERY_NORMAL
+    MASTERY_NORMAL,
+    MASTERY_ARCHERY,
+    MASTERY_THROWING,
+    MASTERY_FIREARMS
 ];
 
 public function feralCombatXP(XP:Number = 0):void       {player.gainCombatXP(MASTERY_FERAL, XP * weaponmasteryXPMulti());}
@@ -16336,7 +16343,7 @@ public function rangePhysicalForce():Number {
 
 public function firearmsForce():Number {
 	var mod:Number = 0;
-    var maxFirearmAttacks:int = player.calculateMaxAttacksForClass(false, 3);
+    var maxFirearmAttacks:int = maxFirearmsAttacks();
 	if (player.hasPerk(PerkLib.JobGunslinger)) mod += .1;
 	if (maxFirearmAttacks >= 2) mod += .05;
 	if (maxFirearmAttacks >= 3) mod += .1;

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -941,15 +941,18 @@ public class PhysicalSpecials extends BaseCombatContent {
 		PSMulti += combat.PASPAS(2);
 		if (player.weaponRangePerk == "Bow") {
 			damage += combat.rangeDamageNoLagSingle(0);
-			if (combat.maxBowAttacks() > 1) damage *= combat.maxBowAttacks();
+			var maxBowAttacks:int = player.calculateMaxAttacksForClass(false, 0);
+			if (maxBowAttacks > 1) damage *= maxBowAttacks;
 		}
 		if (player.weaponRangePerk == "Crossbow") {
 			damage += combat.rangeDamageNoLagSingle(1);
-			if (combat.maxCrossbowAttacks() > 1) damage *= combat.maxCrossbowAttacks();
+			var maxCrossBowAttacks:int = player.calculateMaxAttacksForClass(false, 1);
+			if (maxCrossBowAttacks > 1) damage *= maxCrossBowAttacks;
 		}
 		if (player.weaponRangePerk == "Throwing") {
 			damage += combat.rangeDamageNoLagSingle(2);
-			if (combat.maxThrowingAttacks() > 1) damage *= combat.maxThrowingAttacks();
+			var maxThrowAttacks:int = player.calculateMaxAttacksForClass(false, 2);
+			if (maxThrowAttacks > 1) damage *= maxThrowAttacks;
 		}
 		if (player.hasPerk(PerkLib.PowerShotEx)) {
 			PSMulti += Math.round(PSMulti*0.3);
@@ -1351,11 +1354,12 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		else {
 			if (player.weaponRange == weaponsrange.M1CERBE || player.weaponRange == weaponsrange.TM1CERB) {
-				var M1:Number = 1;
-				if (player.hasPerk(PerkLib.AmateurGunslinger)) damage += 1;
-				if (player.hasPerk(PerkLib.ExpertGunslinger)) damage += 1;
-				if (player.hasPerk(PerkLib.MasterGunslinger)) damage += 1;
-				damage *= M1;
+				var multiplier:Number = 1;
+				var maxFirearmAttacks:int = player.calculateMaxAttacksForClass(false, 3);
+				if (maxFirearmAttacks >= 2) multiplier += 1;
+				if (maxFirearmAttacks >= 3) multiplier += 1;
+				if (maxFirearmAttacks >= 4) multiplier += 1;
+				damage *= multiplier;
 			}
 			if (player.armor == armors.GTECHC_ && !player.isInGoblinMech()) damage *= 1.2;
 			if (player.hasKeyItem("Gun Scope") >= 0) damage *= 1.2;
@@ -3049,11 +3053,12 @@ public class PhysicalSpecials extends BaseCombatContent {
 			else outputText("  " + monster.mf("He","She") + " flushes hotly and " + monster.mf("touches his suddenly-stiff member, moaning lewdly for a moment.","touches a suddenly stiff nipple, moaning lewdly.  You can smell her arousal in the air."));
 			EggThrowLustDamageRepeat();
 			if (flags[kFLAGS.EASTER_BUNNY_EGGS_STORED] > 1) EggThrowLustDamageRepeat();
-			if (player.hasPerk(PerkLib.WeaponRangeDoubleStrike) && flags[kFLAGS.EASTER_BUNNY_EGGS_STORED] > 1){
+			var maxRangedAttacks:int = player.calculateMultiAttacks(false);
+			if (maxRangedAttacks >= 2 && flags[kFLAGS.EASTER_BUNNY_EGGS_STORED] > 1){
 				EggThrowLustDamageRepeat();
 				if (flags[kFLAGS.EASTER_BUNNY_EGGS_STORED] > 1) EggThrowLustDamageRepeat();
 			}
-			if (player.hasPerk(PerkLib.WeaponRangeTripleStrike) && flags[kFLAGS.EASTER_BUNNY_EGGS_STORED] > 1){
+			if (maxRangedAttacks >= 3 && flags[kFLAGS.EASTER_BUNNY_EGGS_STORED] > 1){
 				EggThrowLustDamageRepeat();
 				if (flags[kFLAGS.EASTER_BUNNY_EGGS_STORED] > 1) EggThrowLustDamageRepeat();
 			}
@@ -5781,11 +5786,10 @@ public class PhysicalSpecials extends BaseCombatContent {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
 		clearOutput();
 		var costSidewinder:Number = 1;
-		if (player.hasPerk(PerkLib.Multishot)) costSidewinder += 5;
-		else if (player.hasPerk(PerkLib.WildQuiver)) costSidewinder += 4;
-		else if (player.hasPerk(PerkLib.Manyshot)) costSidewinder += 3;
-		else if (player.hasPerk(PerkLib.WeaponRangeTripleStrike)) costSidewinder += 2;
-		else if (player.hasPerk(PerkLib.WeaponRangeDoubleStrike)) costSidewinder += 1;
+		var maxRangedAttacks:int = player.calculateMultiAttacks(false);
+		if (maxRangedAttacks >= 6) costSidewinder += 5;
+		else costSidewinder += (maxRangedAttacks - 1);
+
 		if (player.fatigue + bowCost(200 * costSidewinder) > player.maxFatigue()) {
 			outputText("You are too tired to attack [themonster].");
 			addButton(0, "Next", combatMenu, false);
@@ -5994,7 +5998,8 @@ public class PhysicalSpecials extends BaseCombatContent {
 
 	public function archerBarrage():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
-		flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = combat.maxBowAttacks();
+		var maxBowAttacks:int = player.calculateMaxAttacksForClass(false, 0);
+		flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = maxBowAttacks;
 		clearOutput();
 		if (player.fatigue + bowCost(200) > player.maxFatigue()) {
 			outputText("You are too tired to attack [themonster].");

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -941,17 +941,17 @@ public class PhysicalSpecials extends BaseCombatContent {
 		PSMulti += combat.PASPAS(2);
 		if (player.weaponRangePerk == "Bow") {
 			damage += combat.rangeDamageNoLagSingle(0);
-			var maxBowAttacks:int = player.calculateMaxAttacksForClass(false, 0);
+			var maxBowAttacks:int = combat.maxBowAttacks();
 			if (maxBowAttacks > 1) damage *= maxBowAttacks;
 		}
 		if (player.weaponRangePerk == "Crossbow") {
 			damage += combat.rangeDamageNoLagSingle(1);
-			var maxCrossBowAttacks:int = player.calculateMaxAttacksForClass(false, 1);
+			var maxCrossBowAttacks:int = combat.maxCrossbowAttacks();
 			if (maxCrossBowAttacks > 1) damage *= maxCrossBowAttacks;
 		}
 		if (player.weaponRangePerk == "Throwing") {
 			damage += combat.rangeDamageNoLagSingle(2);
-			var maxThrowAttacks:int = player.calculateMaxAttacksForClass(false, 2);
+			var maxThrowAttacks:int = combat.maxThrowingAttacks();
 			if (maxThrowAttacks > 1) damage *= maxThrowAttacks;
 		}
 		if (player.hasPerk(PerkLib.PowerShotEx)) {
@@ -1355,7 +1355,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		else {
 			if (player.weaponRange == weaponsrange.M1CERBE || player.weaponRange == weaponsrange.TM1CERB) {
 				var multiplier:Number = 1;
-				var maxFirearmAttacks:int = player.calculateMaxAttacksForClass(false, 3);
+				var maxFirearmAttacks:int = combat.maxFirearmsAttacks();
 				if (maxFirearmAttacks >= 2) multiplier += 1;
 				if (maxFirearmAttacks >= 3) multiplier += 1;
 				if (maxFirearmAttacks >= 4) multiplier += 1;
@@ -6000,7 +6000,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 
 	public function archerBarrage():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
-		var maxBowAttacks:int = player.calculateMaxAttacksForClass(false, 0);
+		var maxBowAttacks:int = combat.maxBowAttacks();
 		flags[kFLAGS.MULTIPLE_ARROWS_STYLE] = maxBowAttacks;
 		clearOutput();
 		if (player.fatigue + bowCost(200) > player.maxFatigue()) {

--- a/classes/classes/display/PerkMenu.as
+++ b/classes/classes/display/PerkMenu.as
@@ -89,7 +89,7 @@ public class PerkMenu extends BaseContent {
 			outputText("\n<b>You can adjust your melee attack settings.</b>");
 			addButton(5, "Melee Opt",meleeOptions);
 		}
-		if (player.hasPerk(PerkLib.WeaponRangeDoubleStrike) || player.hasPerk(PerkLib.ELFTwinShot) || player.hasPerk(PerkLib.ElementalArrows) || player.hasPerk(PerkLib.Cupid) || player.hasPerk(PerkLib.EnvenomedBolt) || player.hasPerk(PerkLib.ELFThornShot) || player.hasPerk(PerkLib.AmateurGunslinger)) {
+		if (player.calculateMultiAttacks(false) > 1 || player.hasPerk(PerkLib.ELFTwinShot) || player.hasPerk(PerkLib.ElementalArrows) || player.hasPerk(PerkLib.Cupid) || player.hasPerk(PerkLib.EnvenomedBolt) || player.hasPerk(PerkLib.ELFThornShot)) {
 			outputText("\n<b>You can adjust your range strike settings.</b>");
 			addButton(6, "Range Opt",rangedOptions);
 		}
@@ -349,6 +349,10 @@ public class PerkMenu extends BaseContent {
 		clearOutput();
 		outputText("Current number of projectiles per shot: " + (currentProj + 1) + "\n");
 		outputText("Maximum number of projectiles per shot with your current weapon: " + maxProj + "\n");
+		var nba:int = player.nextBonusAttack(false);
+		if (nba < 0) outputText("You've reached the maximum number of bonus attacks from mastery!");
+		else outputText("Next bonus attack at mastery level " + nba);
+		outputText("\n\nHow many attacks would you like to deal?");
 		menu();
 		var atk:int = 0;
 		while (atk < maxProj) {


### PR DESCRIPTION
Converted use of perks for determining ranged multi attack to use Dao mastery instead
Fixed damage functions error associated with throwing weapons and bow damage
Bonuses and references previously referring to redundant perks redirected to use Dao mastery instead. 