### PR TITLE
Yggdrasil  Perks

### DIFF
--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -3937,8 +3937,8 @@ public class PerkLib
 				"As a plant when using natural weapon your damage scaling is based on Toughness instead of strength.");
 		public static const RampantMight:PerkType = mk("Rampant Might", "Rampant Might",
 				"As a plant dragon when using natural weapon your damage scaling is based on both Toughness and Strength.");
-		//public static const WisdomoftheAges:PerkType = mk("Wisdom of the Ages", "Wisdom of the Ages",
-		//		"Your bottomless insight somehow transmutes itself into raw power, allowing you to add half of your intelligence and wisdom as a modifier to strength and toughness.");
+		public static const WisdomoftheAges:PerkType = mk("Wisdom of the Ages", "Wisdom of the Ages",
+				"Your bottomless insight somehow transmutes itself into raw power, allowing you to add half of your intelligence and wisdom as a modifier to strength and toughness.");
 		public static const ZenjisInfluence1:PerkType = mk("Zenji's influence 1", "Zenji's influence 1",
 				"Increases maximum mana and fatigue by 10%.")
 				.withBuffs({'maxmana_mult':+0.10,'maxfatigue_mult':+0.10});

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -5446,6 +5446,8 @@ use namespace CoC;
 			if (!hasPerk(PerkLib.Enigma) && statStore.hasBuff('Enigma')) statStore.removeBuffs('Enigma');
 			if (hasPerk(PerkLib.LionHeart)) statStore.replaceBuffObject({'str.mult':Math.round(speStat.mult.value/2)}, 'Lion Heart', { text: 'Lion Heart' });
 			if (!hasPerk(PerkLib.LionHeart) && statStore.hasBuff('Lion Heart')) statStore.removeBuffs('Lion Heart');
+			if (hasPerk(PerkLib.WisdomoftheAges)) statStore.replaceBuffObject({'str.mult':Math.round(((intStat.mult.value/2)+(wisStat.mult.value/2))),'tou.mult':Math.round(((intStat.mult.value/2)+(wisStat.mult.value/2)))}, 'Wisdom of the Ages', { text: 'Wisdom of the Ages' });
+			if (!hasPerk(PerkLib.WisdomoftheAges) && statStore.hasBuff('Wisdom of the Ages')) statStore.removeBuffs('Wisdom of the Ages');
 			if (hasPerk(PerkLib.DeathPriest)) statStore.replaceBuffObject({'int.mult':Math.round(wisStat.mult.value)}, 'Death Priest', { text: 'Death Priest' });
 			if (!hasPerk(PerkLib.DeathPriest) && statStore.hasBuff('Death Priest')) statStore.removeBuffs('Death Priest');
 			if (hasPerk(PerkLib.LustingWarrior) && hasStatusEffect(StatusEffects.Overheat)) statStore.replaceBuffObject({'str.mult':Math.round(libStat.mult.value)}, 'Lusting Warrior', { text: 'Lusting Warrior' });

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -2037,24 +2037,13 @@ public class PlayerEvents extends BaseContent implements TimeAwareInterface {
 				}
 			}
 			//VerdantMight
-			needNext ||= player.gainOrLosePerk(PerkLib.VerdantMight, player.isAnyRaceCached(Races.PLANT, Races.ALRAUNE), "Raw green power flows throught your veins while being a plant hasnt done so much to improve your muscle your general sturdyness more then makes up for it allowing you to use your toughness instead of your strength when delivering blows.", "Being less of a plant you loose the ability to add your own sturdyness to your attacks.");
+			needNext ||= player.gainOrLosePerk(PerkLib.VerdantMight, player.isAnyRaceCached(Races.PLANT, Races.ALRAUNE), "Raw green power flows through your veins. While being a plant hasn't done much to improve your muscle, your general sturdyness more then makes up for it. You can now use your toughness instead of your strength when delivering blows.", "Being less of a plant, you lose the ability to add your own sturdyness to your attacks.");
 			//Enigma
 			needNext ||= player.gainOrLosePerk(PerkLib.Enigma, player.isRaceCached(Races.SPHINX), "Being a sphinx has granted you insight on many things including various secrets to martial combat, guess this is what they mean about using your smarts before your brawn.", "As you no longer possess the insight of a sphinx you no longer have the ability to fully use your smarts to improve your martial prowess.");
-			/*
-			//Rampant Might & Wisdom of the Ages
-			if (player.isRaceCached(Races.YGGDRASIL) && !player.hasPerk(PerkLib.VerdantMight) && !player.hasPerk(PerkLib.VerdantMight)) {
-				outputText("\nRaw green power flows throught your veins while being a partialy plant hasnt done so much to improve your muscle your general sturdyness more then makes up for it allowing you to use your toughness supplementing your strength when delivering blows. Becoming member of yggdrasil race also granted you insight on many things, which you could use in combat. ");
-				outputText("\n\n<b>(gained the Rampant Might & Wisdom of the Ages perk!)</b>\n");
-				if (!player.hasPerk(PerkLib.VerdantMight)) player.createPerk(PerkLib.VerdantMight,0,0,0,0);
-				if (!player.hasPerk(PerkLib.VerdantMight)) player.createPerk(PerkLib.VerdantMight,0,0,0,0);
-				needNext = true;
-			}
-			if (!player.isRaceCached(Races.YGGDRASIL) && (player.hasPerk(PerkLib.VerdantMight) || player.hasPerk(PerkLib.VerdantMight))) {
-				outputText("\nBeing less of a plant dragon you loose the abilities to add your own sturdyness to your attacks and fully use your smarts to improve your martial prowess.\n\n<b>(Lost the Rampant Might & Wisdom of the Ages perks!)</b>\n");
-				if (player.hasPerk(PerkLib.VerdantMight)) player.removePerk(PerkLib.VerdantMight);
-				if (player.hasPerk(PerkLib.VerdantMight)) player.removePerk(PerkLib.VerdantMight);
-				needNext = true;
-			}*/
+			//Rampant Might
+			needNext ||= player.gainOrLosePerk(PerkLib.RampantMight, player.isRaceCached(Races.YGGDRASIL), "Raw green power flows through your veins. While being a plant dragon hasn't done much to improve your muscle, your general sturdyness more then makes up for it. You can now use your toughness and strength when delivering blows.", "Being less of a plant dragon, you lose the ability to add your own sturdyness to your attacks.");
+			//Wisdom of the Ages
+			needNext ||= player.gainOrLosePerk(PerkLib.WisdomoftheAges, player.isRaceCached(Races.YGGDRASIL), "Becoming a member of the Yggdrasil race has granted you insight on many things, which you can use in combat.", "Being less of a plant dragon, you lose the ability to fully use your smarts to improve your martial prowess.");
 			//Vegetal Affinity
 			needNext ||= player.gainOrLosePerk(PerkLib.VegetalAffinity, player.isAnyRaceCached(Races.PLANT, Races.ALRAUNE, Races.YGGDRASIL, Races.WOODELF), "With your connection to the natural flora growing stronger you gained an affinity with plantlife.", "With your connection to the natural world growing weaker you lose your affinity with plantlife.");
 			//Lacta bovine immunities

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -5393,6 +5393,7 @@ public class Combat extends BaseContent {
             outputText("You lash at your opponent with your many vines, striking twelve times.");
             var x:int = 12;
             while (x-->0) ExtraNaturalWeaponAttack();
+            outputText("\n");
         }
         //Unique TENTACLES STRIKES
         if ((player.isScylla() || player.isKraken()) && player.effectiveTallness >= 70){
@@ -5482,7 +5483,13 @@ public class Combat extends BaseContent {
      * @return damage calulation
      */
 	public function meleeDamageNoLagSingle(IsFeralCombat:Boolean = false, damage:Number = 0):Number {
-		if (IsFeralCombat && player.hasPerk(PerkLib.VerdantMight)) {
+		if (IsFeralCombat && player.hasPerk(PerkLib.RampantMight)) {
+            damage += player.tou;
+			damage += scalingBonusToughness() * 0.2;
+            damage += player.str;
+			damage += scalingBonusStrength() * 0.2;
+        }
+        else if (IsFeralCombat && player.hasPerk(PerkLib.VerdantMight)) {
 			damage += player.tou;
 			damage += scalingBonusToughness() * 0.2;
 		}
@@ -5594,7 +5601,13 @@ public class Combat extends BaseContent {
 
 	public function meleeUnarmedDamageNoLagSingle(subtype:Number = 0, IsFeralCombat:Boolean = false):Number {
 		var damage:Number = 0;
-		if (player.hasPerk(PerkLib.VerdantMight)){
+		if (player.hasPerk(PerkLib.RampantMight)) {
+            damage += player.tou;
+			damage += scalingBonusToughness() * 0.25;
+            damage += player.str;
+			damage += scalingBonusStrength() * 0.25;
+        }
+        else if (player.hasPerk(PerkLib.VerdantMight)){
             damage += player.tou;
             damage += scalingBonusToughness() * 0.25;
         }
@@ -7015,7 +7028,13 @@ public class Combat extends BaseContent {
 
     public function CalcBaseDamageUnarmed(damage:Number = 0):Number{
         //BASIC DAMAGE STUFF
-        if (player.hasPerk(PerkLib.VerdantMight)){
+        if (player.hasPerk(PerkLib.RampantMight)) {
+            damage += player.tou;
+			damage += scalingBonusToughness() * 0.25;
+            damage += player.str;
+			damage += scalingBonusStrength() * 0.25;
+        }
+        else if (player.hasPerk(PerkLib.VerdantMight)){
             damage += player.tou;
             damage += scalingBonusToughness() * 0.25;
         }
@@ -7046,7 +7065,13 @@ public class Combat extends BaseContent {
 
     public function CalcBaseDamageArmed(damage:Number = 0):Number{
         //BASIC DAMAGE STUFF
-        if (player.hasPerk(PerkLib.VerdantMight)){
+        if (player.hasPerk(PerkLib.RampantMight)) {
+            damage += player.tou;
+			damage += scalingBonusToughness() * 0.25;
+            damage += player.str;
+			damage += scalingBonusStrength() * 0.25;
+        }
+        else if (player.hasPerk(PerkLib.VerdantMight)){
             damage += player.tou;
             damage += scalingBonusToughness() * 0.25;
         }


### PR DESCRIPTION
Yggdrasil Race now has access to the "Rampant Might" (add toughness and strength to feral combat modifier) and "Wisdom of the Ages" (Add half of Intelligence and Wisdom as a modifier to Strength and Toughness) racial perks