### PR TITLE
Elemental System changes

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -1889,6 +1889,24 @@ public class Creature extends Utils
 		}
 
 		/**
+		 * Check if this creature has any of the specified perks.
+		 * @param ptypes {Array - PerkType}
+		 * @return {Boolean} True if creature has any of the perks, otherwise false.
+		 */
+		public function hasAnyPerk(...ptypes:Array):Boolean {
+			return ptypes.some(function(ptype:PerkType):Boolean { return hasPerk(ptype); });
+		}
+
+		/**
+		 * Check if this creature has all of the specified perks.
+		 * @param ptypes {Array - PerkType}
+		 * @return {Boolean} True if creature has all of the perks, otherwise false.
+		 */
+		public function hasPerks(...ptypes:Array):Boolean {
+			return ptypes.all(function(ptype:PerkType):Boolean { return hasPerk(ptype); });
+		}
+
+		/**
 		 * Get the instance of a perk.
 		 * @param {PerkType} ptype
 		 */

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -2031,6 +2031,22 @@ public class Creature extends Utils
 		public function hasStatusEffect(stype:StatusEffectType):Boolean {
 			return this._statusEffects.hasStatusEffect(stype);
 		}
+		/**
+		 * Check if this creature has any of the specified status effects.
+		 * @param stypes {Array - StatusEffectType}
+		 * @return {Boolean} True if creature has any of the status effects, otherwise false.
+		 */
+		public function hasAnyStatusEffect(...stypes:Array):Boolean {
+			return stypes.some(function(stype:StatusEffectType):Boolean { return hasStatusEffect(stype); });
+		}
+		/**
+		 * Check if this creature has all of the specified status effects.
+		 * @param stypes {Array - StatusEffectType}
+		 * @return {Boolean} True if creature has all of the status effects, otherwise false.
+		 */
+		public function hasStatusEffects(...stypes:Array):Boolean {
+			return stypes.all(function(stype:StatusEffectType):Boolean { return hasStatusEffect(stype); });
+		}
 		public function changeStatusValue(stype:StatusEffectType, statusValueNum:Number = 1, newNum:Number = 0):void
 		{
 			return this._statusEffects.changeStatusValue(stype, statusValueNum, newNum);

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -1990,6 +1990,56 @@ import classes.Scenes.Combat.CombatAbilities;
 			return false;
 		}
 
+		public function monsterIsBleeding():Boolean {
+			var effects:Array = [
+				StatusEffects.KamaitachiBleed,
+				StatusEffects.Hemorrhage,
+				StatusEffects.SharkBiteBleed,
+				StatusEffects.IzmaBleed,
+				StatusEffects.CouatlHurricane,
+				StatusEffects.GoreBleed,
+				StatusEffects.Hemorrhage2,
+				StatusEffects.Briarthorn,
+			]
+			for each (var effect:StatusEffectType in effects) if (hasStatusEffect(effect)) return true;
+			return false;
+		}
+
+		public function monsterIsPoisoned():Boolean {
+			return hasStatusEffect(StatusEffects.PoisonDoT) || hasStatusEffect(StatusEffects.PoisonDoTH);
+		}
+
+		public function monsterIsLustPoisoned():Boolean {
+			var effects:Array = [
+				StatusEffects.LustDoT,
+				StatusEffects.LustDoTH,
+				StatusEffects.LustStick
+			]
+			for each (var effect:StatusEffectType in effects) if (hasStatusEffect(effect)) return true;
+			return false;
+		}
+
+		public function monsterIsBurned():Boolean {
+			var effects:Array = [
+				StatusEffects.BurnDoT,
+				StatusEffects.BurnDoT2,
+				StatusEffects.FirePunchBurnDoT,
+				StatusEffects.ImmolationDoT
+			]
+			for each (var effect:StatusEffectType in effects) if (hasStatusEffect(effect)) return true;
+			return false;
+		}
+
+		public function monsterIsAcidBurned():Boolean {
+			var effects:Array = [
+				StatusEffects.AcidDoT,
+				StatusEffects.SandWormAcid,
+				StatusEffects.AntAcid
+			]
+			for each (var effect:StatusEffectType in effects) if (hasStatusEffect(effect)) return true;
+			return false;
+		}
+
 		public function doAI():void
 		{
 			if (hasStatusEffect(StatusEffects.AbilityCooldown1) ) {
@@ -2785,6 +2835,15 @@ import classes.Scenes.Combat.CombatAbilities;
 		 */
 		public function postCompanionAction():void{
 
+		}
+
+		/**
+		 * Returns a list of statuses unique to the monster that are currently affected by
+		 * To be overwritten by child monster classes
+		 * @return statues (Array) - List of String repreenting each unique status the monster is currently under
+		 */
+		public function displaySpecialStatues():Array {
+			return [];
 		}
 
 		/**

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -3616,8 +3616,8 @@ public class PerkLib
 		// Mutation perks
 		public static const AcidSpit:PerkType = mk("Acid Spit", "Acid Spit",
 				"Allows access to a cave wyrm acid spit attack.");
-		public static const AcidAffinity:PerkType = mk("Fire Affinity", "Fire Affinity",
-				"You have high resistance to fire effects, immunity to the acid condition, and mastery over acid abilities and magic.");
+		public static const AcidAffinity:PerkType = mk("Acid Affinity", "Acid Affinity",
+				"You have high resistance to acid effects, immunity to the acid condition, and mastery over acid abilities and magic.");
 		public static const AlrauneNectar:PerkType = mk("Alraune Nectar", "Alraune Nectar",
 				"You yourself produce an endless supply of alraune nectar.");
 		public static const AzureflameBreath:PerkType = mk("Azureflame Breath", "Azureflame Breath",

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -3668,9 +3668,9 @@ public class PerkLib
 		public static const ChimericalBodySemiEpicStageEx:PerkType = mk("Chimerical Body: Semi-Epic (Ex) Stage", "Chimerical Body: Semi-Epic (Ex) Stage",
 				"Your chimerical body attained Semi-Epic (Ex) Stage. (negate up to 118 racial perk points negative effects // +1/+2/+3 to racial score when PC have first/second/third racial specific mutation perk)").withBuffs({'str.mult':1.1,'tou.mult':1.1,'spe.mult':1.1,'int.mult':0.7,'wis.mult':0.75,'lib.mult':0.65,'sens':70});
 		public static const ColdAffinity:PerkType = mk("Cold Affinity", "Cold Affinity",
-				"You have high resistance to cold effects, immunity to the frozen condition, and mastery over ice abilities and magic. However, you are highly susceptible to fire.");
+				"You have high resistance to cold effects, immunity to the frostburn condition, and mastery over ice abilities and magic. However, you are highly susceptible to fire.");
 		public static const ColdMastery:PerkType = mk("Cold Mastery", "Cold Mastery",
-				"You now have complete control over the ice element adding your own inner power to all cold based attack.");
+				"You now have complete control over the ice element adding your own inner power to all cold based attacks.");
 		public static const CondensedPower:PerkType = mk("Condensed Power", "Condensed Power",
 				"While smaller than 6ft, add half of your inverted size modifier to your strength score.");
 		public static const CorruptedKitsune:PerkType = mk("Corrupted Kitsune", "Corrupted Kitsune",
@@ -3798,8 +3798,6 @@ public class PerkLib
 				"Allows access to a hydra acid breath attack.");
 		public static const HydraRegeneration:PerkType = mk("Hydra Regeneration", "Hydra Regeneration",
 				"(Amount of hydra heads)% health and (Amount of hydra heads) points of fatigue regeneration but double hunger decaying speed. Stops for 5 rounds when damaged by fire.");
-		public static const IceAffinity:PerkType = mk("Ice Affinity", "Ice Affinity",
-				"You have high resistance to ice effects, immunity the frostburn condition, and mastery over ice abilities and magic.");
 		public static const IcyFlesh:PerkType = mk("Icy flesh", "Icy flesh",
 				"You are about as frigid and dead as a corpse however your mastery of ice magic grants you the ability to harden your flesh to the durability of diamonds. Gain an intelligence modifier as a bonus to health calculation equal to that of toughness as well as 1% regeneration. Gain an extra 40% resistance to cold.");
 		public static const ImpNobility:PerkType = mk("Imp Nobility", "Imp Nobility",

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -3616,6 +3616,8 @@ public class PerkLib
 		// Mutation perks
 		public static const AcidSpit:PerkType = mk("Acid Spit", "Acid Spit",
 				"Allows access to a cave wyrm acid spit attack.");
+		public static const AcidAffinity:PerkType = mk("Fire Affinity", "Fire Affinity",
+				"You have high resistance to fire effects, immunity to the acid condition, and mastery over acid abilities and magic.");
 		public static const AlrauneNectar:PerkType = mk("Alraune Nectar", "Alraune Nectar",
 				"You yourself produce an endless supply of alraune nectar.");
 		public static const AzureflameBreath:PerkType = mk("Azureflame Breath", "Azureflame Breath",
@@ -3715,6 +3717,8 @@ public class PerkLib
 				"Allows access to a dragonne regal breath attack.");
 		public static const DragonWaterBreath:PerkType = mk("Dragon water breath", "Dragon water breath",
 				"Allows access to a sea dragon water breath attack. Mixing water with electricity may yield surprising results.");
+		public static const EarthAffinity:PerkType = mk("Earth Affinity", "Earth Affinity",
+				"You have high resistance to earth effects, and mastery over earth abilities and magic.");
 		public static const EasterBunnyBalls:PerkType = mk("Easter bunny balls", "Easter bunny balls",
 				"Your balls constantly grows until emptied through your cock, producing eggs.");
 		public static const ElectrifiedDesire:PerkType = mk("Electrified Desire", "Electrified Desire",
@@ -3794,6 +3798,8 @@ public class PerkLib
 				"Allows access to a hydra acid breath attack.");
 		public static const HydraRegeneration:PerkType = mk("Hydra Regeneration", "Hydra Regeneration",
 				"(Amount of hydra heads)% health and (Amount of hydra heads) points of fatigue regeneration but double hunger decaying speed. Stops for 5 rounds when damaged by fire.");
+		public static const IceAffinity:PerkType = mk("Ice Affinity", "Ice Affinity",
+				"You have high resistance to ice effects, immunity the frostburn condition, and mastery over ice abilities and magic.");
 		public static const IcyFlesh:PerkType = mk("Icy flesh", "Icy flesh",
 				"You are about as frigid and dead as a corpse however your mastery of ice magic grants you the ability to harden your flesh to the durability of diamonds. Gain an intelligence modifier as a bonus to health calculation equal to that of toughness as well as 1% regeneration. Gain an extra 40% resistance to cold.");
 		public static const ImpNobility:PerkType = mk("Imp Nobility", "Imp Nobility",
@@ -3890,6 +3896,8 @@ public class PerkLib
 				"Your nature as a plant gives you an instinctual knowledge of herbalism. Add some of your libido to your herbalism skill scaling and gain herbalism experience faster.");
 		public static const PoisonNails:PerkType = mk("Poison nails", "Poison nails",
 				"Your nails inflict a deadly poison on strike, damaging your foe’s toughness, speed and arousing them.");
+		public static const PoisonAffinity:PerkType = mk("Poison Affinity", "Poison Affinity",
+				"You have high resistance to poison effects, and mastery over poison abilities and magic.");
 		public static const PsionicEmpowerment:PerkType = mk("Psionic Empowerment", "Psionic Empowerment",
 			"Your powers expands in accordance with each new convert that joins the sisterhood hivemind.");
 		public static const PurityBlessing:PerkType = mk("Purity Blessing", "Purity Blessing",
@@ -3937,6 +3945,10 @@ public class PerkLib
 				"As a plant when using natural weapon your damage scaling is based on Toughness instead of strength.");
 		public static const RampantMight:PerkType = mk("Rampant Might", "Rampant Might",
 				"As a plant dragon when using natural weapon your damage scaling is based on both Toughness and Strength.");
+		public static const WaterAffinity:PerkType = mk("Water Affinity", "Water Affinity",
+				"You have high resistance to water effects, and mastery over water abilities and magic.");
+		public static const WindAffinity:PerkType = mk("Wind Affinity", "Wind Affinity",
+				"You have high resistance to wind effects, and mastery over wind abilities and magic.");
 		public static const WisdomoftheAges:PerkType = mk("Wisdom of the Ages", "Wisdom of the Ages",
 				"Your bottomless insight somehow transmutes itself into raw power, allowing you to add half of your intelligence and wisdom as a modifier to strength and toughness.");
 		public static const ZenjisInfluence1:PerkType = mk("Zenji's influence 1", "Zenji's influence 1",
@@ -4352,10 +4364,14 @@ public class PerkLib
 		// Monster perks
 		// Please add any perks below to the enemyPerkList below. Required for PerkDB filtering of PC-unobtainable perks.
 		public static const Acid:PerkType = mk("Acid", "Acid", "");
+		public static const AcidNature:PerkType = mk("Acid Nature", "Acid Nature", "");
+		public static const AcidVulnerability:PerkType = mk("Acid Vulnerability", "Acid Vulnerability", "");//NYU
 		public static const AlwaysSuccesfullRunaway:PerkType = mk("Always Succesfull Runaway", "Always Succesfull Runaway", "");
 		public static const DarknessNature:PerkType = mk("Darkness Nature", "Darkness Nature", "");
 		public static const DarknessVulnerability:PerkType = mk("Darkness Vulnerability", "Darkness Vulnerability", "");//NYU
 		public static const DieHardHP:PerkType = mk("DieHard HP", "DieHard HP", "");
+		public static const EarthNature:PerkType = mk("Earth Nature", "Earth Nature", "");
+		public static const EarthVulnerability:PerkType = mk("Earth Vulnerability", "Earth Vulnerability", "");//NYU
 		public static const Enemy300Type:PerkType = mk("300-type enemy", "300-type enemy", "");
 		public static const EnemyBeastOrAnimalMorphType:PerkType = mk("Beast or Animal-morph enemy type", "Beast or Animal-morph enemy type", "");
 		public static const EnemyBossType:PerkType = mk("Boss-type enemy", "Boss-type enemy", "");
@@ -4395,10 +4411,16 @@ public class PerkLib
 		public static const OverMaxMana:PerkType = mk("OverMax Mana", "OverMax Mana", "");//NYU
 		public static const OverMaxSoulforce:PerkType = mk("OverMax Soulforce", "OverMax Soulforce", "");//NYU
 		public static const OverMaxWrath:PerkType = mk("OverMax Wrath", "OverMax Wrath", "");//NYU
+		public static const PoisonNature:PerkType = mk("Poison Nature", "Poison Nature", "");
+		public static const PoisonVulnerability:PerkType = mk("Poison Vulnerability", "Poison Vulnerability", "");
 		public static const Sentience:PerkType = mk("Sentience", "Sentience", "");
 		public static const ShieldWielder:PerkType = mk("Shield wielder", "Shield wielder", "");
 		public static const TeaseResistance:PerkType = mk("Tease Resistance", "Tease Resistance", "");//NYU
 		public static const UniqueNPC:PerkType = mk("Unique npc", "Unique npc", "");
+		public static const WaterNature:PerkType = mk("Water Nature", "Water Nature", "");
+		public static const WaterVulnerability:PerkType = mk("Water Vulnerability", "Water Vulnerability", "");
+		public static const WindNature:PerkType = mk("Wind Nature", "Wind Nature", "");
+		public static const WindVulnerability:PerkType = mk("Wind Vulnerability", "Wind Vulnerability", "");
 		//public static const :PerkType = mk("", "", "");
 		//public static const :PerkType = mk("", "", "");
 		//public static const :PerkType = mk("", "", "");
@@ -4411,10 +4433,14 @@ public class PerkLib
 		public static function enemyPerkList():Array{
 			var ePerkL:Array = [];
 			ePerkL.push(Acid);
+			ePerkL.push(AcidNature);
+			ePerkL.push(AcidVulnerability);
 			ePerkL.push(AlwaysSuccesfullRunaway);
 			ePerkL.push(DarknessNature);
 			ePerkL.push(DarknessVulnerability);
 			ePerkL.push(DieHardHP);
+			ePerkL.push(EarthNature);
+			ePerkL.push(EarthVulnerability);
 			ePerkL.push(Enemy300Type);
 			ePerkL.push(EnemyBeastOrAnimalMorphType);
 			ePerkL.push(EnemyBossType);
@@ -4454,10 +4480,16 @@ public class PerkLib
 			ePerkL.push(OverMaxMana);
 			ePerkL.push(OverMaxSoulforce);
 			ePerkL.push(OverMaxWrath);
+			ePerkL.push(PoisonNature);
+			ePerkL.push(PoisonVulnerability);
 			ePerkL.push(Sentience);
 			ePerkL.push(ShieldWielder);
 			ePerkL.push(TeaseResistance);
 			ePerkL.push(UniqueNPC);
+			ePerkL.push(WaterNature);
+			ePerkL.push(WaterVulnerability);
+			ePerkL.push(WindNature);
+			ePerkL.push(WindVulnerability);
 			return ePerkL;
 		}
 	

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1371,6 +1371,14 @@ use namespace CoC;
 		{
 			return perkv1(IMutationsLib.SlimeFluidIM) >= 1;
 		}
+		public function immuneToBurn():Boolean
+		{
+			return hasAnyPerk(PerkLib.FireAffinity, PerkLib.AffinityIgnis);
+		}
+		public function immuneToAcid():Boolean
+		{
+			return hasPerk(PerkLib.AcidAffinity);
+		}
 		public function progressBloodDemon():Number
 		{
 			var progressBD:Number = 2;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1377,7 +1377,11 @@ use namespace CoC;
 		}
 		public function immuneToAcid():Boolean
 		{
-			return hasPerk(PerkLib.AcidAffinity);
+			return hasAnyPerk(PerkLib.AcidAffinity, PerkLib.AffinityGnome);
+		}
+		public function immuneToFrostBurn():Boolean
+		{
+			return hasAnyPerk(PerkLib.ColdAffinity, PerkLib.ColdMastery, PerkLib.AffinityUndine);
 		}
 		public function progressBloodDemon():Number
 		{
@@ -3396,8 +3400,8 @@ use namespace CoC;
 			var mult:Number = damageMagicalPercent();
 			if (upperGarmentName == "HB shirt") mult -= 10;
 			if (lowerGarmentName == "HB shorts") mult -= 10;
-			if (hasPerk(PerkLib.FromTheFrozenWaste) || hasPerk(PerkLib.ColdAffinity)) mult += 100;
-			if (hasPerk(PerkLib.FireAffinity)) mult -= 50;
+			if (hasAnyPerk(PerkLib.FromTheFrozenWaste, PerkLib.ColdAffinity, PerkLib.ColdMastery)) mult += 100;
+			if (hasAnyPerk(PerkLib.FireAffinity, PerkLib.AffinityIgnis)) mult -= 50;
 			if (hasPerk(PerkLib.VegetalAffinity)) mult += 50;
 			if (hasStatusEffect(StatusEffects.ShiraOfTheEastFoodBuff1) && (statusEffectv2(StatusEffects.ShiraOfTheEastFoodBuff1) > 0)) mult -= statusEffectv2(StatusEffects.ShiraOfTheEastFoodBuff1);
 			if (hasStatusEffect(StatusEffects.DaoOfFire) && (statusEffectv2(StatusEffects.DaoOfFire) > 3)) mult -= (10 * (statusEffectv2(StatusEffects.DaoOfFire) - 3));
@@ -3450,9 +3454,9 @@ use namespace CoC;
 			if (upperGarmentName == "HB shirt") mult -= 10;
 			if (lowerGarmentName == "HB shorts") mult -= 10;
 			if (necklaceName == "Blue Winter scarf" || necklaceName == "Green Winter scarf" || necklaceName == "Purple Winter scarf" || necklaceName == "Red Winter scarf" || necklaceName == "Yellow Winter scarf") mult -= 20;
-			if (hasPerk(PerkLib.FromTheFrozenWaste) || hasPerk(PerkLib.ColdAffinity)) mult -= 50;
+			if (hasAnyPerk(PerkLib.FromTheFrozenWaste, PerkLib.ColdAffinity, PerkLib.ColdMastery)) mult -= 50;
 			if (hasPerk(PerkLib.IcyFlesh)) mult -= 40;
-			if (hasPerk(PerkLib.FireAffinity) || hasPerk(PerkLib.AffinityIgnis)) mult += 100;
+			if (hasAnyPerk(PerkLib.FireAffinity, PerkLib.AffinityIgnis)) mult += 100;
 			if (headjewelryEffectId == HeadJewelryLib.MODIFIER_ICE_R) mult -= headjewelryEffectMagnitude;
 			if (necklaceEffectId == NecklaceLib.MODIFIER_ICE_R) mult -= necklaceEffectMagnitude;
 			if (jewelry1.hasBuff('res_ice') && jewelry2.hasBuff('res_ice') && jewelry3.hasBuff('res_ice') && jewelry4.hasBuff('res_ice') && headjewelryEffectId == HeadJewelryLib.MODIFIER_ICE_R && necklaceEffectId == NecklaceLib.MODIFIER_ICE_R) mult -= 15;
@@ -3603,6 +3607,7 @@ use namespace CoC;
 
 		public override function damagePoisonPercent():Number {
 			var mult:Number = damageMagicalPercent();
+			if (hasPerk(PerkLib.PoisonAffinity)) mult -= 50;
 			if (perkv1(IMutationsLib.VenomGlandsIM) >= 2) mult -= 5;
 			if (perkv1(IMutationsLib.VenomGlandsIM) >= 3) mult -= 10;
 			if (perkv1(IMutationsLib.VenomGlandsIM) >= 4) mult -= 15;
@@ -3648,7 +3653,8 @@ use namespace CoC;
 		}
 
 		public override function damageWindPercent():Number {
-			var mult:Number = damageMagicalPercent();/*
+			var mult:Number = damageMagicalPercent();
+			if (hasAnyPerk(PerkLib.WindAffinity, PerkLib.AffinitySylph)) mult -= 50;/*
 			if (jewelryEffectId == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude;
 			if (jewelryEffectId2 == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude2;
 			if (jewelryEffectId3 == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude3;
@@ -3694,7 +3700,8 @@ use namespace CoC;
 		}
 
 		public override function damageWaterPercent():Number {
-			var mult:Number = damageMagicalPercent();/*
+			var mult:Number = damageMagicalPercent();
+			if (hasAnyPerk(PerkLib.WaterAffinity, PerkLib.AffinityUndine)) mult -= 50;/*
 			if (jewelryEffectId == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude;
 			if (jewelryEffectId2 == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude2;
 			if (jewelryEffectId3 == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude3;
@@ -3743,7 +3750,8 @@ use namespace CoC;
 		}
 
 		public override function damageEarthPercent():Number {
-			var mult:Number = damageMagicalPercent();/*
+			var mult:Number = damageMagicalPercent();
+			if (hasAnyPerk(PerkLib.EarthAffinity, PerkLib.AffinityGnome)) mult -= 50;/*
 			if (jewelryEffectId == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude;
 			if (jewelryEffectId2 == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude2;
 			if (jewelryEffectId3 == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude3;
@@ -3789,7 +3797,8 @@ use namespace CoC;
 		}
 
 		public override function damageAcidPercent():Number {
-			var mult:Number = damageMagicalPercent();/*
+			var mult:Number = damageMagicalPercent();
+			if (hasPerk(PerkLib.AcidAffinity)) mult -= 50;/*
 			if (jewelryEffectId == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude;
 			if (jewelryEffectId2 == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude2;
 			if (jewelryEffectId3 == JewelryLib.MODIFIER_POIS_R) mult -= jewelryEffectMagnitude3;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1377,7 +1377,7 @@ use namespace CoC;
 		}
 		public function immuneToAcid():Boolean
 		{
-			return hasAnyPerk(PerkLib.AcidAffinity, PerkLib.AffinityGnome);
+			return hasAnyPerk(PerkLib.AcidAffinity);
 		}
 		public function immuneToFrostBurn():Boolean
 		{

--- a/classes/classes/Scenes/Areas/Ashlands/HellCat.as
+++ b/classes/classes/Scenes/Areas/Ashlands/HellCat.as
@@ -36,8 +36,10 @@ import classes.internals.*;
 			var firedamage:int = (inte * 0.45) + rand(10);
 			firedamage = Math.round(firedamage);
 			player.takeFireDamage(firedamage, true);
-			if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
-			else player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(3),0.05,0,0);
+			if (!player.immuneToBurn()) {
+				if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
+				else player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(3),0.05,0,0);
+			}
 			var physdamage:Number = 0;
 			physdamage += eBaseDamage();
 			player.takePhysDamage(physdamage, true);

--- a/classes/classes/Scenes/Areas/Caves/CaveWyrm.as
+++ b/classes/classes/Scenes/Areas/Caves/CaveWyrm.as
@@ -60,10 +60,12 @@ use namespace CoC;
 			firedamage += eBaseIntelligenceDamage() * 1.2;
 			firedamage = Math.round(firedamage);
 			player.takeFireDamage(firedamage, true);
-			if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
-			else {
-				player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(3),0.05,0,0);
-				outputText(" Reeling in pain you begin to burn.");
+			if (!player.immuneToBurn()) {
+				if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
+				else {
+					player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(3),0.05,0,0);
+					outputText(" Reeling in pain you begin to burn.");
+				}
 			}
 		}
 		

--- a/classes/classes/Scenes/Areas/DeepSea/JuvenileAbyssalShark.as
+++ b/classes/classes/Scenes/Areas/DeepSea/JuvenileAbyssalShark.as
@@ -152,6 +152,7 @@ public class JuvenileAbyssalShark extends Monster
 			this.createPerk(PerkLib.SoulPersonage, 0, 0, 0, 0);
 			this.createPerk(PerkLib.SoulWarrior, 0, 0, 0, 0);
 			this.createPerk(PerkLib.DaoistApprenticeStage, 0, 0, 0, 0);
+			this.createPerk(PerkLib.WaterNature, 0, 0, 0, 0);
 			checkMonster();
 		}
 		

--- a/classes/classes/Scenes/Areas/DeepSea/Kraken.as
+++ b/classes/classes/Scenes/Areas/DeepSea/Kraken.as
@@ -106,6 +106,7 @@ public class Kraken extends Monster
 			this.createPerk(PerkLib.TankI, 0, 0, 0, 0);
 			this.createPerk(PerkLib.Regeneration, 0, 0, 0, 0);
 			this.createPerk(PerkLib.InhumanDesireI, 0, 0, 0, 0);
+			this.createPerk(PerkLib.WaterNature, 0, 0, 0, 0);
 			//this.createPerk(PerkLib., 0, 0, 0, 0);
 			//this.createPerk(PerkLib., 0, 0, 0, 0);
 			//this.createPerk(PerkLib., 0, 0, 0, 0);

--- a/classes/classes/Scenes/Areas/Desert/SandWorm.as
+++ b/classes/classes/Scenes/Areas/Desert/SandWorm.as
@@ -23,8 +23,10 @@ public class SandWorm extends Monster
 				dmg1 += eBaseIntelligenceDamage() * 0.2;
 				dmg1 = Math.round(dmg1);
 				dmg1 = player.takeAcidDamage(dmg1, true);
-				if (player.hasStatusEffect(StatusEffects.AcidDoT)) player.addStatusValue(StatusEffects.AcidDoT, 1, 1);
-				else player.createStatusEffect(StatusEffects.AcidDoT, 5, 10, 0, 0);
+				if (!player.immuneToAcid()) {
+					if (player.hasStatusEffect(StatusEffects.AcidDoT)) player.addStatusValue(StatusEffects.AcidDoT, 1, 1);
+					else player.createStatusEffect(StatusEffects.AcidDoT, 5, 10, 0, 0);
+				}
 			}
 		}
 
@@ -38,8 +40,10 @@ public class SandWorm extends Monster
 				dmg1 += eBaseIntelligenceDamage() * 0.2;
 				dmg1 = Math.round(dmg1);
 				dmg1 = player.takeAcidDamage(dmg1, true);
-				if (player.hasStatusEffect(StatusEffects.AcidDoT)) player.addStatusValue(StatusEffects.AcidDoT, 2, 1);
-				else player.createStatusEffect(StatusEffects.AcidDoT, 5, 10, 0, 0);
+				if (!player.immuneToAcid()) {
+					if (player.hasStatusEffect(StatusEffects.AcidDoT)) player.addStatusValue(StatusEffects.AcidDoT, 2, 1);
+					else player.createStatusEffect(StatusEffects.AcidDoT, 5, 10, 0, 0);
+				}
 			}
 		}
 

--- a/classes/classes/Scenes/Areas/GlacialRift/WinterWolf.as
+++ b/classes/classes/Scenes/Areas/GlacialRift/WinterWolf.as
@@ -31,10 +31,14 @@ public class WinterWolf extends Monster
 				if(player.str > 7) {
 					player.addCurse("str", 6,2);
 					showStatDown( 'str' );
-					player.createStatusEffect(StatusEffects.FrostburnDoT,6,0,0,0);
+					if (!player.immuneToFrostBurn()) {
+						player.createStatusEffect(StatusEffects.FrostburnDoT,6,0,0,0);
+					}
 				}
 				else {
-					player.createStatusEffect(StatusEffects.FrostburnDoT,0,0,0,0);
+					if (!player.immuneToFrostBurn()) {
+						player.createStatusEffect(StatusEffects.FrostburnDoT,0,0,0,0);
+					}
 					damage += 30 + Math.round(rand((str + weaponAttack) / 2));
 					player.takeIceDamage(damage);
 					dmgtaken += damage;

--- a/classes/classes/Scenes/Areas/GlacialRift/YukiOnna.as
+++ b/classes/classes/Scenes/Areas/GlacialRift/YukiOnna.as
@@ -43,11 +43,13 @@ public class YukiOnna extends Monster
 			player.takePhysDamage(damage, true);
 			var frostburnPlayer:Number = (this.str + this.spe + this.tou) * 2;
 			player.takeIceDamage(frostburnPlayer, true);
-			if (player.hasStatusEffect(StatusEffects.FrostburnDoT)) {
-				player.addStatusValue(StatusEffects.FrostburnDoT,1,1);
-				player.addStatusValue(StatusEffects.FrostburnDoT,3,1);
+			if (!player.immuneToFrostBurn()) {
+				if (player.hasStatusEffect(StatusEffects.FrostburnDoT)) {
+					player.addStatusValue(StatusEffects.FrostburnDoT,1,1);
+					player.addStatusValue(StatusEffects.FrostburnDoT,3,1);
+				}
+				else player.createStatusEffect(StatusEffects.FrostburnDoT, SceneLib.combat.debuffsOrDoTDuration(4), 0.02, 0, 0);
 			}
-			else player.createStatusEffect(StatusEffects.FrostburnDoT, SceneLib.combat.debuffsOrDoTDuration(4), 0.02, 0, 0);
 		}
 		
 		override protected function performCombatAction():void

--- a/classes/classes/Scenes/Areas/Ocean/Scylla.as
+++ b/classes/classes/Scenes/Areas/Ocean/Scylla.as
@@ -117,6 +117,7 @@ public class Scylla extends Monster
 			this.createPerk(PerkLib.Regeneration, 0, 0, 0, 0);
 			this.createPerk(PerkLib.InhumanDesireI, 0, 0, 0, 0);
 			this.createPerk(PerkLib.EnemyHugeType, 0, 0, 0, 0);
+			this.createPerk(PerkLib.WaterNature, 0, 0, 0, 0);
 			checkMonster();
 		}
 		

--- a/classes/classes/Scenes/Areas/Ocean/SeaAnemone.as
+++ b/classes/classes/Scenes/Areas/Ocean/SeaAnemone.as
@@ -116,6 +116,7 @@ public class SeaAnemone extends Monster
 			this.level = 50;
 			this.gems = rand(50) + 70;
 			this.drop = new WeightedDrop(consumables.DRYTENT, 1);
+			this.createPerk(PerkLib.WaterNature, 0, 0, 0, 0);
 			checkMonster();
 		}
 		

--- a/classes/classes/Scenes/Areas/Ocean/UnderwaterSharkGirl.as
+++ b/classes/classes/Scenes/Areas/Ocean/UnderwaterSharkGirl.as
@@ -90,6 +90,7 @@ public class UnderwaterSharkGirl extends Monster
 			this.special1 = sharkTease;
 			this.special2 = sharkBiteAttack;
 			this.createPerk(PerkLib.EnemyBeastOrAnimalMorphType, 0, 0, 0, 0);
+			this.createPerk(PerkLib.WaterNature, 0, 0, 0, 0);
 			checkMonster();
 		}
 		

--- a/classes/classes/Scenes/Areas/Ocean/UnderwaterSharkGirlsPack.as
+++ b/classes/classes/Scenes/Areas/Ocean/UnderwaterSharkGirlsPack.as
@@ -98,6 +98,7 @@ public class UnderwaterSharkGirlsPack extends Monster
 			this.special2 = sharkBiteAttack;
 			this.createPerk(PerkLib.EnemyBeastOrAnimalMorphType, 0, 0, 0, 0);
 			this.createPerk(PerkLib.EnemyGroupType, 0, 0, 0, 0);
+			this.createPerk(PerkLib.WaterNature, 0, 0, 0, 0);
 			checkMonster();
 		}
 		

--- a/classes/classes/Scenes/Areas/Ocean/UnderwaterTigersharkGirl.as
+++ b/classes/classes/Scenes/Areas/Ocean/UnderwaterTigersharkGirl.as
@@ -93,6 +93,7 @@ public class UnderwaterTigersharkGirl extends Monster
 			this.special1 = sharkTease;
 			this.special2 = sharkBiteAttack;
 			this.createPerk(PerkLib.EnemyBeastOrAnimalMorphType, 0, 0, 0, 0);
+			this.createPerk(PerkLib.WaterNature, 0, 0, 0, 0);
 			checkMonster();
 		}
 		

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -5543,7 +5543,7 @@ public class Combat extends BaseContent {
         if (damage < 10) damage = 10;
 		//All special weapon effects like...fire/ice
 		if (player.weapon == weapons.L_WHIP || player.weapon == weapons.DL_WHIP || player.weapon == weapons.TIDAR)
-            damage = FireTypeDamageBonus(damage);
+            damage = fireTypeDamageBonus(damage);
 		if (isPureWeapon()  || Forgefather.purePearlEaten) {
 			damage = monsterPureDamageBonus(damage);
 		}
@@ -5554,20 +5554,20 @@ public class Combat extends BaseContent {
         if (monster.hasStatusEffect(StatusEffects.Level) && (monster is SandTrap || monster is Alraune)) damage = Math.round(damage * 1.75);
 		if (flags[kFLAGS.FERAL_COMBAT_MODE] == 1 && (player.haveNaturalClaws() || player.haveNaturalClawsTypeWeapon()) && player.hasStatusEffect(StatusEffects.WinterClaw)) {
 			damage *= 2.2;
-			damage = IceTypeDamageBonusLarge(damage);
+			damage = iceTypeDamageBonusLarge(damage);
 		}
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.BlazingBattleSpirit)) {
             if (player.isRaceCached(Races.MOUSE, 2) && (player.jewelryName == "Infernal Mouse ring" || player.jewelryName2 == "Infernal Mouse ring" || player.jewelryName3 == "Infernal Mouse ring" || player.jewelryName4 == "Infernal Mouse ring")) damage *= 2.2;
             else damage *= 2;
-            damage = FireTypeDamageBonusLarge(damage);
+            damage = fireTypeDamageBonusLarge(damage);
 		}
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
-            damage = FireTypeDamageBonus(damage);
+            damage = fireTypeDamageBonus(damage);
 			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1);
 		}
 		if (player.flameBladeActive()) {
             damage += scalingBonusLibido() * 0.20;
-            damage = FireTypeDamageBonus(damage);
+            damage = fireTypeDamageBonus(damage);
         }
 		if (player.weapon == weapons.BFGAUNT || player.hasAetherTwinsTier2()) damage *= 2;
 		if (player.weapon == weapons.FRTAXE && monster.isFlying()) damage *= 1.5;
@@ -6933,39 +6933,147 @@ public class Combat extends BaseContent {
         return damage;
     }
 
-    public function FireTypeDamageBonus(damage:Number):Number {
+    public function fireTypeDamageBonus(damage:Number):Number {
         if (monster.hasPerk(PerkLib.IceNature)) damage *= 1.5;
         if (monster.hasPerk(PerkLib.FireVulnerability)) damage *= 1.2;
         if (monster.hasPerk(PerkLib.IceVulnerability)) damage *= 0.8;
         if (monster.hasPerk(PerkLib.FireNature)) damage *= 0.5;
-        if (player.hasPerk(PerkLib.FireAffinity) || player.hasPerk(PerkLib.AffinityIgnis)) damage *= 2;
+        if (player.hasAnyPerk(PerkLib.FireAffinity, PerkLib.AffinityIgnis)) damage *= 2;
         return damage;
     }
 
-    public function FireTypeDamageBonusLarge(damage:Number):Number {
+    public function fireTypeDamageBonusLarge(damage:Number):Number {
         if (monster.hasPerk(PerkLib.IceNature)) damage *= 10;
         if (monster.hasPerk(PerkLib.FireVulnerability)) damage *= 4;
         if (monster.hasPerk(PerkLib.IceVulnerability)) damage *= 0.25;
         if (monster.hasPerk(PerkLib.FireNature)) damage *= 0.1;
-        if (player.hasPerk(PerkLib.FireAffinity) || player.hasPerk(PerkLib.AffinityIgnis)) damage *= 2;
+        if (player.hasAnyPerk(PerkLib.FireAffinity, PerkLib.AffinityIgnis)) damage *= 2;
         return damage;
     }
 
-    public function IceTypeDamageBonus(damage:Number):Number {
+    public function iceTypeDamageBonus(damage:Number):Number {
         if (monster.hasPerk(PerkLib.FireNature)) damage *= 1.5;
         if (monster.hasPerk(PerkLib.IceVulnerability)) damage *= 1.2;
         if (monster.hasPerk(PerkLib.FireVulnerability)) damage *= 0.8;
         if (monster.hasPerk(PerkLib.IceNature)) damage *= 0.5;
-        if (player.hasPerk(PerkLib.ColdAffinity) || player.hasPerk(PerkLib.AffinityUndine)) damage *= 2;
+        if (player.hasPerk(PerkLib.ColdAffinity)) damage *= 2;
+        if (player.hasPerk(PerkLib.ColdMastery)) damage *= 2;
         return damage;
     }
 
-    public function IceTypeDamageBonusLarge(damage:Number):Number {
+    public function iceTypeDamageBonusLarge(damage:Number):Number {
         if (monster.hasPerk(PerkLib.FireNature)) damage *= 10;
         if (monster.hasPerk(PerkLib.IceVulnerability)) damage *= 4;
         if (monster.hasPerk(PerkLib.FireVulnerability)) damage *= 0.25;
         if (monster.hasPerk(PerkLib.IceNature)) damage *= 0.4;
-        if (player.hasPerk(PerkLib.ColdAffinity) || player.hasPerk(PerkLib.AffinityUndine)) damage *= 2;
+        if (player.hasPerk(PerkLib.ColdAffinity)) damage *= 2;
+        if (player.hasPerk(PerkLib.ColdMastery)) damage *= 2;
+        return damage;
+    }
+
+     public function windTypeDamageBonus(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.WindVulnerability)) damage *= 1.2;
+        if (monster.hasPerk(PerkLib.WindNature)) damage *= 0.5;
+        if (player.hasAnyPerk(PerkLib.WindAffinity, PerkLib.AffinitySylph)) damage *= 2;
+        return damage;
+    }
+
+    public function windTypeDamageBonusLarge(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.WindVulnerability)) damage *= 4;
+        if (monster.hasPerk(PerkLib.WindNature)) damage *= 0.4;
+        if (player.hasAnyPerk(PerkLib.WindAffinity, PerkLib.AffinitySylph)) damage *= 2;
+        return damage;
+    }
+
+     public function earthTypeDamageBonus(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.EarthVulnerability)) damage *= 1.2;
+        if (monster.hasPerk(PerkLib.EarthNature)) damage *= 0.5;
+        if (player.hasAnyPerk(PerkLib.EarthAffinity, PerkLib.AffinityGnome)) damage *= 2;
+        return damage;
+    }
+
+    public function earthTypeDamageBonusLarge(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.EarthVulnerability)) damage *= 4;
+        if (monster.hasPerk(PerkLib.EarthNature)) damage *= 0.4;
+        if (player.hasAnyPerk(PerkLib.EarthAffinity, PerkLib.AffinityGnome)) damage *= 2;
+        return damage;
+    }
+
+     public function waterTypeDamageBonus(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.WaterVulnerability)) damage *= 1.2;
+        if (monster.hasPerk(PerkLib.WaterNature)) damage *= 0.5;
+        if (player.hasAnyPerk(PerkLib.WaterAffinity, PerkLib.AffinityUndine)) damage *= 2;
+        return damage;
+    }
+
+    public function waterTypeDamageBonusLarge(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.WaterVulnerability)) damage *= 4;
+        if (monster.hasPerk(PerkLib.WaterNature)) damage *= 0.4;
+        if (player.hasAnyPerk(PerkLib.WaterAffinity, PerkLib.AffinityUndine)) damage *= 2;
+        return damage;
+    }
+
+     public function lightningTypeDamageBonus(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.DarknessNature)) damage *= 1.5;
+        if (monster.hasPerk(PerkLib.LightningVulnerability)) damage *= 1.2;
+        if (monster.hasPerk(PerkLib.DarknessVulnerability)) damage *= 0.8;
+        if (monster.hasPerk(PerkLib.LightningNature)) damage *= 0.5;
+        if (player.hasPerk(PerkLib.LightningAffinity)) damage *= 2;
+        return damage;
+    }
+
+    public function lightningTypeDamageBonusLarge(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.DarknessNature)) damage *= 10;
+        if (monster.hasPerk(PerkLib.LightningVulnerability)) damage *= 4;
+        if (monster.hasPerk(PerkLib.DarknessVulnerability)) damage *= 0.25;
+        if (monster.hasPerk(PerkLib.LightningNature)) damage *= 0.4;
+        if (player.hasPerk(PerkLib.LightningAffinity)) damage *= 2;
+        return damage;
+    }
+
+     public function darknessTypeDamageBonus(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.LightningNature)) damage *= 1.5;
+        if (monster.hasPerk(PerkLib.DarknessVulnerability)) damage *= 1.2;
+        if (monster.hasPerk(PerkLib.LightningVulnerability)) damage *= 0.8;
+        if (monster.hasPerk(PerkLib.DarknessNature)) damage *= 0.5;
+        if (player.hasPerk(PerkLib.DarknessAffinity)) damage *= 2;
+        return damage;
+    }
+
+    public function darknessTypeDamageBonusLarge(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.LightningNature)) damage *= 10;
+        if (monster.hasPerk(PerkLib.DarknessVulnerability)) damage *= 4;
+        if (monster.hasPerk(PerkLib.LightningVulnerability)) damage *= 0.25;
+        if (monster.hasPerk(PerkLib.DarknessNature)) damage *= 0.4;
+        if (player.hasPerk(PerkLib.DarknessAffinity)) damage *= 2;
+        return damage;
+    }
+
+     public function poisonTypeDamageBonus(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.PoisonVulnerability)) damage *= 1.2;
+        if (monster.hasPerk(PerkLib.PoisonNature)) damage *= 0.5;
+        if (player.hasPerk(PerkLib.PoisonAffinity)) damage *= 2;
+        return damage;
+    }
+
+    public function poisonTypeDamageBonusLarge(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.PoisonVulnerability)) damage *= 4;
+        if (monster.hasPerk(PerkLib.PoisonNature)) damage *= 0.4;
+        if (player.hasPerk(PerkLib.PoisonAffinity)) damage *= 2;
+        return damage;
+    }
+
+     public function acidTypeDamageBonus(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.AcidVulnerability)) damage *= 1.2;
+        if (monster.hasPerk(PerkLib.AcidNature)) damage *= 0.5;
+        if (player.hasPerk(PerkLib.AcidAffinity)) damage *= 2;
+        return damage;
+    }
+
+    public function acidTypeDamageBonusLarge(damage:Number):Number {
+        if (monster.hasPerk(PerkLib.AcidVulnerability)) damage *= 4;
+        if (monster.hasPerk(PerkLib.AcidNature)) damage *= 0.4;
+        if (player.hasPerk(PerkLib.AcidAffinity)) damage *= 2;
         return damage;
     }
 
@@ -8421,7 +8529,7 @@ public class Combat extends BaseContent {
 		if (!ignoreDR) damage *= (monster.damageMagicalPercent() / 100);
         if (player.weapon === weapons.R_STAFF) damage *= 1.4;
 		if (monster.hasPerk(PerkLib.TrollResistance)) damage *= 0.925;
-        damage = FireTypeDamageBonus(damage);
+        damage = fireTypeDamageBonus(damage);
         if (player.hasStatusEffect(StatusEffects.YukiOnnaKimono)) damage *= 0.2;
         if (player.hasPerk(PerkLib.WalpurgisIzaliaRobe)) damage *= 2;
         if (player.hasPerk(PerkLib.IceQueenGown)) damage = damage / 100;
@@ -8483,13 +8591,9 @@ public class Combat extends BaseContent {
 		if (!ignoreDR) damage *= (monster.damageMagicalPercent() / 100);
 		if (player.weapon == weapons.S_STAFF) damage *= 1.4;
         if (monster.hasStatusEffect(StatusEffects.FrostburnDoT) && monster.statusEffectv3(StatusEffects.FrostburnDoT) > 0) damage *= (1 + (0.5 * monster.statusEffectv3(StatusEffects.FrostburnDoT)));
+        damage = iceTypeDamageBonus(damage);
         if (monster.hasPerk(PerkLib.TrollResistance)) damage *= 0.85;
-        if (monster.hasPerk(PerkLib.IceNature)) damage *= 0.2;
-        if (monster.hasPerk(PerkLib.FireVulnerability)) damage *= 0.5;
-        if (monster.hasPerk(PerkLib.IceVulnerability)) damage *= 2;
-        if (monster.hasPerk(PerkLib.FireNature)) damage *= 5;
         if (monster.hasPerk(PerkLib.IcyFlesh)) damage *= 0.6;
-        if (player.hasPerk(PerkLib.ColdMastery) || player.hasPerk(PerkLib.ColdAffinity)) damage *= 2;
         if (player.hasStatusEffect(StatusEffects.YukiOnnaKimono)) damage *= 1.4;
         if (player.hasPerk(PerkLib.IceQueenGown)) damage *= 2;
         if (player.hasPerk(PerkLib.WalpurgisIzaliaRobe)) damage = damage / 100;
@@ -8537,13 +8641,9 @@ public class Combat extends BaseContent {
         damage = doElementalDamageMultiplier(damage);
 		if (!ignoreDR) damage *= (monster.damageMagicalPercent() / 100);
         if (player.weapon == weapons.T_STAFF) damage *= 1.4;
+        damage = lightningTypeDamageBonus(damage);
 		if (monster.hasPerk(PerkLib.TrollResistance)) damage *= 0.85;
-        if (monster.hasPerk(PerkLib.LightningNature)) damage *= 0.2;
-        if (monster.hasPerk(PerkLib.DarknessVulnerability)) damage *= 0.5;
-        if (monster.hasPerk(PerkLib.LightningVulnerability)) damage *= 2;
         if (monster.hasStatusEffect(StatusEffects.DragonWaterBreath)) damage *= 5;
-        if (monster.hasPerk(PerkLib.DarknessNature)) damage *= 5;
-        if (player.hasPerk(PerkLib.LightningAffinity)) damage *= 2;
         if (player.perkv1(IMutationsLib.RaijuCathodeIM) >= 2) damage *= 1.20;
         if (player.perkv1(IMutationsLib.HeartOfTheStormIM) >= 1) damage *= 1.1;
         if (player.perkv1(IMutationsLib.HeartOfTheStormIM) >= 2) damage *= 1.2;
@@ -8594,17 +8694,12 @@ public class Combat extends BaseContent {
         damage = doElementalDamageMultiplier(damage);
 		if (!ignoreDR) damage *= (monster.damageMagicalPercent() / 100);
         if (player.weapon == weapons.A_STAFF) damage *= 1.4;
+        damage = darknessTypeDamageBonus(damage);
 		if (monster.hasPerk(PerkLib.TrollResistance)) damage *= 0.85;
-        if (monster.hasPerk(PerkLib.DarknessNature)) damage *= 0.2;
-        if (monster.hasPerk(PerkLib.LightningVulnerability)) damage *= 0.5;
-        if (monster.hasPerk(PerkLib.DarknessVulnerability)) damage *= 2;
-        if (monster.hasPerk(PerkLib.LightningNature)) damage *= 5;
-        if (player.hasPerk(PerkLib.DarknessAffinity)) damage *= 2;
         if (player.hasPerk(PerkLib.WalpurgisIzaliaRobe)) damage *= 2;
         if (player.hasPerk(PerkLib.VladimirRegalia)) damage *= 2;
         if (player.hasPerk(PerkLib.IceQueenGown)) damage = damage / 100;
         if (player.shieldName == "Nekonomicon") damage *= 2;
-//	if (player.hasPerk(PerkLib.ColdMastery) || player.hasPerk(PerkLib.ColdAffinity)) damage *= 2;
 		damage *= EyesOfTheHunterDamageBonus();
         if (damage == 0) MSGControllForEvasion = true;
         if (monster.HP - damage <= monster.minHP()) {
@@ -8644,6 +8739,7 @@ public class Combat extends BaseContent {
         damage *= doDamageReduction();
         damage = doElementalDamageMultiplier(damage);
 		if (!ignoreDR) damage *= (monster.damageMagicalPercent() / 100);
+        damage = poisonTypeDamageBonus(damage);
         if (monster.hasPerk(PerkLib.TrollResistance)) damage *= 0.85;
 		damage *= EyesOfTheHunterDamageBonus();
         if (damage == 0) MSGControllForEvasion = true;
@@ -8688,6 +8784,7 @@ public class Combat extends BaseContent {
         damage *= doDamageReduction();
         damage = doElementalDamageMultiplier(damage);
 		if (!ignoreDR) damage *= (monster.damageMagicalPercent() / 100);
+        damage = windTypeDamageBonus(damage);
         if (monster.hasPerk(PerkLib.TrollResistance)) damage *= 0.85;
 		damage *= EyesOfTheHunterDamageBonus();
         if (damage == 0) MSGControllForEvasion = true;
@@ -8728,6 +8825,7 @@ public class Combat extends BaseContent {
         damage *= doDamageReduction();
         damage = doElementalDamageMultiplier(damage);
 		if (!ignoreDR) damage *= (monster.damageMagicalPercent() / 100);
+        damage = waterTypeDamageBonus(damage);
         if (monster.hasPerk(PerkLib.TrollResistance)) damage *= 0.85;
 		damage *= EyesOfTheHunterDamageBonus();
         if (damage == 0) MSGControllForEvasion = true;
@@ -8772,6 +8870,7 @@ public class Combat extends BaseContent {
         damage *= doDamageReduction();
         damage = doElementalDamageMultiplier(damage);
 		if (!ignoreDR) damage *= (monster.damageMagicalPercent() / 100);
+        damage = earthTypeDamageBonus(damage);
         if (monster.hasPerk(PerkLib.TrollResistance)) damage *= 0.85;
 		damage *= EyesOfTheHunterDamageBonus();
         if (damage == 0) MSGControllForEvasion = true;
@@ -8812,6 +8911,7 @@ public class Combat extends BaseContent {
         damage *= doDamageReduction();
         damage = doElementalDamageMultiplier(damage);
 		if (!ignoreDR) damage *= (monster.damageMagicalPercent() / 100);
+        damage = acidTypeDamageBonus(damage);
 		if (monster.hasPerk(PerkLib.TrollResistance)) damage *= 0.85;
 		damage *= EyesOfTheHunterDamageBonus();
         if (damage == 0) MSGControllForEvasion = true;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -8122,19 +8122,6 @@ public class Combat extends BaseContent {
 		return EOTHDBonus;
 	}
 
-    public function MonsterIsBleeding():Boolean {
-        var isBleeding:Boolean = false;
-        if (monster.hasStatusEffect(StatusEffects.KamaitachiBleed)) isBleeding = true;
-        if (monster.hasStatusEffect(StatusEffects.Hemorrhage)) isBleeding = true;
-        if (monster.hasStatusEffect(StatusEffects.SharkBiteBleed)) isBleeding = true;
-        if (monster.hasStatusEffect(StatusEffects.IzmaBleed)) isBleeding = true;
-        if (monster.hasStatusEffect(StatusEffects.CouatlHurricane)) isBleeding = true;
-        if (monster.hasStatusEffect(StatusEffects.GoreBleed)) isBleeding = true;
-        if (monster.hasStatusEffect(StatusEffects.Hemorrhage2)) isBleeding = true;
-        if (monster.hasStatusEffect(StatusEffects.Briarthorn)) isBleeding = true;
-        return isBleeding;
-    }
-
     //DEAL DAMAGE
     public function doTrueDamage(damage:Number, apply:Boolean = true, display:Boolean = false):Number {
         MDOCount++; // for multipile attacks to prevent stupid repeating of damage messages
@@ -8195,7 +8182,7 @@ public class Combat extends BaseContent {
             if (monster.hasPerk(PerkLib.BerserkerArmor)) BonusWrathMult = 1.20;
             if (monster.hasPerk(PerkLib.FuelForTheFire)) WrathGains += Math.round((damage / 5)*BonusWrathMult);
             else WrathGains += Math.round((damage / 10) * BonusWrathMult);
-			if (MonsterIsBleeding() && player.hasPerk(PerkLib.YourPainMyPower)) {
+			if (monster.monsterIsBleeding() && player.hasPerk(PerkLib.YourPainMyPower)) {
 				player.HP += damage;
 				if (player.HP > (player.maxHP() + player.maxOverHP())) player.HP = player.maxHP() + player.maxOverHP();
 				if (flags[kFLAGS.YPMP_WRATH_GEN] == 0) EngineCore.WrathChange(WrathGains);
@@ -8276,7 +8263,7 @@ public class Combat extends BaseContent {
             if (monster.hasPerk(PerkLib.BerserkerArmor)) BonusWrathMult = 1.20;
             if (monster.hasPerk(PerkLib.FuelForTheFire)) WrathGains += Math.round((damage / 5)*BonusWrathMult);
             else WrathGains += Math.round((damage / 10) * BonusWrathMult);
-			if (MonsterIsBleeding() && player.hasPerk(PerkLib.YourPainMyPower)) {
+			if (monster.monsterIsBleeding() && player.hasPerk(PerkLib.YourPainMyPower)) {
 				player.HP += damage;
 				if (player.HP > (player.maxHP() + player.maxOverHP())) player.HP = player.maxHP() + player.maxOverHP();
 				if (flags[kFLAGS.YPMP_WRATH_GEN] == 0) EngineCore.WrathChange(WrathGains);
@@ -8293,7 +8280,7 @@ public class Combat extends BaseContent {
     }
 
 	public function doPhysicalDamage(damage:Number, apply:Boolean = true, display:Boolean = false, ignoreDR:Boolean = false):Number {
-        if (player.perkv1(IMutationsLib.SharkOlfactorySystemIM) >= 1 && MonsterIsBleeding()) {
+        if (player.perkv1(IMutationsLib.SharkOlfactorySystemIM) >= 1 && monster.monsterIsBleeding()) {
 			var ddd:Number = 1.1;
 			if (player.perkv1(IMutationsLib.SharkOlfactorySystemIM) >= 2) ddd += 0.15;
 			if (player.perkv1(IMutationsLib.SharkOlfactorySystemIM) >= 3) ddd += 0.2;
@@ -10130,7 +10117,7 @@ public class Combat extends BaseContent {
         }
         //Blood Frenzy until ennemies stops bleeding
         if (player.hasStatusEffect(StatusEffects.BloodFrenzy)) {
-            if (!MonsterIsBleeding()) {
+            if (!monster.monsterIsBleeding()) {
                 player.removeStatusEffect(StatusEffects.BloodFrenzy);
                 player.statStore.removeBuffs("Blood Frenzy");
                 outputText("<b>With no blood in the air, your mind clears, your frenzy fades. </b>\n\n");
@@ -11970,6 +11957,7 @@ public class Combat extends BaseContent {
             }
             var generalTypes:/*String*/Array = [];
             var elementalTypes:/*String*/Array = [];
+            var statusTypes:/*String*/Array = [];
             if (player.hasPerk(PerkLib.EyesOfTheHunterNovice) && player.sens >= 25) {
                 if (monster.hasPerk(PerkLib.EnemyBeastOrAnimalMorphType)) generalTypes.push("Beast or Animal-morph");
                 if (monster.hasPerk(PerkLib.EnemyColossalType)) generalTypes.push("Colossal");
@@ -11995,15 +11983,45 @@ public class Combat extends BaseContent {
                 if (monster.hasPerk(PerkLib.FireNature)) elementalTypes.push("Fire Nature");
                 if (monster.hasPerk(PerkLib.IceNature)) elementalTypes.push("Ice Nature");
                 if (monster.hasPerk(PerkLib.LightningNature)) elementalTypes.push("Lightning Nature");
+                if (monster.hasPerk(PerkLib.WaterNature)) elementalTypes.push("Water Nature");
+                if (monster.hasPerk(PerkLib.EarthNature)) elementalTypes.push("Earth Nature");
+                if (monster.hasPerk(PerkLib.PoisonNature)) elementalTypes.push("Poison Nature");
+                if (monster.hasPerk(PerkLib.AcidNature)) elementalTypes.push("Acid Nature");
+                if (monster.hasPerk(PerkLib.WindNature)) elementalTypes.push("Wind Nature");
 				if (monster.hasPerk(PerkLib.DarknessVulnerability)) elementalTypes.push("Darkness Vulnerability");
                 if (monster.hasPerk(PerkLib.FireVulnerability)) elementalTypes.push("Fire Vulnerability");
                 if (monster.hasPerk(PerkLib.IceVulnerability)) elementalTypes.push("Ice Vulnerability");
                 if (monster.hasPerk(PerkLib.LightningVulnerability)) elementalTypes.push("Lightning Vulnerability");
+                if (monster.hasPerk(PerkLib.AcidVulnerability)) elementalTypes.push("Acid Vulnerability");
+                if (monster.hasPerk(PerkLib.EarthVulnerability)) elementalTypes.push("Earth Vulnerability");
+                if (monster.hasPerk(PerkLib.PoisonVulnerability)) elementalTypes.push("Poison Vulnerability");
+                if (monster.hasPerk(PerkLib.WaterVulnerability)) elementalTypes.push("Water Vulnerability");
+                if (monster.hasPerk(PerkLib.WindVulnerability)) elementalTypes.push("Wind Vulnerability");
+            }
+            if (player.hasPerk(PerkLib.EyesOfTheHunterExpert) && player.sens >= 75) {
+                if (monster.monsterIsStunned()) statusTypes.push("Stunned");
+                if (monster.monsterIsConstricted()) statusTypes.push("Constricted");
+                if (monster.monsterIsBleeding()) statusTypes.push("Bleeding");
+                if (monster.monsterIsPoisoned()) statusTypes.push("Poisoned");
+                if (monster.monsterIsLustPoisoned()) statusTypes.push("Lust Poisoned");
+                if (monster.monsterIsAcidBurned()) statusTypes.push("Acid Burned");
+                if (monster.hasStatusEffect(StatusEffects.Provoke)) statusTypes.push("Provoked");
+                if (monster.hasStatusEffect(StatusEffects.Fear)) statusTypes.push("Afraid");
+                if (monster.hasStatusEffect(StatusEffects.ConfusionM)) statusTypes.push("Confused");
+                if (monster.hasStatusEffect(StatusEffects.FrostburnDoT)) statusTypes.push("Frostbitten");
+                if (monster.hasStatusEffect(StatusEffects.Flying)) statusTypes.push("Flying");
+                if (player.hasStatusEffect(StatusEffects.MonsterDig)) statusTypes.push("Underground");
+                if (combat.isEnemyInvisibleButNotUnderground) statusTypes.push("Invisible");
+                if (monster.lustVuln == 0) statusTypes.push("Lust Immune");
+                statusTypes.concat(monster.displaySpecialStatues());
             }
             outputText("\n");
             if (player.hasPerk(PerkLib.EyesOfTheHunterNovice)){
                 outputText("Enemy information - General: " + generalTypes.join(", ") + "\n");
                 outputText("Enemy information - Elemental: " + elementalTypes.join(", ") + "\n");
+            }
+            if (player.hasPerk(PerkLib.EyesOfTheHunterExpert)){
+                outputText("Enemy information - Status: " + statusTypes.join(", ") + "\n");
             }
         }
         if (debug) {

--- a/classes/classes/Scenes/Combat/CombatSoulskills.as
+++ b/classes/classes/Scenes/Combat/CombatSoulskills.as
@@ -667,7 +667,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		if (player.weapon == weapons.TIDAR) (player.weapon as Tidarion).afterStrike();
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
 			var damage1:Number = damage;
-			damage = combat.FireTypeDamageBonus(damage);
+			damage = combat.fireTypeDamageBonus(damage);
 			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
 			damage += damage1;
 			damage *= 1.1;
@@ -767,7 +767,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		}
 		if (player.weapon == weapons.TIDAR) (player.weapon as Tidarion).afterStrike();
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
-			damage = combat.FireTypeDamageBonus(damage);
+			damage = combat.fireTypeDamageBonus(damage);
 			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
 			damage *= 1.1;
 		}
@@ -1139,10 +1139,10 @@ public class CombatSoulskills extends BaseCombatContent {
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.BlazingBattleSpirit)) {
 			if (player.isRaceCached(Races.MOUSE, 2) && (player.jewelryName == "Infernal Mouse ring" || player.jewelryName2 == "Infernal Mouse ring" || player.jewelryName3 == "Infernal Mouse ring" || player.jewelryName4 == "Infernal Mouse ring")) damage *= 2.2;
 			else damage *= 2;
-			damage = combat.FireTypeDamageBonusLarge(damage);
+			damage = combat.fireTypeDamageBonusLarge(damage);
 		}
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
-			damage = combat.FireTypeDamageBonus(damage);
+			damage = combat.fireTypeDamageBonus(damage);
 			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
 			damage *= 1.1;
 		}
@@ -1342,10 +1342,10 @@ public class CombatSoulskills extends BaseCombatContent {
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.BlazingBattleSpirit)) {
 			if (player.isRaceCached(Races.MOUSE, 2) && (player.jewelryName == "Infernal Mouse ring" || player.jewelryName2 == "Infernal Mouse ring" || player.jewelryName3 == "Infernal Mouse ring" || player.jewelryName4 == "Infernal Mouse ring")) damage *= 2.2;
 			else damage *= 2;
-			damage = combat.FireTypeDamageBonusLarge(damage);
+			damage = combat.fireTypeDamageBonusLarge(damage);
 		}
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
-			damage = combat.FireTypeDamageBonus(damage);
+			damage = combat.fireTypeDamageBonus(damage);
 			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
 			damage *= 1.1;
 		}

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -2687,10 +2687,6 @@ public class MagicSpecials extends BaseCombatContent {
 			damage = calcGlacialMod(damage, true);
 			damage = calcVoltageMod(damage, true);
 			damage = calcEclypseMod(damage, true);
-			damage = calcTideMod(damage, true);
-			damage = calcQuakeMod(damage, true);
-			damage = calcGaleMod(damage, true);
-			damage = calcCorrosionMod(damage, true);
 
 			if(player.hasStatusEffect(StatusEffects.DragonBreathBoost)) {
 				player.removeStatusEffect(StatusEffects.DragonBreathBoost);
@@ -6833,12 +6829,6 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("You gather energy in your Talisman and unleash the spell contained within.  A wave of cold air gathers around [themonster], slowly freezing [monster him].");
 		var damage:int = int(100+(player.inte/2 + rand(player.inte)) * spellMod());
 		damage = calcGlacialMod(damage, true);
-		if (monster.hasPerk(PerkLib.IceNature)) damage *= 0.2;
-		if (monster.hasPerk(PerkLib.FireVulnerability)) damage *= 0.5;
-		if (monster.hasPerk(PerkLib.IceVulnerability)) damage *= 2;
-		if (monster.hasPerk(PerkLib.FireNature)) damage *= 5;
-//	if (player.hasPerk(PerkLib.ColdMastery)) damage *= 2;
-//	if (player.hasPerk(PerkLib.ColdAffinity)) damage *= 2;
 		damage = Math.round(damage);
 		doIceDamage(damage);
 		outputText(" <b>(<font color=\"#800000\">" + damage + "</font>)</b>\n\n");

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -749,7 +749,7 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		if (player.perkv1(IMutationsLib.SharkOlfactorySystemIM) >= 1 || player.isAnyRaceCached(Races.SHARK, Races.ABYSSAL_SHARK)) {
 			bd = buttons.add("Blood Frenzy", bloodFrenzy);
-			if (combat.MonsterIsBleeding()) {
+			if (monster.monsterIsBleeding()) {
 				bd.hint("Lose yourself to a blood fueled trance increasing your speed, libido and weakening your inteligence. The trance last for as long as the opponent is bleeding and cannot be disangaged willingly.\n");
 			}
 			else bd.disable("You can't go into a blood frenzy if your opponent is not bleeding.");

--- a/classes/classes/Scenes/Combat/Soulskills/CleansingPalmSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/CleansingPalmSkill.as
@@ -58,10 +58,10 @@ public class CleansingPalmSkill extends AbstractSoulSkill {
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.BlazingBattleSpirit)) {
 			if (player.isRaceCached(Races.MOUSE, 2) && (player.jewelryName == "Infernal Mouse ring" || player.jewelryName2 == "Infernal Mouse ring" || player.jewelryName3 == "Infernal Mouse ring" || player.jewelryName4 == "Infernal Mouse ring")) damage *= 2.2;
 			else damage *= 2;
-			damage = combat.FireTypeDamageBonusLarge(damage);
+			damage = combat.fireTypeDamageBonusLarge(damage);
 		}
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
-			damage = combat.FireTypeDamageBonus(damage);
+			damage = combat.fireTypeDamageBonus(damage);
 			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
 			damage *= 1.1;
 		}

--- a/classes/classes/Scenes/Combat/Soulskills/DracoSweepSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/DracoSweepSkill.as
@@ -48,7 +48,7 @@ public class DracoSweepSkill extends AbstractSoulSkill {
 		}
 		if (player.weapon == weapons.TIDAR) (player.weapon as Tidarion).afterStrike();
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
-			damage = combat.FireTypeDamageBonus(damage);
+			damage = combat.fireTypeDamageBonus(damage);
 			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
 			damage *= 1.1;
 		}

--- a/classes/classes/Scenes/Combat/Soulskills/MultiThrustSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/MultiThrustSkill.as
@@ -54,7 +54,7 @@ public class MultiThrustSkill extends AbstractSoulSkill {
 		if (player.weapon == weapons.TIDAR) (player.weapon as Tidarion).afterStrike();
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
 			var damage1:Number = damage;
-			damage = combat.FireTypeDamageBonus(damage);
+			damage = combat.fireTypeDamageBonus(damage);
 			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
 			damage += damage1;
 			damage *= 1.1;

--- a/classes/classes/Scenes/Combat/Soulskills/PunishingKickSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/PunishingKickSkill.as
@@ -55,10 +55,10 @@ public class PunishingKickSkill extends AbstractSoulSkill {
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.BlazingBattleSpirit)) {
 			if (player.isRaceCached(Races.MOUSE, 2) && (player.jewelryName == "Infernal Mouse ring" || player.jewelryName2 == "Infernal Mouse ring" || player.jewelryName3 == "Infernal Mouse ring" || player.jewelryName4 == "Infernal Mouse ring")) damage *= 2.2;
 			else damage *= 2;
-			damage = combat.FireTypeDamageBonusLarge(damage);
+			damage = combat.fireTypeDamageBonusLarge(damage);
 		}
 		if (player.isFistOrFistWeapon() && player.hasStatusEffect(StatusEffects.HinezumiCoat)) {
-			damage = combat.FireTypeDamageBonus(damage);
+			damage = combat.fireTypeDamageBonus(damage);
 			if (player.lust > player.lust100 * 0.5) dynStats("lus", -1, "scale", false);
 			damage *= 1.1;
 		}

--- a/classes/classes/Scenes/Dungeons/DemonLab/ProjectTyrant.as
+++ b/classes/classes/Scenes/Dungeons/DemonLab/ProjectTyrant.as
@@ -130,8 +130,10 @@ public class ProjectTyrant extends Monster {
             dmg1 += eBaseIntelligenceDamage() * 0.2;
             dmg1 = Math.round(dmg1);
             player.takeAcidDamage(dmg1, true);
-            if (player.hasStatusEffect(StatusEffects.AcidDoT)) player.addStatusValue(StatusEffects.AcidDoT, 1, 1);
-            else player.createStatusEffect(StatusEffects.AcidDoT, 3, 10, 0, 0);
+            if (!player.immuneToAcid()) {
+                if (player.hasStatusEffect(StatusEffects.AcidDoT)) player.addStatusValue(StatusEffects.AcidDoT, 1, 1);
+                else player.createStatusEffect(StatusEffects.AcidDoT, 3, 10, 0, 0);
+            }
             player.buff("Goop Web").addStats({"spe": -25}).withText("Goop Web").combatPermanent();
         }
     }

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/HellfireSnail.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/HellfireSnail.as
@@ -42,7 +42,7 @@ use namespace CoC;
 			damage *= damage2;
 			damage = Math.round(damage);
 			damage = player.takeFireDamage(damage, true);
-			if (!player.hasPerk(PerkLib.FireAffinity) && !player.hasPerk(PerkLib.AffinityIgnis)) {
+			if (!player.immuneToBurn()) {
 				if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
 				else player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(3),0.05,0,0);
 				outputText(" You’re on fire!!!");

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/Hydra.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/Hydra.as
@@ -38,8 +38,10 @@ use namespace CoC;
 			damage += eBaseIntelligenceDamage() * 0.2;
 			damage = Math.round(damage);
 			damage = player.takeAcidDamage(damage, true);
-			if (player.hasStatusEffect(StatusEffects.AcidDoT)) player.addStatusValue(StatusEffects.AcidDoT, 2, 10); //More heads will produce more potent acid
-			else player.createStatusEffect(StatusEffects.AcidDoT, 6, 10, 0, 0);
+			if (!player.immuneToAcid()) {
+				if (player.hasStatusEffect(StatusEffects.AcidDoT)) player.addStatusValue(StatusEffects.AcidDoT, 2, 10); //More heads will produce more potent acid
+				else player.createStatusEffect(StatusEffects.AcidDoT, 6, 10, 0, 0);
+			}
 		}
 		
 		private function hydraOmnibites():void

--- a/classes/classes/Scenes/Dungeons/RiverDungeon/AirElemental.as
+++ b/classes/classes/Scenes/Dungeons/RiverDungeon/AirElemental.as
@@ -208,6 +208,7 @@ public class AirElemental extends Monster
 			this.weaponVerb = "smash";
 			this.armorName = "air currents armor";
 			this.createPerk(PerkLib.EnemyElementalType, 0, 0, 0, 0);
+			this.createPerk(PerkLib.WindNature, 0, 0, 0, 0);
 			if (flags[kFLAGS.RIVER_DUNGEON_ELEMENTAL_MIXER] == 4) {
 				this.createPerk(PerkLib.EnemyHugeType, 0, 0, 0, 0);
 				this.createPerk(PerkLib.EnemyBossType, 0, 0, 0, 0);

--- a/classes/classes/Scenes/Dungeons/RiverDungeon/EarthElemental.as
+++ b/classes/classes/Scenes/Dungeons/RiverDungeon/EarthElemental.as
@@ -188,6 +188,7 @@ public class EarthElemental extends Monster
 			this.weaponVerb = "smash";
 			this.armorName = "earth skin";
 			this.createPerk(PerkLib.EnemyElementalType, 0, 0, 0, 0);
+			this.createPerk(PerkLib.EarthNature, 0, 0, 0, 0);
 			if (flags[kFLAGS.RIVER_DUNGEON_ELEMENTAL_MIXER] == 4) {
 				this.createPerk(PerkLib.EnemyHugeType, 0, 0, 0, 0);
 				this.createPerk(PerkLib.EnemyBossType, 0, 0, 0, 0);

--- a/classes/classes/Scenes/Dungeons/RiverDungeon/WaterElemental.as
+++ b/classes/classes/Scenes/Dungeons/RiverDungeon/WaterElemental.as
@@ -194,7 +194,7 @@ public class WaterElemental extends Monster
 			this.weaponVerb = "smash";
 			this.armorName = "water skin";
 			this.createPerk(PerkLib.EnemyElementalType, 0, 0, 0, 0);
-			this.createPerk(PerkLib.IceNature, 0, 0, 0, 0);
+			this.createPerk(PerkLib.WaterNature, 0, 0, 0, 0);
 			this.createPerk(PerkLib.MonsterRegeneration, 2, 0, 0, 0);
 			if (flags[kFLAGS.RIVER_DUNGEON_ELEMENTAL_MIXER] == 4) {
 				this.createPerk(PerkLib.EnemyHugeType, 0, 0, 0, 0);

--- a/classes/classes/Scenes/Monsters/Magnar.as
+++ b/classes/classes/Scenes/Monsters/Magnar.as
@@ -23,7 +23,7 @@ import classes.internals.*;
 		public function heatWave():void {
 			outputText("The blue flame from the massive demon’s maw vanishes… but you can feel the heat rising.  ");
 			createStatusEffect(StatusEffects.Uber, 5, 0, 0, 0);
-			if (player.hasPerk(PerkLib.FireAffinity) || player.hasPerk(PerkLib.AffinityIgnis)) {
+			if (player.immuneToBurn()) {
 				outputText("You don’t care overmuch, but your guests retreat from the creature, cringing away from the heat. ");
 			} else if (player.hasStatusEffect(StatusEffects.FieryBand)) {
 				outputText("The cool metal of Kiha’s wedding band seems to spread through your body, chasing the heat away. Your guests, however, don’t have a dragon-bride giving them such protection. ");
@@ -218,8 +218,10 @@ import classes.internals.*;
 			addCurse("str.mult", 0.30,1);
 			addCurse("spe.mult", 0.30,1);
 
-			if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
-			else player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(3),0.02,0,0);
+			if (!player.immuneToBurn()) {
+				if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
+				else player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(3),0.02,0,0);
+			}
 		}
 		
 		override protected function performCombatAction():void

--- a/classes/classes/Scenes/NPCs/Alvina.as
+++ b/classes/classes/Scenes/NPCs/Alvina.as
@@ -95,8 +95,10 @@ public class Alvina extends Monster
 			outputText("Alvina weaves her scythe above her head tracing complicated arcane signs, as a purple flame surges under you, searing your flesh. ");
 			//outputText(". (" + damage + ")");
 			player.takeFireDamage(damage, true);//, true
-			if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
-			else player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(5),0.05,0,0);
+			if (!player.immuneToBurn()) {
+				if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
+				else player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(5),0.05,0,0);
+			}
 			statScreenRefresh();
 			outputText("\n");
 		}

--- a/classes/classes/Scenes/NPCs/Asuka.as
+++ b/classes/classes/Scenes/NPCs/Asuka.as
@@ -38,10 +38,12 @@ public class Asuka extends Monster
 			else {
 				outputText(capitalA + short + "'s tail catches you as you try to dodge.  Your [armor] sizzles, and you leap back with a yelp as she gives you a light burning. ");
 				player.takeFireDamage(damage, true);
-				if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
-				else {
-					player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(3),0.05,0,0);
-					outputText(" Reeling in pain you begin to burn.");
+				if (!player.immuneToBurn()) {
+					if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
+					else {
+						player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(3),0.05,0,0);
+						outputText(" Reeling in pain you begin to burn.");
+					}
 				}
 			}
 		}

--- a/classes/classes/Scenes/NPCs/Dinah.as
+++ b/classes/classes/Scenes/NPCs/Dinah.as
@@ -212,8 +212,10 @@ import classes.internals.*;
 			var firedamage:int = (inte * 0.45) + rand(10);
 			firedamage = Math.round(firedamage);
 			player.takeFireDamage(firedamage, true);
-			if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
-			else player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(3),0.05,0,0);
+			if (!player.immuneToBurn()) {
+				if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
+				else player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(3),0.05,0,0);
+			}
 			var physdamage:Number = 0;
 			physdamage += eBaseDamage();
 			player.takePhysDamage(physdamage, true);

--- a/classes/classes/Scenes/NPCs/Lilith.as
+++ b/classes/classes/Scenes/NPCs/Lilith.as
@@ -41,8 +41,10 @@ import classes.internals.*;
 			if (hasStatusEffect(StatusEffects.Maleficium)) damage *= 2;
 			outputText("Goth girl moves her hands in air tracing complicated arcane signs, as a purple flame surges under you, searing your flesh. ");
 			player.takeFireDamage(damage, true);
-			if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
-			else player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(5),0.05,0,0);
+			if (!player.immuneToBurn()) {
+				if (player.hasStatusEffect(StatusEffects.BurnDoT)) player.addStatusValue(StatusEffects.BurnDoT, 1, 1);
+				else player.createStatusEffect(StatusEffects.BurnDoT,SceneLib.combat.debuffsOrDoTDuration(5),0.05,0,0);
+			}
 			statScreenRefresh();
 			outputText("\n");
 		}

--- a/classes/classes/Scenes/NPCs/Tyrantia.as
+++ b/classes/classes/Scenes/NPCs/Tyrantia.as
@@ -55,8 +55,10 @@ public class Tyrantia extends Monster
 				dmg1 += eBaseIntelligenceDamage() * 0.2;
 				dmg1 = Math.round(dmg1);
 				dmg1 = player.takeAcidDamage(dmg1, true);
-				if (player.hasStatusEffect(StatusEffects.AcidDoT)) player.addStatusValue(StatusEffects.AcidDoT, 1, 1);
-				else player.createStatusEffect(StatusEffects.AcidDoT, 5, 10, 0, 0);
+				if (!player.immuneToAcid()) {
+					if (player.hasStatusEffect(StatusEffects.AcidDoT)) player.addStatusValue(StatusEffects.AcidDoT, 1, 1);
+					else player.createStatusEffect(StatusEffects.AcidDoT, 5, 10, 0, 0);
+				}
 				player.buff("Goop Web").addStats( {"spe":-25} ).withText("Goop Web").combatPermanent();
 			}
 		}

--- a/classes/classes/Scenes/Soulforce.as
+++ b/classes/classes/Scenes/Soulforce.as
@@ -417,10 +417,10 @@ public class Soulforce extends BaseContent
 			dao = rand(6);
 			switch(daoname){
 				case "Fire":
-					if (player.hasPerk(PerkLib.FireAffinity) || player.hasPerk(PerkLib.AffinityIgnis)) dao += 1 + rand(3);
+					if (player.hasAnyPerk(PerkLib.FireAffinity, PerkLib.AffinityIgnis)) dao += 1 + rand(3);
 					break;
 				case "Ice":
-					if (player.hasPerk(PerkLib.ColdAffinity)) dao += 1 + rand(3);
+					if (player.hasAnyPerk(PerkLib.ColdAffinity, PerkLib.ColdMastery)) dao += 1 + rand(3);
 					break;
 				case "Lightning":
 					if (player.hasPerk(PerkLib.LightningAffinity)) dao += 1 + rand(3);
@@ -428,15 +428,25 @@ public class Soulforce extends BaseContent
 				case "Darkness":
 					if (player.hasPerk(PerkLib.DarknessAffinity)) dao += 1 + rand(3);
 					break;
-				case "Wind":
-					if (player.hasPerk(PerkLib.AffinitySylph)) dao += 1 + rand(3);
+				case "Poison":
+					if (player.hasPerk(PerkLib.PoisonAffinity)) dao += 1 + rand(3);
 					break;
-				case "Earth":
-					if (player.hasPerk(PerkLib.AffinityGnome)) dao += 1 + rand(3);
+				case "Wind":
+					if (player.hasAnyPerk(PerkLib.WindAffinity, PerkLib.AffinitySylph)) dao += 1 + rand(3);
+					break;
+				case "Blood":
+					if (player.hasAnyPerk(PerkLib.BloodAffinity, PerkLib.BloodMastery, PerkLib.WayOfTheBlood)) dao += 1 + rand(3);
 					break;
 				case "Water":
-					if (player.hasPerk(PerkLib.AffinityUndine)) dao += 1 + rand(3);
+					if (player.hasAnyPerk(PerkLib.WaterAffinity, PerkLib.AffinityUndine)) dao += 1 + rand(3);
 					break;
+				case "Earth":
+					if (player.hasAnyPerk(PerkLib.EarthAffinity, PerkLib.AffinityGnome)) dao += 1 + rand(3);
+					break;
+				case "Acid":
+					if (player.hasPerk(PerkLib.AcidAffinity)) dao += 1 + rand(3);
+					break;
+				
 			}
 		}
 		//uzycie w kontemplacji niebianskich skarbow zwiazanych z danym zywiolem daje bonusowe punkty


### PR DESCRIPTION
Added functions for checking a creature for multiple perks at once
Added functions to check a monster for multiple status effect categories
Add affinity, nature and vulnerability perks for Ice, Wind, Water, Earth, Acid and Poison
Added functions to check when the the player is immune to burn or acid
Enemies now cannot burn the player if they have Fire Affinity
Having the "Eyes of the Hunter- Expert" perk will allow the player to view the general status of the enemy

Added "hasAnyStatusEffect" and "hasStatusEffects" helper functions
Added "immuneToFrostburn" player helper function
Players wit the the Cold Affinity/Cold Mastery/Affinity Undine perk cannot be given Frostburn
Players with an affinity perk take half damage from that particular element
Players with an affinity perk will gain increased Dao Contemplation speed for that element
Monsters in the Ocean area have been given the "Water Nature" perk
Players with an affinity perk will now deal double damage with that element. Added damage modifier function to combat.as to support this
Air Elemental has been given the "Wind Nature" perk
Earth Elemental has been given the "Earth Nature" perk
Water Elemental has been given the "Water Nature" perk instead of the "Ice Nature" perk