### PR TITLE
Elemental Bloodline Perk

### DIFF
--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -1058,6 +1058,9 @@ public class PerkLib
 		public static const ElementalArrows:PerkType = mk("Elemental Arrows", "Elemental Arrows",
 				"Shoot elemental arrows adding your intelligence to your damage. (+20% range physical attacks multiplier)",
 				"You've chosen the 'Elemental Arrows' perk, allowing you to shoot elemental arrows. (+20% range physical attacks multiplier)");
+		public static const ElementalBloodline:PerkType =  mk("Elemental Bloodline", "Elemental Bloodline",
+				"When in an infused state, passively gain Dao Comprehension for the associated element. Increases Dao Comprehension speed when in an infused state for the associated element.",
+				"You've chosen the 'Elemental Bloodline' perk. Enables passive Dao Comprehension and increased Comprehension speed when in an infused state");
 		public static const ElementalBolt:PerkType = mk("Elemental Bolt", "Elemental Bolt",
 				"Enable use of Elemental bolt. (would prevent decay of buff from building up elemental damage)",
 				"You've chosen the 'Elemental Bolt' perk. Enable use of Elemental bolt. (would prevent decay of buff from building up elemental damage)");
@@ -6489,6 +6492,8 @@ public class PerkLib
 					.requireCustomFunction(function (player:Player):Boolean {
                         return (player.hasPerk(PerkLib.ElementalContractRank7) || (player.hasPerk(PerkLib.DaoOfTheElements) && player.perkv1(PerkLib.DaoOfTheElements) >= 2)) && !player.hasPerk(PerkLib.PrestigeJobDruid);
                     }, "Having Elemental Contract Rank 7 or Dao of the Elements (layer 2 or higher) perks");
+			ElementalBloodline.requirePerk(PrestigeJobDruid)
+					.requireLevel(54);
             ElementalContractRank10.requirePerk(ElementalContractRank9)
                     .requireWis(250)
                     .requireLevel(54);

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -40,6 +40,7 @@ import classes.Scenes.SceneLib;
 import classes.Scenes.Soulforce;
 import classes.StatusEffects.VampireThirstEffect;
 import classes.lists.BreastCup;
+import classes.Races.ElementalRace;
 
 public class PlayerEvents extends BaseContent implements TimeAwareInterface {
 		//Handles all timeChange events for the player. Needed because player is not unique.
@@ -1395,6 +1396,23 @@ public class PlayerEvents extends BaseContent implements TimeAwareInterface {
 							}
 						}
 					}
+				}
+			}
+			if (player.hasPerk(PerkLib.ElementalBloodline) && player.hasPerk(PerkLib.ElementalBody)) {
+				var element:int = ElementalRace.getElement(player);
+				var dao:Array;
+				switch(element) {
+					case ElementalRace.ELEMENT_SYLPH: 	dao = Soulforce.daos[5];
+														break;
+					case ElementalRace.ELEMENT_GNOME: 	dao = Soulforce.daos[8];
+														break;
+					case ElementalRace.ELEMENT_IGNIS: 	dao = Soulforce.daos[0];
+														break;
+					case ElementalRace.ELEMENT_UNDINE: 	dao = Soulforce.daos[7];
+														break;	
+				}
+				if (dao && player.statusEffectv2(dao[1]) < SceneLib.soulforce.highestLayerOfDaoComprehension()) {
+					SceneLib.soulforce.daoContemplationsEffect(dao[1], dao[0], false, true);
 				}
 			}
 			if (InCollection("Kiha", flags[kFLAGS.PLAYER_COMPANION_0], flags[kFLAGS.PLAYER_COMPANION_2], flags[kFLAGS.PLAYER_COMPANION_3])) {

--- a/classes/classes/Scenes/Soulforce.as
+++ b/classes/classes/Scenes/Soulforce.as
@@ -406,8 +406,8 @@ public class Soulforce extends BaseContent
 		addButton(14, "Back", accessSoulforceMenu);
 	}
 
-	public function daoContemplationsEffect(statusEffect:StatusEffectType, daoname:String, clone:Boolean = false):void {
-		if (!clone) {
+	public function daoContemplationsEffect(statusEffect:StatusEffectType, daoname:String, clone:Boolean = false, elementalBody:Boolean = false):void {
+		if (!clone && !elementalBody) {
 			clearOutput();
 			outputText("You find a flat, comfortable rock to sit down on and contemplate.  Minute after minute you feel immersed into elements that surrounds you.  How they flow around you, how they change on their own and how they interact with each other.  All this while trying to understand, despite being insignificant while the great dao manifests around you.\n\n");
 		}
@@ -417,7 +417,7 @@ public class Soulforce extends BaseContent
 			dao = rand(6);
 			switch(daoname){
 				case "Fire":
-					if (player.hasPerk(PerkLib.FireAffinity)) dao += 1 + rand(3);
+					if (player.hasPerk(PerkLib.FireAffinity) || player.hasPerk(PerkLib.AffinityIgnis)) dao += 1 + rand(3);
 					break;
 				case "Ice":
 					if (player.hasPerk(PerkLib.ColdAffinity)) dao += 1 + rand(3);
@@ -428,11 +428,20 @@ public class Soulforce extends BaseContent
 				case "Darkness":
 					if (player.hasPerk(PerkLib.DarknessAffinity)) dao += 1 + rand(3);
 					break;
+				case "Wind":
+					if (player.hasPerk(PerkLib.AffinitySylph)) dao += 1 + rand(3);
+					break;
+				case "Earth":
+					if (player.hasPerk(PerkLib.AffinityGnome)) dao += 1 + rand(3);
+					break;
+				case "Water":
+					if (player.hasPerk(PerkLib.AffinityUndine)) dao += 1 + rand(3);
+					break;
 			}
 		}
 		//uzycie w kontemplacji niebianskich skarbow zwiazanych z danym zywiolem daje bonusowe punkty
 		if (dao > 0) {
-			if (!clone) outputText("After the session ends you managed to progress in Dao of "+daoname+".");
+			if (!clone && !elementalBody) outputText("After the session ends you managed to progress in Dao of "+daoname+".");
 			if (player.hasStatusEffect(statusEffect)) {
 				player.addStatusValue(statusEffect, 1, dao);
 				var thres:Array = [20, 40, 60, 100, 140, 180, 220, 260, 300];
@@ -450,7 +459,7 @@ public class Soulforce extends BaseContent
 			} else player.createStatusEffect(statusEffect, dao, 0, 0, 0);
 		}
 		else outputText("After the session ends, you did not manage to progress in your comprehension.\n\n");
-		if (!clone) doNext(camp.returnToCampUseEightHours);
+		if (!clone && !elementalBody) doNext(camp.returnToCampUseEightHours);
 	}
 
 	public function highestLayerOfDaoComprehension():Number {


### PR DESCRIPTION
Added Tier 9 Wisdom Perk: Elemental Bloodline
Requires: Level 54 and Prestige Job Druid
Effect: Enables passive Dao Comprehension and increased Comprehension speed when in an infused state