### PR TITLE
Blood DoT changes

### DIFF
--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -3422,6 +3422,7 @@ import classes.Scenes.Combat.CombatAbilities;
 				if (statusEffectv2(StatusEffects.CouatlHurricane) > 0) store14 *= statusEffectv2(StatusEffects.CouatlHurricane);
 				store14 += statusEffectv1(StatusEffects.CouatlHurricane); //Stacks on itself growing ever stronger
 				store14 += maxHP()*0.02;
+				store14 = SceneLib.combat.fixPercentDamage(store14);
 				store14 = SceneLib.combat.doDamage(store14);
 				if(plural) outputText("[Themonster] is violently struck by the ever intensifying windstorm. ");
 				else outputText("[Themonster] are violently struck by the ever intensifying windstorm. ");
@@ -3444,12 +3445,12 @@ import classes.Scenes.Combat.CombatAbilities;
 				//Deal damage if still wounded.
 				else {
 					var procentvalue:Number = (4 + rand(7));
-					var procentvalue1:Number = SceneLib.combat.BleedDamageBoost();
 					if (statusEffectv2(StatusEffects.IzmaBleed) > 0) procentvalue += statusEffectv2(StatusEffects.IzmaBleed);
-					procentvalue *= procentvalue1;
 					procentvalue = Math.round(procentvalue);
+
 					var store:Number = maxHP() * (procentvalue) / 100;
-					store = boundInt(1, store, maxHP()*.05);
+					store *= SceneLib.combat.BleedDamageBoost();
+					store = SceneLib.combat.fixPercentDamage(store);
 					store = SceneLib.combat.doDamage(store);
 					if (plural) outputText("[Themonster] bleed profusely from the jagged wounds your weapon left behind. ");
 					else outputText("[Themonster] bleeds profusely from the jagged wounds your weapon left behind. ");

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -3564,24 +3564,6 @@ import classes.Scenes.Combat.CombatAbilities;
 					outputText("[pg]");
 				}
 			}
-			if (hasStatusEffect(StatusEffects.HemorrhageShield)) {
-				if (hasPerk(PerkLib.EnemyFleshConstructType)) addStatusValue(StatusEffects.HemorrhageShield, 1, -2);
-				else addStatusValue(StatusEffects.HemorrhageShield, 1, -1);
-				if (statusEffectv1(StatusEffects.HemorrhageShield) <= 0) {
-					outputText("The wounds your shield left on [themonster] stop bleeding so profusely.\n\n");
-					removeStatusEffect(StatusEffects.HemorrhageShield);
-				}
-				else {
-					var hemorrhage3:Number = maxHP() * statusEffectv2(StatusEffects.HemorrhageShield);
-					hemorrhage3 *= SceneLib.combat.BleedDamageBoost();
-					hemorrhage3 = SceneLib.combat.fixPercentDamage(hemorrhage3);
-					hemorrhage3 = SceneLib.combat.doDamage(hemorrhage3);
-					if (plural) outputText("[Themonster] bleed profusely from the jagged wounds your shield left behind. ");
-					else outputText("[Themonster] bleeds profusely from the jagged wounds your shield left behind. ");
-					SceneLib.combat.CommasForDigits(hemorrhage3);
-					outputText("[pg]");
-				}
-			}
 			if(hasStatusEffect(StatusEffects.Hemorrhage2)) {
 				if (hasPerk(PerkLib.EnemyFleshConstructType)) addStatusValue(StatusEffects.Hemorrhage2, 1, -2);
 				else addStatusValue(StatusEffects.Hemorrhage2, 1, -1);

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -3415,27 +3415,38 @@ import classes.Scenes.Combat.CombatAbilities;
 				addStatusValue(StatusEffects.Hypermode,1,-1);
 			}
 			if(hasStatusEffect(StatusEffects.CouatlHurricane)) {
-				//Deal severe true damage each round
-				var store14:Number = (player.inte + player.spe) * 2;
-				var couatlExtraDmg:Number = (player.spe*5)+(player.inte*5);
+				//Countdown to heal
+				if (hasPerk(PerkLib.EnemyFleshConstructType)) addStatusValue(StatusEffects.CouatlHurricane, 1, -2);
+				else addStatusValue(StatusEffects.CouatlHurricane, 1, -1);
 
-				if (statusEffectv2(StatusEffects.CouatlHurricane) > 0) store14 += couatlExtraDmg; //If reapplied, temporarily increase damage
-				store14 += maxHP()*0.02;
-				store14 = SceneLib.combat.fixPercentDamage(store14, false);
-				store14 = SceneLib.combat.doDamage(store14);
-				if(plural) outputText("[Themonster] is violently struck by the ever intensifying windstorm. ");
-				else outputText("[Themonster] are violently struck by the ever intensifying windstorm. ");
-				SceneLib.combat.CommasForDigits(store14);
-				outputText("[pg]");
-				if(rand(4) == 3 && !monster.hasPerk(PerkLib.Resolute)) {
-					createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0); 
-					outputText("<b>A random flying object caught in the hurricane rams into your opponent, stunning it!</b>");
+				//Heal wounds
+				if (statusEffectv1(StatusEffects.CouatlHurricane) <= 0) {
+					outputText("The wounds you left on [themonster] stop bleeding so profusely.\n\n");
+					removeStatusEffect(StatusEffects.CouatlHurricane);
 				}
-				if (statusEffectv2(StatusEffects.CouatlHurricane) > 0) {
-					changeStatusValue(StatusEffects.CouatlHurricane, 2, 0);
-					outputText("\nThe hurricane winds returned to their regular intensity.");
+				else {
+					//Deal severe true damage each round
+					var store14:Number = (player.inte + player.spe) * 2;
+					var couatlExtraDmg:Number = (player.spe*5)+(player.inte*5);
+
+					if (statusEffectv2(StatusEffects.CouatlHurricane) > 0) store14 += couatlExtraDmg; //If reapplied, temporarily increase damage
+					store14 += maxHP()*0.02;
+					store14 = SceneLib.combat.fixPercentDamage(store14, false);
+					store14 = SceneLib.combat.doDamage(store14);
+					if(plural) outputText("[Themonster] is violently struck by the ever intensifying windstorm. ");
+					else outputText("[Themonster] are violently struck by the ever intensifying windstorm. ");
+					SceneLib.combat.CommasForDigits(store14);
+					outputText("[pg]");
+					if(rand(4) == 3 && !hasPerk(PerkLib.Resolute)) {
+						createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0); 
+						outputText("<b>A random flying object caught in the hurricane rams into your opponent, stunning it!</b>");
+					}
+					if (statusEffectv2(StatusEffects.CouatlHurricane) > 0) {
+						changeStatusValue(StatusEffects.CouatlHurricane, 2, 0);
+						outputText("\nThe hurricane winds returned to their regular intensity.");
+					}
+					outputText("\n\n");
 				}
-				outputText("\n\n");
 			}
 			if(hasStatusEffect(StatusEffects.IzmaBleed)) {
 				//Countdown to heal

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -3417,19 +3417,25 @@ import classes.Scenes.Combat.CombatAbilities;
 			if(hasStatusEffect(StatusEffects.CouatlHurricane)) {
 				//Deal severe true damage each round
 				var store14:Number = (player.inte + player.spe) * 2;
-				createStatusEffect(StatusEffects.CouatlHurricane, (player.spe*5)+(player.inte*5), 1, 0, 0);
-				store14 = Math.round(store14);
-				if (statusEffectv2(StatusEffects.CouatlHurricane) > 0) store14 *= statusEffectv2(StatusEffects.CouatlHurricane);
-				store14 += statusEffectv1(StatusEffects.CouatlHurricane); //Stacks on itself growing ever stronger
+				var couatlExtraDmg:Number = (player.spe*5)+(player.inte*5);
+
+				if (statusEffectv2(StatusEffects.CouatlHurricane) > 0) store14 += couatlExtraDmg; //If reapplied, temporarily increase damage
 				store14 += maxHP()*0.02;
-				store14 = SceneLib.combat.fixPercentDamage(store14);
+				store14 = SceneLib.combat.fixPercentDamage(store14, false);
 				store14 = SceneLib.combat.doDamage(store14);
 				if(plural) outputText("[Themonster] is violently struck by the ever intensifying windstorm. ");
 				else outputText("[Themonster] are violently struck by the ever intensifying windstorm. ");
 				SceneLib.combat.CommasForDigits(store14);
 				outputText("[pg]");
-				temp = rand(4);
-				if(temp == 3) createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0); outputText("<b>A random flying object caught in the hurricane rams into your opponent, stunning it!</b>\n\n");
+				if(rand(4) == 3 && !monster.hasPerk(PerkLib.Resolute)) {
+					createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0); 
+					outputText("<b>A random flying object caught in the hurricane rams into your opponent, stunning it!</b>");
+				}
+				if (statusEffectv2(StatusEffects.CouatlHurricane) > 0) {
+					changeStatusValue(StatusEffects.CouatlHurricane, 2, 0);
+					outputText("\nThe hurricane winds returned to their regular intensity.");
+				}
+				outputText("\n\n");
 			}
 			if(hasStatusEffect(StatusEffects.IzmaBleed)) {
 				//Countdown to heal
@@ -3472,7 +3478,7 @@ import classes.Scenes.Combat.CombatAbilities;
 					var store3:Number = SceneLib.combat.CalcBaseDamageUnarmed()/2;
 					store3 *= SceneLib.combat.BleedDamageBoost(true);
 					if (statusEffectv2(StatusEffects.SharkBiteBleed) > 0) store3 *= statusEffectv2(StatusEffects.SharkBiteBleed);
-					store3 = SceneLib.combat.fixPercentDamage(store3);
+					store3 = SceneLib.combat.fixPercentDamage(store3, false);
 					store3 = SceneLib.combat.doDamage(store3);
 					if(plural) outputText("[Themonster] bleed profusely from the jagged wounds your bite left behind. ");
 					else outputText("[Themonster] bleeds profusely from the jagged wounds your bite left behind. ");
@@ -3518,7 +3524,7 @@ import classes.Scenes.Combat.CombatAbilities;
 				else {
 					var store5:Number = SceneLib.combat.CalcBaseDamageUnarmed()/2;
 					store5 *= SceneLib.combat.BleedDamageBoost();
-					store5 = SceneLib.combat.fixPercentDamage(store5);
+					store5 = SceneLib.combat.fixPercentDamage(store5, false);
 					store5 = SceneLib.combat.doDamage(store5);
 					if (plural) outputText("[Themonster] bleed profusely from the jagged ");
 					else outputText("[Themonster] bleeds profusely from the jagged ")
@@ -3538,7 +3544,7 @@ import classes.Scenes.Combat.CombatAbilities;
 				}
 				else {
 					var hemorrhage1:Number = maxHP() * statusEffectv2(StatusEffects.Hemorrhage)
-					hemorrhage1 *= SceneLib.combat.BleedDamageBoost(true);
+					hemorrhage1 *= SceneLib.combat.BleedDamageBoost();
 					hemorrhage1 = SceneLib.combat.fixPercentDamage(hemorrhage1);
 					hemorrhage1 = SceneLib.combat.doDamage(hemorrhage1);
 					if (plural) outputText("[Themonster] bleed profusely from the jagged wounds your attack left behind. ");
@@ -3576,8 +3582,8 @@ import classes.Scenes.Combat.CombatAbilities;
 					var hemorrhage4:Number = maxHP() * statusEffectv2(StatusEffects.Hemorrhage2);
 					hemorrhage4 = SceneLib.combat.fixPercentDamage(hemorrhage4);
 					hemorrhage4 = SceneLib.combat.doDamage(hemorrhage4);
-					if (plural) outputText("[Themonster] bleed profusely from the jagged wounds your companion attack left behind. ");
-					else outputText("[Themonster] bleeds profusely from the jagged wounds your companion attack left behind. ");
+					if (plural) outputText("[Themonster] bleed profusely from the jagged wounds your companion's attack left behind. ");
+					else outputText("[Themonster] bleeds profusely from the jagged wounds your companion's attack left behind. ");
 					SceneLib.combat.CommasForDigits(hemorrhage4);
 					outputText("[pg]");
 				}
@@ -3623,12 +3629,11 @@ import classes.Scenes.Combat.CombatAbilities;
 			}
 			if(hasStatusEffect(StatusEffects.Briarthorn)) {
 				var store16:Number = (player.str + player.spe) * 2;
-				var store16a:Number = SceneLib.combat.BleedDamageBoost();
-				store16 *= store16a;
+				store16 *= SceneLib.combat.BleedDamageBoost();
 				store16 += maxHP()*0.05;
 				store16 = SceneLib.combat.fixPercentDamage(store16);
 				store16 = SceneLib.combat.doDamage(store16);
-				if(plural) outputText("[Themonster] bleeds profusely from the deep wounds your vine thorns left behind. ");
+				if(plural) outputText("[Themonster] bleed profusely from the deep wounds your vine thorns left behind. ");
 				else outputText("[Themonster] bleeds profusely from the deep wounds your vine thorns left behind. ");
 				SceneLib.combat.CommasForDigits(store16);
 				outputText("[pg]");
@@ -3639,9 +3644,8 @@ import classes.Scenes.Combat.CombatAbilities;
 					outputText("<b>Bleeding cause by deep wounds your rose thorns left behind stopped!</b>[pg]");
 				} else {
 					var store17:Number = (player.str + player.spe);
-					var store17a:Number = SceneLib.combat.BleedDamageBoost() *
-							statusEffectv1(StatusEffects.Rosethorn)*0.1;
-					store17 *= store17a;
+					store17 *= SceneLib.combat.BleedDamageBoost();
+					store17 *= statusEffectv1(StatusEffects.Rosethorn) * 0.1;
 					store17 += maxHP()*0.01;
 					store17 = SceneLib.combat.fixPercentDamage(store17);
 					store17 = SceneLib.combat.doDamage(store17);

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -7668,10 +7668,12 @@ public class Combat extends BaseContent {
 		if (monster.hasPerk(PerkLib.EnemyConstructType) || monster.hasPerk(PerkLib.EnemyPlantType) || monster.hasPerk(PerkLib.EnemyGooType) || monster.hasPerk(PerkLib.EnemyUndeadType)) bleedChance = 0;
         if (rand(100) < bleedChance) bleed = true;
 		if (bleed) {
-			if (monster.hasStatusEffect(StatusEffects.HemorrhageShield)) monster.addStatusValue(StatusEffects.HemorrhageShield, 1, 2);
-			else monster.createStatusEffect(StatusEffects.HemorrhageShield, 2, 0.01, 0, 0);
-            if (player.shield == shields.SPIH_SH) monster.addStatusValue(StatusEffects.HemorrhageShield, 2, 0.01);
-            if (player.shield == shields.SPIM_SH) monster.addStatusValue(StatusEffects.HemorrhageShield, 2, 0.04);
+			if (monster.hasStatusEffect(StatusEffects.Hemorrhage)) monster.addStatusValue(StatusEffects.Hemorrhage, 1, 2);
+			else { 
+                monster.createStatusEffect(StatusEffects.Hemorrhage, 2, 0.01, 0, 0);
+                if (player.shield == shields.SPIH_SH) monster.addStatusValue(StatusEffects.Hemorrhage, 2, 0.01);
+                else if (player.shield == shields.SPIM_SH) monster.addStatusValue(StatusEffects.Hemorrhage, 2, 0.04);
+            }
 			if (monster.plural) outputText("\n[Themonster] bleed profusely from the many bloody gashes your [shield] leave behind.");
             else outputText("\n[Themonster] bleeds profusely from the many bloody gashes your [shield] leave behind.");
 		}

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -8093,7 +8093,6 @@ public class Combat extends BaseContent {
         if (monster.hasStatusEffect(StatusEffects.IzmaBleed)) isBleeding = true;
         if (monster.hasStatusEffect(StatusEffects.CouatlHurricane)) isBleeding = true;
         if (monster.hasStatusEffect(StatusEffects.GoreBleed)) isBleeding = true;
-        if (monster.hasStatusEffect(StatusEffects.HemorrhageShield)) isBleeding = true;
         if (monster.hasStatusEffect(StatusEffects.Hemorrhage2)) isBleeding = true;
         if (monster.hasStatusEffect(StatusEffects.Briarthorn)) isBleeding = true;
         return isBleeding;

--- a/classes/classes/Scenes/Combat/CombatTeases.as
+++ b/classes/classes/Scenes/Combat/CombatTeases.as
@@ -120,23 +120,6 @@ public class CombatTeases extends BaseCombatContent {
 		return lustDmg;
 	}
 
-	/**
-	 * Function used to ensure that aura damage can onlu deals a certain % of lust,
-	 * even taking difiiculty settings into account.
-	 * @param lustDmg (Number) - inital damage to be checked
-	 * @param bound (iny) - Upper bound (out of 100) % of lust attack can inflict
-	 * @return lustDmg (Number) - final damage, bounded to the % deamage if needed
-	 */
-	public function boundLustDamage(lustDmg:Number, monster:Monster, bound:int = 10):Number {
-		var monsterBoundLust:Number = monster.maxLust() * (bound / 100);
-
-		if ((lustDmg * (1 / monster.damageReductionBasedOnDifficulty())) > monsterBoundLust) {
-			lustDmg = monsterBoundLust * monster.damageReductionBasedOnDifficulty();
-		}
-
-		return lustDmg;
-	}
-
 	// Just text should force the function to purely emit the test text to the output display, and not have any other side effects
 	public function tease(justText:Boolean = false):void {
 		if (!justText) clearOutput();

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -5640,8 +5640,9 @@ public class MagicSpecials extends BaseCombatContent {
 			damage *= (1.75 * combat.windDamageBoostedByDao());
 			damage = Math.round(damage);
 			doWindDamage(damage, true, true);
-			if (!monster.hasStatusEffect(StatusEffects.CouatlHurricane)) monster.createStatusEffect(StatusEffects.CouatlHurricane,(player.spe*5)+(player.inte*5),1,0,0);
-			else{
+			if (!monster.hasStatusEffect(StatusEffects.CouatlHurricane)) monster.createStatusEffect(StatusEffects.CouatlHurricane,3,0,0,0);
+			else {
+				monster.addStatusValue(StatusEffects.CouatlHurricane, 1, 1);
 				monster.changeStatusValue(StatusEffects.CouatlHurricane, 2, 1);
 				outputText("\n\nThe strength of the hurricane winds has increased even further.");
 			}
@@ -5673,8 +5674,9 @@ public class MagicSpecials extends BaseCombatContent {
 				outputText("too resolute to be stunned by your attack.</b> ");
 			}
 			doWindDamage(damage, true, true);
-			if (!monster.hasStatusEffect(StatusEffects.CouatlHurricane)) monster.createStatusEffect(StatusEffects.CouatlHurricane,(player.spe*5)+(player.inte*5),0,0,0);
+			if (!monster.hasStatusEffect(StatusEffects.CouatlHurricane)) monster.createStatusEffect(StatusEffects.CouatlHurricane,3,0,0,0);
 			else {
+				monster.addStatusValue(StatusEffects.CouatlHurricane, 1, 1);
 				monster.changeStatusValue(StatusEffects.CouatlHurricane, 2, 1);
 				outputText("\n\nThe strength of the hurricane winds has increased even further.");
 			}

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -5724,9 +5724,10 @@ public class MagicSpecials extends BaseCombatContent {
 			damage *= (1.75 * combat.windDamageBoostedByDao());
 			damage = Math.round(damage);
 			doWindDamage(damage, true, true);
-			if (!monster.hasStatusEffect(StatusEffects.KamaitachiBleed)) monster.createStatusEffect(StatusEffects.KamaitachiBleed,combat.CalcBaseDamageUnarmed()*5*combat.BleedDamageBoost(true),1,0,0);
+			if (!monster.hasStatusEffect(StatusEffects.KamaitachiBleed)) monster.createStatusEffect(StatusEffects.KamaitachiBleed,3,0,0,1);
 			else{
-				monster.addStatusValue(StatusEffects.KamaitachiBleed, 1, combat.CalcBaseDamageUnarmed()*5*combat.BleedDamageBoost(true));
+				monster.addStatusValue(StatusEffects.KamaitachiBleed, 1, 1);
+				monster.addStatusValue(StatusEffects.KamaitachiBleed, 4, 1);
 				outputText("\n\nYour attack greatly worsened the bleeding your opponents suffers.");
 			}
 			combatRoundOver();
@@ -5757,9 +5758,9 @@ public class MagicSpecials extends BaseCombatContent {
 				outputText("too resolute to be stunned by your attack.</b> ");
 			}
 			doWindDamage(damage, true, true);
-			if (!monster.hasStatusEffect(StatusEffects.KamaitachiBleed)) monster.createStatusEffect(StatusEffects.KamaitachiBleed,combat.CalcBaseDamageUnarmed()*5*combat.BleedDamageBoost(true),0,0,0);
+			if (!monster.hasStatusEffect(StatusEffects.KamaitachiBleed)) monster.createStatusEffect(StatusEffects.KamaitachiBleed,3,0,0,1);
 			else {
-				monster.addStatusValue(StatusEffects.KamaitachiBleed, 1, combat.CalcBaseDamageUnarmed()*5*combat.BleedDamageBoost(true));
+				monster.addStatusValue(StatusEffects.KamaitachiBleed, 1, 1);
 				outputText("\n\nYour attack greatly worsened the bleeding your opponent suffers.");
 			}
 		}

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -5642,7 +5642,7 @@ public class MagicSpecials extends BaseCombatContent {
 			doWindDamage(damage, true, true);
 			if (!monster.hasStatusEffect(StatusEffects.CouatlHurricane)) monster.createStatusEffect(StatusEffects.CouatlHurricane,(player.spe*5)+(player.inte*5),1,0,0);
 			else{
-				monster.createStatusEffect(StatusEffects.CouatlHurricane, (player.spe*5)+(player.inte*5), 1, 0, 0);
+				monster.changeStatusValue(StatusEffects.CouatlHurricane, 2, 1);
 				outputText("\n\nThe strength of the hurricane winds has increased even further.");
 			}
 			combatRoundOver();
@@ -5675,7 +5675,7 @@ public class MagicSpecials extends BaseCombatContent {
 			doWindDamage(damage, true, true);
 			if (!monster.hasStatusEffect(StatusEffects.CouatlHurricane)) monster.createStatusEffect(StatusEffects.CouatlHurricane,(player.spe*5)+(player.inte*5),0,0,0);
 			else {
-				monster.createStatusEffect(StatusEffects.CouatlHurricane, (player.spe*5)+(player.inte*5), 1, 0, 0);
+				monster.changeStatusValue(StatusEffects.CouatlHurricane, 2, 1);
 				outputText("\n\nThe strength of the hurricane winds has increased even further.");
 			}
 		}

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -5624,10 +5624,12 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		checkAchievementDamage(damage);
 		if ((player.shield == shields.SPIL_SH || player.shield == shields.SPIH_SH || player.shield == shields.SPIM_SH || (player.shield == shields.AETHERS && player.weapon == weapons.AETHERD && AetherTwinsFollowers.AetherTwinsShape == "Sky-tier Gaunlets")) && !monster.isImmuneToBleed()) {
-			if (monster.hasStatusEffect(StatusEffects.HemorrhageShield)) monster.addStatusValue(StatusEffects.HemorrhageShield, 1, 3);
-			else monster.createStatusEffect(StatusEffects.HemorrhageShield, 3, 0.02, 0, 0);
-            if (player.shield == shields.SPIH_SH) monster.addStatusValue(StatusEffects.HemorrhageShield, 2, 0.02);
-            if (player.shield == shields.SPIM_SH) monster.addStatusValue(StatusEffects.HemorrhageShield, 2, 0.08);
+			if (monster.hasStatusEffect(StatusEffects.Hemorrhage)) monster.addStatusValue(StatusEffects.Hemorrhage, 1, 1);
+			else {
+				monster.createStatusEffect(StatusEffects.Hemorrhage, 3, 0.02, 0, 0);
+            	if (player.shield == shields.SPIH_SH) monster.addStatusValue(StatusEffects.Hemorrhage, 2, 0.02);
+            	else if (player.shield == shields.SPIM_SH) monster.addStatusValue(StatusEffects.Hemorrhage, 2, 0.05);
+			}
 			if (monster.plural) outputText("\n[Themonster] bleed profusely from the many bloody gashes your [shield] leave behind.");
             else outputText("\n[Themonster] bleeds profusely from the many bloody gashes your [shield] leave behind.");
 		}


### PR DESCRIPTION
Damage bounding for periodic damage/lust effects is currently calculated using the following:

If the monster is equal or higher level, the DoT damage is limited to a max of 20%. If the monster is up to 9 levels below the player, tha max damage increases up to 50%, and any greater gap is unbounded Kamaitachi Bleed now has an inital damage value +20%/+40% (depending on racial tier) per stack of bleed with no ceiling. Normal attacks add 1 stack and the "Wind Scythe" special adds 3. Each turn in which the bleed is not applied reduces the stacks by 1 (min. of 1 stack) 

General code cleanup for bleed DoT effects

Added number formatting to the tease damage display