### PR TITLE
Perm Tier 3 Magic

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -29,6 +29,8 @@ import classes.lists.BreastCup;
 import classes.lists.Gender;
 
 import coc.view.MainView;
+import classes.Scenes.Combat.CombatAbility;
+
 
 //import flash.events.MouseEvent;
 
@@ -1961,6 +1963,7 @@ import coc.view.MainView;
 			addButton(1, "Perk Select(2)", ascensionPerkMenu2).hint("Spend Ascension Perk Points on special perks!", "Perk Selection");
 			addButton(2, "Rare Perks(1)", rarePerks1).hint("Spend Ascension Points on rare special perks!", "Perk Selection");
 			addButton(3, "Rare Perks(2)", rarePerks2).hint("Spend Ascension Points on rare special perks!", "Perk Selection");
+			addButton(4, "Perm Spells", acensionPermSpellMenu).hint("Spend Ascension Perk Points to make certain spells permanent (10 points)", "Spell Selection");
 			addButton(5, "Perm Perks", ascensionPermeryMenu).hint("Spend Ascension Perk Points to make certain perks permanent (5/10 points).", "Perk Selection");
 			genMemPatch();
 			if (player.hasStatusEffect(StatusEffects.TranscendentalGeneticMemory)) {
@@ -2634,6 +2637,23 @@ import coc.view.MainView;
 			outputText("Your have gained new Bloodline.");
 		}
 
+		private function acensionPermSpellMenu(page:int = 1):void {
+			clearOutput();
+			outputText("For the price of ten points, you can make certain spells permanent and they will carry over in future ascensions. In addition, they can be used even if you don't have access to the specifc category spells yet.");
+			outputText("\n\nAscension Perk Points: " + player.ascensionPerkPoints);
+			menu();
+			if (page == 1) {
+				if (player.hasStatusEffect(StatusEffects.KnowsPolarMidnight) && player.statusEffectv4(StatusEffects.KnowsPolarMidnight) != 9000) addButton(0, "Polar Midnight", permanentizeSpell, StatusEffects.KnowsPolarMidnight, 1);
+				else if (player.hasStatusEffect(StatusEffects.KnowsPolarMidnight) && player.statusEffectv4(StatusEffects.KnowsPolarMidnight) == 9000) addButtonDisabled(0, "Polar Midnight", "Polar Midnight spell is already permanent.");
+				else addButtonDisabled(0, "???", "You haven't learnt this spell yet!");
+
+				if (player.hasStatusEffect(StatusEffects.KnowsMeteorShower) && player.statusEffectv4(StatusEffects.KnowsMeteorShower) != 9000) addButton(1, "Meteor Shower", permanentizeSpell, StatusEffects.KnowsMeteorShower, 1);
+				else if (player.hasStatusEffect(StatusEffects.KnowsMeteorShower) && player.statusEffectv4(StatusEffects.KnowsMeteorShower) == 9000) addButtonDisabled(1, "Meteor Shower", "Meteor Shower spell is already permanent.");
+				else addButtonDisabled(1, "???", "You haven't learnt this spell yet!");
+			}
+			addButton(14, "Back", ascensionMenu);
+		}
+
 		private function ascensionPermeryMenu(page:int = 1):void {
 			clearOutput();
 			outputText("For the price of five points, you can make certain perks permanent and they will carry over in future ascensions. In addition, if the perks come from transformations, they will stay even if you no longer meet the requirements.");
@@ -2761,6 +2781,16 @@ import coc.view.MainView;
 			addButton(14, "Back", ascensionMenu);
 		}
 
+		private function permanentizeSpell(statusEffect:StatusEffectType, returnPage:int = 1):void {
+			//Not enough points or perk already permed? Cancel.
+			if (player.ascensionPerkPoints < 10) return;
+			if (player.statusEffectv4(statusEffect) == 9000) return;
+			//Deduct points
+			player.ascensionPerkPoints -= 10;
+			//Permanentize a perk
+			player.changeStatusValue(statusEffect, 4, 9000);
+			acensionPermSpellMenu(returnPage);
+		}
 		private function permanentizePerk1(perk:PerkType):void {
 			//Not enough points or perk already permed? Cancel.
 			if (player.ascensionPerkPoints < 5) return;
@@ -3282,5 +3312,21 @@ import coc.view.MainView;
 		private function isSpecialStatus(statusEffects:StatusEffectClass, statusEffect:* = null):Boolean {
 			return (statusEffect == StatusEffects.KnowsWereBeast || statusEffects.value4 == 9000);	//na razie jest tu tylko werebeast
 		}	//ale potem zamienić to na specialne soulskills z każdego z klanów
+
+		public static function hasAscensionSpell(spellCat:int):Boolean {
+			var spellsToCheck:/*StatusEffect*/Array;
+			switch(spellCat) {
+				case CombatAbility.CAT_SPELL_WHITE: spellsToCheck = [StatusEffects.KnowsMeteorShower];
+													break;
+				case CombatAbility.CAT_SPELL_BLACK: spellsToCheck = [StatusEffects.KnowsPolarMidnight];
+													break;
+			}
+			if (spellsToCheck) {
+				return spellsToCheck.some(function (statusEffect:StatusEffectType):Boolean {
+					return player.hasStatusEffect(statusEffect) && player.statusEffectv4(statusEffect) == 9000;
+				});
+			} else
+				return false;
+		}
 	} // what the fuck are those weird comments here? ^
 }


### PR DESCRIPTION
Added Ability to make permanent certain spells between ascensions. Currently available for Polar Midnight and Meteor Shower Tier 3 Spells