### PR TITLE
Lethice Adaption Fixes

### DIFF
--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -822,8 +822,6 @@ public class Combat extends BaseContent {
             outputText("<b>  Even physical special attacks are out of the question.</b>");
             removeButton(1); //Removes bow usage.
         }
-        //Enable Lethice Adaption for player actions
-        if (monster is Lethice && (monster as Lethice).fightPhase != 2) (monster as Lethice).deflectActive = true;
     }
 
     internal function buildOtherActions(buttons:ButtonDataList, backFunc:Function, aspectButtons:ButtonDataList = null):void {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -771,6 +771,8 @@ public class Combat extends BaseContent {
 			if (player.armor == armors.BMARMOR) dynStats("lus", -(Math.round(player.maxLust() * 0.05)));
 			if (player.hasStatusEffect(StatusEffects.TyrantState)) dynStats("lus", (Math.round(player.maxLust() * 0.05)));
 			if (player.hasStatusEffect(StatusEffects.VampThirstStacksHPMana)) player.removeStatusEffect(StatusEffects.VampThirstStacksHPMana);
+            //Prevent Lethice from adapting to DoT/Followers
+            if (monster is Lethice && (monster as Lethice).fightPhase != 2) (monster as Lethice).deflectActive = false;
         }
         mainView.hideMenuButton(MainView.MENU_DATA);
         mainView.hideMenuButton(MainView.MENU_APPEARANCE);
@@ -820,6 +822,8 @@ public class Combat extends BaseContent {
             outputText("<b>  Even physical special attacks are out of the question.</b>");
             removeButton(1); //Removes bow usage.
         }
+        //Enable Lethice Adaption for player actions
+        if (monster is Lethice && (monster as Lethice).fightPhase != 2) (monster as Lethice).deflectActive = true;
     }
 
     internal function buildOtherActions(buttons:ButtonDataList, backFunc:Function, aspectButtons:ButtonDataList = null):void {

--- a/classes/classes/Scenes/Combat/CombatUI.as
+++ b/classes/classes/Scenes/Combat/CombatUI.as
@@ -595,6 +595,9 @@ public class CombatUI extends BaseCombatContent {
 							btnSpecial1.show("Dispel", lethice.dispellRapetacles);
 						}
 					}
+
+					//Enable Lethice Adaption for player actions
+        			if (lethice.fightPhase != 2) lethice.deflectActive = true;
 				}
 				else if (monster is WoodElvesHuntingParty) {
 					var woodelves:WoodElvesHuntingParty = monster as WoodElvesHuntingParty;

--- a/classes/classes/Scenes/Dungeons/D3/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/D3/Lethice.as
@@ -90,6 +90,9 @@ public class Lethice extends Monster
 					}
 					else{
 						str += "\n\nHaving recalled what happened earlier, It is probably the best to <b>attempt alternate strategy</b> before repeating the same move quickly.";
+						if (player.hasPerk(PerkLib.EyesOfTheHunterMaster) && dictOrder.length) {
+							str += " Luckily, your senses are strong to notice that she seems ready to counter the following types of damage: <b>" + printImmuneDamageTypes() + "</b>.";
+						}
 					}
 					if(dictOrder.indexOf("hplossimmune")>-1){
 						str += "\n\nPerhaps out of your sheer willpower or rage you still manage to stand up to fight for another day, seeing Lethice's grin in response, you realized that <b>you might not able to survive</b> another blow from her should you still retain your grievous injuries!"
@@ -123,6 +126,9 @@ public class Lethice extends Monster
 				}
 
 				str += "\n\nHaving recalled what happened earlier, It is probably the best to attempt <b>alternate strategy</b> before repeating the same move quickly.";
+				if (player.hasPerk(PerkLib.EyesOfTheHunterMaster) && dictOrder.length) {
+					str += " Luckily, your senses are strong to notice that she seems ready to counter the following types of damage: <b>" + printImmuneDamageTypes() + "</b>.";
+				}
 
 				if(dictOrder.indexOf("hplossimmune")>-1){
 					str += "\n\nPerhaps out of your sheer willpower or rage you still manage to stand up to fight for another day, seeing Lethice's grin in response, you realized that <b>you might not able to survive</b> another blow from her should you still retain your grievous injuries!"
@@ -307,6 +313,29 @@ public class Lethice extends Monster
 			else{
 				return false;
 			}
+		}
+		private function printImmuneDamageTypes():String {
+			var printTranslation:Object = {
+				"physical": "Physical",
+				"magic": "Magic",
+				"fire": "Fire",
+				"cold": "Ice",
+				"lightning": "Lightning",
+				"dark": "Darkness",
+				"poison": "Poison",
+				"wind": "Wind",
+				"water": "Water",
+				"acid": "Acid",
+				"earth": "Earth",
+				"true": "True",
+				"lust": "Lust"
+			};
+			return dictOrder.filter(function (type:String, index:int, array:Array):Boolean {
+				return printTranslation.hasOwnProperty(type);
+			})
+			.map(function (type:String, index:int, array:Array):String {
+				return printTranslation[type];
+			}).join(", ");
 		}
 		override public function combatRoundUpdate():void{
 			if(_fightPhase!=2){

--- a/classes/classes/Scenes/Dungeons/D3/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/D3/Lethice.as
@@ -164,6 +164,7 @@ public class Lethice extends Monster
 		private var dictAttacked:Array = [];
 		private var roundCheck:int = 0;
 		private var decayCheck:Boolean = false;
+		public var deflectActive:Boolean = true;
 
 		private function furubeYuraYuraYatsukaNoTsurugiIkaishinshoMakora():void{
 			var _statusEffects:Array = statusEffects;
@@ -314,7 +315,7 @@ public class Lethice extends Monster
 			super.combatRoundUpdate();
 		}
 		private function adaptionDeflect(damage:Number, font:String, dict:String="physical"):Number {
-			if(_fightPhase!=2){
+			if(_fightPhase!=2 && deflectActive){
 				var index:int = dictOrder.indexOf(dict);
 				if(index>-1){
 					var numberformat:NumberFormatter = new NumberFormatter();
@@ -323,20 +324,20 @@ public class Lethice extends Monster
 					if(dict=="lust"){
 						if(deflectDamage>player.maxOverLust()*0.2){
 							var _tmp:Number = Math.round(player.maxOverLust()*0.2);
-							player.lust += _tmp;
+							player.takeLustDamage(_tmp);
 							dmgText = numberformat.format(Math.floor(Math.abs(_tmp)));
 						}
 						else
-							player.lust += deflectDamage;
+							player.takeLustDamage(deflectDamage);
 					}
 					else{
 						if(deflectDamage>player.maxOverHP()*0.4){
 							var __tmp:Number = Math.round(player.maxOverHP()*0.4);
-							player.HP -= __tmp;
+							player.takeDamage(__tmp);
 							dmgText = numberformat.format(Math.floor(Math.abs(__tmp)));
 						}
 						else
-							player.HP -= deflectDamage;
+							player.takeDamage(deflectDamage);
 					}
 					outputText("<b>([font-" + font + "]" + "Deflected! " + dmgText + "[/font])</b>");
 
@@ -455,7 +456,7 @@ public class Lethice extends Monster
 
 			// Lettuce now adapt to player loss immunity HA
 			if(_fightPhase!=2){
-				if(player.HP<=player.minHP()){
+				if(player.HP<=player.minHP() + 1 && (player.hasStatusEffect(StatusEffects.TooAngryTooDie) || player.hasPerk(PerkLib.Immortality) || player.hasPerk(PerkLib.WhatIsReality))){
 					if(dictOrder.indexOf("hplossimmune")>-1){
 						doNext(SceneLib.combat.endHpLoss);
 					}

--- a/classes/classes/Scenes/Dungeons/D3/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/D3/Lethice.as
@@ -300,7 +300,7 @@ public class Lethice extends Monster
 				default:
 					string = "restrain";
 			}
-			if(statusHandler(statusEffect.id)){
+			if(_fightPhase != 2 && statusHandler(statusEffect.id)){
 				outputText("\n\nAs you attempt to " + string + " Lethice, much to your surprise she remain unfazed. Looks like she has adapted to your ability.");
 				return true;
 			}


### PR DESCRIPTION
Lethice now cannot adapt/deflect DoT and companions (since some sources such as auras cannot be turned off in battle)

Lethice reflection damage now uses proper damage functions, so that player defenses are properly taken into account 
Lethice's "hplossimmune" adaption now takes the correct HP value into account.