### PR TITLE
E aspect changes

### DIFF
--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -51,6 +51,7 @@ import classes.internals.Utils;
 import classes.internals.WeightedDrop;
 
 import flash.utils.getQualifiedClassName;
+import classes.Scenes.Combat.CombatAbilities;
 
 /**
 	 * ...
@@ -1028,7 +1029,7 @@ import flash.utils.getQualifiedClassName;
 			if (statusEffectv1(StatusEffects.OniRampage) > 0) {
 				multShared += 20;
 			}
-			if (statusEffectv1(StatusEffects.EarthStance) > 0) {
+			if (CombatAbilities.EarthStance.isActive()) {
 				multShared += 30;
 			}
 			//Misc

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -73,6 +73,9 @@ use namespace CoC;
 			for (var i:int = 0; i < CombatAbility.Registry.length; i++) {
 				cooldowns[i] = 0;
 			}
+			for (var duration:int = 0; duration < CombatAbility.Registry.length; duration++) {
+				durations[duration] = 0;
+			}
 			//Item things
 			itemSlot1 = new ItemSlotClass();
 			itemSlot2 = new ItemSlotClass();
@@ -193,6 +196,9 @@ use namespace CoC;
 
 		//Combat ability cooldowns. Index is ability id.
 		public var cooldowns:/*int*/Array = [];
+
+		//Combat ability durations. Index is ability id.
+		public var durations:/*int*/Array = [];
 		
 		//Mining attributes
 		public var miningLevel:Number = 0;
@@ -3159,7 +3165,7 @@ use namespace CoC;
 			if (statusEffectv1(StatusEffects.OniRampage) > 0) {
 				mult -= 20;
 			}
-			if (statusEffectv1(StatusEffects.EarthStance) > 0) {
+			if (CombatAbilities.EarthStance.isActive()) {
 				mult -= 30;
 			}
 			if (statusEffectv1(StatusEffects.AcidDoT) > 0) {
@@ -5580,6 +5586,7 @@ use namespace CoC;
 			var HPPercent:Number;
 			HPPercent = HP/maxHP();
 			resetCooldowns();
+			resetDurations();
 			if (hasStatusEffect(StatusEffects.DriderIncubusVenom))
 			{
 				removeStatusEffect(StatusEffects.DriderIncubusVenom);
@@ -7416,6 +7423,11 @@ use namespace CoC;
 			for (var i:int = 0; i<cooldowns.length; i++) {
 				if (oncePerDay || cooldowns[i] != -2)
 					cooldowns[i] = 0;
+			}
+		}
+		public function resetDurations():void {
+			for (var i:int = 0; i<durations.length; i++) {
+				durations[i] = 0;
 			}
 		}		
 	}

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -857,9 +857,8 @@ use namespace CoC;
 			if (hasStatusEffect(StatusEffects.ChargeArmor) && (!isNaked() || (isNaked() && haveNaturalArmor() && hasPerk(PerkLib.ImprovingNaturesBlueprintsNaturalArmor)))) armorDef += Math.round(statusEffectv1(StatusEffects.ChargeArmor));
 			if (hasStatusEffect(StatusEffects.ArmorPotion) && (!isNaked() || (isNaked() && haveNaturalArmor() && hasPerk(PerkLib.ImprovingNaturesBlueprintsNaturalArmor)))) armorDef += Math.round(statusEffectv1(StatusEffects.ArmorPotion));
 			if (hasStatusEffect(StatusEffects.CompBoostingPCArmorValue)) armorDef += (level * newGamePlusMod);
-			if (hasStatusEffect(StatusEffects.StoneSkin)) armorDef += Math.round(statusEffectv1(StatusEffects.StoneSkin));
-			if (hasStatusEffect(StatusEffects.BarkSkin)) armorDef += Math.round(statusEffectv1(StatusEffects.BarkSkin));
-			if (hasStatusEffect(StatusEffects.MetalSkin)) armorDef += Math.round(statusEffectv1(StatusEffects.MetalSkin));
+			if (CombatAbilities.EAspectEarth.isActive()) armorDef += CombatAbilities.EAspectEarth.getBonus();
+			if (CombatAbilities.EAspectWood.isActive()) armorDef += CombatAbilities.EAspectWood.getBonus();
 			if (CoC.instance.monster.hasStatusEffect(StatusEffects.TailWhip)) {
 				armorDef -= CoC.instance.monster.statusEffectv1(StatusEffects.TailWhip);
 				if(armorDef < 0) armorDef = 0;
@@ -1063,9 +1062,9 @@ use namespace CoC;
 			if (hasStatusEffect(StatusEffects.Berzerking) && !hasPerk(PerkLib.ColderFury)) armorMDef = 0;
 			if (hasStatusEffect(StatusEffects.Lustzerking) && !hasPerk(PerkLib.ColderLust)) armorMDef = 0;
 			//if (hasStatusEffect(StatusEffects.ChargeArmor) && (!isNaked() || (isNaked() && haveNaturalArmor() && hasPerk(PerkLib.ImprovingNaturesBlueprintsNaturalArmor)))) armorDef += Math.round(statusEffectv1(StatusEffects.ChargeArmor));
-			if (hasStatusEffect(StatusEffects.StoneSkin)) armorMDef += Math.round(statusEffectv1(StatusEffects.StoneSkin));
-			if (hasStatusEffect(StatusEffects.BarkSkin)) armorMDef += Math.round(statusEffectv1(StatusEffects.BarkSkin));
-			if (hasStatusEffect(StatusEffects.MetalSkin)) armorMDef += Math.round(statusEffectv1(StatusEffects.MetalSkin));/*
+			if (CombatAbilities.EAspectEarth.isActive()) armorMDef += CombatAbilities.EAspectEarth.getBonus();
+			if (CombatAbilities.EAspectWood.isActive()) armorMDef += CombatAbilities.EAspectWood.getBonus();
+			/*
 			if (CoC.instance.monster.hasStatusEffect(StatusEffects.TailWhip)) {
 				armorDef -= CoC.instance.monster.statusEffectv1(StatusEffects.TailWhip);
 				if(armorDef < 0) armorDef = 0;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -7412,9 +7412,10 @@ use namespace CoC;
 					}
 			)
 		}
-		public function resetCooldowns():void {
+		public function resetCooldowns(oncePerDay:Boolean = false):void {
 			for (var i:int = 0; i<cooldowns.length; i++) {
-				cooldowns[i] = 0;
+				if (oncePerDay || cooldowns[i] != -2)
+					cooldowns[i] = 0;
 			}
 		}		
 	}

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -1080,6 +1080,8 @@ public class PlayerEvents extends BaseContent implements TimeAwareInterface {
 				if (player.hasStatusEffect(StatusEffects.DragonWaterBreathCooldown) && !player.perkv1(IMutationsLib.DraconicLungIM) >= 1) player.removeStatusEffect(StatusEffects.DragonWaterBreathCooldown);
 				if (player.hasStatusEffect(StatusEffects.DragonFaerieBreathCooldown) && !player.perkv1(IMutationsLib.DraconicLungIM) >= 1) player.removeStatusEffect(StatusEffects.DragonFaerieBreathCooldown);
 				if (player.hasStatusEffect(StatusEffects.DragonRoyalBreathCooldown) && !player.perkv1(IMutationsLib.DraconicLungIM) >= 1) player.removeStatusEffect(StatusEffects.DragonRoyalBreathCooldown);
+				//Reset once a day cooldowns
+				player.resetCooldowns(true);
 				//Reset Mara Fruit daily counter
 				flags[kFLAGS.DAILY_MARA_FRUIT_COUNTER] = 0;
 				//Alraune flags

--- a/classes/classes/PlayerInfo.as
+++ b/classes/classes/PlayerInfo.as
@@ -5,6 +5,7 @@ import classes.IMutations.IMutationsLib;
 import classes.Scenes.Combat.CombatAbility;
 import classes.Scenes.Combat.AbstractSpell;
 import classes.Scenes.Combat.AbstractSoulSkill;
+import classes.Scenes.Combat.AbstractMagicSpecial;
 import classes.Scenes.Crafting;
 import classes.Scenes.NPCs.BelisaFollower;
 import classes.Scenes.NPCs.CharybdisFollower;
@@ -59,6 +60,7 @@ public class PlayerInfo extends BaseContent {
 			addButton(10, "All", displayStatsAbilities);
 			addButtonIfTrue(11, "Spells", curry(displayStatsAbilities, AbstractSpell, 11), "You currently have no spells", player.hasknownAbilitiesOfClass(AbstractSpell));
 			addButtonIfTrue(12, "SoulSkills", curry(displayStatsAbilities, AbstractSoulSkill, 12), "You currently have no soulskills", player.hasknownAbilitiesOfClass(AbstractSoulSkill));
+			addButtonIfTrue(13, "M. Specials", curry(displayStatsAbilities, AbstractMagicSpecial, 13), "You currently have no magical specials", player.hasknownAbilitiesOfClass(AbstractMagicSpecial));
 
 			if (currentButton != 4){
 				button(currentButton).disable("You are currently viewing this category.");

--- a/classes/classes/Scenes/Areas/Bog/LizanRogue.as
+++ b/classes/classes/Scenes/Areas/Bog/LizanRogue.as
@@ -8,6 +8,7 @@ import classes.IMutations.*;
 import classes.Scenes.SceneLib;
 import classes.StatusEffects.Combat.LizanBlowpipeDebuff;
 import classes.internals.*;
+import classes.Scenes.Combat.CombatAbilities;
 
 public class LizanRogue extends Monster
 	{
@@ -16,9 +17,9 @@ public class LizanRogue extends Monster
 		//3 - spe
 		//4 - sens
 		public function blowGun():void {
-			if (player.hasStatusEffect(StatusEffects.WindWall)) {
+			if (CombatAbilities.EAspectAir.isActive()) {
 				outputText("The lizan flings himself back.  In the air he puts a blowgun to his lips.  Then that tiny dart is stopeed by the wind wall that still surrounds you.");
-				player.addStatusValue(StatusEffects.WindWall,2,-1);
+				CombatAbilities.EAspectAir.advance(true);
 			}
 			else if (player.getEvasionRoll()) {
 				outputText("The lizan flings himself back.  In the air he puts a blowgun to his lips.  You move just in time to avoid the tiny dart.");

--- a/classes/classes/Scenes/Areas/Plains/GnollSpearThrower.as
+++ b/classes/classes/Scenes/Areas/Plains/GnollSpearThrower.as
@@ -5,6 +5,7 @@ import classes.BodyParts.Butt;
 import classes.BodyParts.Hips;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
+import classes.Scenes.Combat.CombatAbilities;
 
 /**
 	 * ...
@@ -16,9 +17,9 @@ import classes.internals.*;
 		//<Writers note: I recommend that the javelin have a chance to greatly decrease speed for the remaining battle.  I am writing the flavor text for this event if you choose to include it>
 		private function hyenaJavelinAttack():void {
 			//<Hyena Attack 2 – Javelin – Unsuccessful – Dodged>
-			if(player.hasStatusEffect(StatusEffects.WindWall)) {
+			if(CombatAbilities.EAspectAir.isActive()) {
 				outputText("The gnoll pulls a javelin from behind her and throws it at you, but it's stopped by the wind wall.");
-				player.addStatusValue(StatusEffects.WindWall,2,-1);
+				CombatAbilities.EAspectAir.advance(true);
 			}
 			//Blind dodge change
 			if(player.getEvasionRoll()) {

--- a/classes/classes/Scenes/Camp/CampMakeWinions.as
+++ b/classes/classes/Scenes/Camp/CampMakeWinions.as
@@ -7,6 +7,7 @@ package classes.Scenes.Camp
 import classes.*;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.SceneLib;
+import classes.Scenes.Combat.CombatAbilities;
 
 public class CampMakeWinions extends BaseContent
 	{
@@ -1633,7 +1634,7 @@ public class CampMakeWinions extends BaseContent
 			outputText("-When attacking, it has an increased critical damage multiplied from 150% to 175%.\n");
 			outputText("-When attacking, it will ignore enemy damage reduction.\n");
 			outputText("-When attacking, it will deal Wind type damage.\n");
-			outputText("-M. Special: Creates a Wind Wall that deflects incoming projectiles for few turns. Duration depends on elemental rank.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectAir.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomeEarth():void {
@@ -1641,14 +1642,14 @@ public class CampMakeWinions extends BaseContent
 			outputText("<b>Earth Elemental</b>\n\n");
 			outputText("-When attacking, it has an increased damage by 100%.\n");
 			outputText("-When attacking, it will deal Earth type damage.\n");
-			outputText("-M. Special: Creates an Earth armor around PC, increasing armor and magic resistance for a few turns. Duration depends on elemental rank.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectEarth.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomeFire():void {
 			clearOutput();
 			outputText("<b>Fire Elemental</b>\n\n");
 			outputText("-When attacking, it will deal Fire type damage.\n");
-			outputText("-M. Special: Stronger version of fire attributed attack.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectFire.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomeWater():void {
@@ -1656,7 +1657,7 @@ public class CampMakeWinions extends BaseContent
 			outputText("<b>Water Elemental</b>\n\n");
 			outputText("-When attacking, it has an increased critical damage chance by 10%.\n");
 			outputText("-When attacking, it will deal Water type damage.\n");
-			outputText("-M. Special: Heals PC.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectWater.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomeEther():void {
@@ -1665,14 +1666,14 @@ public class CampMakeWinions extends BaseContent
 			outputText("-When attacking, it has an increased critical damage chance by 10%.\n");
 			outputText("-When attacking, it has an increased critical damage multiplied from 150% to 200%.\n");
 			outputText("-When attacking, it will ignore enemy damage reduction.\n");
-			outputText("-M. Special: Deals increased damage as a bonus to enemy if enemy is weak to any of the four major elements.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectEther.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomeWood():void {
 			clearOutput();
 			outputText("<b>Wood Elemental</b>\n\n");
 			outputText("-When attacking, it has an increased damage by 100%.\n");
-			outputText("-M. Special: PC (Minor) Healing and small increase to armor / magic resistance for a few turns. Duration depends on elemental rank.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectWood.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomeMetal():void {
@@ -1681,49 +1682,49 @@ public class CampMakeWinions extends BaseContent
 			outputText("-When attacking, it has an increased critical damage chance by 10%.\n");
 			outputText("-When attacking, it has an increased critical damage multiplied from 150% to 175%.\n");
 			outputText("-When attacking, it has an increased damage by 30%.\n");
-			outputText("-M. Special: Increases PC unarmed damage for a few turns. Duration depends on elemental rank.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectMetal.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomeIce():void {
 			clearOutput();
 			outputText("<b>Ice Elemental</b>\n\n");
 			outputText("-When attacking, it will deal Ice type damage.\n");
-			outputText("-M. Special: Stronger version of ice attributed attack.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectIce.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomeLightning():void {
 			clearOutput();
 			outputText("<b>Lightning Elemental</b>\n\n");
 			outputText("-When attacking, it will deal Lightning type damage.\n");
-			outputText("-M. Special: Stronger version of lightning attributed attack.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectLightning.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomeDarkness():void {
 			clearOutput();
 			outputText("<b>Darkness Elemental</b>\n\n");
 			outputText("-When attacking, it will deal Darkness type damage.\n");
-			outputText("-M. Special: Stronger version of darkness attributed attack.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectDarkness.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomePoison():void {
 			clearOutput();
 			outputText("<b>Poison Elemental</b>\n\n");
 			outputText("-When attacking, it will deal Poison type damage.\n");
-			outputText("-M. Special: Stronger version of poison attributed attack.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectPoison.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomePurity():void {
 			clearOutput();
 			outputText("<b>Purity Elemental</b>\n\n");
 			outputText("-When attacking, it will deal increased damage based on enemy corruption. The higher the corruption the higher bonus to damage. (60%-300%)\n");
-			outputText("-M. Special: Stronger version of purity attributed attack.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectPurity.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTomeCorruption():void {
 			clearOutput();
 			outputText("<b>Corruption Elemental</b>\n\n");
 			outputText("-When attacking, it will deal increased damage based on enemy corruption. The lower the corruption the higher bonus to damage. (60%-300%)\n");
-			outputText("-M. Special: Stronger version of corruption attributed attack.\n");
+			outputText("-M. Special: " + CombatAbilities.EAspectCorruption.description + "\n");
 			doNext(evocationTome);
 		}
 		private function evocationTome4():void {

--- a/classes/classes/Scenes/Combat/AbstractBloodSoulSkill.as
+++ b/classes/classes/Scenes/Combat/AbstractBloodSoulSkill.as
@@ -64,6 +64,8 @@ public class AbstractBloodSoulSkill extends AbstractSoulSkill {
     }
 
     override public function useResources():void {
+        //Set last attack type for Blood Soulskill
+        CombatAbility.prototype.useResources.call(this);
         HPChange(sfCost(), false);
 
         if (sfInfusion) {

--- a/classes/classes/Scenes/Combat/AbstractMagicSpecial.as
+++ b/classes/classes/Scenes/Combat/AbstractMagicSpecial.as
@@ -1,0 +1,96 @@
+package classes.Scenes.Combat {
+
+import classes.StatusEffectType;
+import classes.PerkType;
+import classes.Races;
+import classes.PerkLib;
+import classes.StatusEffects;
+
+public class AbstractMagicSpecial extends AbstractSpecial {
+
+    public function AbstractMagicSpecial (
+            name:String,
+            desc:String,
+            targetType:int,
+            timingType:int,
+            tags:/*int*/Array,
+            knownCondition:*
+    ) {
+        super(name, desc, targetType, timingType, tags, knownCondition);
+        this.knownCondition = knownCondition;
+    }
+
+	override public function get category():int {
+        return CAT_MAGICAL_SPECIAL;
+    }
+
+    /**
+    * Function to be used with elemental aspect magic specials to produce their base damage based on the level of the associated basic element
+    * @param aspectStatusEffect StatusEffectType - contains the level of the assoicatedbasic elemental
+    * @param damage Number - the starting damage of the function
+    * @param halfEffect Boolean - Used with Wood Elemental Aspect, halves the effects of each modifier
+    * @return damage Number - The final caluclated damage
+    */
+    protected function elementalAspectBaseDamage(aspectStatusEffect: StatusEffectType, damage:Number = 0, halfEffect:Boolean = false):Number {
+        var multiplier:Number = halfEffect? 0.5: 1;
+        var multiInt:Number = 0.5 * multiplier;
+		var multiWis:Number = 0.5 * multiplier;
+		if (player.statusEffectv2(aspectStatusEffect) >= 2) {
+			multiInt += (0.2 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 1);
+			multiWis += (0.2 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 1);
+		}
+		if (player.statusEffectv2(aspectStatusEffect) >= 5) {
+			multiInt += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 4);
+			multiWis += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 4);
+		}
+		if (player.statusEffectv2(aspectStatusEffect) >= 9) {
+			multiInt += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 8);
+			multiWis += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 8);
+		}
+		if (player.statusEffectv2(aspectStatusEffect) >= 13) {
+			multiInt += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 12);
+			multiWis += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 12);
+		}
+		if (player.statusEffectv2(aspectStatusEffect) >= 17) {
+			multiInt += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 16);
+			multiWis += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 16);
+		}
+		if (player.statusEffectv2(aspectStatusEffect) >= 21) {
+			multiInt += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 20);
+			multiWis += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 20);
+		}
+		if (player.statusEffectv2(aspectStatusEffect) >= 25) {
+			multiInt += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 24);
+			multiWis += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 24);
+		}
+		if (player.statusEffectv2(aspectStatusEffect) >= 29) {
+			multiInt += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 28);
+			multiWis += (0.1 * multiplier) * (player.statusEffectv2(aspectStatusEffect) - 28);
+		}
+		damage += scalingBonusIntelligence() * multiInt;
+		damage += scalingBonusWisdom() * multiWis;
+        return damage;
+    }
+
+    protected function elementalAspectBaseDuration(aspectStatusEffect: StatusEffectType, duration:int = 0):int {
+        if (player.statusEffectv2(aspectStatusEffect) >= 1) duration += player.statusEffectv2(aspectStatusEffect);
+        if (player.statusEffectv2(aspectStatusEffect) >= 9) duration += player.statusEffectv2(aspectStatusEffect) - 8;
+        if (player.statusEffectv2(aspectStatusEffect) >= 21) duration += player.statusEffectv2(aspectStatusEffect) - 20;
+
+        return duration;
+    }
+
+    protected function elementalAspectDamageMod(aspectStatusEffect: StatusEffectType, damage:Number = 0):Number {
+        damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(aspectStatusEffect));
+
+        var perkMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
+		damage *= perkMultiplier;
+
+		damage *= 3;
+
+        return damage;
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/AbstractMagicSpecial.as
+++ b/classes/classes/Scenes/Combat/AbstractMagicSpecial.as
@@ -92,5 +92,33 @@ public class AbstractMagicSpecial extends AbstractSpecial {
 
         return damage;
     }
+
+	protected function elementalAspectManaCost(aspectStatusEffect: StatusEffectType, manaCost:Number = 1):Number {
+		var manaCostInt:Number = 8;
+		var manaCostWis:Number = 8;
+		var summonedElementals:Number = 5 * player.statusEffectv2(aspectStatusEffect);
+
+		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) {
+			manaCostInt += 17;
+			manaCostWis += 42;
+		}
+		manaCost += summonedElementals;
+		if (summonedElementals >= 11) manaCost += summonedElementals;
+		if (summonedElementals >= 21) manaCost += summonedElementals;
+		if (summonedElementals >= 29) manaCost += summonedElementals;
+		manaCost += player.inte / manaCostInt;
+		manaCost += player.wis / manaCostWis;
+		if (summonedElementals >= 2 && manaCost > 11 && player.hasPerk(PerkLib.StrongElementalBond)) manaCost -= 10;
+		if (summonedElementals >= 4 && manaCost > 22 && player.hasPerk(PerkLib.StrongElementalBondEx)) manaCost -= 20;
+		if (summonedElementals >= 6 && manaCost > 33 && player.hasPerk(PerkLib.StrongElementalBondSu)) manaCost -= 30;
+		if (summonedElementals >= 9 && manaCost > 44 && player.hasPerk(PerkLib.StrongerElementalBond)) manaCost -= 40;
+		if (summonedElementals >= 12 && manaCost > 55 && player.hasPerk(PerkLib.StrongerElementalBondEx)) manaCost -= 50;
+		if (summonedElementals >= 15 && manaCost > 66 && player.hasPerk(PerkLib.StrongerElementalBondSu)) manaCost -= 60;
+		if (summonedElementals >= 19 && manaCost > 77 && player.hasPerk(PerkLib.StrongestElementalBond)) manaCost -= 70;
+		if (summonedElementals >= 23 && manaCost > 88 && player.hasPerk(PerkLib.StrongestElementalBondEx)) manaCost -= 80;
+		if (summonedElementals >= 27 && manaCost > 99 && player.hasPerk(PerkLib.StrongestElementalBondSu)) manaCost -= 90;
+		if (manaCost > 1 && player.hasPerk(PerkLib.FirstAttackElementalsSu)) manaCost *= 0.5;
+		return Math.round(manaCost);
+	}
 }
 }

--- a/classes/classes/Scenes/Combat/AbstractSoulSkill.as
+++ b/classes/classes/Scenes/Combat/AbstractSoulSkill.as
@@ -57,6 +57,7 @@ public class AbstractSoulSkill extends CombatAbility {
     }
 
     override public function useResources():void {
+        super.useResources();
         if (player.hasStatusEffect(StatusEffects.BloodCultivator) && canUseBlood) {
             player.takePhysDamage(sfCost());
         } 

--- a/classes/classes/Scenes/Combat/AbstractSpecial.as
+++ b/classes/classes/Scenes/Combat/AbstractSpecial.as
@@ -19,8 +19,6 @@ public class AbstractSpecial extends CombatAbility {
         this.knownCondition = knownCondition;
     }
 
-    
-
     override public function get isKnown():Boolean {
         if (knownCondition is StatusEffectType)
             return player.hasStatusEffect(knownCondition);
@@ -29,6 +27,55 @@ public class AbstractSpecial extends CombatAbility {
         if (knownCondition is Races)
             return player.isRaceCached(knownCondition);
         return false;
+    }
+
+    override public function useResources():void {
+        super.useResources();
+
+        var finalManaCost:Number = manaCost();
+        var finalFatigueCost:Number = fatigueCost();
+        var finalSFCost:Number = sfCost();
+        var finalWrathCost:Number = wrathCost();
+
+        if (finalManaCost > 0) {
+            useMana(finalManaCost);
+        }
+
+        if (finalFatigueCost > 0) {
+            fatigue(finalFatigueCost);
+        }
+
+        if (finalSFCost > 0) {
+            player.soulforce -= finalSFCost;
+        }
+
+        if (finalWrathCost > 0) {
+            player.wrath -= finalWrathCost;
+        }   
+    }
+
+    override protected function usabilityCheck():String {
+        // Run all check applicable to all abilities
+		var uc:String = super.usabilityCheck();
+		if (uc) return uc;
+
+        if (player.fatigueLeft() < fatigueCost()) {
+			return "You are too tired to use this ability."
+		}
+
+        if (player.mana < manaCost()) {
+			return "Your mana is too low to use this ability."
+		}
+
+        if (player.soulforce < sfCost()) {
+			return "Your soulforce is too low to use this ability."
+		}
+
+        if (player.wrath < wrathCost()) {
+			return "Your wrath is too low to use this ability!"
+		}
+
+        return "";
     }
 }
 }

--- a/classes/classes/Scenes/Combat/AbstractSpecial.as
+++ b/classes/classes/Scenes/Combat/AbstractSpecial.as
@@ -1,0 +1,34 @@
+package classes.Scenes.Combat {
+
+import classes.StatusEffectType;
+import classes.PerkType;
+import classes.Races;
+
+public class AbstractSpecial extends CombatAbility {
+    protected var knownCondition:*;
+
+    public function AbstractSpecial (
+            name:String,
+            desc:String,
+            targetType:int,
+            timingType:int,
+            tags:/*int*/Array,
+            knownCondition:*
+    ) {
+        super(name, desc, targetType, timingType, tags);
+        this.knownCondition = knownCondition;
+    }
+
+    
+
+    override public function get isKnown():Boolean {
+        if (knownCondition is StatusEffectType)
+            return player.hasStatusEffect(knownCondition);
+        if (knownCondition is PerkType)
+            return player.hasPerk(knownCondition);
+        if (knownCondition is Races)
+            return player.isRaceCached(knownCondition);
+        return false;
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/AbstractSpell.as
+++ b/classes/classes/Scenes/Combat/AbstractSpell.as
@@ -33,6 +33,7 @@ public class AbstractSpell extends CombatAbility {
 	) {
 		super(name, desc, targetType, timingType, tags);
 		this.useManaType = useManaType;
+		this.lastAttackType = Combat.LAST_ATTACK_SPELL;
 	}
 
 	override public function manaCost():Number {
@@ -40,7 +41,7 @@ public class AbstractSpell extends CombatAbility {
 	}
 	
 	override public function useResources():void {
-		flags[kFLAGS.LAST_ATTACK_TYPE] = 2;
+		super.useResources();
 		//var realManaCost:Number = combat.finalSpellCost(manaCost(), useManaType);
 		var realManaCost:Number = manaCost();
 		var realWrathCost:Number = wrathCost();

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -826,7 +826,7 @@ public class Combat extends BaseContent {
         }
     }
 
-    internal function buildOtherActions(buttons:ButtonDataList):void {
+    internal function buildOtherActions(buttons:ButtonDataList, backFunc:Function, aspectButtons:ButtonDataList = null):void {
         var bd:ButtonData;
 		buttons.add("Surrender(H)", combat.surrenderByHP, "Stop defending youself. You'll take a hell of a beating. Why would you do this?");
         buttons.add("Surrender(L)", combat.surrenderByLust, "Fantasize about your opponent in a sexual way so much it would fill up your lust. You'll end up getting raped...But is it rape if you get what you want?");
@@ -905,7 +905,16 @@ public class Combat extends BaseContent {
 			bd = buttons.add("Heal Zenji", HealZenji);
 		}
 		if (player.hasPerk(PerkLib.JobGolemancer) && (flags[kFLAGS.TEMPORAL_GOLEMS_BAG] > 0 || flags[kFLAGS.PERMANENT_GOLEMS_BAG] > 0 || flags[kFLAGS.IMPROVED_PERMANENT_GOLEMS_BAG] > 0 || flags[kFLAGS.PERMANENT_STEEL_GOLEMS_BAG] > 0 || flags[kFLAGS.IMPROVED_PERMANENT_STEEL_GOLEMS_BAG] > 0)) bd = buttons.add("Golems", GolemsMenu);
-		if (player.hasPerk(PerkLib.JobElementalConjurer) && player.statusEffectv1(StatusEffects.SummonedElementals) >= 1) bd = buttons.add("Elem.Asp", ElementalAspectsMenu);
+		if (player.hasPerk(PerkLib.JobElementalConjurer) && player.statusEffectv1(StatusEffects.SummonedElementals) >= 1) {
+            var buttonFunc:Function;
+            if (aspectButtons != null) {
+                buttonFunc = curry(submenu, aspectButtons, backFunc);
+            }
+            else {
+                buttonFunc = ElementalAspectsMenu
+            }
+            bd = buttons.add("Elem.Asp", buttonFunc, "Use the once-per-battle elemental aspects of your basic elementals.", "Elemental Aspects");
+        }
 		if (player.hasPerk(PerkLib.PrestigeJobNecromancer) && player.perkv2(PerkLib.PrestigeJobNecromancer) > 0) {
 			bd = buttons.add("S.S. to F.", sendSkeletonToFight).hint("Send Skeleton to fight - Order your Skeletons to beat the crap out of your foe.");
 			if (monster.isFlying() && (!player.hasPerk(PerkLib.GreaterHarvest) || (player.perkv1(PerkLib.GreaterHarvest) == 0 && player.perkv2(PerkLib.GreaterHarvest) == 0))) {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -6734,10 +6734,7 @@ public class Combat extends BaseContent {
         if (player.hasPerk(PerkLib.FclassHeavenTribulationSurvivor)) unarmed += 24 * (1 + player.newGamePlusMod());
         if (player.hasPerk(PerkLib.FFclassHeavenTribulationSurvivor)) unarmed += 30 * (1 + player.newGamePlusMod());
         if (player.hasPerk(PerkLib.EclassHeavenTribulationSurvivor)) unarmed += 36 * (1 + player.newGamePlusMod());
-        if (CombatAbilities.EAspectMetal.isActive()) {
-            if (player.statusEffectv2(StatusEffects.SummonedElementalsMetal) >= 6) unarmed += 4 * player.statusEffectv2(StatusEffects.SummonedElementalsMetal) * (1 + player.newGamePlusMod());
-            else unarmed += 2 * player.statusEffectv2(StatusEffects.SummonedElementalsMetal) * (1 + player.newGamePlusMod());
-        }
+        if (CombatAbilities.EAspectMetal.isActive()) unarmed += CombatAbilities.EAspectMetal.getBonus();
         if (player.hasPerk(PerkLib.ElementalBody)) {
             switch (ElementalRace.getElementAndTier(player)) {
                 case ElementalRace.SYLPH_1:
@@ -10928,31 +10925,6 @@ public class Combat extends BaseContent {
         }
         //Companion Boosting PC Armor Value
         if (player.hasStatusEffect(StatusEffects.CompBoostingPCArmorValue)) player.removeStatusEffect(StatusEffects.CompBoostingPCArmorValue);
-        //Elemental Aspect status effects
-        /*if (player.hasStatusEffect(StatusEffects.WindWall)) {
-            if (player.statusEffectv2(StatusEffects.WindWall) <= 0) {
-                player.removeStatusEffect(StatusEffects.WindWall);
-                outputText("<b>Wind Wall effect wore off!</b>\n\n");
-            } else player.addStatusValue(StatusEffects.WindWall, 2, -1);
-        }*/
-        /*if (player.hasStatusEffect(StatusEffects.StoneSkin)) {
-            if (player.statusEffectv2(StatusEffects.StoneSkin) <= 0) {
-                player.removeStatusEffect(StatusEffects.StoneSkin);
-                outputText("<b>Stone Skin effect wore off!</b>\n\n");
-            } else player.addStatusValue(StatusEffects.StoneSkin, 2, -1);
-        }*/
-        /*if (player.hasStatusEffect(StatusEffects.BarkSkin)) {
-            if (player.statusEffectv2(StatusEffects.BarkSkin) <= 0) {
-                player.removeStatusEffect(StatusEffects.BarkSkin);
-                outputText("<b>Bark Skin effect wore off!</b>\n\n");
-            } else player.addStatusValue(StatusEffects.BarkSkin, 2, -1);
-        } */
-        if (player.hasStatusEffect(StatusEffects.MetalSkin)) {
-            if (player.statusEffectv2(StatusEffects.MetalSkin) <= 0) {
-                player.removeStatusEffect(StatusEffects.MetalSkin);
-                outputText("<b>Metal Skin effect wore off!</b>\n\n");
-            } else player.addStatusValue(StatusEffects.MetalSkin, 2, -1);
-        }
         //Possess
         if (player.hasStatusEffect(StatusEffects.CooldownPossess)) {
             if (player.statusEffectv1(StatusEffects.CooldownPossess) <= 0) {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -6734,7 +6734,7 @@ public class Combat extends BaseContent {
         if (player.hasPerk(PerkLib.FclassHeavenTribulationSurvivor)) unarmed += 24 * (1 + player.newGamePlusMod());
         if (player.hasPerk(PerkLib.FFclassHeavenTribulationSurvivor)) unarmed += 30 * (1 + player.newGamePlusMod());
         if (player.hasPerk(PerkLib.EclassHeavenTribulationSurvivor)) unarmed += 36 * (1 + player.newGamePlusMod());
-        if (player.hasStatusEffect(StatusEffects.MetalSkin)) {
+        if (CombatAbilities.EAspectMetal.isActive()) {
             if (player.statusEffectv2(StatusEffects.SummonedElementalsMetal) >= 6) unarmed += 4 * player.statusEffectv2(StatusEffects.SummonedElementalsMetal) * (1 + player.newGamePlusMod());
             else unarmed += 2 * player.statusEffectv2(StatusEffects.SummonedElementalsMetal) * (1 + player.newGamePlusMod());
         }
@@ -10935,18 +10935,18 @@ public class Combat extends BaseContent {
                 outputText("<b>Wind Wall effect wore off!</b>\n\n");
             } else player.addStatusValue(StatusEffects.WindWall, 2, -1);
         }*/
-        if (player.hasStatusEffect(StatusEffects.StoneSkin)) {
+        /*if (player.hasStatusEffect(StatusEffects.StoneSkin)) {
             if (player.statusEffectv2(StatusEffects.StoneSkin) <= 0) {
                 player.removeStatusEffect(StatusEffects.StoneSkin);
                 outputText("<b>Stone Skin effect wore off!</b>\n\n");
             } else player.addStatusValue(StatusEffects.StoneSkin, 2, -1);
-        }
-        if (player.hasStatusEffect(StatusEffects.BarkSkin)) {
+        }*/
+        /*if (player.hasStatusEffect(StatusEffects.BarkSkin)) {
             if (player.statusEffectv2(StatusEffects.BarkSkin) <= 0) {
                 player.removeStatusEffect(StatusEffects.BarkSkin);
                 outputText("<b>Bark Skin effect wore off!</b>\n\n");
             } else player.addStatusValue(StatusEffects.BarkSkin, 2, -1);
-        }
+        } */
         if (player.hasStatusEffect(StatusEffects.MetalSkin)) {
             if (player.statusEffectv2(StatusEffects.MetalSkin) <= 0) {
                 player.removeStatusEffect(StatusEffects.MetalSkin);

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1883,27 +1883,9 @@ public class Combat extends BaseContent {
         if (summonedElementals >= 9) elementalDamage += baseDamage;
         if (summonedElementals >= 13) elementalDamage += baseDamage;
         if (elementalDamage < 10) elementalDamage = 10;
-        if (player.hasPerk(PerkLib.HistoryTactician) || player.hasPerk(PerkLib.PastLifeTactician)) elementalDamage *= historyTacticianBonus();
-        if (flags[kFLAGS.ELEMENTAL_CONJUER_SUMMONS] == 2 || flags[kFLAGS.ELEMENTAL_CONJUER_SUMMONS] == 4) {
-            if (summonedElementals >= 9) elementalDamage *= 4;
-            else if (summonedElementals >= 5) elementalDamage *= 3;
-            else elementalDamage *= 2;
-        }
-        var elementalamplification:Number = 1;
-        if (player.hasPerk(PerkLib.ElementalConjurerResolve)) elementalamplification += 0.1 * flags[kFLAGS.NEW_GAME_PLUS_LEVEL];
-        if (player.hasPerk(PerkLib.ElementalConjurerDedication)) elementalamplification += 0.2 * flags[kFLAGS.NEW_GAME_PLUS_LEVEL];
-        if (player.hasPerk(PerkLib.ElementalConjurerSacrifice)) elementalamplification += 0.3 * flags[kFLAGS.NEW_GAME_PLUS_LEVEL];
-        if (player.weapon == weapons.SCECOMM) elementalamplification += 0.5;
-		if (player.weaponRange == weaponsrange.E_TOME_) elementalamplification += 0.5;
-        if (player.shield == shields.Y_U_PAN) elementalamplification += 0.25;
-        if (flags[kFLAGS.WILL_O_THE_WISP] == 2) {
-            elementalamplification += 0.1;
-            if (player.hasPerk(PerkLib.WispLieutenant)) elementalamplification += 0.2;
-            if (player.hasPerk(PerkLib.WispCaptain)) elementalamplification += 0.3;
-            if (player.hasPerk(PerkLib.WispMajor)) elementalamplification += 0.4;
-            if (player.hasPerk(PerkLib.WispColonel)) elementalamplification += 0.5;
-        }
-        elementalDamage *= elementalamplification;
+        
+        elementalDamage *= elementalAmplificationMod(summonedElementals);
+
         //Determine if critical hit!
         var crit:Boolean = false;
         var critChance:int = 5;
@@ -1926,7 +1908,7 @@ public class Combat extends BaseContent {
                     break;
             }
         }
-        if (elementType != AIR && elementType != AIR_E && elementType != ETHER) elementalDamage *= (monster.damagePercent() / 100);
+        
         elementalDamage = Math.round(elementalDamage);
         switch (elementType) {
             case EARTH:
@@ -7082,6 +7064,32 @@ public class Combat extends BaseContent {
         if (monster.hasPerk(PerkLib.IceNature)) damage *= 0.4;
         if (player.hasPerk(PerkLib.ColdAffinity) || player.hasPerk(PerkLib.AffinityUndine)) damage *= 2;
         return damage;
+    }
+
+    public function elementalAmplificationMod(summonedElementals:int):Number {
+        var elementalamplification:Number = 1;
+        if (player.hasPerk(PerkLib.ElementalConjurerResolve)) elementalamplification += 0.1 * flags[kFLAGS.NEW_GAME_PLUS_LEVEL];
+        if (player.hasPerk(PerkLib.ElementalConjurerDedication)) elementalamplification += 0.2 * flags[kFLAGS.NEW_GAME_PLUS_LEVEL];
+        if (player.hasPerk(PerkLib.ElementalConjurerSacrifice)) elementalamplification += 0.3 * flags[kFLAGS.NEW_GAME_PLUS_LEVEL];
+        if (player.weapon == weapons.SCECOMM) elementalamplification += 0.5;
+		if (player.weaponRange == weaponsrange.E_TOME_) elementalamplification += 0.5;
+        if (player.shield == shields.Y_U_PAN) elementalamplification += 0.25;
+        if (flags[kFLAGS.WILL_O_THE_WISP] == 2) {
+            elementalamplification += 0.1;
+            if (player.hasPerk(PerkLib.WispLieutenant)) elementalamplification += 0.2;
+            if (player.hasPerk(PerkLib.WispCaptain)) elementalamplification += 0.3;
+            if (player.hasPerk(PerkLib.WispMajor)) elementalamplification += 0.4;
+            if (player.hasPerk(PerkLib.WispColonel)) elementalamplification += 0.5;
+        }
+        if (player.hasPerk(PerkLib.HistoryTactician) || player.hasPerk(PerkLib.PastLifeTactician)) elementalamplification += (1 - historyTacticianBonus());
+        
+        if (flags[kFLAGS.ELEMENTAL_CONJUER_SUMMONS] == 2 || flags[kFLAGS.ELEMENTAL_CONJUER_SUMMONS] == 4) {
+            if (summonedElementals >= 9) elementalamplification += 3;
+            else if (summonedElementals >= 5) elementalamplification += 2;
+            else elementalamplification += 1;
+        }
+
+        return elementalamplification;
     }
 
     public function lustDamageCalc():Number {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -10963,12 +10963,12 @@ public class Combat extends BaseContent {
         //Companion Boosting PC Armor Value
         if (player.hasStatusEffect(StatusEffects.CompBoostingPCArmorValue)) player.removeStatusEffect(StatusEffects.CompBoostingPCArmorValue);
         //Elemental Aspect status effects
-        if (player.hasStatusEffect(StatusEffects.WindWall)) {
+        /*if (player.hasStatusEffect(StatusEffects.WindWall)) {
             if (player.statusEffectv2(StatusEffects.WindWall) <= 0) {
                 player.removeStatusEffect(StatusEffects.WindWall);
                 outputText("<b>Wind Wall effect wore off!</b>\n\n");
             } else player.addStatusValue(StatusEffects.WindWall, 2, -1);
-        }
+        }*/
         if (player.hasStatusEffect(StatusEffects.StoneSkin)) {
             if (player.statusEffectv2(StatusEffects.StoneSkin) <= 0) {
                 player.removeStatusEffect(StatusEffects.StoneSkin);
@@ -11019,34 +11019,6 @@ public class Combat extends BaseContent {
                 player.addStatusValue(StatusEffects.CooldownSpectralScream, 1, -1);
             }
         }
-        /*//Hurricane Dance
-        if (player.hasStatusEffect(StatusEffects.CooldownHurricaneDance)) {
-            if (player.statusEffectv1(StatusEffects.CooldownHurricaneDance) <= 0) {
-                player.removeStatusEffect(StatusEffects.CooldownHurricaneDance);
-            } else {
-                player.addStatusValue(StatusEffects.CooldownHurricaneDance, 1, -1);
-            }
-        }
-        if (player.hasStatusEffect(StatusEffects.HurricaneDance)) {
-            if (player.statusEffectv1(StatusEffects.HurricaneDance) <= 0) {
-                player.removeStatusEffect(StatusEffects.HurricaneDance);
-                outputText("<b>Hurricane Dance effect wore off!</b>\n\n");
-            } else player.addStatusValue(StatusEffects.HurricaneDance, 1, -1);
-        }
-        //Earth Stance
-        if (player.hasStatusEffect(StatusEffects.CooldownEarthStance)) {
-            if (player.statusEffectv1(StatusEffects.CooldownEarthStance) <= 0) {
-                player.removeStatusEffect(StatusEffects.CooldownEarthStance);
-            } else {
-                player.addStatusValue(StatusEffects.CooldownEarthStance, 1, -1);
-            }
-        }
-        if (player.hasStatusEffect(StatusEffects.EarthStance)) {
-            if (player.statusEffectv1(StatusEffects.EarthStance) <= 0) {
-                player.removeStatusEffect(StatusEffects.EarthStance);
-                outputText("<b>Earth Stance effect wore off!</b>\n\n");
-            } else player.addStatusValue(StatusEffects.EarthStance, 1, -1);
-        } */
         //Punishing Kick
         if (player.hasStatusEffect(StatusEffects.CooldownPunishingKick)) {
             if (player.statusEffectv1(StatusEffects.CooldownPunishingKick) <= 0) {

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -338,16 +338,37 @@ public class CombatAbilities {
 
 	public static const EAspectFire:EAspectFireSkill = new EAspectFireSkill();
 	public static const EAspectAir:EAspectAirSkill = new EAspectAirSkill();
+	public static const EAspectEarth:EAspectEarthSkill = new EAspectEarthSkill();
+	public static const EAspectWater:EAspectWaterSkill = new EAspectWaterSkill();
+	public static const EAspectEther:EAspectEtherSkill = new EAspectEtherSkill();
+	public static const EAspectWood:EAspectWoodSkill = new EAspectWoodSkill();
+	public static const EAspectMetal:EAspectMetalSkill = new EAspectMetalSkill();
+	public static const EAspectIce:EAspectIceSkill = new EAspectIceSkill();
+	public static const EAspectLightning:EAspectLightningSkill = new EAspectLightningSkill();
+	public static const EAspectDarkness:EAspectDarknessSkill = new EAspectDarknessSkill();
+	public static const EAspectPoison:EAspectPoisonSkill = new EAspectPoisonSkill();
+	public static const EAspectPurity:EAspectPuritySkill = new EAspectPuritySkill();
+	public static const EAspectCorruption:EAspectCorruptionSkill = new EAspectCorruptionSkill();
 
 	public static const ALL_ELEMENTAL_ASPECTS:/*CombatAbility*/Array = [
 		EAspectFire,
-		EAspectAir
+		EAspectAir,
+		EAspectEarth,
+		EAspectWater,
+		EAspectEther,
+		EAspectWood,
+		EAspectMetal,
+		EAspectIce,
+		EAspectLightning,
+		EAspectDarkness,
+		EAspectPoison,
+		EAspectPurity,
+		EAspectCorruption
 	]
 
 	public static const ALL_MAGICAL_SPECIALS:/*CombatAbility*/Array = [
 		
-	]
-	.concat(ALL_ELEMENTAL_ASPECTS);
+	];
 	
 	/*
 	 * Difference from CombatAbility.Registry:
@@ -357,7 +378,8 @@ public class CombatAbilities {
 	public static const ALL:/*CombatAbility*/Array = []
 			.concat(ALL_SPELLS)
 			.concat(ALL_SOULSKILLS)
-			.concat(ALL_MAGICAL_SPECIALS);
+			.concat(ALL_MAGICAL_SPECIALS)
+			.concat(ALL_ELEMENTAL_ASPECTS);
 	;
 	
 	function CombatAbilities() {

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -8,6 +8,7 @@ import classes.Scenes.Combat.SpellsNecro.*;
 import classes.Scenes.Combat.SpellsGrey.*;
 import classes.Scenes.Combat.SpellsBlood.*;
 import classes.Scenes.Combat.Soulskills.*;
+import classes.Scenes.Combat.SpecialsMagic.EAspectFireSkill;
 
 public class CombatAbilities {
 	
@@ -334,6 +335,17 @@ public class CombatAbilities {
 		BloodRequiemSF,
 		ScarletSpiritCharge
 	]
+
+	public static const EAspectFire:EAspectFireSkill = new EAspectFireSkill();
+
+	public static const ALL_ELEMENTAL_ASPECTS:/*CombatAbility*/Array = [
+		EAspectFire
+	]
+
+	public static const ALL_MAGICAL_SPECIALS:/*CombatAbility*/Array = [
+		
+	]
+	.concat(ALL_ELEMENTAL_ASPECTS);
 	
 	/*
 	 * Difference from CombatAbility.Registry:
@@ -343,6 +355,7 @@ public class CombatAbilities {
 	public static const ALL:/*CombatAbility*/Array = []
 			.concat(ALL_SPELLS)
 			.concat(ALL_SOULSKILLS)
+			.concat(ALL_MAGICAL_SPECIALS);
 	;
 	
 	function CombatAbilities() {

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -8,7 +8,7 @@ import classes.Scenes.Combat.SpellsNecro.*;
 import classes.Scenes.Combat.SpellsGrey.*;
 import classes.Scenes.Combat.SpellsBlood.*;
 import classes.Scenes.Combat.Soulskills.*;
-import classes.Scenes.Combat.SpecialsMagic.EAspectFireSkill;
+import classes.Scenes.Combat.SpecialsMagic.*;
 
 public class CombatAbilities {
 	
@@ -337,9 +337,11 @@ public class CombatAbilities {
 	]
 
 	public static const EAspectFire:EAspectFireSkill = new EAspectFireSkill();
+	public static const EAspectAir:EAspectAirSkill = new EAspectAirSkill();
 
 	public static const ALL_ELEMENTAL_ASPECTS:/*CombatAbility*/Array = [
-		EAspectFire
+		EAspectFire,
+		EAspectAir
 	]
 
 	public static const ALL_MAGICAL_SPECIALS:/*CombatAbility*/Array = [

--- a/classes/classes/Scenes/Combat/CombatAbility.as
+++ b/classes/classes/Scenes/Combat/CombatAbility.as
@@ -225,6 +225,7 @@ public class CombatAbility extends BaseCombatContent {
 	public var baseSFCost:Number = 0;
 	public var baseFatigueCost:Number = 0;
 	public var processPostCallback:Boolean = true;
+	protected var lastAttackType:int = 0;
 	
 	public function CombatAbility(
 			name:String,
@@ -460,7 +461,8 @@ public class CombatAbility extends BaseCombatContent {
 	 * Use mana, increment counters etc. At this point ability still might fail or be intercepted by monster
 	 */
 	public function useResources():void {
-		/* do nothing */
+		if (lastAttackType != 0)
+			flags[kFLAGS.LAST_ATTACK_TYPE] = lastAttackType;
 	}
 	
 	/**
@@ -517,6 +519,10 @@ public class CombatAbility extends BaseCombatContent {
 		var ccd:int = currentCooldown;
 		if (ccd > 0) {
 			return "You need to wait "+numberOfThings(ccd, "more round")+" before you can use this ability again."
+		} else if (ccd == -1) {
+			return "This ability can only be used once per battle."
+		} else if (ccd == -2) {
+			return "This ability can only be used once per day."
 		}
 		return "";
 	}

--- a/classes/classes/Scenes/Combat/CombatAbility.as
+++ b/classes/classes/Scenes/Combat/CombatAbility.as
@@ -6,6 +6,7 @@ import classes.StatusEffectType;
 import coc.view.ButtonData;
 import classes.GlobalFlags.kFLAGS;
 import classes.Appearance;
+import mx.formatters.NumberFormatter;
 
 /**
  * A combat ability invokable by player (spell, special, skill, etc).
@@ -295,6 +296,7 @@ public class CombatAbility extends BaseCombatContent {
 	public function isActive():Boolean {
 		if (timingType == TIMING_INSTANT) return false;
 		if (timingType == TIMING_LASTING) return (player.durations[id] > 0);
+		if (timingType == TIMING_TOGGLE) return (player.durations[id] == -1);
 		throw new Error("Method isActive() is not implemented for ability "+name+", or it's timing type is incorrect");
 	}
 	
@@ -599,5 +601,17 @@ public class CombatAbility extends BaseCombatContent {
 	public function durationEnd(display:Boolean = true):void {
 
 	}
+
+	/**
+	 * Function used to format damage number properly for tooltips
+	 * @param damage (Number) - Number to be formatted
+	 * @return text (String) - Formatted number
+	 * For printing out damage numbers on the main screen, combat.CommasForDigits() should be used instead
+	 */
+	public function numberFormat(damage:Number):String {
+		var numberformat:NumberFormatter = new NumberFormatter();
+        return numberformat.format(Math.floor(Math.abs(damage)));
+	}
+
 }
 }

--- a/classes/classes/Scenes/Combat/CombatAbility.as
+++ b/classes/classes/Scenes/Combat/CombatAbility.as
@@ -4,6 +4,7 @@ import classes.internals.EnumValue;
 import classes.StatusEffectType;
 
 import coc.view.ButtonData;
+import classes.GlobalFlags.kFLAGS;
 
 /**
  * A combat ability invokable by player (spell, special, skill, etc).

--- a/classes/classes/Scenes/Combat/CombatUI.as
+++ b/classes/classes/Scenes/Combat/CombatUI.as
@@ -53,6 +53,7 @@ public class CombatUI extends BaseCombatContent {
 	private var bloodSpellButtons:ButtonDataList = new ButtonDataList();
 	private var greenSpellButtons:ButtonDataList = new ButtonDataList();
 	private var soulforceButtons:ButtonDataList = new ButtonDataList();
+	private var eAspectButtons:ButtonDataList = new ButtonDataList();
 	private var otherButtons:ButtonDataList = new ButtonDataList();
 	public function mainMenu():void {
 		menu();
@@ -68,6 +69,7 @@ public class CombatUI extends BaseCombatContent {
 		bloodSpellButtons.clear();
 		greenSpellButtons.clear();
 		soulforceButtons.clear();
+		eAspectButtons.clear();
 		otherButtons.clear();
 
 		var btnMelee:CoCButton      = button(0).icon("A_Melee");
@@ -240,7 +242,8 @@ public class CombatUI extends BaseCombatContent {
 		buildAbilityMenu(CombatAbilities.ALL_SOULSKILLS, soulforceButtons);
 		if (soulforceButtons.length > 0) btnSoulskills.show("Soulforce", submenuSoulforce, "Soulforce attacks menu.", "Soulforce Specials");
 		// Submenu - Other
-		combat.buildOtherActions(otherButtons);
+		buildAbilityMenu(CombatAbilities.ALL_ELEMENTAL_ASPECTS, eAspectButtons);
+		combat.buildOtherActions(otherButtons, submenuOther, eAspectButtons);
 		if (otherButtons.length > 0) btnOther.show("Other", submenuOther, "Combat options and uncategorized actions");
 
 		btnFantasize.show("Fantasize", combat.fantasize, "Fantasize about your opponent in a sexual way.  Its probably a pretty bad idea to do this unless you want to end up getting raped.");

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -6090,23 +6090,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
-		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsFire));
-		damage = calcInfernoMod(damage, true);
-
-		var perkMultiplier:Number = 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
-		damage *= perkMultiplier;
-
-		//Determine if critical hit!
-        var crit:Boolean = false;
-        var critChance:int = 5;
-        critChance += combatMagicalCritical();
-        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-        if (rand(100) < critChance) {
-            crit = true;
-			damage *= 1.5;
-		}
 		
 		//crits for elementals specials inclused too? with some perk maybe or just like that same as crit % chance for PC?
 		damage = Math.round(damage);
@@ -6122,7 +6105,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your fire elemental douses your opponent with a torrent of fire ");
 		doFireDamage(damage, true, true);
-		if (crit) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
@@ -6225,22 +6207,6 @@ public class MagicSpecials extends BaseCombatContent {
 		if (monster.hasPerk(PerkLib.DarknessNature)) damage *= 5;
 		if (monster.hasPerk(PerkLib.DarknessVulnerability)) damage *= 2;
 
-		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsEther));
-
-		var perkMultiplier:Number = 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
-		damage *= perkMultiplier;
-
-		//Determine if critical hit!
-        var crit:Boolean = false;
-        var critChance:int = 5;
-        critChance += combatMagicalCritical();
-        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-        if (rand(100) < critChance) {
-            crit = true;
-			damage *= 1.5;
-		}
 		//crits for elementals specials inclused too? with some perk maybe or just like that same as crit % chance for PC?
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
@@ -6255,7 +6221,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your elemental unleash a barrage of star shaped bolts of arcane energy, blasting your opponent. ");
 		doMagicDamage(damage, true, true);
-		if (crit) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
@@ -6431,22 +6396,6 @@ public class MagicSpecials extends BaseCombatContent {
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
 		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsIce));
-		damage = calcInfernoMod(damage, true);
-
-		var perkMultiplier:Number = 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
-		damage *= perkMultiplier;
-
-		//Determine if critical hit!
-        var crit:Boolean = false;
-        var critChance:int = 5;
-        critChance += combatMagicalCritical();
-        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-        if (rand(100) < critChance) {
-            crit = true;
-			damage *= 1.5;
-		}
 
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
@@ -6461,7 +6410,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your elemental produces a ray of hyper condensed cold and aims it straight at [themonster] dealing ");
 		doIceDamage(damage, true, true);
-		if (crit) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
@@ -6508,23 +6456,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
-		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsLightning));
-		damage = calcGlacialMod(damage, true);
-
-		var perkMultiplier:Number = 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
-		damage *= perkMultiplier;
-
-		//Determine if critical hit!
-        var crit:Boolean = false;
-        var critChance:int = 5;
-        critChance += combatMagicalCritical();
-        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-        if (rand(100) < critChance) {
-            crit = true;
-			damage *= 1.5;
-		}
 
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
@@ -6539,7 +6470,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your elemental charges electricity, then discharges it with a blinding bolt doing ");
 		doLightingDamage(damage, true, true);
-		if (crit) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
@@ -6586,23 +6516,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
-		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsDarkness));
-		damage = calcEclypseMod(damage, true);
-
-		var perkMultiplier:Number = 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
-		damage *= perkMultiplier;
-
-		//Determine if critical hit!
-        var crit:Boolean = false;
-        var critChance:int = 5;
-        critChance += combatMagicalCritical();
-        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-        if (rand(100) < critChance) {
-            crit = true;
-			damage *= 1.5;
-		}
 
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
@@ -6617,7 +6530,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your darkness elemental condenses shadows into solid matter, striking your opponent with them ");
 		doDarknessDamage(damage, true, true);
-		if (crit) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
@@ -6664,22 +6576,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
-		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsPoison));
-
-		var perkMultiplier:Number = 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
-		damage *= perkMultiplier;
-
-		//Determine if critical hit!
-        var crit:Boolean = false;
-        var critChance:int = 5;
-        critChance += combatMagicalCritical();
-        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-        if (rand(100) < critChance) {
-            crit = true;
-			damage *= 1.5;
-		}
 
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
@@ -6694,7 +6590,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your poison elemental condenses aphrodisiac poison into spike, striking your opponent with them ");
 		doPoisonDamage(damage, true, true);
-		if (crit) outputText(" <b>Critical!</b> ");
 
 		var lustdamage:Number = 20 + rand(player.statusEffectv2(StatusEffects.SummonedElementalsPoison) + 1);
 		if (player.statusEffectv2(StatusEffects.SummonedElementalsPoison) >= 2) lustdamage += 1 * (player.statusEffectv2(StatusEffects.SummonedElementalsPoison) - 1);
@@ -6750,22 +6645,6 @@ public class MagicSpecials extends BaseCombatContent {
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
 		damage *= combat.purityScalingDA();
-		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsPurity));
-
-		var perkMultiplier:Number = 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
-		damage *= perkMultiplier;
-
-		//Determine if critical hit!
-        var crit:Boolean = false;
-        var critChance:int = 5;
-        critChance += combatMagicalCritical();
-        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-        if (rand(100) < critChance) {
-            crit = true;
-			damage *= 1.5;
-		}
 
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
@@ -6780,7 +6659,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your purity elemental produces a ray of hyper condensed and pure light and aims it straight at [themonster] ");
 		doMagicDamage(damage, true, true);
-		if (crit) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
@@ -6828,22 +6706,6 @@ public class MagicSpecials extends BaseCombatContent {
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
 		damage *= combat.corruptionScalingDA();
-		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsCorruption));
-
-		var perkMultiplier:Number = 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
-		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
-		damage *= perkMultiplier;
-
-		//Determine if critical hit!
-        var crit:Boolean = false;
-        var critChance:int = 5;
-        critChance += combatMagicalCritical();
-        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-        if (rand(100) < critChance) {
-            crit = true;
-			damage *= 1.5;
-		}
 
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
@@ -6858,7 +6720,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your corruption elemental condenses corruption from air into solid matter, striking your opponent with them ");
 		doMagicDamage(damage, true, true);
-		if (crit) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -6051,7 +6051,7 @@ public class MagicSpecials extends BaseCombatContent {
 
 	public function ElementalAspectFire():void {
 		clearOutput();
-		flags[kFLAGS.LAST_ATTACK_TYPE] = 2;
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
 		player.createStatusEffect(StatusEffects.CooldownEAspectFire, 0, 0, 0, 0);
 		var damage:Number = 0;
 		var multiInt:Number = 0.5;
@@ -6090,10 +6090,24 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
-		if (monster.hasPerk(PerkLib.IceNature)) damage *= 5;
-		if (monster.hasPerk(PerkLib.FireVulnerability)) damage *= 2;
-		if (monster.hasPerk(PerkLib.IceVulnerability)) damage *= 0.5;
-		if (monster.hasPerk(PerkLib.FireNature)) damage *= 0.2;
+		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsFire));
+		damage = calcInfernoMod(damage, true);
+
+		var perkMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
+		damage *= perkMultiplier;
+
+		//Determine if critical hit!
+        var crit:Boolean = false;
+        var critChance:int = 5;
+        critChance += combatMagicalCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+        if (rand(100) < critChance) {
+            crit = true;
+			damage *= 1.5;
+		}
+		
 		//crits for elementals specials inclused too? with some perk maybe or just like that same as crit % chance for PC?
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
@@ -6108,7 +6122,8 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your fire elemental douses your opponent with a torrent of fire ");
 		doFireDamage(damage, true, true);
-		outputText(" damage.\n\n");
+		if (crit) outputText(" <b>Critical!</b>");
+		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
 	}
@@ -6162,7 +6177,7 @@ public class MagicSpecials extends BaseCombatContent {
 
 	public function ElementalAspectEther():void {
 		clearOutput();
-		flags[kFLAGS.LAST_ATTACK_TYPE] = 2;
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
 		player.createStatusEffect(StatusEffects.CooldownEAspectEther, 0, 0, 0, 0);
 		var damage:Number = 0;
 		var multiInt:Number = 0.5;
@@ -6209,6 +6224,23 @@ public class MagicSpecials extends BaseCombatContent {
 		if (monster.hasPerk(PerkLib.LightningVulnerability)) damage *= 2;
 		if (monster.hasPerk(PerkLib.DarknessNature)) damage *= 5;
 		if (monster.hasPerk(PerkLib.DarknessVulnerability)) damage *= 2;
+
+		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsEther));
+
+		var perkMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
+		damage *= perkMultiplier;
+
+		//Determine if critical hit!
+        var crit:Boolean = false;
+        var critChance:int = 5;
+        critChance += combatMagicalCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+        if (rand(100) < critChance) {
+            crit = true;
+			damage *= 1.5;
+		}
 		//crits for elementals specials inclused too? with some perk maybe or just like that same as crit % chance for PC?
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
@@ -6223,6 +6255,7 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your elemental unleash a barrage of star shaped bolts of arcane energy, blasting your opponent. ");
 		doMagicDamage(damage, true, true);
+		if (crit) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
@@ -6358,7 +6391,7 @@ public class MagicSpecials extends BaseCombatContent {
 
 	public function ElementalAspectIce():void {
 		clearOutput();
-		flags[kFLAGS.LAST_ATTACK_TYPE] = 2;
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
 		player.createStatusEffect(StatusEffects.CooldownEAspectIce, 0, 0, 0, 0);
 		var damage:Number = 0;
 		var multiInt:Number = 0.5;
@@ -6397,6 +6430,24 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
+		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsIce));
+		damage = calcInfernoMod(damage, true);
+
+		var perkMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
+		damage *= perkMultiplier;
+
+		//Determine if critical hit!
+        var crit:Boolean = false;
+        var critChance:int = 5;
+        critChance += combatMagicalCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+        if (rand(100) < critChance) {
+            crit = true;
+			damage *= 1.5;
+		}
+
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
 			outputText("  [Themonster] reels as your wave of force slams into [monster him] like a ton of rock!  The impact sends [monster him] crashing to the ground, too dazed to strike back.");
@@ -6410,14 +6461,15 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your elemental produces a ray of hyper condensed cold and aims it straight at [themonster] dealing ");
 		doIceDamage(damage, true, true);
-		outputText(" damage.\n\n");
+		if (crit) outputText(" <b>Critical!</b>");
+		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
 	}
 
 	public function ElementalAspectLightning():void {
 		clearOutput();
-		flags[kFLAGS.LAST_ATTACK_TYPE] = 2;
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
 		player.createStatusEffect(StatusEffects.CooldownEAspectLightning, 0, 0, 0, 0);
 		var damage:Number = 0;
 		var multiInt:Number = 0.5;
@@ -6456,6 +6508,24 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
+		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsLightning));
+		damage = calcGlacialMod(damage, true);
+
+		var perkMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
+		damage *= perkMultiplier;
+
+		//Determine if critical hit!
+        var crit:Boolean = false;
+        var critChance:int = 5;
+        critChance += combatMagicalCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+        if (rand(100) < critChance) {
+            crit = true;
+			damage *= 1.5;
+		}
+
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
 			outputText("  [Themonster] reels as your wave of force slams into [monster him] like a ton of rock!  The impact sends [monster him] crashing to the ground, too dazed to strike back.");
@@ -6469,14 +6539,15 @@ public class MagicSpecials extends BaseCombatContent {
 		}*/
 		outputText("Your elemental charges electricity, then discharges it with a blinding bolt doing ");
 		doLightingDamage(damage, true, true);
-		outputText(" damage.\n\n");
+		if (crit) outputText(" <b>Critical!</b>");
+		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
 	}
 
 	public function ElementalAspectDarkness():void {
 		clearOutput();
-		flags[kFLAGS.LAST_ATTACK_TYPE] = 2;
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
 		player.createStatusEffect(StatusEffects.CooldownEAspectDarkness, 0, 0, 0, 0);
 		var damage:Number = 0;
 		var multiInt:Number = 0.5;
@@ -6515,6 +6586,24 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
+		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsDarkness));
+		damage = calcEclypseMod(damage, true);
+
+		var perkMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
+		damage *= perkMultiplier;
+
+		//Determine if critical hit!
+        var crit:Boolean = false;
+        var critChance:int = 5;
+        critChance += combatMagicalCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+        if (rand(100) < critChance) {
+            crit = true;
+			damage *= 1.5;
+		}
+
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
 			outputText("  [Themonster] reels as your wave of force slams into [monster him] like a ton of rock!  The impact sends [monster him] crashing to the ground, too dazed to strike back.");
@@ -6526,16 +6615,17 @@ public class MagicSpecials extends BaseCombatContent {
 			else outputText("are");
 			outputText("too resolute to be stunned by your attack.</b>");
 		}*/
-		outputText("Your darkness elemental condenses shadows into solid matter, striking your opponent with them doing ");
+		outputText("Your darkness elemental condenses shadows into solid matter, striking your opponent with them ");
 		doDarknessDamage(damage, true, true);
-		outputText(" damage.\n\n");
+		if (crit) outputText(" <b>Critical!</b>");
+		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
 	}
 
 	public function ElementalAspectPoison():void {
 		clearOutput();
-		flags[kFLAGS.LAST_ATTACK_TYPE] = 2;
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
 		player.createStatusEffect(StatusEffects.CooldownEAspectPoison, 0, 0, 0, 0);
 		var damage:Number = 0;
 		var multiInt:Number = 0.5;
@@ -6574,6 +6664,23 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
+		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsPoison));
+
+		var perkMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
+		damage *= perkMultiplier;
+
+		//Determine if critical hit!
+        var crit:Boolean = false;
+        var critChance:int = 5;
+        critChance += combatMagicalCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+        if (rand(100) < critChance) {
+            crit = true;
+			damage *= 1.5;
+		}
+
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
 			outputText("  [Themonster] reels as your wave of force slams into [monster him] like a ton of rock!  The impact sends [monster him] crashing to the ground, too dazed to strike back.");
@@ -6585,9 +6692,10 @@ public class MagicSpecials extends BaseCombatContent {
 			else outputText("are");
 			outputText("too resolute to be stunned by your attack.</b>");
 		}*/
-		outputText("Your poison elemental condenses aphrodisiac poison into spike, striking your opponent with them doing ");
+		outputText("Your poison elemental condenses aphrodisiac poison into spike, striking your opponent with them ");
 		doPoisonDamage(damage, true, true);
-		outputText(" damage.");
+		if (crit) outputText(" <b>Critical!</b> ");
+
 		var lustdamage:Number = 20 + rand(player.statusEffectv2(StatusEffects.SummonedElementalsPoison) + 1);
 		if (player.statusEffectv2(StatusEffects.SummonedElementalsPoison) >= 2) lustdamage += 1 * (player.statusEffectv2(StatusEffects.SummonedElementalsPoison) - 1);
 		if (player.statusEffectv2(StatusEffects.SummonedElementalsPoison) >= 9) lustdamage += 1 * (player.statusEffectv2(StatusEffects.SummonedElementalsPoison) - 8);
@@ -6602,7 +6710,7 @@ public class MagicSpecials extends BaseCombatContent {
 
 	public function ElementalAspectPurity():void {
 		clearOutput();
-		flags[kFLAGS.LAST_ATTACK_TYPE] = 2;
+		flags[kFLAGS.LAST_ATTACK_TYPE] = Combat.LAST_ATTACK_SPELL;
 		player.createStatusEffect(StatusEffects.CooldownEAspectPurity, 0, 0, 0, 0);
 		var damage:Number = 0;
 		var multiInt:Number = 0.5;
@@ -6642,6 +6750,23 @@ public class MagicSpecials extends BaseCombatContent {
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
 		damage *= combat.purityScalingDA();
+		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsPurity));
+
+		var perkMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
+		damage *= perkMultiplier;
+
+		//Determine if critical hit!
+        var crit:Boolean = false;
+        var critChance:int = 5;
+        critChance += combatMagicalCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+        if (rand(100) < critChance) {
+            crit = true;
+			damage *= 1.5;
+		}
+
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
 			outputText("  [Themonster] reels as your wave of force slams into [monster him] like a ton of rock!  The impact sends [monster him] crashing to the ground, too dazed to strike back.");
@@ -6653,8 +6778,10 @@ public class MagicSpecials extends BaseCombatContent {
 			else outputText("are");
 			outputText("too resolute to be stunned by your attack.</b>");
 		}*/
-		outputText("Your purity elemental produces a ray of hyper condensed and pure light and aims it straight at [themonster] doing ");
-		doMagicDamage(damage, true, true);outputText(" damage.\n\n");
+		outputText("Your purity elemental produces a ray of hyper condensed and pure light and aims it straight at [themonster] ");
+		doMagicDamage(damage, true, true);
+		if (crit) outputText(" <b>Critical!</b>");
+		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
 	}
@@ -6701,6 +6828,23 @@ public class MagicSpecials extends BaseCombatContent {
 		damage += scalingBonusIntelligence() * multiInt;
 		damage += scalingBonusWisdom() * multiWis;
 		damage *= combat.corruptionScalingDA();
+		damage *= combat.elementalAmplificationMod(5 * player.statusEffectv2(StatusEffects.SummonedElementalsCorruption));
+
+		var perkMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsEx) && player.hasStatusEffect(StatusEffects.SummonedElementals)) perkMultiplier += 1;
+		if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) perkMultiplier += 2;
+		damage *= perkMultiplier;
+
+		//Determine if critical hit!
+        var crit:Boolean = false;
+        var critChance:int = 5;
+        critChance += combatMagicalCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+        if (rand(100) < critChance) {
+            crit = true;
+			damage *= 1.5;
+		}
+
 		damage = Math.round(damage);
 		/*if(!monster.hasPerk(PerkLib.Resolute)) {
 			outputText("  [Themonster] reels as your wave of force slams into [monster him] like a ton of rock!  The impact sends [monster him] crashing to the ground, too dazed to strike back.");
@@ -6712,9 +6856,10 @@ public class MagicSpecials extends BaseCombatContent {
 			else outputText("are");
 			outputText("too resolute to be stunned by your attack.</b>");
 		}*/
-		outputText("Your corruption elemental condenses corruption from air into solid matter, striking your opponent with them doing ");
+		outputText("Your corruption elemental condenses corruption from air into solid matter, striking your opponent with them ");
 		doMagicDamage(damage, true, true);
-		outputText(" damage.\n\n");
+		if (crit) outputText(" <b>Critical!</b>");
+		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();
 	}

--- a/classes/classes/Scenes/Combat/Soulskills/EarthStanceSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/EarthStanceSkill.as
@@ -21,22 +21,11 @@ public class EarthStanceSkill extends AbstractSoulSkill {
 		return "Earth Stance";
 	}
 
-	override public function isActive():Boolean {
-		return player.hasStatusEffect(StatusEffects.EarthStance);
-	}
-
-    override public function advance(display:Boolean):void {
-        function endFunction(ability:CombatAbility, display:Boolean):void {
-            if (display) outputText("<b>Earth Stance effect wore off!</b>\n\n");
-        }
-        advanceDuration(StatusEffects.EarthStance, endFunction, display);
-    }
-
     override public function calcCooldown():int {
         return 10;
     }
 
-    public function calcDuration():int {
+    override public function calcDuration():int {
         return 3;
     }
 
@@ -47,8 +36,11 @@ public class EarthStanceSkill extends AbstractSoulSkill {
     override public function doEffect(display:Boolean = true):void {
 		if (display)
 			outputText("Your body suddenly hardens like rock. You will be way harder to damage for a while.\n\n");
-		
-		player.createStatusEffect(StatusEffects.EarthStance, calcDuration(), 0, 0, 0);
+		setDuration();
+    }
+
+    override public function durationEnd(display:Boolean = true):void {
+        if (display) outputText("<b>Earth Stance effect wore off!</b>\n\n");
     }
 }
 }

--- a/classes/classes/Scenes/Combat/Soulskills/HurricaneDanceSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/HurricaneDanceSkill.as
@@ -21,22 +21,11 @@ public class HurricaneDanceSkill extends AbstractSoulSkill {
 		return "Hurricane Dance";
 	}
 
-	override public function isActive():Boolean {
-		return player.hasStatusEffect(StatusEffects.HurricaneDance);
-	}
-
-    override public function advance(display:Boolean):void {
-        function endFunction(ability:CombatAbility, display:Boolean):void {
-            if (display) outputText("<b>Hurricane Dance effect wore off!</b>\n\n");
-        }
-        advanceDuration(StatusEffects.HurricaneDance, endFunction, display);
-    }
-
     override public function calcCooldown():int {
         return 10;
     }
 
-    public function calcDuration():int {
+    override public function calcDuration():int {
         return 5;
     }
 
@@ -47,8 +36,11 @@ public class HurricaneDanceSkill extends AbstractSoulSkill {
     override public function doEffect(display:Boolean = true):void {
 		if (display)
 			outputText("Your movement becomes more fluid and precise, increasing your speed and evasion.\n\n");
-		
-		player.createStatusEffect(StatusEffects.HurricaneDance, calcDuration(), 0, 0, 0);
+		setDuration();
+    }
+
+    override public function durationEnd(display:Boolean = true):void {
+        if (display) outputText("<b>Hurricane Dance effect wore off!</b>\n\n");
     }
 }
 }

--- a/classes/classes/Scenes/Combat/Soulskills/PunishingKickSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/PunishingKickSkill.as
@@ -43,7 +43,7 @@ public class PunishingKickSkill extends AbstractSoulSkill {
         return 10;
     }
 
-	public function calcDuration():int {
+	override public function calcDuration():int {
         return 5;
     }
 

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectAirSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectAirSkill.as
@@ -26,6 +26,10 @@ public class EAspectAirSkill extends AbstractMagicSpecial {
         return elementalAspectBaseDuration(StatusEffects.SummonedElementalsAir) + combat.magic.perkRelatedDurationBoosting();
     }
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsAir) * costMultiplier();
+    }
+
     private function costMultiplier():Number {
 		var spellMightMultiplier:Number = 1;
 		if (player.hasPerk(PerkLib.EverLastingBuffs)) spellMightMultiplier *= 2;

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectAirSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectAirSkill.as
@@ -3,6 +3,7 @@ package classes.Scenes.Combat.SpecialsMagic {
 import classes.Scenes.Combat.AbstractMagicSpecial;
 import classes.StatusEffects;
 import classes.Monster;
+import classes.PerkLib;
 
 public class EAspectAirSkill extends AbstractMagicSpecial {
     public function EAspectAirSkill() {
@@ -22,20 +23,15 @@ public class EAspectAirSkill extends AbstractMagicSpecial {
     }
 
     override public function calcDuration():int {
-        var duration:int = 1;
-        if (player.inte >= 20) duration += 1;
-		if (player.inte >= 40) duration += 1;
-		if (player.inte >= 60) duration += 1;
-		if (player.inte >= 80) duration += 1;
-		if (player.inte >= 100) duration += Math.round((player.inte - 50) / 50);
-
-		if (player.wis >= 20) duration += 1;
-		if (player.wis >= 40) duration += 1;
-		if (player.wis >= 60) duration += 1;
-		if (player.wis >= 80) duration += 1;
-		if (player.wis >= 100) duration += Math.round((player.wis - 50) / 50);
-        return elementalAspectBaseDuration(StatusEffects.SummonedElementalsAir, duration) * 2;
+        return elementalAspectBaseDuration(StatusEffects.SummonedElementalsAir) + combat.magic.perkRelatedDurationBoosting();
     }
+
+    private function costMultiplier():Number {
+		var spellMightMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.EverLastingBuffs)) spellMightMultiplier *= 2;
+		if (player.hasPerk(PerkLib.EternalyLastingBuffs)) spellMightMultiplier *= 2;
+		return spellMightMultiplier;
+	}
 
     override public function get buttonName():String {
 		return "Air E.Asp";
@@ -45,12 +41,7 @@ public class EAspectAirSkill extends AbstractMagicSpecial {
 		return "Blocks certain projectile attacks for " + calcDuration() + " rounds";
     }
 
-    /*override public function isActive():Boolean {
-        return player.hasStatusEffect(StatusEffects.WindWall);
-    }*/
-
     override public function doEffect(display:Boolean = true):void {
-        //player.createStatusEffect(StatusEffects.WindWall, 0, duration, 0, 0);
 		if (display) outputText("You call on your elemental projecting a air wall between you and [themonster] to deflect incoming projectiles.\n\n");
         setDuration();
     }

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectAirSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectAirSkill.as
@@ -1,0 +1,62 @@
+package classes.Scenes.Combat.SpecialsMagic {
+
+import classes.Scenes.Combat.AbstractMagicSpecial;
+import classes.StatusEffects;
+import classes.Monster;
+
+public class EAspectAirSkill extends AbstractMagicSpecial {
+    public function EAspectAirSkill() {
+        super (
+            "Elemental Aspect: Air",
+            "Creates a Wind Wall that deflects incoming projectiles for a few turns. Each attack blocked lowers duration by one round",
+            TARGET_SELF,
+            TIMING_LASTING,
+            [TAG_BUFF, TAG_WIND, TAG_TIER2],
+            StatusEffects.SummonedElementalsAir
+        )
+        
+    }
+
+    override public function calcCooldown():int {
+        return -1;
+    }
+
+    override public function calcDuration():int {
+        var duration:int = 1;
+        if (player.inte >= 20) duration += 1;
+		if (player.inte >= 40) duration += 1;
+		if (player.inte >= 60) duration += 1;
+		if (player.inte >= 80) duration += 1;
+		if (player.inte >= 100) duration += Math.round((player.inte - 50) / 50);
+
+		if (player.wis >= 20) duration += 1;
+		if (player.wis >= 40) duration += 1;
+		if (player.wis >= 60) duration += 1;
+		if (player.wis >= 80) duration += 1;
+		if (player.wis >= 100) duration += Math.round((player.wis - 50) / 50);
+        return elementalAspectBaseDuration(StatusEffects.SummonedElementalsAir, duration) * 2;
+    }
+
+    override public function get buttonName():String {
+		return "Air E.Asp";
+	}
+
+    override public function describeEffectVs(target:Monster):String {
+		return "Blocks certain projectile attacks for " + calcDuration() + " rounds";
+    }
+
+    /*override public function isActive():Boolean {
+        return player.hasStatusEffect(StatusEffects.WindWall);
+    }*/
+
+    override public function doEffect(display:Boolean = true):void {
+        //player.createStatusEffect(StatusEffects.WindWall, 0, duration, 0, 0);
+		if (display) outputText("You call on your elemental projecting a air wall between you and [themonster] to deflect incoming projectiles.\n\n");
+        setDuration();
+    }
+
+    override public function durationEnd(display:Boolean = true):void {
+        if (display) outputText("<b>Wind Wall effect wore off!</b>\n\n");
+    }
+}
+}  

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectCorruptionSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectCorruptionSkill.as
@@ -6,15 +6,15 @@ import classes.Monster;
 import classes.PerkLib;
 import classes.Scenes.Combat.Combat;
 
-public class EAspectFireSkill extends AbstractMagicSpecial {
-    public function EAspectFireSkill() {
+public class EAspectCorruptionSkill extends AbstractMagicSpecial {
+    public function EAspectCorruptionSkill() {
         super (
-            "Elemental Aspect: Fire",
-            "Attack with a stronger version of a fire-attributed basic elemental attack",
+            "Elemental Aspect: Corruption",
+            "Attack with a stronger version of a corruption-attributed basic elemental attack. Damage is increased the more pure the enemy.",
             TARGET_ENEMY,
             TIMING_INSTANT,
-            [TAG_DAMAGING, TAG_FIRE, TAG_MAGICAL, TAG_TIER2],
-            StatusEffects.SummonedElementalsFire
+            [TAG_DAMAGING, TAG_MAGICAL, TAG_TIER2],
+            StatusEffects.SummonedElementalsCorruption
         )
         this.lastAttackType = Combat.LAST_ATTACK_SPELL;
     }
@@ -24,17 +24,17 @@ public class EAspectFireSkill extends AbstractMagicSpecial {
     }
 
     override public function get buttonName():String {
-		return "Fire E.Asp";
+		return "Corruption E.Asp";
 	}
 
     override public function describeEffectVs(target:Monster):String {
-		return "~" + numberFormat(calcDamage(monster)) + " fire damage ";
+		return "~" + numberFormat(calcDamage(monster)) + " magical damage";
     }
 
     public function calcDamage(monster:Monster):Number {
-        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsFire);
-        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsFire, damage);
-        damage = calcInfernoMod(damage, true);
+        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsCorruption);
+        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsCorruption, damage);
+        if (monster) damage *= combat.corruptionScalingDA();
 
         return damage;
     }
@@ -54,8 +54,8 @@ public class EAspectFireSkill extends AbstractMagicSpecial {
 
         damage = Math.round(damage);
 
-        if (display) outputText("Your fire elemental douses your opponent with a torrent of fire ");
-		doFireDamage(damage, true, display);
+        if (display) outputText("Your corruption elemental condenses corruption from air into solid matter, striking your opponent with them ");
+		doMagicDamage(damage, true, display);
 		if (crit && display) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
     }

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectCorruptionSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectCorruptionSkill.as
@@ -31,6 +31,10 @@ public class EAspectCorruptionSkill extends AbstractMagicSpecial {
 		return "~" + numberFormat(calcDamage(monster)) + " magical damage";
     }
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsCorruption);
+    }
+
     public function calcDamage(monster:Monster):Number {
         var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsCorruption);
         damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsCorruption, damage);

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectDarknessSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectDarknessSkill.as
@@ -6,15 +6,15 @@ import classes.Monster;
 import classes.PerkLib;
 import classes.Scenes.Combat.Combat;
 
-public class EAspectFireSkill extends AbstractMagicSpecial {
-    public function EAspectFireSkill() {
+public class EAspectDarknessSkill extends AbstractMagicSpecial {
+    public function EAspectDarknessSkill() {
         super (
-            "Elemental Aspect: Fire",
-            "Attack with a stronger version of a fire-attributed basic elemental attack",
+            "Elemental Aspect: Darkness",
+            "Attack with a stronger version of a darkness-attributed basic elemental attack",
             TARGET_ENEMY,
             TIMING_INSTANT,
-            [TAG_DAMAGING, TAG_FIRE, TAG_MAGICAL, TAG_TIER2],
-            StatusEffects.SummonedElementalsFire
+            [TAG_DAMAGING, TAG_DARKNESS, TAG_MAGICAL, TAG_TIER2],
+            StatusEffects.SummonedElementalsDarkness
         )
         this.lastAttackType = Combat.LAST_ATTACK_SPELL;
     }
@@ -24,17 +24,17 @@ public class EAspectFireSkill extends AbstractMagicSpecial {
     }
 
     override public function get buttonName():String {
-		return "Fire E.Asp";
+		return "Darkness E.Asp";
 	}
 
     override public function describeEffectVs(target:Monster):String {
-		return "~" + numberFormat(calcDamage(monster)) + " fire damage ";
+		return "~" + numberFormat(calcDamage(monster)) + " darkness damage";
     }
 
     public function calcDamage(monster:Monster):Number {
-        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsFire);
-        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsFire, damage);
-        damage = calcInfernoMod(damage, true);
+        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsDarkness);
+        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsDarkness, damage);
+        damage = calcEclypseMod(damage, true);
 
         return damage;
     }
@@ -54,8 +54,8 @@ public class EAspectFireSkill extends AbstractMagicSpecial {
 
         damage = Math.round(damage);
 
-        if (display) outputText("Your fire elemental douses your opponent with a torrent of fire ");
-		doFireDamage(damage, true, display);
+        if (display) outputText("Your darkness elemental condenses shadows into solid matter, striking your opponent with them ");
+		doDarknessDamage(damage, true, display);
 		if (crit && display) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
     }

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectDarknessSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectDarknessSkill.as
@@ -31,6 +31,10 @@ public class EAspectDarknessSkill extends AbstractMagicSpecial {
 		return "~" + numberFormat(calcDamage(monster)) + " darkness damage";
     }
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsDarkness);
+    }
+
     public function calcDamage(monster:Monster):Number {
         var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsDarkness);
         damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsDarkness, damage);

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectEarthSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectEarthSkill.as
@@ -37,6 +37,10 @@ public class EAspectEarthSkill extends AbstractMagicSpecial {
 		return spellMightMultiplier;
 	}
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsCorruption) * costMultiplier();
+    }
+
     override public function describeEffectVs(target:Monster):String {
 		return "Increases physical and magical resistance by " + numberFormat(getBonus()) + " for " + calcDuration() + " rounds";
     }

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectEarthSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectEarthSkill.as
@@ -1,0 +1,64 @@
+package classes.Scenes.Combat.SpecialsMagic {
+
+import classes.Scenes.Combat.AbstractMagicSpecial;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.PerkLib;
+
+public class EAspectEarthSkill extends AbstractMagicSpecial {
+    public function EAspectEarthSkill() {
+        super (
+            "Elemental Aspect: Earth",
+            "Creates an Earth armor around the player, increasing armor and magic resistance for a few turns.",
+            TARGET_SELF,
+            TIMING_LASTING,
+            [TAG_BUFF, TAG_EARTH, TAG_TIER2],
+            StatusEffects.SummonedElementalsEarth
+        )
+        
+    }
+
+    override public function calcCooldown():int {
+        return -1;
+    }
+
+    override public function calcDuration():int {
+        return elementalAspectBaseDuration(StatusEffects.SummonedElementalsEarth) + combat.magic.perkRelatedDurationBoosting();
+    }
+
+    override public function get buttonName():String {
+		return "Earth E.Asp";
+	}
+
+    private function costMultiplier():Number {
+		var spellMightMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.EverLastingBuffs)) spellMightMultiplier *= 2;
+		if (player.hasPerk(PerkLib.EternalyLastingBuffs)) spellMightMultiplier *= 2;
+		return spellMightMultiplier;
+	}
+
+    override public function describeEffectVs(target:Monster):String {
+		return "Increases physical and magical resistance by " + numberFormat(getBonus()) + " for " + calcDuration() + " rounds";
+    }
+
+    /**
+     * Returns the bonus of this ability grants to physical and magical resistance
+     * @return stoneskinbonus (Number) - ability defense bonus
+     */
+    public function getBonus():Number {
+        var stoneskinbonus:Number = 0;
+		stoneskinbonus += player.inte * 0.5;
+		stoneskinbonus += player.wis * 0.5;
+		return Math.round(stoneskinbonus);
+    }
+
+    override public function doEffect(display:Boolean = true):void {
+		if (display) outputText("Your elemental lifts stone and dirt from the ground, encasing you in a earthen shell stronger than any armor.\n\n");
+        setDuration();
+    }
+
+    override public function durationEnd(display:Boolean = true):void {
+        if (display) outputText("<b>Stone Skin effect wore off!</b>\n\n");
+    }
+}
+}  

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectEtherSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectEtherSkill.as
@@ -31,6 +31,10 @@ public class EAspectEtherSkill extends AbstractMagicSpecial {
 		return "~" + numberFormat(calcDamage(monster)) + " magic damage";
     }
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsEther);
+    }
+
     public function calcDamage(monster:Monster):Number {
         var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsEther);
         damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsEther, damage);

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectEtherSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectEtherSkill.as
@@ -1,0 +1,72 @@
+package classes.Scenes.Combat.SpecialsMagic {
+
+import classes.Scenes.Combat.AbstractMagicSpecial;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.PerkLib;
+import classes.Scenes.Combat.Combat;
+
+public class EAspectEtherSkill extends AbstractMagicSpecial {
+    public function EAspectEtherSkill() {
+        super (
+            "Elemental Aspect: Ether",
+            "Attack with a stronger version of a ether-attributed basic elemental attack. Deals increased damage if the enemy is weak to Fire, Ice, Lightning or Darkness.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_MAGICAL, TAG_TIER2],
+            StatusEffects.SummonedElementalsEther
+        )
+        this.lastAttackType = Combat.LAST_ATTACK_SPELL;
+    }
+
+    override public function calcCooldown():int {
+        return -1;
+    }
+
+    override public function get buttonName():String {
+		return "Ether E.Asp";
+	}
+
+    override public function describeEffectVs(target:Monster):String {
+		return "~" + numberFormat(calcDamage(monster)) + " magic damage";
+    }
+
+    public function calcDamage(monster:Monster):Number {
+        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsEther);
+        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsEther, damage);
+        damage *= 0.5;
+
+        if (monster && monster.hasPerk(PerkLib.FireNature)) damage *= 5;
+		if (monster && monster.hasPerk(PerkLib.FireVulnerability)) damage *= 2;
+		if (monster && monster.hasPerk(PerkLib.IceNature)) damage *= 5;
+		if (monster && monster.hasPerk(PerkLib.IceVulnerability)) damage *= 2;
+		if (monster && monster.hasPerk(PerkLib.LightningNature)) damage *= 5;
+		if (monster && monster.hasPerk(PerkLib.LightningVulnerability)) damage *= 2;
+		if (monster && monster.hasPerk(PerkLib.DarknessNature)) damage *= 5;
+		if (monster && monster.hasPerk(PerkLib.DarknessVulnerability)) damage *= 2;
+
+        return damage;
+    }
+
+    override public function doEffect(display:Boolean = true):void {
+        var damage:Number = calcDamage(monster);
+
+        //Determine if critical hit!
+        var crit:Boolean = false;
+        var critChance:int = 5;
+        critChance += combatMagicalCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+        if (rand(100) < critChance) {
+            crit = true;
+			damage *= 1.5;
+		}
+
+        damage = Math.round(damage);
+
+        if (display) outputText("Your elemental unleash a barrage of star shaped bolts of arcane energy, blasting your opponent. ");
+		doMagicDamage(damage, true, display);
+		if (crit && display) outputText(" <b>Critical!</b>");
+		outputText("\n\n");
+    }
+}
+}  

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectFireSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectFireSkill.as
@@ -1,0 +1,63 @@
+package classes.Scenes.Combat.SpecialsMagic {
+
+import classes.Scenes.Combat.AbstractMagicSpecial;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.PerkLib;
+import classes.Scenes.Combat.Combat;
+
+public class EAspectFireSkill extends AbstractMagicSpecial {
+    public function EAspectFireSkill() {
+        super (
+            "Elemental Aspect: Fire",
+            "Attack with a stronger version of a fire-attributed basic elemental attack",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_FIRE, TAG_MAGICAL, TAG_TIER2],
+            StatusEffects.SummonedElementalsFire
+        )
+        this.lastAttackType = Combat.LAST_ATTACK_SPELL;
+    }
+
+    override public function calcCooldown():int {
+        return -1;
+    }
+
+    override public function get buttonName():String {
+		return "Fire E.Asp";
+	}
+
+    override public function describeEffectVs(target:Monster):String {
+		return "~" + Math.round(calcDamage(monster)) + " fire damage ";
+    }
+
+    public function calcDamage(monster:Monster):Number {
+        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsFire);
+        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsFire, damage);
+        damage = calcInfernoMod(damage, true);
+
+        return damage;
+    }
+
+    override public function doEffect(display:Boolean = true):void {
+        var damage:Number = calcDamage(monster);
+
+        //Determine if critical hit!
+        var crit:Boolean = false;
+        var critChance:int = 5;
+        critChance += combatMagicalCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+        if (rand(100) < critChance) {
+            crit = true;
+			damage *= 1.5;
+		}
+
+        damage = Math.round(damage);
+
+        if (display) outputText("Your fire elemental douses your opponent with a torrent of fire ");
+		doFireDamage(damage, true, display);
+		if (crit && display) outputText(" <b>Critical!</b>");
+		outputText("\n\n");
+    }
+}
+}  

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectFireSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectFireSkill.as
@@ -31,6 +31,10 @@ public class EAspectFireSkill extends AbstractMagicSpecial {
 		return "~" + numberFormat(calcDamage(monster)) + " fire damage ";
     }
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsFire);
+    }
+
     public function calcDamage(monster:Monster):Number {
         var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsFire);
         damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsFire, damage);

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectIceSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectIceSkill.as
@@ -6,15 +6,15 @@ import classes.Monster;
 import classes.PerkLib;
 import classes.Scenes.Combat.Combat;
 
-public class EAspectFireSkill extends AbstractMagicSpecial {
-    public function EAspectFireSkill() {
+public class EAspectIceSkill extends AbstractMagicSpecial {
+    public function EAspectIceSkill() {
         super (
-            "Elemental Aspect: Fire",
-            "Attack with a stronger version of a fire-attributed basic elemental attack",
+            "Elemental Aspect: Ice",
+            "Attack with a stronger version of a ice-attributed basic elemental attack.",
             TARGET_ENEMY,
             TIMING_INSTANT,
-            [TAG_DAMAGING, TAG_FIRE, TAG_MAGICAL, TAG_TIER2],
-            StatusEffects.SummonedElementalsFire
+            [TAG_DAMAGING, TAG_ICE, TAG_MAGICAL, TAG_TIER2],
+            StatusEffects.SummonedElementalsIce
         )
         this.lastAttackType = Combat.LAST_ATTACK_SPELL;
     }
@@ -24,17 +24,17 @@ public class EAspectFireSkill extends AbstractMagicSpecial {
     }
 
     override public function get buttonName():String {
-		return "Fire E.Asp";
+		return "Ice E.Asp";
 	}
 
     override public function describeEffectVs(target:Monster):String {
-		return "~" + numberFormat(calcDamage(monster)) + " fire damage ";
+		return "~" + numberFormat(calcDamage(monster)) + " ice damage";
     }
 
     public function calcDamage(monster:Monster):Number {
-        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsFire);
-        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsFire, damage);
-        damage = calcInfernoMod(damage, true);
+        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsIce);
+        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsIce, damage);
+        damage = calcGlacialMod(damage, true);
 
         return damage;
     }
@@ -54,8 +54,8 @@ public class EAspectFireSkill extends AbstractMagicSpecial {
 
         damage = Math.round(damage);
 
-        if (display) outputText("Your fire elemental douses your opponent with a torrent of fire ");
-		doFireDamage(damage, true, display);
+        if (display) outputText("Your elemental produces a ray of hyper condensed cold and aims it straight at [themonster] dealing ");
+		doIceDamage(damage, true, display);
 		if (crit && display) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
     }

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectIceSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectIceSkill.as
@@ -31,6 +31,10 @@ public class EAspectIceSkill extends AbstractMagicSpecial {
 		return "~" + numberFormat(calcDamage(monster)) + " ice damage";
     }
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsIce);
+    }
+
     public function calcDamage(monster:Monster):Number {
         var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsIce);
         damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsIce, damage);

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectLightningSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectLightningSkill.as
@@ -31,6 +31,10 @@ public class EAspectLightningSkill extends AbstractMagicSpecial {
 		return "~" + numberFormat(calcDamage(monster)) + " lightning damage";
     }
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsLightning);
+    }
+
     public function calcDamage(monster:Monster):Number {
         var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsLightning);
         damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsLightning, damage);

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectLightningSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectLightningSkill.as
@@ -6,15 +6,15 @@ import classes.Monster;
 import classes.PerkLib;
 import classes.Scenes.Combat.Combat;
 
-public class EAspectFireSkill extends AbstractMagicSpecial {
-    public function EAspectFireSkill() {
+public class EAspectLightningSkill extends AbstractMagicSpecial {
+    public function EAspectLightningSkill() {
         super (
-            "Elemental Aspect: Fire",
-            "Attack with a stronger version of a fire-attributed basic elemental attack",
+            "Elemental Aspect: Lightning",
+            "Attack with a stronger version of a lightning-attributed basic elemental attack.",
             TARGET_ENEMY,
             TIMING_INSTANT,
-            [TAG_DAMAGING, TAG_FIRE, TAG_MAGICAL, TAG_TIER2],
-            StatusEffects.SummonedElementalsFire
+            [TAG_DAMAGING, TAG_LIGHTNING, TAG_MAGICAL, TAG_TIER2],
+            StatusEffects.SummonedElementalsLightning
         )
         this.lastAttackType = Combat.LAST_ATTACK_SPELL;
     }
@@ -24,17 +24,17 @@ public class EAspectFireSkill extends AbstractMagicSpecial {
     }
 
     override public function get buttonName():String {
-		return "Fire E.Asp";
+		return "Lightning E.Asp";
 	}
 
     override public function describeEffectVs(target:Monster):String {
-		return "~" + numberFormat(calcDamage(monster)) + " fire damage ";
+		return "~" + numberFormat(calcDamage(monster)) + " lightning damage";
     }
 
     public function calcDamage(monster:Monster):Number {
-        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsFire);
-        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsFire, damage);
-        damage = calcInfernoMod(damage, true);
+        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsLightning);
+        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsLightning, damage);
+        damage = calcVoltageMod(damage, true);
 
         return damage;
     }
@@ -54,8 +54,8 @@ public class EAspectFireSkill extends AbstractMagicSpecial {
 
         damage = Math.round(damage);
 
-        if (display) outputText("Your fire elemental douses your opponent with a torrent of fire ");
-		doFireDamage(damage, true, display);
+        if (display) outputText("Your elemental charges electricity, then discharges it with a blinding bolt doing ");
+		doLightingDamage(damage, true, display);
 		if (crit && display) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
     }

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectMetalSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectMetalSkill.as
@@ -1,0 +1,64 @@
+package classes.Scenes.Combat.SpecialsMagic {
+
+import classes.Scenes.Combat.AbstractMagicSpecial;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.PerkLib;
+
+public class EAspectMetalSkill extends AbstractMagicSpecial {
+    public function EAspectMetalSkill() {
+        super (
+            "Elemental Aspect: Metal",
+            "Increases the player's unarmed damage for a few turns.",
+            TARGET_SELF,
+            TIMING_LASTING,
+            [TAG_BUFF, TAG_TIER2],
+            StatusEffects.SummonedElementalsMetal
+        )
+        
+    }
+
+    override public function calcCooldown():int {
+        return -1;
+    }
+
+    override public function calcDuration():int {
+        return elementalAspectBaseDuration(StatusEffects.SummonedElementalsMetal) + combat.magic.perkRelatedDurationBoosting();
+    }
+
+    override public function get buttonName():String {
+		return "Metal E.Asp";
+	}
+
+    private function costMultiplier():Number {
+		var spellMightMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.EverLastingBuffs)) spellMightMultiplier *= 2;
+		if (player.hasPerk(PerkLib.EternalyLastingBuffs)) spellMightMultiplier *= 2;
+		return spellMightMultiplier;
+	}
+
+    override public function describeEffectVs(target:Monster):String {
+		return "Increases unarmed damage by " + numberFormat(getBonus()) + " for " + calcDuration() + " rounds";
+    }
+
+    /**
+     * Returns the bonus of this ability grants to physical and magical resistance
+     * @return stoneskinbonus (Number) - ability defense bonus
+     */
+    public function getBonus():Number {
+        var metalskinbonus:Number = 0;
+		metalskinbonus += player.inte * 0.5;
+		metalskinbonus += player.wis * 0.5;
+		return Math.round(metalskinbonus);
+    }
+
+    override public function doEffect(display:Boolean = true):void {
+		if (display) outputText("Your elemental encases your body into a layer of flexible yet solid steel. The metal gives strength to your frame, empowering your unarmed strikes.\n\n");
+        setDuration();
+    }
+
+    override public function durationEnd(display:Boolean = true):void {
+        if (display) outputText("<b>Metal Skin effect wore off!</b>\n\n");
+    }
+}
+}  

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectMetalSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectMetalSkill.as
@@ -46,14 +46,14 @@ public class EAspectMetalSkill extends AbstractMagicSpecial {
     }
 
     /**
-     * Returns the bonus of this ability grants to physical and magical resistance
-     * @return stoneskinbonus (Number) - ability defense bonus
+     * Returns the bonus of this ability grants to unarmed attack
+     * @return unarmedBonus (Number) - unarmed attack bonus
      */
     public function getBonus():Number {
-        var metalskinbonus:Number = 0;
-		metalskinbonus += player.inte * 0.5;
-		metalskinbonus += player.wis * 0.5;
-		return Math.round(metalskinbonus);
+    if (player.statusEffectv2(StatusEffects.SummonedElementalsMetal) >= 6) 
+        return 6 * player.statusEffectv2(StatusEffects.SummonedElementalsMetal) * (1 + player.newGamePlusMod());
+    else 
+        return 4 * player.statusEffectv2(StatusEffects.SummonedElementalsMetal) * (1 + player.newGamePlusMod());
     }
 
     override public function doEffect(display:Boolean = true):void {

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectMetalSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectMetalSkill.as
@@ -37,6 +37,10 @@ public class EAspectMetalSkill extends AbstractMagicSpecial {
 		return spellMightMultiplier;
 	}
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsMetal) * costMultiplier();
+    }
+
     override public function describeEffectVs(target:Monster):String {
 		return "Increases unarmed damage by " + numberFormat(getBonus()) + " for " + calcDuration() + " rounds";
     }

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectPoisonSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectPoisonSkill.as
@@ -1,0 +1,74 @@
+package classes.Scenes.Combat.SpecialsMagic {
+
+import classes.Scenes.Combat.AbstractMagicSpecial;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.PerkLib;
+import classes.Scenes.Combat.Combat;
+
+public class EAspectPoisonSkill extends AbstractMagicSpecial {
+    public function EAspectPoisonSkill() {
+        super (
+            "Elemental Aspect: Poison",
+            "Attack with a stronger version of a poison-attributed basic elemental attack.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_DAMAGING, TAG_LUSTDMG, TAG_MAGICAL, TAG_TIER2],
+            StatusEffects.SummonedElementalsPoison
+        )
+        this.lastAttackType = Combat.LAST_ATTACK_SPELL;
+    }
+
+    override public function calcCooldown():int {
+        return -1;
+    }
+
+    override public function get buttonName():String {
+		return "Poison E.Asp";
+	}
+
+    override public function describeEffectVs(target:Monster):String {
+		return "~" + numberFormat(calcDamage(monster)) + " poison damage and ~" + numberFormat(calcLustDamage(monster)) + " lust damage";
+    }
+
+    public function calcDamage(monster:Monster):Number {
+        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsPoison);
+        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsPoison, damage);
+
+        return damage;
+    }
+
+    public function calcLustDamage(monster:Monster):Number {
+        var lustDamage:Number = calcDamage(monster) * 0.75;
+
+        if (player.armor == armors.ELFDRES && player.isElf()) lustDamage *= 2;
+        if (player.armor == armors.FMDRESS && player.isWoodElf()) lustDamage *= 2;
+
+        return lustDamage;
+    }
+
+    override public function doEffect(display:Boolean = true):void {
+        var damage:Number = calcDamage(monster);
+
+        //Determine if critical hit!
+        var crit:Boolean = false;
+        var critChance:int = 5;
+        critChance += combatMagicalCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+        if (rand(100) < critChance) {
+            crit = true;
+			damage *= 1.5;
+		}
+
+        damage = Math.round(damage);
+
+        if (display) outputText("Your poison elemental condenses aphrodisiac poison into spikes, striking your opponent with them ");
+		doPoisonDamage(damage, true, display);
+		if (crit && display) outputText(" <b>Critical!</b>");
+
+        var lustDamage:Number = calcLustDamage(monster);
+        monster.teased(Math.round(monster.lustVuln * lustDamage));
+		outputText("\n\n");
+    }
+}
+}  

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectPoisonSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectPoisonSkill.as
@@ -31,6 +31,10 @@ public class EAspectPoisonSkill extends AbstractMagicSpecial {
 		return "~" + numberFormat(calcDamage(monster)) + " poison damage and ~" + numberFormat(calcLustDamage(monster)) + " lust damage";
     }
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsPoison);
+    }
+
     public function calcDamage(monster:Monster):Number {
         var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsPoison);
         damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsPoison, damage);

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectPuritySkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectPuritySkill.as
@@ -39,6 +39,10 @@ public class EAspectPuritySkill extends AbstractMagicSpecial {
         return damage;
     }
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsPurity);
+    }
+
     override public function doEffect(display:Boolean = true):void {
         var damage:Number = calcDamage(monster);
 

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectPuritySkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectPuritySkill.as
@@ -6,15 +6,15 @@ import classes.Monster;
 import classes.PerkLib;
 import classes.Scenes.Combat.Combat;
 
-public class EAspectFireSkill extends AbstractMagicSpecial {
-    public function EAspectFireSkill() {
+public class EAspectPuritySkill extends AbstractMagicSpecial {
+    public function EAspectPuritySkill() {
         super (
-            "Elemental Aspect: Fire",
-            "Attack with a stronger version of a fire-attributed basic elemental attack",
+            "Elemental Aspect: Purity",
+            "Attack with a stronger version of a purity-attributed basic elemental attack. Damage is increased the more corrupt the enemy.",
             TARGET_ENEMY,
             TIMING_INSTANT,
-            [TAG_DAMAGING, TAG_FIRE, TAG_MAGICAL, TAG_TIER2],
-            StatusEffects.SummonedElementalsFire
+            [TAG_DAMAGING, TAG_MAGICAL, TAG_TIER2],
+            StatusEffects.SummonedElementalsPurity
         )
         this.lastAttackType = Combat.LAST_ATTACK_SPELL;
     }
@@ -24,17 +24,17 @@ public class EAspectFireSkill extends AbstractMagicSpecial {
     }
 
     override public function get buttonName():String {
-		return "Fire E.Asp";
+		return "Purity E.Asp";
 	}
 
     override public function describeEffectVs(target:Monster):String {
-		return "~" + numberFormat(calcDamage(monster)) + " fire damage ";
+		return "~" + numberFormat(calcDamage(monster)) + " magical damage";
     }
 
     public function calcDamage(monster:Monster):Number {
-        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsFire);
-        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsFire, damage);
-        damage = calcInfernoMod(damage, true);
+        var damage:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsPurity);
+        damage = elementalAspectDamageMod(StatusEffects.SummonedElementalsPurity, damage);
+        if (monster) damage *= combat.purityScalingDA();
 
         return damage;
     }
@@ -54,8 +54,8 @@ public class EAspectFireSkill extends AbstractMagicSpecial {
 
         damage = Math.round(damage);
 
-        if (display) outputText("Your fire elemental douses your opponent with a torrent of fire ");
-		doFireDamage(damage, true, display);
+        if (display) outputText("Your purity elemental produces a ray of hyper condensed and pure light and aims it straight at [themonster] ");
+		doMagicDamage(damage, true, display);
 		if (crit && display) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
     }

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectWaterSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectWaterSkill.as
@@ -1,0 +1,57 @@
+package classes.Scenes.Combat.SpecialsMagic {
+
+import classes.Scenes.Combat.AbstractMagicSpecial;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.PerkLib;
+import classes.Scenes.Combat.Combat;
+
+public class EAspectWaterSkill extends AbstractMagicSpecial {
+    public function EAspectWaterSkill() {
+        super (
+            "Elemental Aspect: Water",
+            "Restores the user's HP.",
+            TARGET_SELF,
+            TIMING_INSTANT,
+            [TAG_HEALING, TAG_WATER, TAG_TIER2],
+            StatusEffects.SummonedElementalsWater
+        )
+    }
+
+    override public function calcCooldown():int {
+        return -1;
+    }
+
+    override public function get buttonName():String {
+		return "Water E.Asp";
+	}
+
+    override public function describeEffectVs(target:Monster):String {
+		return "Heals the player for ~" + numberFormat(calcDamage(monster)) + " HP";
+    }
+
+    public function calcDamage(monster:Monster):Number {
+        var amountToHeal:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsWater);
+
+        if (player.hasPerk(PerkLib.WisenedHealer)) amountToHeal += scalingBonusWisdom();
+        if (player.armor == armors.NURSECL) amountToHeal *= 1.2;
+		if (player.weapon == weapons.U_STAFF) amountToHeal *= 1.5;
+		if (player.weapon == weapons.ECLIPSE) amountToHeal *= 0.5;
+		if (player.weapon == weapons.OCCULUS) amountToHeal *= 1.5;
+		if (player.hasPerk(PerkLib.CloseToDeath) && player.HP < (player.maxHP() * 0.25)) {
+			if (player.hasPerk(PerkLib.CheatDeath) && player.HP < (player.maxHP() * 0.1)) amountToHeal *= 2.5;
+			else amountToHeal *= 1.5;
+		}
+
+        return amountToHeal;
+    }
+
+    override public function doEffect(display:Boolean = true):void {
+        var amountToHeal:Number = Math.round(calcDamage(monster));
+
+        if (display) outputText("Your elemental encases your body within a bubble of curative spring water, slowly closing your wounds. The bubbles pop leaving you wet, but on the way to full recovery. <b>([font-heal]+" + numberFormat(amountToHeal) + "</font>)</b>");
+		HPChange(amountToHeal,false);
+		if (display) outputText("\n\n");        
+    }
+}
+}  

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectWaterSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectWaterSkill.as
@@ -30,6 +30,10 @@ public class EAspectWaterSkill extends AbstractMagicSpecial {
 		return "Heals the player for ~" + numberFormat(calcDamage(monster)) + " HP";
     }
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsWater);
+    }
+
     public function calcDamage(monster:Monster):Number {
         var amountToHeal:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsWater);
 

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectWoodSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectWoodSkill.as
@@ -52,6 +52,10 @@ public class EAspectWoodSkill extends AbstractMagicSpecial {
 		return Math.round(barkskinbonus);
     }
 
+    override public function manaCost():Number {
+        return elementalAspectManaCost(StatusEffects.SummonedElementalsWood) * costMultiplier();
+    }
+
     public function calcDamage(monster:Monster):Number {
         var amountToHeal:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsWood, 0, true);
 

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectWoodSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectWoodSkill.as
@@ -1,0 +1,83 @@
+package classes.Scenes.Combat.SpecialsMagic {
+
+import classes.Scenes.Combat.AbstractMagicSpecial;
+import classes.StatusEffects;
+import classes.Monster;
+import classes.PerkLib;
+
+public class EAspectWoodSkill extends AbstractMagicSpecial {
+    public function EAspectWoodSkill() {
+        super (
+            "Elemental Aspect: Wood",
+            "Heals the player by a minor amount. Grants a minor increase to armor / magic resistance for a few turns.",
+            TARGET_SELF,
+            TIMING_LASTING,
+            [TAG_BUFF, TAG_TIER2],
+            StatusEffects.SummonedElementalsWood
+        )
+        
+    }
+
+    override public function calcCooldown():int {
+        return -1;
+    }
+
+    override public function calcDuration():int {
+        return elementalAspectBaseDuration(StatusEffects.SummonedElementalsWood) + combat.magic.perkRelatedDurationBoosting();
+    }
+
+    override public function get buttonName():String {
+		return "Wood E.Asp";
+	}
+
+    private function costMultiplier():Number {
+		var spellMightMultiplier:Number = 1;
+		if (player.hasPerk(PerkLib.EverLastingBuffs)) spellMightMultiplier *= 2;
+		if (player.hasPerk(PerkLib.EternalyLastingBuffs)) spellMightMultiplier *= 2;
+		return spellMightMultiplier;
+	}
+
+    override public function describeEffectVs(target:Monster):String {
+		return "Increases physical and magical resistance by " + numberFormat(getBonus()) + " for " + calcDuration() + " rounds. Heals the player for " + numberFormat(calcDamage(monster)) + " HP.";
+    }
+
+    /**
+     * Returns the bonus of this ability grants to physical and magical resistance
+     * @return stoneskinbonus (Number) - ability defense bonus
+     */
+    public function getBonus():Number {
+        var barkskinbonus:Number = 0;
+		barkskinbonus += player.inte * 0.25;
+		barkskinbonus += player.wis * 0.25;
+		return Math.round(barkskinbonus);
+    }
+
+    public function calcDamage(monster:Monster):Number {
+        var amountToHeal:Number = elementalAspectBaseDamage(StatusEffects.SummonedElementalsWood, 0, true);
+
+        if (player.hasPerk(PerkLib.WisenedHealer)) amountToHeal += (scalingBonusWisdom() / 2);
+        if (player.armor == armors.NURSECL) amountToHeal *= 1.2;
+		if (player.weapon == weapons.U_STAFF) amountToHeal *= 1.5;
+		if (player.weapon == weapons.ECLIPSE) amountToHeal *= 0.5;
+		if (player.weapon == weapons.OCCULUS) amountToHeal *= 1.5;
+		if (player.hasPerk(PerkLib.CloseToDeath) && player.HP < (player.maxHP() * 0.25)) {
+			if (player.hasPerk(PerkLib.CheatDeath) && player.HP < (player.maxHP() * 0.1)) amountToHeal *= 2.5;
+			else amountToHeal *= 1.5;
+		}
+
+        return amountToHeal;
+    }
+
+    override public function doEffect(display:Boolean = true):void {
+        var amountToHeal:Number = Math.round(calcDamage(monster));
+        if (display) outputText("Your elemental temporarily covers your skin with bark, shielding you against strikes. This is the bark of medicinal plants and as such you recover from your injuries. <b>([font-heal]+" + numberFormat(amountToHeal) + "</font>)</b>");
+		HPChange(amountToHeal,false);
+		if (display) outputText("\n\n");   
+        setDuration();
+    }
+
+    override public function durationEnd(display:Boolean = true):void {
+        if (display) outputText("<b>Bark Skin effect wore off!</b>\n\n");
+    }
+}
+}  

--- a/classes/classes/Scenes/Combat/SpellsBlack/BlinkSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsBlack/BlinkSpell.as
@@ -70,7 +70,7 @@ public class BlinkSpell extends AbstractBlackSpell {
 		return Math.round(BlinkBoost);
 	}
 	
-	public function calcDuration():Number {
+	override public function calcDuration():int {
 		var BlinkDuration:Number = 5;
 		BlinkDuration += combat.magic.perkRelatedDurationBoosting();
 		return BlinkDuration;

--- a/classes/classes/Scenes/Combat/SpellsBlack/MightSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsBlack/MightSpell.as
@@ -75,7 +75,7 @@ public class MightSpell extends AbstractBlackSpell {
 		return Math.round(MightBoost);
 	}
 	
-	public function calcDuration():Number {
+	override public function calcDuration():int {
 		var MightDuration:Number = 5;
 		MightDuration += combat.magic.perkRelatedDurationBoosting();
 		return MightDuration;

--- a/classes/classes/Scenes/Combat/SpellsBlack/RegenerateSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsBlack/RegenerateSpell.as
@@ -47,7 +47,7 @@ public class RegenerateSpell extends AbstractBlackSpell {
 		return Math.round(hpChange2);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		return 7;
 	}
 	

--- a/classes/classes/Scenes/Combat/SpellsBlood/BloodChainsSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsBlood/BloodChainsSpell.as
@@ -35,7 +35,7 @@ public class BloodChainsSpell extends AbstractBloodSpell {
 		return calcC;
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		var calcD:int = 2;
 		if (player.hasPerk(PerkLib.BloodDemonIntelligence)) calcD *= 2;
 		return calcD;

--- a/classes/classes/Scenes/Combat/SpellsBlood/BloodFieldSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsBlood/BloodFieldSpell.as
@@ -29,7 +29,7 @@ public class BloodFieldSpell extends AbstractBloodSpell {
 		return player.hasStatusEffect(StatusEffects.BloodField);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		var calcD:int = 3;
 		if (player.hasPerk(PerkLib.BloodDemonIntelligence)) calcD *= 2;
 		return calcD;

--- a/classes/classes/Scenes/Combat/SpellsBlood/LifestealEnchantmentSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsBlood/LifestealEnchantmentSpell.as
@@ -33,7 +33,7 @@ public class LifestealEnchantmentSpell extends AbstractBloodSpell {
 		return player.hasStatusEffect(StatusEffects.LifestealEnchantment);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		var calcD:int = 2;
 		calcD += (3 - spellGenericCooldown());
 		if (player.hasPerk(PerkLib.BloodDemonIntelligence)) calcD *= 2;

--- a/classes/classes/Scenes/Combat/SpellsDivine/AegisSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsDivine/AegisSpell.as
@@ -29,7 +29,7 @@ public class AegisSpell extends AbstractDivineSpell {
 		return player.hasStatusEffect(StatusEffects.Aegis);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		var AegisDuration:int = 6;
 		AegisDuration += combat.magic.perkRelatedDurationBoosting();
 		return AegisDuration;

--- a/classes/classes/Scenes/Combat/SpellsDivine/DivineShieldSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsDivine/DivineShieldSpell.as
@@ -27,7 +27,7 @@ public class DivineShieldSpell extends AbstractDivineSpell {
 		return player.hasStatusEffect(StatusEffects.DivineShield);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		var duration:Number = 6;
 		duration += combat.magic.perkRelatedDurationBoosting();
 		return duration;

--- a/classes/classes/Scenes/Combat/SpellsDivine/ThunderstormSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsDivine/ThunderstormSpell.as
@@ -36,7 +36,7 @@ public class ThunderstormSpell extends AbstractDivineSpell {
 		return super.usabilityCheck();
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		return 30;
 	}
 	

--- a/classes/classes/Scenes/Combat/SpellsGreen/EntangleSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/EntangleSpell.as
@@ -49,7 +49,7 @@ public class EntangleSpell extends AbstractGreenSpell {
 		return player.statusEffectv1(StatusEffects.Entangled) > 0;
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		var dura:Number = 6;
 		if (player.hasPerk(PerkLib.GreenMagic)) dura *= 2;
 		return dura;

--- a/classes/classes/Scenes/Combat/SpellsGreen/PlantGrowthSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/PlantGrowthSpell.as
@@ -45,7 +45,7 @@ public class PlantGrowthSpell extends AbstractGreenSpell {
 		return adjustLustDamage(baseDamage, monster, CAT_SPELL_GREEN, randomize);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		var dura:Number = 4;
 		if (player.hasPerk(PerkLib.GreenMagic)) dura *= 2;
 		return dura;

--- a/classes/classes/Scenes/Combat/SpellsGrey/BalanceOfLifeSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGrey/BalanceOfLifeSpell.as
@@ -35,7 +35,7 @@ public class BalanceOfLifeSpell extends AbstractGreySpell {
 		return calcC;
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		var duration:Number = 4;
 		if (player.hasPerk(PerkLib.DefensiveStaffChanneling)) duration *= 1.1;
 		return Math.round(duration);

--- a/classes/classes/Scenes/Combat/SpellsGrey/EnergyDrainSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGrey/EnergyDrainSpell.as
@@ -30,7 +30,7 @@ public class EnergyDrainSpell extends AbstractGreySpell {
 		return calcC;
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		return 7;
 	}
 	

--- a/classes/classes/Scenes/Combat/SpellsGrey/RestoreSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGrey/RestoreSpell.as
@@ -36,7 +36,7 @@ public class RestoreSpell extends AbstractGreySpell {
 		return calcC;
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		return 7;
 	}
 	

--- a/classes/classes/Scenes/Combat/SpellsHex/ConsumingDarknessSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsHex/ConsumingDarknessSpell.as
@@ -38,7 +38,7 @@ public class ConsumingDarknessSpell extends AbstractHexSpell {
 		return monster.hasStatusEffect(StatusEffects.ConsumingDarkness);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		return 7;
 	}
 	

--- a/classes/classes/Scenes/Combat/SpellsHex/CurseOfDesireSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsHex/CurseOfDesireSpell.as
@@ -41,7 +41,7 @@ public class CurseOfDesireSpell extends AbstractHexSpell {
 		return monster.hasStatusEffect(StatusEffects.CurseOfDesire);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		return 8;
 	}
 	

--- a/classes/classes/Scenes/Combat/SpellsHex/CurseOfWeepingSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsHex/CurseOfWeepingSpell.as
@@ -39,7 +39,7 @@ public class CurseOfWeepingSpell extends AbstractHexSpell {
 		return monster.hasStatusEffect(StatusEffects.CurseOfWeeping);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		return 6;
 	}
 	

--- a/classes/classes/Scenes/Combat/SpellsHex/LifeSiphonSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsHex/LifeSiphonSpell.as
@@ -33,7 +33,7 @@ public class LifeSiphonSpell extends AbstractHexSpell {
 		return player.hasStatusEffect(StatusEffects.LifeSiphon);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		return 15;
 	}
 	

--- a/classes/classes/Scenes/Combat/SpellsNecro/BoneArmorSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsNecro/BoneArmorSpell.as
@@ -35,7 +35,7 @@ public class BoneArmorSpell extends AbstractNecroSpell {
 		return player.hasStatusEffect(StatusEffects.BoneArmor);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		var duration:Number = 5;
 		duration *= boneSoulBonus(demonBonesCost());
 		return Math.floor(duration);

--- a/classes/classes/Scenes/Combat/SpellsWhite/MentalShieldSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsWhite/MentalShieldSpell.as
@@ -34,7 +34,7 @@ public class MentalShieldSpell extends AbstractWhiteSpell{
 		return player.hasStatusEffect(StatusEffects.MentalShield);
 	}
 	
-	public function calcDuration():int {
+	override public function calcDuration():int {
 		var mentalshieldduration:Number = 10;
 		if (player.hasPerk(PerkLib.DefensiveStaffChanneling)) mentalshieldduration *= 1.1;
 		return Math.round(mentalshieldduration)

--- a/classes/classes/Scenes/Monsters/DarkElfs.as
+++ b/classes/classes/Scenes/Monsters/DarkElfs.as
@@ -10,6 +10,7 @@ import classes.BodyParts.Hips;
 import classes.BodyParts.LowerBody;
 import classes.GlobalFlags.kFLAGS;
 import classes.internals.*;
+import classes.Scenes.Combat.CombatAbilities;
 
 public class DarkElfs extends Monster
 	{
@@ -34,9 +35,9 @@ public class DarkElfs extends Monster
 		
 		public function PoisonedBowShoot():void
 		{
-			if (player.hasStatusEffect(StatusEffects.WindWall)) {
+			if (CombatAbilities.EAspectAir.isActive()) {
 				outputText("An arrow hits the wind wall dealing no damage to you.\n\n");
-				player.addStatusValue(StatusEffects.WindWall,2,-1);
+				CombatAbilities.EAspectAir.advance(true);
 			}
 			else {
 				var damage:Number = 0;
@@ -63,9 +64,9 @@ public class DarkElfs extends Monster
 		
 		public function WingClip():void
 		{
-			if (player.hasStatusEffect(StatusEffects.WindWall)) {
+			if (CombatAbilities.EAspectAir.isActive()) {
 				outputText("An arrow hits wind wall dealing no damage to you.\n\n");
-				player.addStatusValue(StatusEffects.WindWall,2,-1);
+				CombatAbilities.EAspectAir.advance(true);
 			}
 			else {
 				outputText("The dark elf smirks wickedly before shooting an arrow straight into your wing. You fall, unable to fly, and crash into the ground. ");

--- a/classes/classes/Scenes/Monsters/LightElfs.as
+++ b/classes/classes/Scenes/Monsters/LightElfs.as
@@ -11,6 +11,7 @@ import classes.BodyParts.LowerBody;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
+import classes.Scenes.Combat.CombatAbilities;
 
 public class LightElfs extends Monster
 	{
@@ -56,9 +57,9 @@ public class LightElfs extends Monster
 		
 		public function PoisonedBowShoot():void
 		{
-			if (player.hasStatusEffect(StatusEffects.WindWall)) {
+			if (CombatAbilities.EAspectAir.isActive()) {
 				outputText("An arrow hits the wind wall dealing no damage to you.\n\n");
-				player.addStatusValue(StatusEffects.WindWall,2,-1);
+				CombatAbilities.EAspectAir.advance(true);
 			}
 			else {
 				var damage:Number = 0;
@@ -85,9 +86,9 @@ public class LightElfs extends Monster
 		
 		public function WingClip():void
 		{
-			if (player.hasStatusEffect(StatusEffects.WindWall)) {
+			if (CombatAbilities.EAspectAir.isActive()) {
 				outputText("An arrow hits wind wall dealing no damage to you.\n\n");
-				player.addStatusValue(StatusEffects.WindWall,2,-1);
+				CombatAbilities.EAspectAir.advance(true);
 			}
 			else {
 				outputText("The light elf smirks wickedly before shooting an arrow straight into your wing. You fall, unable to fly, and crash into the ground. ");

--- a/classes/classes/Scenes/Monsters/Malikore.as
+++ b/classes/classes/Scenes/Monsters/Malikore.as
@@ -15,6 +15,7 @@ import classes.BodyParts.Wings;
 import classes.Scenes.SceneLib;
 import classes.Scenes.NPCs.BashemathFollower;
 import classes.internals.*;
+import classes.Scenes.Combat.CombatAbilities;
 
 use namespace CoC;
 
@@ -34,9 +35,9 @@ use namespace CoC;
 		public function TailSpike():void {
 			outputText("The malikore's tail curls over and shoots a spike at you. The bony spike ");
 			if (rand(100) < (this.spe - player.spe) / 2) {
-				if (player.hasStatusEffect(StatusEffects.WindWall)) {
+				if (CombatAbilities.EAspectAir.isActive()) {
 					outputText("hits wind wall doing no damage to you.");
-					player.addStatusValue(StatusEffects.WindWall,2,-1);
+					CombatAbilities.EAspectAir.advance(true);
 				}
 				else {
 					var tailspikedmg:Number = Math.round(this.str / 12);

--- a/classes/classes/Scenes/Monsters/Manticore.as
+++ b/classes/classes/Scenes/Monsters/Manticore.as
@@ -15,6 +15,7 @@ import classes.BodyParts.Wings;
 import classes.Scenes.SceneLib;
 import classes.Scenes.NPCs.EtnaFollower;
 import classes.internals.*;
+import classes.Scenes.Combat.CombatAbilities;
 
 use namespace CoC;
 
@@ -30,9 +31,9 @@ use namespace CoC;
 		public function moveTailSpike():void {
 			outputText("The manticore's tail curls over and shoots a spike at you. The bony spike ");
 			if (rand(100) < (this.spe - player.spe) / 2) {
-				if (player.hasStatusEffect(StatusEffects.WindWall)) {
+				if (CombatAbilities.EAspectAir.isActive()) {
 					outputText("hits wind wall doing no damage to you.");
-					player.addStatusValue(StatusEffects.WindWall,2,-1);
+					CombatAbilities.EAspectAir.advance(true);
 				}
 				else {
 					var tailspikedmg:Number = Math.round(this.str / 16);

--- a/classes/classes/Scenes/NPCs/Amily.as
+++ b/classes/classes/Scenes/NPCs/Amily.as
@@ -5,6 +5,7 @@ import classes.BodyParts.Butt;
 import classes.BodyParts.Hips;
 import classes.Scenes.SceneLib;
 import classes.StatusEffects.Combat.AmilyVenomDebuff;
+import classes.Scenes.Combat.CombatAbilities;
 
 /**
 	 * ...
@@ -131,9 +132,9 @@ import classes.StatusEffects.Combat.AmilyVenomDebuff;
 		//-Poison Dart: Deals speed and str damage to the PC. (Not constant)
 		private function amilyDartGo():void
 		{
-			if (player.hasStatusEffect(StatusEffects.WindWall)) {
+			if (CombatAbilities.EAspectAir.isActive()) {
 				outputText(capitalA + short + " attack from her dartgun stops at wind wall weakening it slightly.\n");
-				player.addStatusValue(StatusEffects.WindWall,2,-1);
+				CombatAbilities.EAspectAir.advance(true);
 				return;
 			}
 			//Dodged

--- a/classes/classes/Scenes/NPCs/Bashemath.as
+++ b/classes/classes/Scenes/NPCs/Bashemath.as
@@ -15,6 +15,7 @@ import classes.BodyParts.Wings;
 import classes.Scenes.SceneLib;
 import classes.Scenes.NPCs.BashemathFollower;
 import classes.internals.*;
+import classes.Scenes.Combat.CombatAbilities;
 
 use namespace CoC;
 
@@ -32,9 +33,9 @@ use namespace CoC;
 		public function TailSpike():void {
 			outputText("The malikore's tail curls over and shoots a spike at you. The bony spike ");
 			if (rand(100) < (this.spe - player.spe) / 2) {
-				if (player.hasStatusEffect(StatusEffects.WindWall)) {
+				if (CombatAbilities.EAspectAir.isActive()) {
 					outputText("hits wind wall doing no damage to you.");
-					player.addStatusValue(StatusEffects.WindWall,2,-1);
+					CombatAbilities.EAspectAir.advance(true);
 				}
 				else {
 					var tailspikedmg:Number = Math.round(this.str / 12);

--- a/classes/classes/Scenes/NPCs/Etna.as
+++ b/classes/classes/Scenes/NPCs/Etna.as
@@ -16,6 +16,7 @@ import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.SceneLib;
 import classes.Scenes.NPCs.EtnaFollower;
 import classes.internals.*;
+import classes.Scenes.Combat.CombatAbilities;
 
 use namespace CoC;
 
@@ -41,9 +42,9 @@ use namespace CoC;
 			else outputText("The manticore");
 			outputText("'s tail curls over and shoots a spike at you. The bony spike ");
 			if (rand(100) < (this.spe - player.spe) / 2) {
-				if (player.hasStatusEffect(StatusEffects.WindWall)) {
+				if (CombatAbilities.EAspectAir.isActive()) {
 					outputText("hits wind wall doing no damage to you.");
-					player.addStatusValue(StatusEffects.WindWall,2,-1);
+					CombatAbilities.EAspectAir.advance(true);
 				}
 				else {
 					var tailspikedmg:Number = Math.round(this.str / 16);

--- a/classes/classes/Scenes/NPCs/Jinx.as
+++ b/classes/classes/Scenes/NPCs/Jinx.as
@@ -8,6 +8,7 @@ import classes.*;
 import classes.BodyParts.Butt;
 import classes.BodyParts.Hips;
 import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.Combat.CombatAbilities;
 
 use namespace CoC;
 	
@@ -15,9 +16,9 @@ use namespace CoC;
 	{
 		private function jinxBaseAttack():void {
 			outputText("Ayotech maniac casually fires "+this.weaponRangeName+" at you with high skill. ");
-			if (player.hasStatusEffect(StatusEffects.WindWall)) {
+			if (CombatAbilities.EAspectAir.isActive()) {
 				outputText("That is then stopped by wind wall.");
-				player.addStatusValue(StatusEffects.WindWall,2,-1);
+				CombatAbilities.EAspectAir.advance(true);
 			}
 			else {
 				jinxBaseAttackDamage();

--- a/classes/classes/Scenes/NPCs/Jinx.as
+++ b/classes/classes/Scenes/NPCs/Jinx.as
@@ -37,9 +37,11 @@ use namespace CoC;
 			if (EngineCore.silly()) this.weaponRangeName = "Fishbones";
 			else this.weaponRangeName = "ayotech canon";
 			outputText("Ayotech maniac casually fires "+this.weaponRangeName+" at you with high skill. ");
-			if (player.hasStatusEffect(StatusEffects.WindWall)) {
+			if (CombatAbilities.EAspectAir.isActive()) {
 				outputText("Still your wind wall manages to stops it.");
-				player.addStatusValue(StatusEffects.WindWall,2,-3);
+				CombatAbilities.EAspectAir.advance(true);
+				CombatAbilities.EAspectAir.advance(true);
+				CombatAbilities.EAspectAir.advance(true);
 			}
 			else {
 				var damage:Number = 0;

--- a/classes/classes/Scenes/NPCs/Kindra.as
+++ b/classes/classes/Scenes/NPCs/Kindra.as
@@ -9,6 +9,7 @@ import classes.BodyParts.Butt;
 import classes.BodyParts.Hips;
 import classes.GlobalFlags.kFLAGS;
 import classes.internals.*;
+import classes.Scenes.Combat.CombatAbilities;
 
 use namespace CoC;
 	
@@ -80,9 +81,9 @@ use namespace CoC;
 			if (flags[kFLAGS.KINDRA_AFFECTION] < 7) outputText("Sheep-morph archer");
 			if (flags[kFLAGS.KINDRA_AFFECTION] >= 7) outputText("Kindra");
 			outputText(" casually fire an arrow at you with supreme skill.");
-			if (player.hasStatusEffect(StatusEffects.WindWall)) {
+			if (CombatAbilities.EAspectAir.isActive()) {
 				outputText(" Still surrounding you wind wall stops it without much trouble.");
-				player.addStatusValue(StatusEffects.WindWall,2,-1);
+				CombatAbilities.EAspectAir.advance(true);
 			}
 			else {
 				var damage:Number = 0;

--- a/classes/classes/Scenes/NPCs/Lily.as
+++ b/classes/classes/Scenes/NPCs/Lily.as
@@ -12,6 +12,7 @@ import classes.GlobalFlags.kFLAGS;
 import classes.Items.WeaponLib;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
+import classes.Scenes.Combat.CombatAbilities;
 
 	public class Lily extends Monster//drider cumdump slave from swamp area
 	{
@@ -93,7 +94,7 @@ import classes.internals.*;
 			while (lFB-->0) LilyFireBow();
 		}
 		public function LilyFireBow():void {
-			if (player.hasStatusEffect(StatusEffects.WindWall)) player.addStatusValue(StatusEffects.WindWall,2,-1);
+			if (CombatAbilities.EAspectAir.isActive()) CombatAbilities.EAspectAir.advance(true);
 			else damageCalc();
 		}
 		

--- a/classes/classes/Scenes/NPCs/Lily.as
+++ b/classes/classes/Scenes/NPCs/Lily.as
@@ -85,7 +85,7 @@ import classes.Scenes.Combat.CombatAbilities;
 		
 		private function lilyVolley():void {
 			outputText("Several arrows come flying at you, and you see the Drider-woman’s top half through the treeline. You gasp, disbelieving, as said arrows seem to multiply into a veritable shower of shafts, and you barely have time to crouch down, making yourself less of a target. ");
-			if (player.hasStatusEffect(StatusEffects.WindWall)) outputText("Still surrounding you wind wall stops them without much trouble. ");
+			if (CombatAbilities.EAspectAir.isActive()) outputText("Still surrounding you wind wall stops them without much trouble. ");
 			var lFB:Number = 6;
 			if (flags[kFLAGS.LILY_LVL_UP] >= 3) lFB += 3;
 			if (flags[kFLAGS.LILY_LVL_UP] >= 5) lFB += 3;

--- a/classes/classes/Scenes/Places/Farm/Kelt.as
+++ b/classes/classes/Scenes/Places/Farm/Kelt.as
@@ -7,6 +7,7 @@ import classes.BodyParts.LowerBody;
 import classes.BodyParts.Tail;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.SceneLib;
+import classes.Scenes.Combat.CombatAbilities;
 
 public class Kelt extends Monster
 	{
@@ -44,9 +45,9 @@ public class Kelt extends Monster
 				outputText("You manage to avoid the missile by the skin of your teeth!");
 				return;
 			}
-			if (player.hasStatusEffect(StatusEffects.WindWall)) {
+			if (CombatAbilities.EAspectAir.isActive()) {
 				outputText("Still his arrow hits wind wall dealing no damage to you.");
-				player.addStatusValue(StatusEffects.WindWall,2,-1);
+				CombatAbilities.EAspectAir.advance(true);
 				return;
 			}
 


### PR DESCRIPTION
Converted all Elemental Aspects to use  the CombatAbility class
Add ability to manage ability durations in the CombatAbility class
Added ability to handle once a battle/day cooldowns to CombatAbility class
Added AbstractSpecial and AbstractMagicalSpecial child classes
Can now view Magical Specials from the "stats" screen (currently only Elemental Aspects)

Adjusted Elemental Aspects;
All Damaging Aspects given similar damage bonuses to a standard epic elemental attack
All aspects given mana cost similar to an epic elemental attack
Damaging Elemental Aspect attacks can now crit

Air Aspect no longer gets additional duration from intelligence and wisdom
Air and Earth Aspects now get additional duration from Enchanter perks
Water Aspect now gains additional healing from Healer perks
Metal Aspect only raises unarmed damage, not damage resistance as well
Ether Aspects deals lower base damage, but has a higher weakness modifier to other Aspects compared to other attacks
Poison Aspect lust damage is now 75% of its magical damage, instead of minimal damage
