### PR TITLE
Magic perks

### DIFF
--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -1779,6 +1779,15 @@ public class PerkLib
 		public static const HotNCold:PerkType = mk("Hot N Cold", "Hot N Cold",
 				"You're Hot N Cold and can't cross 75% minimum lust threshold.",
 				"You've chosen the 'Hot N Cold' perk, causing your minimum lust never cross 75% threshold.");
+		public static const HowlingGale:PerkType = mk("Howling Gale", "Howling Gale",
+				"Cumulative 40% damage increase for every subsequent wind spell. Each turn without cast wind spell lower damage by 40% down to normal (100%) damage. Maximum 5 stacks.",
+				"You've chosen the 'Howling Gale' perk. Cumulative 40% damage increase for every subsequent wind spell. Each turn without cast wind spell lower damage by 40% down to normal (100%) damage. Maximum 5 stacks.");
+		public static const HowlingGaleEx:PerkType = mk("Howling Gale (Ex)", "Howling Gale (Ex)",
+				"Increase to cumulative damage by 20%. Penalty for turn without casted wind spell decreased by 10%. Maximum 15 stacks.",
+				"You've chosen the 'Howling Gale (Ex)' perk. Increase to cumulative damage by 20%. Penalty for turn without casted wind spell decreased by 10%. Maximum 15 stacks.");
+		public static const HowlingGaleSu:PerkType = mk("Howling Gale (Su)", "Howling Gale (Su)",
+				"Prevent decay of cumulative damage increase bonus when channeling wind based attack. Penalty for turn without casted wind spell decreased by another 10%. Maximum 75 stacks.",
+				"You've chosen the 'Howling Gale (Su)' perk. Prevent decay of cumulative damage increase bonus when channeling wind based attack. Penalty for turn without casted wind spell decreased by another 10%. Maximum 75 stacks.");
 		public static const ImmovableObject:PerkType = mk("Immovable Object", "Immovable Object",
 				"[if(player.tou>=75)" +
 						"Grants 10% physical damage reduction.</b>" +
@@ -2616,6 +2625,15 @@ public class PerkLib
 						"<b>You aren't tough enough to benefit from this anymore.</b>" +
 						"]",
 				"You've chosen the 'Resolute' perk, granting immunity to stuns and some statuses.</b>");
+		public static const RumblingQuake:PerkType = mk("Rumbling Quake", "Rumbling Quake",
+				"Cumulative 40% damage increase for every subsequent earth spell. Each turn without cast earth spell lower damage by 40% down to normal (100%) damage. Maximum 5 stacks.",
+				"You've chosen the 'Rumbling Quake' perk. Cumulative 40% damage increase for every subsequent earth spell. Each turn without cast earth spell lower damage by 40% down to normal (100%) damage. Maximum 5 stacks.");
+		public static const RumblingQuakeEx:PerkType = mk("Rumbling Quake (Ex)", "Rumbling Quake (Ex)",
+				"Increase to cumulative damage by 20%. Penalty for turn without casted earth spell decreased by 10%. Maximum 15 stacks.",
+				"You've chosen the 'Rumbling Quake (Ex)' perk. Increase to cumulative damage by 20%. Penalty for turn without casted earth spell decreased by 10%. Maximum 15 stacks.");
+		public static const RumblingQuakeSu:PerkType = mk("Rumbling Quake (Su)", "Rumbling Quake (Su)",
+				"Prevent decay of cumulative damage increase bonus when channeling earth based attack. Penalty for turn without casted earth spell decreased by another 10%. Maximum 75 stacks.",
+				"You've chosen the 'Rumbling Quake (Su)' perk. Prevent decay of cumulative damage increase bonus when channeling earth based attack. Penalty for turn without casted earth spell decreased by another 10%. Maximum 75 stacks.");
 		public static const Runner:PerkType = mk("Runner", "Runner",
 				"Increases chances of escaping combat.",
 				"You've chosen the 'Runner' perk, increasing your chances to escape from your foes when fleeing!");
@@ -5695,7 +5713,8 @@ public class PerkLib
                                 || player.hasPerk(FireLord)
                                 || player.hasPerk(Hellfire)
                                 || player.hasPerk(EnlightenedKitsune)
-                                || player.hasPerk(CorruptedKitsune);
+                                || player.hasPerk(CorruptedKitsune)
+								|| player.hasStatusEffect(StatusEffects.SummonedElementalsFireE);
                     }, "Any fire spell")
                     .requireLevel(12)
                     .requireInt(75);
@@ -5734,8 +5753,27 @@ public class PerkLib
                     .requireCustomFunction(function (player:Player):Boolean {
                         return player.hasStatusEffect(StatusEffects.KnowsWaterBall)
                                 || player.hasStatusEffect(StatusEffects.KnowsWaterSphere)
-                                || player.hasPerk(DragonWaterBreath);
+                                || player.hasPerk(DragonWaterBreath)
+								|| (StatusEffects.SummonedElementalsWaterE);
                     }, "Any water spell")
+                    .requireLevel(12)
+                    .requireInt(75);
+			HowlingGale.requireAnyPerk(GrandMage, ArchmageEx)
+					.requirePerk(Channeling)
+                    .requireCustomFunction(function (player:Player):Boolean {
+                        return player.hasStatusEffect(StatusEffects.KnowsWindBullet)
+                                || player.hasStatusEffect(StatusEffects.KnowsWindBlast)
+								|| player.hasStatusEffect(StatusEffects.SummonedElementalsAirE);
+                    }, "Any wind spell")
+                    .requireLevel(12)
+                    .requireInt(75);
+			RumblingQuake.requireAnyPerk(GrandMage, ArchmageEx)
+					.requirePerk(Channeling)
+                    .requireCustomFunction(function (player:Player):Boolean {
+                        return player.hasStatusEffect(StatusEffects.KnowsStalagmite)
+                                || player.hasStatusEffect(StatusEffects.KnowsShatterstone)
+								|| player.hasStatusEffect(StatusEffects.SummonedElementalsEarthE);
+                    }, "Any earth spell")
                     .requireLevel(12)
                     .requireInt(75);
             // Spell-boosting perks
@@ -5875,7 +5913,7 @@ public class PerkLib
 					.requirePerk(ArcaneRegenerationEpic)
                     .requireInt(125)
                     .requireLevel(24);
-			ElementalBolt.requireAnyPerk(RagingInferno, GlacialStorm, HighVoltage, EclipsingShadow, HighTide)
+			ElementalBolt.requireAnyPerk(RagingInferno, GlacialStorm, HighVoltage, EclipsingShadow, HighTide, HowlingGale, RumblingQuake)
                     .requireInt(125)
                     .requireLevel(24);
             WarMageAdept.requirePerk(WarMageApprentice)
@@ -5930,6 +5968,12 @@ public class PerkLib
                     .requireLevel(30)
                     .requireInt(150);
             HighTideEx.requirePerks(GrandArchmage, HighTide)
+                    .requireLevel(30)
+                    .requireInt(150);
+			HowlingGaleEx.requirePerks(GrandArchmage, HowlingGale)
+                    .requireLevel(30)
+                    .requireInt(150);
+			RumblingQuakeEx.requirePerks(GrandArchmage, RumblingQuake)
                     .requireLevel(30)
                     .requireInt(150);/*
             SpellpowerGrey.requirePerk(SpellpowerGrey)
@@ -6022,6 +6066,12 @@ public class PerkLib
                     .requireLevel(54)
                     .requireInt(300);
             HighTideSu.requirePerks(GrandArchmage3rdCircle, HighTideEx)
+                    .requireLevel(54)
+                    .requireInt(300)
+			HowlingGaleSu.requirePerks(GrandArchmage3rdCircle, HowlingGaleEx)
+                    .requireLevel(54)
+                    .requireInt(300)
+			RumblingQuakeSu.requirePerks(GrandArchmage3rdCircle, RumblingQuakeEx)
                     .requireLevel(54)
                     .requireInt(300);
             //Tier 10 Intelligence perks

--- a/classes/classes/Scenes/Combat/AbstractSpell.as
+++ b/classes/classes/Scenes/Combat/AbstractSpell.as
@@ -310,10 +310,12 @@ public class AbstractSpell extends CombatAbility {
 				break;
 			}
 			case DamageType.WIND: {
+				damage = calcGaleMod(damage, casting);
 				damage *= combat.windDamageBoostedByDao();
 				break;
 			}
 			case DamageType.EARTH: {
+				damage = calcQuakeMod(damage, casting);
 				damage *= combat.earthDamageBoostedByDao();
 				break;
 			}

--- a/classes/classes/Scenes/Combat/BaseCombatContent.as
+++ b/classes/classes/Scenes/Combat/BaseCombatContent.as
@@ -306,5 +306,39 @@ public class BaseCombatContent extends BaseContent {
 	protected function calcTideMod(damage:Number, incCnt:Boolean):Number {
 		return combat.magic.calcTideModImpl(damage, incCnt);
 	}
+	protected function calcQuakeMod(damage:Number, incCnt:Boolean):Number {
+		return combat.magic.calcQuakeModImpl(damage, incCnt);
+	}
+	protected function calcGaleMod(damage:Number, incCnt:Boolean):Number {
+		return combat.magic.calcGaleModImpl(damage, incCnt);
+	}
+
+	protected function maintainInfernoMod():void {
+        combat.magic.maintainInfernoModImpl();
+	}
+
+    protected function maintainGlacialMod():void {
+        combat.magic.maintainGlacialModImpl();
+	}
+
+    protected function maintainVoltageMod():void {
+        combat.magic.maintainVoltageModImpl();
+	}
+
+    protected function maintainEclypseMod():void {
+        combat.magic.maintainEclypseModImpl();
+    }
+
+    protected function maintainTideMod():void {
+        combat.magic.maintainTideModImpl();
+    }
+
+	protected function maintainQuakeMod():void {
+        combat.magic.maintainQuakeModImpl();
+    }
+
+	protected function maintainGaleMod():void {
+        combat.magic.maintainGaleModImpl();
+    }
 }
 }

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -9473,7 +9473,8 @@ public class Combat extends BaseContent {
                     crit = true;
                     damage *= 1.75;
                 }
-                damage = magic.calcInfernoModImpl(damage, true);
+                damage = magic.calcInfernoModImpl(damage, false);
+                magic.maintainInfernoModImpl();
                 damage *= 0.5;
                 var SpellMultiplier:Number = 1;
                 SpellMultiplier += spellMod() - 1;
@@ -9727,7 +9728,8 @@ public class Combat extends BaseContent {
                     crit3 = true;
                     damageBFA *= 1.75;
                 }
-                damageBFA = magic.calcGlacialModImpl(damageBFA, true)/2;
+                damageBFA = magic.calcGlacialModImpl(damageBFA, false)/2;
+                magic.maintainGlacialModImpl();
                 var SpellMultiplier2:Number = 1;
                 SpellMultiplier2 += spellMod() - 1;
                 damageBFA *= SpellMultiplier2;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1512,12 +1512,10 @@ public class Combat extends BaseContent {
     public function stopChanneledSpecial():void {
         clearOutput();
         outputText("You decided to stop preparing your super ultra hyper mega fabulous attack!\n\n");
-		if (player.hasPerk(PerkLib.RagingInfernoSu) && player.hasStatusEffect(StatusEffects.CounterRagingInferno)) player.addStatusValue(StatusEffects.CounterRagingInferno, 3, -1);
-		if (player.hasPerk(PerkLib.GlacialStormSu) && player.hasStatusEffect(StatusEffects.CounterGlacialStorm)) player.addStatusValue(StatusEffects.CounterGlacialStorm, 3, -1);
-		if (player.hasPerk(PerkLib.HighVoltageSu) && player.hasStatusEffect(StatusEffects.CounterHighVoltage)) player.addStatusValue(StatusEffects.CounterHighVoltage, 3, -1);
-		if (player.hasPerk(PerkLib.EclipsingShadowSu) && player.hasStatusEffect(StatusEffects.CounterEclipsingShadow)) player.addStatusValue(StatusEffects.CounterEclipsingShadow, 3, -1);
-		if (player.hasPerk(PerkLib.HighTideSu) && player.hasStatusEffect(StatusEffects.CounterHighTide)) player.addStatusValue(StatusEffects.CounterHighTide, 3, -1);
-        player.removeStatusEffect(StatusEffects.ChanneledAttack);
+        for each (var perkObj:Object in CombatMagic.magicCounterPerks) {
+            if (player.hasPerk(perkObj.tier3) && player.hasStatusEffect(perkObj.counter)) player.addStatusValue(perkObj.counter, 3, -1);
+        }
+		player.removeStatusEffect(StatusEffects.ChanneledAttack);
         player.removeStatusEffect(StatusEffects.ChanneledAttackType);
         combatRoundOver();
     }
@@ -3730,6 +3728,7 @@ public class Combat extends BaseContent {
      * Elemental range attack from Elemental Body or Moonlight Greatsword
      */
     public function throwElementalAttack():void {
+        clearOutput();
         var damage:Number = 0;
 		damage += player.str;
 		var crit:Boolean = false;
@@ -3792,11 +3791,13 @@ public class Combat extends BaseContent {
         switch (elementalVariant) {
             case ElementalRace.ELEMENT_SYLPH:
                 outputText("You form and unleash a wind blade. ");
+                damage = magic.calcGaleModImpl(damage, true);
                 damage *= windDamageBoostedByDao();
 				doWindDamage(damage, true, true);
                 break;
             case ElementalRace.ELEMENT_GNOME:
                 outputText("You launch a huge rock. ");
+                damage = magic.calcQuakeModImpl(damage, true);
                 damage *= earthDamageBoostedByDao();
 				doEarthDamage(damage, true, true);
                 break;
@@ -9171,46 +9172,18 @@ public class Combat extends BaseContent {
                 player.removeStatusEffect(StatusEffects.LethicesRapeTentacles);
             }
         }
-        if (player.hasStatusEffect(StatusEffects.CounterHighTide)) {
-            if (player.statusEffectv1(StatusEffects.CounterHighTide) > 0 && player.statusEffectv2(StatusEffects.CounterHighTide) == 0 && player.statusEffectv3(StatusEffects.CounterHighTide) == 0) {
-				if (player.hasPerk(PerkLib.HighTideSu)) player.addStatusValue(StatusEffects.CounterHighTide, 1, -2);
-				else if (player.hasPerk(PerkLib.HighTideEx)) player.addStatusValue(StatusEffects.CounterHighTide, 1, -3);
-				player.addStatusValue(StatusEffects.CounterHighTide, 1, -4);
+        //Manage cumulative magic damage counter degradation
+        for each (var perkObj:Object in CombatMagic.magicCounterPerks) {
+            if (player.hasStatusEffect(perkObj.counter)) {
+            if (player.statusEffectv1(perkObj.counter) > 0 && player.statusEffectv2(perkObj.counter) == 0 && player.statusEffectv3(perkObj.counter) == 0) {
+				if (player.hasPerk(perkObj.tier3)) player.addStatusValue(perkObj.counter, 1, -2);
+				else if (player.hasPerk(perkObj.tier2)) player.addStatusValue(perkObj.counter, 1, -3);
+				player.addStatusValue(perkObj.counter, 1, -4);
 			}
-			if (player.statusEffectv2(StatusEffects.CounterEclipsingShadow) > 0) player.addStatusValue(StatusEffects.CounterEclipsingShadow, 2, -1);
+			if (player.statusEffectv2(perkObj.counter) > 0) player.addStatusValue(perkObj.counter, 2, -1);
         }
-        if (player.hasStatusEffect(StatusEffects.CounterEclipsingShadow)) {
-            if (player.statusEffectv1(StatusEffects.CounterEclipsingShadow) > 0 && player.statusEffectv2(StatusEffects.CounterEclipsingShadow) == 0 && player.statusEffectv3(StatusEffects.CounterEclipsingShadow) == 0) {
-				if (player.hasPerk(PerkLib.EclipsingShadowSu)) player.addStatusValue(StatusEffects.CounterEclipsingShadow, 1, -2);
-				else if (player.hasPerk(PerkLib.EclipsingShadowEx)) player.addStatusValue(StatusEffects.CounterEclipsingShadow, 1, -3);
-				player.addStatusValue(StatusEffects.CounterEclipsingShadow, 1, -4);
-			}
-			if (player.statusEffectv2(StatusEffects.CounterEclipsingShadow) > 0) player.addStatusValue(StatusEffects.CounterEclipsingShadow, 2, -1);
         }
-        if (player.hasStatusEffect(StatusEffects.CounterGlacialStorm)) {
-            if (player.statusEffectv1(StatusEffects.CounterGlacialStorm) > 0 && player.statusEffectv2(StatusEffects.CounterGlacialStorm) == 0 && player.statusEffectv3(StatusEffects.CounterGlacialStorm) == 0) {
-				if (player.hasPerk(PerkLib.GlacialStormSu)) player.addStatusValue(StatusEffects.CounterGlacialStorm, 1, -2);
-				else if (player.hasPerk(PerkLib.GlacialStormEx)) player.addStatusValue(StatusEffects.CounterGlacialStorm, 1, -3);
-				player.addStatusValue(StatusEffects.CounterGlacialStorm, 1, -4);
-			}
-			if (player.statusEffectv2(StatusEffects.CounterGlacialStorm) > 0) player.addStatusValue(StatusEffects.CounterGlacialStorm, 2, -1);
-        }
-        if (player.hasStatusEffect(StatusEffects.CounterHighVoltage)) {
-            if (player.statusEffectv1(StatusEffects.CounterHighVoltage) > 0 && player.statusEffectv2(StatusEffects.CounterHighVoltage) == 0 && player.statusEffectv3(StatusEffects.CounterHighVoltage) == 0) {
-				if (player.hasPerk(PerkLib.HighVoltageSu)) player.addStatusValue(StatusEffects.CounterHighVoltage, 1, -2);
-				else if (player.hasPerk(PerkLib.HighVoltageEx)) player.addStatusValue(StatusEffects.CounterHighVoltage, 1, -3);
-				player.addStatusValue(StatusEffects.CounterHighVoltage, 1, -4);
-			}
-			if (player.statusEffectv2(StatusEffects.CounterHighVoltage) > 0) player.addStatusValue(StatusEffects.CounterHighVoltage, 2, -1);
-        }
-        if (player.hasStatusEffect(StatusEffects.CounterRagingInferno)) { //if has perk
-            if (player.statusEffectv1(StatusEffects.CounterRagingInferno) > 0 && player.statusEffectv2(StatusEffects.CounterRagingInferno) == 0 && player.statusEffectv3(StatusEffects.CounterRagingInferno) == 0) {
-                if (player.hasPerk(PerkLib.RagingInfernoSu)) player.addStatusValue(StatusEffects.CounterRagingInferno, 1, -2); //decrease by 10%
-				else if (player.hasPerk(PerkLib.RagingInfernoEx)) player.addStatusValue(StatusEffects.CounterRagingInferno, 1, -3); //decrease by 15%
-				player.addStatusValue(StatusEffects.CounterRagingInferno, 1, -4); //decrease by full 20%
-			}//v3 = 1 - jesli chaneluje zaklecie/special to nie traci wzmocnienia
-			if (player.statusEffectv2(StatusEffects.CounterRagingInferno) > 0) player.addStatusValue(StatusEffects.CounterRagingInferno, 2, -1);
-        }
+        
 		if (player.perkv1(IMutationsLib.FerasBirthrightIM) >= 3 && player.HP < 1 && !player.hasStatusEffect(StatusEffects.RegenSurge)) {
 			if (player.perkv1(IMutationsLib.FerasBirthrightIM) == 3) player.createStatusEffect(StatusEffects.RegenSurge,3,0,0,0);
 			if (player.perkv1(IMutationsLib.FerasBirthrightIM) == 4) player.createStatusEffect(StatusEffects.RegenSurge,4,0,0,0);

--- a/classes/classes/Scenes/Combat/CombatMagic.as
+++ b/classes/classes/Scenes/Combat/CombatMagic.as
@@ -48,11 +48,9 @@ public class CombatMagic extends BaseCombatContent {
 	}
 
 	internal function cleanupAfterCombatImpl():void {
-		if (player.hasStatusEffect(StatusEffects.CounterRagingInferno)) player.removeStatusEffect(StatusEffects.CounterRagingInferno);
-		if (player.hasStatusEffect(StatusEffects.CounterGlacialStorm)) player.removeStatusEffect(StatusEffects.CounterGlacialStorm);
-		if (player.hasStatusEffect(StatusEffects.CounterHighVoltage)) player.removeStatusEffect(StatusEffects.CounterHighVoltage);
-		if (player.hasStatusEffect(StatusEffects.CounterEclipsingShadow)) player.removeStatusEffect(StatusEffects.CounterEclipsingShadow);
-		if (player.hasStatusEffect(StatusEffects.CounterHighTide)) player.removeStatusEffect(StatusEffects.CounterHighTide);
+		for each (var perkObj:Object in magicCounterPerks) {
+			if (player.hasStatusEffect(perkObj.counter)) player.removeStatusEffect(perkObj.counter);
+		}
 	}
 
 	internal function costChange_all():Number {
@@ -627,200 +625,159 @@ public class CombatMagic extends BaseCombatContent {
 		return perkRelatedDB;
 	}
 
-	internal function calcInfernoModImpl(damage:Number, casting:Boolean = true):int {
-        var modDmg:Number = damage;
+	public static var magicCounterPerks:Object = {
+		"fire": {
+			tier1: PerkLib.RagingInferno,
+			tier2: PerkLib.RagingInfernoEx,
+			tier3: PerkLib.RagingInfernoSu,
+			counter: StatusEffects.CounterRagingInferno,
+			type: "fire"
+		},
+		"earth": {
+			tier1: PerkLib.RumblingQuake,
+			tier2: PerkLib.RumblingQuakeEx,
+			tier3: PerkLib.RumblingQuakeSu,
+			counter: StatusEffects.CounterRumblingQuake,
+			type: "earth"
+		},
+		"wind": {
+			tier1: PerkLib.HowlingGale,
+			tier2: PerkLib.HowlingGaleEx,
+			tier3: PerkLib.HowlingGaleSu,
+			counter: StatusEffects.CounterHowlingGale,
+			type: "wind"
+		},
+		"water": {
+			tier1: PerkLib.HighTide,
+			tier2: PerkLib.HighTideEx,
+			tier3: PerkLib.HighTideSu,
+			counter: StatusEffects.CounterHighTide,
+			type: "water"
+		},
+		"ice": {
+			tier1: PerkLib.GlacialStorm,
+			tier2: PerkLib.GlacialStormEx,
+			tier3: PerkLib.GlacialStormSu,
+			counter: StatusEffects.CounterGlacialStorm,
+			type: "ice"
+		},
+		"lightning": {
+			tier1: PerkLib.HighVoltage,
+			tier2: PerkLib.HighVoltageEx,
+			tier3: PerkLib.HighVoltageSu,
+			counter: StatusEffects.CounterHighVoltage,
+			type: "lightning"
+		},
+		"darkness": {
+			tier1: PerkLib.EclipsingShadow,
+			tier2: PerkLib.EclipsingShadowEx,
+			tier3: PerkLib.EclipsingShadowSu,
+			counter: StatusEffects.CounterEclipsingShadow,
+			type: "darkness"
+		}
+	};
+
+	internal function calcMagicCounterModImpl(perkObj:Object, damage:Number, casting:Boolean = true):Number {
+		var modDmg:Number = damage;
         //v1 is counter value in 5% (for later tiers),
-		if (player.hasPerk(PerkLib.RagingInferno)) { //if has perk
+		if (player.hasPerk(perkObj.tier1)) { //if has perk
             if (casting) {
-                if (player.hasStatusEffect(StatusEffects.CounterRagingInferno)) { //counter created
+                if (player.hasStatusEffect(perkObj.counter)) { //counter created
 					var cap:Number = 40;
-					if (player.hasPerk(PerkLib.RagingInfernoEx)) cap += 80;
-					if (player.hasPerk(PerkLib.RagingInfernoSu)) cap += 480;
+					if (player.hasPerk(perkObj.tier2)) cap += 80;
+					if (player.hasPerk(perkObj.tier3)) cap += 480;
                     //calculating damage
-                    if (player.statusEffectv1(StatusEffects.CounterRagingInferno) > 0)
-                        modDmg = Math.round(damage * (1 + player.statusEffectv1(StatusEffects.CounterRagingInferno) * 0.05));
+                    if (player.statusEffectv1(perkObj.counter) > 0)
+                        modDmg = Math.round(damage * (1 + player.statusEffectv1(perkObj.counter) * 0.05));
                     //fancy messages
-                    if (player.statusEffectv1(StatusEffects.CounterRagingInferno) == 0)
-                        outputText("\nUnfortunately, traces of your previously used fire magic are too weak to be used.\n\n");
+                    if (player.statusEffectv1(perkObj.counter) == 0)
+                        outputText("\nUnfortunately, traces of your previously used " + perkObj.type +" magic are too weak to be used.\n\n");
                     else
-					    outputText("\nTraces of your previously used fire magic are still here, and you use them to empower another spell!\n\n");
+					    outputText("\nTraces of your previously used " + perkObj.type + " magic are still here, and you use them to empower another spell!\n\n");
                     //increasing counters
 					var increase:Number = 8;
-					if (player.hasPerk(PerkLib.RagingInfernoEx)) increase += 4;
-					if (player.statusEffectv1(StatusEffects.CounterRagingInferno) < cap) {
-						player.addStatusValue(StatusEffects.CounterRagingInferno, 1, increase);
-						player.addStatusValue(StatusEffects.CounterRagingInferno, 2, 1);
+					if (player.hasPerk(perkObj.tier2)) increase += 4;
+					if (player.statusEffectv1(perkObj.counter) < cap) {
+						player.addStatusValue(perkObj.counter, 1, increase);
+						player.addStatusValue(perkObj.counter, 2, 1);
 					}
                 }
                 else {
-                    if (player.hasPerk(PerkLib.RagingInfernoEx))
-                        player.createStatusEffect(StatusEffects.CounterRagingInferno,12,1,0,0);
+                    if (player.hasPerk(perkObj.tier2))
+                        player.createStatusEffect(perkObj.counter,12,1,0,0);
                     else
-                        player.createStatusEffect(StatusEffects.CounterRagingInferno,8,1,0,0);
+                        player.createStatusEffect(perkObj.counter,8,1,0,0);
                 }
             }
             else //just calc damage
-                if (player.hasStatusEffect(StatusEffects.CounterRagingInferno) && player.statusEffectv1(StatusEffects.CounterRagingInferno) > 0)
-                    modDmg = Math.round(damage * (1 + player.statusEffectv1(StatusEffects.CounterRagingInferno) * 0.05));
+                if (player.hasStatusEffect(perkObj.counter) && player.statusEffectv1(perkObj.counter) > 0)
+                    modDmg = Math.round(damage * (1 + player.statusEffectv1(perkObj.counter) * 0.05));
         }
 		return modDmg;
 	}
 
-    internal function calcGlacialModImpl(damage:Number, casting:Boolean = true):int {
-        var modDmg:Number = damage;
-        //v1 is counter value in 5% (for later tiers),
-		if (player.hasPerk(PerkLib.GlacialStorm)) { //if has perk
-            if (casting) {
-                if (player.hasStatusEffect(StatusEffects.CounterGlacialStorm)) { //counter created
-                    var cap:Number = 40;
-					if (player.hasPerk(PerkLib.GlacialStormEx)) cap += 80;
-					if (player.hasPerk(PerkLib.GlacialStormSu)) cap += 480;
-                    //calculating damage
-                    if (player.statusEffectv1(StatusEffects.CounterGlacialStorm) > 0)
-                        modDmg = Math.round(damage * (1 + player.statusEffectv1(StatusEffects.CounterGlacialStorm) * 0.05));
-                    //fancy messages
-                    if (player.statusEffectv1(StatusEffects.CounterGlacialStorm) == 0)
-                        outputText("\nUnfortunately, traces of your previously used ice magic are too weak to be used.\n\n");
-                    else
-					    outputText("\nTraces of your previously used ice magic are still here, and you use them to empower another spell!\n\n");
-                    //increasing counters
-					var increase:Number = 8;
-					if (player.hasPerk(PerkLib.GlacialStormEx)) increase += 4;
-					if (player.statusEffectv1(StatusEffects.CounterGlacialStorm) < cap) {
-						player.addStatusValue(StatusEffects.CounterGlacialStorm, 1, increase);
-						player.addStatusValue(StatusEffects.CounterGlacialStorm, 2, 1);
-					}
-                }
-                else {
-                    if (player.hasPerk(PerkLib.GlacialStormEx))
-                        player.createStatusEffect(StatusEffects.CounterGlacialStorm,12,1,0,0);
-                    else
-                        player.createStatusEffect(StatusEffects.CounterGlacialStorm,8,1,0,0);
-                }
-            }
-            else //just calc damage
-                if (player.hasStatusEffect(StatusEffects.CounterGlacialStorm) && player.statusEffectv1(StatusEffects.CounterGlacialStorm) > 0)
-                    modDmg = Math.round(damage * (1 + player.statusEffectv1(StatusEffects.CounterGlacialStorm) * 0.05));
-        }
-		return modDmg;
+	internal function maintainMagicCounter(perkObj:Object):void {
+		if (player.hasStatusEffect(perkObj.counter)) {
+			if (player.hasPerk(perkObj.tier3)) player.addStatusValue(perkObj.counter, 1, 2);
+			else if (player.hasPerk(perkObj.tier3)) player.addStatusValue(perkObj.counter, 1, 3);
+			player.addStatusValue(perkObj.counter, 1, 4);
+		}	
 	}
 
-    internal function calcVoltageModImpl(damage:Number, casting:Boolean = true):int {
-        var modDmg:Number = damage;
-        //v1 is counter value in 5% (for later tiers),
-		if (player.hasPerk(PerkLib.HighVoltage)) { //if has perk
-            if (casting) {
-                if (player.hasStatusEffect(StatusEffects.CounterHighVoltage)) { //counter created
-                    var cap:Number = 40;
-					if (player.hasPerk(PerkLib.HighVoltageEx)) cap += 80;
-					if (player.hasPerk(PerkLib.HighVoltageSu)) cap += 480;
-                    //calculating damage
-                    if (player.statusEffectv1(StatusEffects.CounterHighVoltage) > 0)
-                        modDmg = Math.round(damage * (1 + player.statusEffectv1(StatusEffects.CounterHighVoltage) * 0.05));
-                    if (player.statusEffectv1(StatusEffects.CounterHighVoltage) == 0)
-                    //fancy messages
-                        outputText("\nUnfortunately, traces of your previously used lightning magic are too weak to be used.\n\n");
-                    else
-					    outputText("\nTraces of your previously used lightning magic are still here, and you use them to empower another spell!\n\n");
-                    //increasing counters
-					var increase:Number = 8;
-					if (player.hasPerk(PerkLib.HighVoltageEx)) increase += 4;
-					if (player.statusEffectv1(StatusEffects.CounterHighVoltage) < cap) {
-						if (player.hasPerk(PerkLib.HighVoltageEx))
-						player.addStatusValue(StatusEffects.CounterHighVoltage, 1, increase);
-						player.addStatusValue(StatusEffects.CounterHighVoltage, 2, 1);
-					}
-                }
-                else {
-                    if (player.hasPerk(PerkLib.HighVoltageEx))
-                        player.createStatusEffect(StatusEffects.CounterHighVoltage,12,1,0,0);
-                    else
-                        player.createStatusEffect(StatusEffects.CounterHighVoltage,4,1,0,0);
-                }
-            }
-            else //just calc damage
-                if (player.hasStatusEffect(StatusEffects.CounterHighVoltage) && player.statusEffectv1(StatusEffects.CounterHighVoltage) > 0)
-                    modDmg = Math.round(damage * (1 + player.statusEffectv1(StatusEffects.CounterHighVoltage) * 0.05));
-        }
-		return modDmg;
+	internal function calcInfernoModImpl(damage:Number, casting:Boolean = true):Number {
+        return calcMagicCounterModImpl(magicCounterPerks["fire"], damage, casting);
 	}
 
-    internal function calcEclypseModImpl(damage:Number, casting:Boolean = true):int {
-        var modDmg:Number = damage;
-        //v1 is counter value in 5% (for later tiers),
-		if (player.hasPerk(PerkLib.EclipsingShadow)) { //if has perk
-            if (casting) {
-                if (player.hasStatusEffect(StatusEffects.CounterEclipsingShadow)) { //counter created
-                    var cap:Number = 40;
-					if (player.hasPerk(PerkLib.EclipsingShadowEx)) cap += 80;
-					if (player.hasPerk(PerkLib.EclipsingShadowSu)) cap += 480;
-                    //calculating damage
-                    if (player.statusEffectv1(StatusEffects.CounterEclipsingShadow) > 0)
-                        modDmg = Math.round(damage * (1 + player.statusEffectv1(StatusEffects.CounterEclipsingShadow) * 0.05));
-                    //fancy messages
-                    if (player.statusEffectv1(StatusEffects.CounterEclipsingShadow) == 0)
-                        outputText("\nUnfortunately, traces of your previously used darkness magic are too weak to be used.\n\n");
-                    else
-					    outputText("\nTraces of your previously used darkness magic are still here, and you use them to empower another spell!\n\n");
-                    //increasing counters
-					var increase:Number = 8;
-					if (player.hasPerk(PerkLib.EclipsingShadowEx)) increase += 4;
-					if (player.statusEffectv1(StatusEffects.CounterEclipsingShadow) < cap) {
-						player.addStatusValue(StatusEffects.CounterEclipsingShadow, 1, increase);
-						player.addStatusValue(StatusEffects.CounterEclipsingShadow, 2, 1);
-					}
-                }
-                else {
-                    if (player.hasPerk(PerkLib.EclipsingShadowEx))
-                        player.createStatusEffect(StatusEffects.CounterEclipsingShadow,12,1,0,0);
-                    else
-                        player.createStatusEffect(StatusEffects.CounterEclipsingShadow,8,1,0,0);
-                }
-            }
-            else //just calc damage
-                if (player.hasStatusEffect(StatusEffects.CounterEclipsingShadow) && player.statusEffectv1(StatusEffects.CounterEclipsingShadow) > 0)
-                    modDmg = Math.round(damage * (1 + player.statusEffectv1(StatusEffects.CounterEclipsingShadow) * 0.05));
-        }
-		return modDmg;
+    internal function calcGlacialModImpl(damage:Number, casting:Boolean = true):Number {
+        return calcMagicCounterModImpl(magicCounterPerks["ice"], damage, casting);
+	}
+
+    internal function calcVoltageModImpl(damage:Number, casting:Boolean = true):Number {
+        return calcMagicCounterModImpl(magicCounterPerks["lightning"], damage, casting);
+	}
+
+    internal function calcEclypseModImpl(damage:Number, casting:Boolean = true):Number {
+        return calcMagicCounterModImpl(magicCounterPerks["darkness"], damage, casting);
     }
 
-    internal function calcTideModImpl(damage:Number, casting:Boolean = true):int {
-        var modDmg:Number = damage;
-        //v1 is counter value in 5% (for later tiers),
-		if (player.hasPerk(PerkLib.HighTide)) { //if has perk
-            if (casting) {
-                if (player.hasStatusEffect(StatusEffects.CounterHighTide)) { //counter created
-                    var cap:Number = 40;
-					if (player.hasPerk(PerkLib.HighTideEx)) cap += 80;
-					if (player.hasPerk(PerkLib.HighTideSu)) cap += 480;
-                    //calculating damage
-                    if (player.statusEffectv1(StatusEffects.CounterHighTide) > 0)
-                        modDmg = Math.round(damage * (1 + player.statusEffectv1(StatusEffects.CounterHighTide) * 0.05));
-                    //fancy messages
-                    if (player.statusEffectv1(StatusEffects.CounterHighTide) == 0)
-                        outputText("\nUnfortunately, traces of your previously used water magic are too weak to be used.\n\n");
-                    else
-					    outputText("\nTraces of your previously used water magic are still here, and you use them to empower another spell!\n\n");
-                    //increasing counters
-					var increase:Number = 8;
-					if (player.hasPerk(PerkLib.HighTideEx)) increase += 4;
-					if (player.statusEffectv1(StatusEffects.CounterHighTide) < cap) {
-						player.addStatusValue(StatusEffects.CounterHighTide, 1, increase);
-						player.addStatusValue(StatusEffects.CounterHighTide, 2, 1);
-					}
-                }
-                else {
-                    if (player.hasPerk(PerkLib.HighTideEx))
-                        player.createStatusEffect(StatusEffects.CounterHighTide,12,1,0,0);
-                    else
-                        player.createStatusEffect(StatusEffects.CounterHighTide,8,1,0,0);
-                }
-            }
-            else //just calc damage
-                if (player.hasStatusEffect(StatusEffects.CounterHighTide) && player.statusEffectv1(StatusEffects.CounterHighTide) > 0)
-                    modDmg = Math.round(damage * (1 + player.statusEffectv1(StatusEffects.CounterHighTide) * 0.05));
-        }
-		return modDmg;
+    internal function calcTideModImpl(damage:Number, casting:Boolean = true):Number {
+        return calcMagicCounterModImpl(magicCounterPerks["water"], damage, casting);
+    }
+
+	internal function calcQuakeModImpl(damage:Number, casting:Boolean = true):Number {
+        return calcMagicCounterModImpl(magicCounterPerks["earth"], damage, casting);
+    }
+
+	internal function calcGaleModImpl(damage:Number, casting:Boolean = true):Number {
+        return calcMagicCounterModImpl(magicCounterPerks["wind"], damage, casting);
+    }
+
+	internal function maintainInfernoModImpl():void {
+        maintainMagicCounter(magicCounterPerks["fire"]);
+	}
+
+    internal function maintainGlacialModImpl():void {
+        maintainMagicCounter(magicCounterPerks["ice"]);
+	}
+
+    internal function maintainVoltageModImpl():void {
+        maintainMagicCounter(magicCounterPerks["lightning"]);
+	}
+
+    internal function maintainEclypseModImpl():void {
+        maintainMagicCounter(magicCounterPerks["darkness"]);
+    }
+
+    internal function maintainTideModImpl():void {
+        maintainMagicCounter(magicCounterPerks["water"]);
+    }
+
+	internal function maintainQuakeModImpl():void {
+        maintainMagicCounter(magicCounterPerks["earth"]);
+    }
+
+	internal function maintainGaleModImpl():void {
+        maintainMagicCounter(magicCounterPerks["wind"]);
     }
 	
 	public function MagicPrefixEffect():void {
@@ -979,30 +936,8 @@ public class CombatMagic extends BaseCombatContent {
 		combat.heroBaneProc(damage);
 		statScreenRefresh();
 		if (player.hasPerk(PerkLib.ElementalBolt)) {
-			if (player.hasStatusEffect(StatusEffects.CounterHighTide)) {
-				if (player.hasPerk(PerkLib.HighTideSu)) player.addStatusValue(StatusEffects.CounterHighTide, 1, 2);
-				else if (player.hasPerk(PerkLib.HighTideEx)) player.addStatusValue(StatusEffects.CounterHighTide, 1, 3);
-				player.addStatusValue(StatusEffects.CounterHighTide, 1, 4);
-			}
-			if (player.hasStatusEffect(StatusEffects.CounterEclipsingShadow)) {
-				if (player.hasPerk(PerkLib.EclipsingShadowSu)) player.addStatusValue(StatusEffects.CounterEclipsingShadow, 1, 2);
-				else if (player.hasPerk(PerkLib.EclipsingShadowEx)) player.addStatusValue(StatusEffects.CounterEclipsingShadow, 1, 3);
-				player.addStatusValue(StatusEffects.CounterEclipsingShadow, 1, 4);
-			}
-			if (player.hasStatusEffect(StatusEffects.CounterGlacialStorm)) {
-				if (player.hasPerk(PerkLib.GlacialStormSu)) player.addStatusValue(StatusEffects.CounterGlacialStorm, 1, 2);
-				else if (player.hasPerk(PerkLib.GlacialStormEx)) player.addStatusValue(StatusEffects.CounterGlacialStorm, 1, 3);
-				player.addStatusValue(StatusEffects.CounterGlacialStorm, 1, 4);
-			}
-			if (player.hasStatusEffect(StatusEffects.CounterHighVoltage)) {
-				if (player.hasPerk(PerkLib.HighVoltageSu)) player.addStatusValue(StatusEffects.CounterHighVoltage, 1, 2);
-				else if (player.hasPerk(PerkLib.HighVoltageEx)) player.addStatusValue(StatusEffects.CounterHighVoltage, 1, 3);
-				player.addStatusValue(StatusEffects.CounterHighVoltage, 1, 4);
-			}
-			if (player.hasStatusEffect(StatusEffects.CounterRagingInferno)) {
-				if (player.hasPerk(PerkLib.RagingInfernoSu)) player.addStatusValue(StatusEffects.CounterRagingInferno, 1, 2);
-				else if (player.hasPerk(PerkLib.RagingInfernoEx)) player.addStatusValue(StatusEffects.CounterRagingInferno, 1, 3);
-				player.addStatusValue(StatusEffects.CounterRagingInferno, 1, 4);
+			for each (var perkObj:Object in magicCounterPerks) {
+				maintainMagicCounter(perkObj);
 			}
 		}
 		if(monster.HP <= monster.minHP()) doNext(endHpVictory);

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -2748,11 +2748,10 @@ public class MagicSpecials extends BaseCombatContent {
 			player.createStatusEffect(StatusEffects.DragonBreathCooldown,0,0,0,0);
 			player.removeStatusEffect(StatusEffects.ChanneledAttack);
 			player.removeStatusEffect(StatusEffects.ChanneledAttackType);
-			if (player.hasPerk(PerkLib.RagingInfernoSu) && player.hasStatusEffect(StatusEffects.CounterRagingInferno)) player.addStatusValue(StatusEffects.CounterRagingInferno, 3, -1);
-			if (player.hasPerk(PerkLib.GlacialStormSu) && player.hasStatusEffect(StatusEffects.CounterGlacialStorm)) player.addStatusValue(StatusEffects.CounterGlacialStorm, 3, -1);
-			if (player.hasPerk(PerkLib.HighVoltageSu) && player.hasStatusEffect(StatusEffects.CounterHighVoltage)) player.addStatusValue(StatusEffects.CounterHighVoltage, 3, -1);
-			if (player.hasPerk(PerkLib.EclipsingShadowSu) && player.hasStatusEffect(StatusEffects.CounterEclipsingShadow)) player.addStatusValue(StatusEffects.CounterEclipsingShadow, 3, -1);
-			if (player.hasPerk(PerkLib.HighTideSu) && player.hasStatusEffect(StatusEffects.CounterHighTide)) player.addStatusValue(StatusEffects.CounterHighTide, 3, -1);
+			for each (var perkObj:Object in CombatMagic.magicCounterPerks) {
+				if (player.hasPerk(perkObj.tier3) && player.hasStatusEffect(perkObj.counter)) player.addStatusValue(perkObj.counter, 3, -1);
+			}
+
 			var damage:Number = 0;
 			var damult:Number = 1;
 			damage += scalingBonusIntelligence() * 5;
@@ -2834,6 +2833,8 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasPerk(PerkLib.HighVoltageSu)) player.addStatusValue(StatusEffects.CounterHighVoltage, 3, 1);
 			if (player.hasPerk(PerkLib.EclipsingShadowSu)) player.addStatusValue(StatusEffects.CounterEclipsingShadow, 3, 1);
 			if (player.hasPerk(PerkLib.HighTideSu)) player.addStatusValue(StatusEffects.CounterHighTide, 3, 1);
+			if (player.hasPerk(PerkLib.RumblingQuakeSu)) player.addStatusValue(StatusEffects.CounterRumblingQuake, 3, 1);
+			if (player.hasPerk(PerkLib.HowlingGaleSu)) player.addStatusValue(StatusEffects.CounterHowlingGale, 3, 1);
 			enemyAI();
 		}
 	}
@@ -6743,6 +6744,8 @@ public class MagicSpecials extends BaseCombatContent {
 		damage += scalingBonusWisdom() * multiWis;
 		if (type == 1) {
 			outputText("You rub your palms together before unleashing the energy in the form of razor sharp winds. [Themonster] eyes grow wide in surprise as your attack leaves deep bleeding cuts in its flesh! ");
+			damage = calcGaleMod(damage, true);
+			damage = Math.round(damage * combat.windDamageBoostedByDao());
 			doWindDamage(damage, true, true);
 			if (player.isFistOrFistWeapon() && player.hasPerk(PerkLib.ElementalTouch)) {
 				if (monster.hasStatusEffect(StatusEffects.Hemorrhage)) monster.addStatusValue(StatusEffects.Hemorrhage, 1, 1*combat.BleedDamageBoost());
@@ -6751,6 +6754,8 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		if (type == 2) {
 			outputText("You smash both of your fists into the ground, causing vegetation to grow at an accelerated rate. [Themonster] is punched out of nowhere as a grown tree suddenly sprouts from beneath! ");
+			damage = calcQuakeMod(damage, true);
+			damage = Math.round(damage * combat.earthDamageBoostedByDao());
 			doEarthDamage(damage, true, true);
 			if (player.isFistOrFistWeapon() && player.hasPerk(PerkLib.ElementalTouch)) {
 				if (monster.hasStatusEffect(StatusEffects.AcidDoT)) {
@@ -6773,6 +6778,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (type == 4) {
 			outputText("You push both of your palms toward your opponent, your arms turning to a pair of powerful water jets that batters [themonster] with rock crushing pressure! ");
 			damage = calcTideMod(damage, true);
+			damage = Math.round(damage * combat.waterDamageBoostedByDao());
 			doWaterDamage(damage, true, true);
 			if (player.isFistOrFistWeapon() && player.hasPerk(PerkLib.ElementalTouch)) {
 				monster.statStore.addBuffObject({str:-10,spe:-10}, "Poison",{text:"Poison"});

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -2762,6 +2762,9 @@ public class MagicSpecials extends BaseCombatContent {
 			damage = calcVoltageMod(damage, true);
 			damage = calcEclypseMod(damage, true);
 			damage = calcTideMod(damage, true);
+			damage = calcQuakeMod(damage, true);
+			damage = calcGaleMod(damage, true);
+
 			if(player.hasStatusEffect(StatusEffects.DragonBreathBoost)) {
 				player.removeStatusEffect(StatusEffects.DragonBreathBoost);
 				damage *= 3;
@@ -5688,6 +5691,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.RacialParagon)) damage *= combat.RacialParagonAbilityBoost();
 		if (player.hasPerk(PerkLib.NaturalArsenal)) damage *= 1.50;
 		if (player.hasPerk(PerkLib.LionHeart)) damage *= 2;
+		damage = calcGaleMod(damage, true);
 		damage = Math.round(damage * combat.windDamageBoostedByDao());
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
@@ -5771,6 +5775,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.RacialParagon)) damage *= combat.RacialParagonAbilityBoost();
 		if (player.hasPerk(PerkLib.NaturalArsenal)) damage *= 1.50;
 		if (player.hasPerk(PerkLib.LionHeart)) damage *= 2;
+		damage = calcGaleMod(damage, true);
 		damage = Math.round(damage * combat.windDamageBoostedByDao());
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {

--- a/classes/classes/StatusEffects.as
+++ b/classes/classes/StatusEffects.as
@@ -1131,6 +1131,8 @@ import classes.StatusEffects.VampireThirstEffect;
 		public static const CounterHighVoltage:StatusEffectType        = mkCombat("Counter High Voltage");
 		public static const CounterRagingInferno:StatusEffectType      = mkCombat("Counter Raging Inferno");
 		public static const CounterHighTide:StatusEffectType           = mkCombat("Counter High Tide");
+		public static const CounterHowlingGale:StatusEffectType           = mkCombat("Counter Howling Gale");
+		public static const CounterRumblingQuake:StatusEffectType           = mkCombat("Counter Rumbling Quake");
 
 		//cooldowns
 		public static const CooldownAdamantineShell:StatusEffectType           	= mkCombat("Cooldown Adamantine Shell");


### PR DESCRIPTION
Added cumulative magic damage perks for wind and earth damage (Howling Gale/ Rumbling Earth)

Streamlined cumulative magic damage functions in backend
Added Howling Gale/ Rumbling Earth bonuses to Elemental fusion attacks
Wind Mod added to "Hurricane" and "Wind Scythe" magical specials
Wind Mod added to Wind Spells
Earth Mod added to Earth Spells
"Aura of Purity" and "Black Frost Aura" Auras now only maintain current counter for fire/ice cumulative damage perks