### PR TITLE
Tease changes

### DIFF
--- a/classes/classes/Items/Consumables/ThunderBalls.as
+++ b/classes/classes/Items/Consumables/ThunderBalls.as
@@ -42,7 +42,7 @@ package classes.Items.Consumables
 				}
 				if (game.monster.hasPerk(PerkLib.EnemyGroupType) || game.monster.hasPerk(PerkLib.EnemyLargeGroupType)) damage *= 5;
 				outputText(game.monster.capitalA + game.monster.short + " is hit with the THUNDERballs!  They crackle and shock, electrocuting " + game.monster.pronoun2 + ". ");
-				damage = SceneLib.combat.doLightingDamage(damage, true, true);
+				damage = SceneLib.combat.doLightningDamage(damage, true, true);
 				if (game.monster.HP < game.monster.minHP()) game.monster.HP = game.monster.minHP() - 1;
 			}
 			return(false);

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -2354,7 +2354,7 @@ import classes.Scenes.Combat.CombatAbilities;
 			}
 			else if (hasStatusEffect(StatusEffects.FrozenSolid)) {
 				if (plural) EngineCore.outputText("Your foes are too busy trying to break out of their icy prison to fight back.");
-				else EngineCore.outputText("Your foe is too busy trying to break out of his icy prison to fight back.");
+				else EngineCore.outputText("Your foe is too busy trying to break out of its icy prison to fight back.");
 			}
 			else if (hasStatusEffect(StatusEffects.Sleep)) {
 				if (plural) EngineCore.outputText("Your foes are fast asleep.");
@@ -2365,7 +2365,7 @@ import classes.Scenes.Combat.CombatAbilities;
 				else EngineCore.outputText("Your foe is still looking for you, swearing in annoyance.");
 			}
 			else if (hasStatusEffect(StatusEffects.Polymorphed)) EngineCore.outputText("[Themonster] is fighting against the curse.");
-			else if (hasStatusEffect(StatusEffects.MonsterAttacksDisabled)) EngineCore.outputText("[Themonster] try to hit you but is unable to reach you!");
+			else if (hasStatusEffect(StatusEffects.MonsterAttacksDisabled)) EngineCore.outputText("[Themonster] tries to hit you, but is unable to reach you!");
 			else {
 				if (plural) EngineCore.outputText("Your foes are too dazed from your last hit to strike back!");
 				else {

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -2877,8 +2877,10 @@ import classes.Scenes.Combat.CombatAbilities;
 		/**
 		 * Display tease reaction message. Then call applyTease() to increase lust.
 		 * @param lustDelta value to be added to lust (already modified by lustVuln etc)
+		 * @param isNotSilent (Boolean) - Choose whether the default monster tease reaction text should be printed
+		 * @param display (Boolean) - Choose whether the tease damage number should be displayed
 		 */
-		public function teased(lustDelta:Number, isNotSilent:Boolean = true):void
+		public function teased(lustDelta:Number, isNotSilent:Boolean = true, display:Boolean = true):void
 		{
 			if(isNotSilent)
 			{
@@ -2896,7 +2898,7 @@ import classes.Scenes.Combat.CombatAbilities;
 				}
 			}
 			if (hasStatusEffect(StatusEffects.BerzerkingSiegweird)) lustDelta *= 0.5;
-			applyTease(lustDelta);
+			applyTease(lustDelta, display);
 		}
 
 		protected function outputDefaultTeaseReaction(lustDelta:Number):void
@@ -2931,11 +2933,12 @@ import classes.Scenes.Combat.CombatAbilities;
 			}
 		}
 
-		protected function applyTease(lustDelta:Number):void{
+		protected function applyTease(lustDelta:Number, display:Boolean = true):void{
 			if (damageReductionBasedOnDifficulty() > 1) lustDelta *= (1 / damageReductionBasedOnDifficulty());
+			lustDelta *= SceneLib.combat.doDamageReduction();
 			lustDelta = Math.round(lustDelta);
 			lust += lustDelta;
-			outputText(" <b>([font-lust]" + Utils.formatNumber(lustDelta) + "</font>)</b>");
+			if (display) SceneLib.combat.CommasForDigits(lustDelta, true);//outputText(" <b>([font-lust]" + Utils.formatNumber(lustDelta) + "</font>)</b>");
 			if (player.armor == armors.ELFDRES && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0 && lustDelta >= 1) {
 				outputText(" You cool down a little bit ");
 				player.takeLustDamage(Math.round(-lustDelta)/20);

--- a/classes/classes/Scenes/Areas/Beach/DemonPackBeach.as
+++ b/classes/classes/Scenes/Areas/Beach/DemonPackBeach.as
@@ -16,14 +16,14 @@ import classes.internals.WeightedDrop;
 public class DemonPackBeach extends Monster
 	{
 		
-		override public function teased(lustDelta:Number, isNotSilent:Boolean = true):void
+		override public function teased(lustDelta:Number, isNotSilent:Boolean = true, display:Boolean = true):void
 		{
 			outputText("\n");
 			if(lustDelta == 0) outputText("\n" + capitalA + short + " seems unimpressed.");
 			else if(lustDelta > 0 && lustDelta < 5) outputText("The demons lessen somewhat in the intensity of their attack, and some even eye up your assets as they strike at you.");
 			else if(lustDelta >= 5 && lustDelta < 10) outputText("The demons are obviously steering clear from damaging anything you might use to fuck and they're starting to leave their hands on you just a little longer after each blow. Some are starting to cop quick feels with their other hands and you can smell the demonic lust of a dozen bodies on the air.");
 			else if(lustDelta >= 10) outputText("The demons are less and less willing to hit you and more and more willing to just stroke their hands sensuously over you. The smell of demonic lust is thick on the air and part of the group just stands there stroking themselves openly.");
-			applyTease(lustDelta);
+			applyTease(lustDelta, display);
 		}
 		
 		public function DemonPackBeach()

--- a/classes/classes/Scenes/Areas/BlightRidge/DemonPackBlightRidge.as
+++ b/classes/classes/Scenes/Areas/BlightRidge/DemonPackBlightRidge.as
@@ -18,14 +18,14 @@ import classes.internals.WeightedDrop;
 public class DemonPackBlightRidge extends Monster
 	{
 		
-		override public function teased(lustDelta:Number, isNotSilent:Boolean = true):void
+		override public function teased(lustDelta:Number, isNotSilent:Boolean = true, display:Boolean = true):void
 		{
 			outputText("\n");
 			if(lustDelta == 0) outputText("\n" + capitalA + short + " seems unimpressed.");
 			else if(lustDelta > 0 && lustDelta < 5) outputText("The demons lessen somewhat in the intensity of their attack, and some even eye up your assets as they strike at you.");
 			else if(lustDelta >= 5 && lustDelta < 10) outputText("The demons are obviously steering clear from damaging anything you might use to fuck and they're starting to leave their hands on you just a little longer after each blow. Some are starting to cop quick feels with their other hands and you can smell the demonic lust of a dozen bodies on the air.");
 			else if(lustDelta >= 10) outputText("The demons are less and less willing to hit you and more and more willing to just stroke their hands sensuously over you. The smell of demonic lust is thick on the air and part of the group just stands there stroking themselves openly.");
-			applyTease(lustDelta);
+			applyTease(lustDelta, display);
 		}
 		
 		override public function defeated(hpVictory:Boolean):void

--- a/classes/classes/Scenes/Areas/Bog/Phouka.as
+++ b/classes/classes/Scenes/Areas/Bog/Phouka.as
@@ -135,7 +135,7 @@ public class Phouka extends Monster
 			}
 		}
 
-		override public function teased(lustDelta:Number, isNotSilent:Boolean = true):void
+		override public function teased(lustDelta:Number, isNotSilent:Boolean = true, display:Boolean = true):void
 		{
 			if (lustDelta >= 10)
 				outputText("\n\nThe " + this.short + " breaks off its attack in the face of your teasing.  Its drooling member leaves a trail of precum along the ground and you get the feeling it needs to end this fight quickly.");
@@ -143,7 +143,7 @@ public class Phouka extends Monster
 				outputText("\n\nThe " + this.short + " stops its assault for a moment.  A glob of precum oozes from its cock before it shakes its head and gets ready to attack again.");
 			else if (lustDelta > 0)
 				outputText("\n\nThe " + this.short + " hesitates and slows down.  You see its cock twitch and then it readies for the next attack.");
-			applyTease(lustDelta);
+			applyTease(lustDelta, display);
 		}
   
 		override public function defeated(hpVictory:Boolean):void

--- a/classes/classes/Scenes/Areas/DefiledRavine/DemonPackDefiledRavine.as
+++ b/classes/classes/Scenes/Areas/DefiledRavine/DemonPackDefiledRavine.as
@@ -16,14 +16,14 @@ import classes.internals.WeightedDrop;
 public class DemonPackDefiledRavine extends Monster
 	{
 		
-		override public function teased(lustDelta:Number, isNotSilent:Boolean = true):void
+		override public function teased(lustDelta:Number, isNotSilent:Boolean = true, display:Boolean = true):void
 		{
 			outputText("\n");
 			if(lustDelta == 0) outputText("\n" + capitalA + short + " seems unimpressed.");
 			else if(lustDelta > 0 && lustDelta < 5) outputText("The demons lessen somewhat in the intensity of their attack, and some even eye up your assets as they strike at you.");
 			else if(lustDelta >= 5 && lustDelta < 10) outputText("The demons are obviously steering clear from damaging anything you might use to fuck and they're starting to leave their hands on you just a little longer after each blow. Some are starting to cop quick feels with their other hands and you can smell the demonic lust of a dozen bodies on the air.");
 			else if(lustDelta >= 10) outputText("The demons are less and less willing to hit you and more and more willing to just stroke their hands sensuously over you. The smell of demonic lust is thick on the air and part of the group just stands there stroking themselves openly.");
-			applyTease(lustDelta);
+			applyTease(lustDelta, display);
 		}
 		
 		public function DemonPackDefiledRavine()

--- a/classes/classes/Scenes/Areas/Desert/DemonPackDesert.as
+++ b/classes/classes/Scenes/Areas/Desert/DemonPackDesert.as
@@ -68,14 +68,14 @@ public class DemonPackDesert extends Monster
 		}
 
 
-		override public function teased(lustDelta:Number, isNotSilent:Boolean = true):void
+		override public function teased(lustDelta:Number, isNotSilent:Boolean = true, display:Boolean = true):void
 		{
 			outputText("\n");
 			if(lustDelta == 0) outputText("\n" + capitalA + short + " seems unimpressed.");
 			else if(lustDelta > 0 && lustDelta < 5) outputText("The demons lessen somewhat in the intensity of their attack, and some even eye up your assets as they strike at you.");
 			else if(lustDelta >= 5 && lustDelta < 10) outputText("The demons are obviously steering clear from damaging anything you might use to fuck and they're starting to leave their hands on you just a little longer after each blow. Some are starting to cop quick feels with their other hands and you can smell the demonic lust of a dozen bodies on the air.");
 			else if(lustDelta >= 10) outputText("The demons are less and less willing to hit you and more and more willing to just stroke their hands sensuously over you. The smell of demonic lust is thick on the air and part of the group just stands there stroking themselves openly.");
-			applyTease(lustDelta);
+			applyTease(lustDelta, display);
 		}
 
 		public function DemonPackDesert()

--- a/classes/classes/Scenes/Areas/Desert/NagaScene.as
+++ b/classes/classes/Scenes/Areas/Desert/NagaScene.as
@@ -1063,36 +1063,8 @@ public function naggaTease():void {
     //==============================
     //Determine basic damage.
     //==============================
-    damage = 6 + rand(3);
-    if (player.hasPerk(PerkLib.SensualLover)) {
-        damage += 2;
-    }
-    if (player.hasPerk(PerkLib.Seduction)) damage += 5;
-    //+ slutty armor bonus
-    damage += player.teaseDmgStat.value;
-    //10% for bimbo shits
-    if (bimbo || bro || futa) {
-        damage += 5;
-    }
-    if (player.hasPerk(PerkLib.FlawlessBody)) damage += 10;
-    damage += player.level;
-    damage += player.teaseLevel;
-    damage += rand(7);
-    //partial skins bonuses
-    switch (player.coatType()) {
-        case Skin.FUR:
-            damage += (1 + player.newGamePlusMod());
-            break;
-        case Skin.SCALES:
-            damage += (2 * (1 + player.newGamePlusMod()));
-            break;
-        case Skin.CHITIN:
-            damage += (3 * (1 + player.newGamePlusMod()));
-            break;
-        case Skin.BARK:
-            damage += (4 * (1 + player.newGamePlusMod()));
-            break;
-    }
+    damage = combat.teases.teaseBaseLustDamage() * 0.5;
+    
     chance += 2;
     //Specific cases for slimes and demons, as the normal ones would make no sense
     if (monster.short == "demons") {
@@ -1115,33 +1087,23 @@ public function naggaTease():void {
     }
     //Land the hit!
     if (rand(100) <= chance) {
-        //NERF TEASE DAMAGE
-        damage *= .9;
 		var damagemultiplier:Number = 1;
-        if (player.hasPerk(PerkLib.HistoryWhore) || player.hasPerk(PerkLib.PastLifeWhore)) damagemultiplier += combat.historyWhoreBonus();
-        if (player.hasPerk(PerkLib.DazzlingDisplay) && rand(100) < 10) damagemultiplier += 0.2;
-		if (player.hasPerk(PerkLib.SuperSensual) && chance > 100) damagemultiplier += (0.01 * (chance - 100));
-		if (player.armorName == "desert naga pink and black silk dress") damagemultiplier += 0.1;
-		if (player.headjewelryName == "pair of Golden Naga Hairpins") damagemultiplier += 0.1;
 		if (player.hasPerk(PerkLib.UnbreakableBind)) damagemultiplier += 1;
 		if (player.hasStatusEffect(StatusEffects.ControlFreak)) damagemultiplier += (2 - player.statusEffectv1(StatusEffects.ControlFreak));
-		if (player.hasPerk(PerkLib.Sadomasochism)) damage *= player.sadomasochismBoost();
 		damage *= damagemultiplier;
+        if (player.hasPerk(PerkLib.Sadomasochism)) damage *= player.sadomasochismBoost();
+
         //Determine if critical tease!
         var crit:Boolean = false;
         var critChance:int = 5;
-        if (player.hasPerk(PerkLib.CriticalPerformance)) {
-            if (player.lib <= 100) critChance += player.lib / 5;
-            if (player.lib > 100) critChance += 20;
-        }
+        critChance += combat.teases.combatTeaseCritical();
+        if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
         if (rand(100) < critChance) {
             crit = true;
             damage *= 1.75;
         }
 		if (monster.hasStatusEffect(StatusEffects.HypnosisNaga)) damage *= 0.5;
 		if (player.hasPerk(PerkLib.RacialParagon)) damage *= combat.RacialParagonAbilityBoost();
-        if (player.armor == armors.ELFDRES && player.isElf()) damage *= 2;
-        if (player.armor == armors.FMDRESS && player.isWoodElf()) damage *= 2;
 		monster.teased(Math.round(monster.lustVuln * damage));
         if (crit) outputText(" <b>Critical!</b>");
         SceneLib.combat.teaseXP(1 + SceneLib.combat.bonusExpAfterSuccesfullTease());

--- a/classes/classes/Scenes/Areas/Lake/GooGirl.as
+++ b/classes/classes/Scenes/Areas/Lake/GooGirl.as
@@ -125,7 +125,7 @@ public class GooGirl extends Monster
 			}
 		}
 
-		override public function teased(lustDelta:Number, isNotSilent:Boolean = true):void
+		override public function teased(lustDelta:Number, isNotSilent:Boolean = true, display:Boolean = true):void
 		{
 			if (lust <= maxLust() * 0.99) {
 				if (lustDelta <= 0) outputText("\nThe goo-girl looks confused by your actions, as if she's trying to understand what you're doing.");
@@ -133,7 +133,7 @@ public class GooGirl extends Monster
 				else outputText("\nThe girl begins to understand your intent. She opens and closes her mouth, as if panting, while she works slimy fingers between her thighs and across her jiggling nipples.");
 			}
 			else outputText("\nIt appears the goo-girl has gotten lost in her mimicry, squeezing her breasts and jilling her shiny " + bodyColor + " clit, her desire to investigate you forgotten.");
-			applyTease(lustDelta);
+			applyTease(lustDelta, display);
 		}
 
 		public function GooGirl(noInit:Boolean = false)

--- a/classes/classes/Scenes/Combat/AbstractSpell.as
+++ b/classes/classes/Scenes/Combat/AbstractSpell.as
@@ -504,7 +504,7 @@ public class AbstractSpell extends CombatAbility {
 				damageFn = doIceDamage;
 				break;
 			case DamageType.LIGHTNING:
-				damageFn = doLightingDamage;
+				damageFn = doLightningDamage;
 				break;
 			case DamageType.WATER:
 				damageFn = doWaterDamage;

--- a/classes/classes/Scenes/Combat/BaseCombatContent.as
+++ b/classes/classes/Scenes/Combat/BaseCombatContent.as
@@ -60,8 +60,8 @@ public class BaseCombatContent extends BaseContent {
 	protected function doIceDamage(damage:Number, apply:Boolean = true, display:Boolean = false, ignoreDR:Boolean = false):Number {
 		return combat.doIceDamage(damage, apply, display, ignoreDR);
 	}
-	protected function doLightingDamage(damage:Number, apply:Boolean = true, display:Boolean = false, ignoreDR:Boolean = false):Number {
-		return combat.doLightingDamage(damage, apply, display, ignoreDR);
+	protected function doLightningDamage(damage:Number, apply:Boolean = true, display:Boolean = false, ignoreDR:Boolean = false):Number {
+		return combat.doLightningDamage(damage, apply, display, ignoreDR);
 	}
 	protected function doDarknessDamage(damage:Number, apply:Boolean = true, display:Boolean = false, ignoreDR:Boolean = false):Number {
 		return combat.doDarknessDamage(damage, apply, display, ignoreDR);

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -12776,37 +12776,37 @@ public function StraddleTease():void {
     straddleDamage = Math.round(straddleDamage);
 
     //Select the scene
-    var TeaseFunctionList:Array = [RandomTeaseKiss];
-    if (monster.hasBreasts()) TeaseFunctionList.push(RandomTeaseViolateOpponentBreast);
+    var teaseFunctionList:Array = [RandomTeaseKiss];
+    if (monster.hasBreasts()) teaseFunctionList.push(RandomTeaseViolateOpponentBreast);
     if (monster.hasVagina()) {
-        TeaseFunctionList.push(RandomTeaseViolateOpponentPussy);
-        if (player.tongue.type == Tongue.DEMONIC || player.tongue.type == Tongue.DRACONIC || player.tongue.type == Tongue.SNAKE) TeaseFunctionList.push(RandomTeaseLongTongue);
+        teaseFunctionList.push(RandomTeaseViolateOpponentPussy);
+        if (player.tongue.type == Tongue.DEMONIC || player.tongue.type == Tongue.DRACONIC || player.tongue.type == Tongue.SNAKE) teaseFunctionList.push(RandomTeaseLongTongue);
     }
     if (monster.hasCock()) {
-        if (player.tail.type == Tail.DEMONIC || player.tail.type == Tail.MOUSE || player.tail.type == Tail.THUNDERBIRD || player.tail.type == Tail.HINEZUMI) TeaseFunctionList.push(RandomTeaseStranglingTail);
-        if (player.tail.type == Tail.MANTICORE_PUSSYTAIL) TeaseFunctionList.push(RandomTeaseManticoreTailfuckInitiate);
-        if (player.hasVagina() && !player.hasVirginVagina()) TeaseFunctionList.push(RandomTeaseIfEnnemyCockIfPCNoVirgin);
-        TeaseFunctionList.push(RandomTeaseIfEnnemyCock);
+        if (player.tail.type == Tail.DEMONIC || player.tail.type == Tail.MOUSE || player.tail.type == Tail.THUNDERBIRD || player.tail.type == Tail.HINEZUMI) teaseFunctionList.push(RandomTeaseStranglingTail);
+        if (player.tail.type == Tail.MANTICORE_PUSSYTAIL) teaseFunctionList.push(RandomTeaseManticoreTailfuckInitiate);
+        if (player.hasVagina() && !player.hasVirginVagina()) teaseFunctionList.push(RandomTeaseIfEnnemyCockIfPCNoVirgin);
+        teaseFunctionList.push(RandomTeaseIfEnnemyCock);
     }
-    if (player.tail.type == Tail.MANTICORE_PUSSYTAIL && player.tailVenom >= player.VenomWebCost()) TeaseFunctionList.push(RandomTeaseManticoreTailSpike);
-    if (player.hairType == Hair.MINDBREAKERMALE) TeaseFunctionList.push(RandomTeaseMindflayerCriticalOverload);
-    if (player.tail.type == Tail.LIZARD || player.tail.type == Tail.CAVE_WYRM || player.tail.type == Tail.SALAMANDER) TeaseFunctionList.push(RandomTeaseButtfuckTail);
+    if (player.tail.type == Tail.MANTICORE_PUSSYTAIL && player.tailVenom >= player.VenomWebCost()) teaseFunctionList.push(RandomTeaseManticoreTailSpike);
+    if (player.hairType == Hair.MINDBREAKERMALE) teaseFunctionList.push(RandomTeaseMindflayerCriticalOverload);
+    if (player.tail.type == Tail.LIZARD || player.tail.type == Tail.CAVE_WYRM || player.tail.type == Tail.SALAMANDER) teaseFunctionList.push(RandomTeaseButtfuckTail);
     if (player.lowerBody == LowerBody.PLANT_FLOWER || player.lowerBody == LowerBody.FLOWER_LILIRAUNE){
-        if (player.isLiliraune()) TeaseFunctionList.push(RandomTeaseLiliraune);
-        else TeaseFunctionList.push(RandomTeaseAlraune);
+        if (player.isLiliraune()) teaseFunctionList.push(RandomTeaseLiliraune);
+        else teaseFunctionList.push(RandomTeaseAlraune);
     }
-    if (player.rearBody.type == RearBody.DISPLACER_TENTACLES && !monster.hasPerk(PerkLib.EnemyConstructType)) TeaseFunctionList.push(RandomTeaseDisplacerMilkingInitiate);
+    if (player.rearBody.type == RearBody.DISPLACER_TENTACLES && !monster.hasPerk(PerkLib.EnemyConstructType)) teaseFunctionList.push(RandomTeaseDisplacerMilkingInitiate);
     if (player.lowerBody == LowerBody.GOO){
-        TeaseFunctionList.push(RandomTeaseSlime);
-        TeaseFunctionList.push(RandomTeaseSlimeInsert);
+        teaseFunctionList.push(RandomTeaseSlime);
+        teaseFunctionList.push(RandomTeaseSlimeInsert);
     }
-    if (player.countCocksOfType(CockTypesEnum.ANEMONE) > 0) TeaseFunctionList.push(RandomTeaseAnemone);
-    if (player.hasPerk(PerkLib.ElectrifiedDesire)) TeaseFunctionList.push(RandomTeaseRaiju);
-    if (player.hasPerk(PerkLib.DragonLustPoisonBreath) && player.tailVenom >= player.VenomWebCost()) TeaseFunctionList.push(RandomTeaseJabberwocky);
-    if (player.isAnyRace(Races.HarpylikeRaces)) TeaseFunctionList.push(RandomTeaseHarpy);
-    if (player.isRaceCached(Races.KITSUNE)) TeaseFunctionList.push(RandomTeaseKitsune);
-    if (player.perkv1(IMutationsLib.BlackHeartIM) > 0) TeaseFunctionList.push(RandomTeaseLustStrike);
-    var chosenTease:Function = randomChoice(TeaseFunctionList);
+    if (player.countCocksOfType(CockTypesEnum.ANEMONE) > 0) teaseFunctionList.push(RandomTeaseAnemone);
+    if (player.hasPerk(PerkLib.ElectrifiedDesire)) teaseFunctionList.push(RandomTeaseRaiju);
+    if (player.hasPerk(PerkLib.DragonLustPoisonBreath) && player.tailVenom >= player.VenomWebCost()) teaseFunctionList.push(RandomTeaseJabberwocky);
+    if (player.isAnyRace(Races.HarpylikeRaces)) teaseFunctionList.push(RandomTeaseHarpy);
+    if (player.isRaceCached(Races.KITSUNE)) teaseFunctionList.push(RandomTeaseKitsune);
+    if (player.perkv1(IMutationsLib.BlackHeartIM) > 0) teaseFunctionList.push(RandomTeaseLustStrike);
+    var chosenTease:Function = randomChoice(teaseFunctionList);
     chosenTease();
     combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
     outputText("\n\n");

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1792,7 +1792,7 @@ public class Combat extends BaseContent {
                 doIceDamage(elementalDamage, true, true);
                 break;
             case LIGHTNING:
-                doLightingDamage(elementalDamage, true, true);
+                doLightningDamage(elementalDamage, true, true);
                 break;
             case DARKNESS:
                 doDarknessDamage(elementalDamage, true, true);
@@ -3412,7 +3412,7 @@ public class Combat extends BaseContent {
 			doIceDamage(damage, true, true, ignoreDR);
 		}
         else if (flags[kFLAGS.ELEMENTAL_ARROWS] == 3) {
-			doLightingDamage(damage, true, true, ignoreDR);
+			doLightningDamage(damage, true, true, ignoreDR);
 		}
         else if (flags[kFLAGS.ELEMENTAL_ARROWS] == 4) {
 			doDarknessDamage(damage, true, true, ignoreDR);
@@ -3558,7 +3558,7 @@ public class Combat extends BaseContent {
 			}
 			else if (player.weaponRange == weaponsrange.TTKNIFE) {
 				damage = Math.round(damage * lightningDamageBoostedByDao());
-				doLightingDamage(damage, true, true);
+				doLightningDamage(damage, true, true);
 			}
 			else if (player.weaponRange == weaponsrange.ATKNIFE) {
 				damage = Math.round(damage * darknessDamageBoostedByDao());
@@ -6017,7 +6017,7 @@ public class Combat extends BaseContent {
                     }
                     else if (isLightningTypeWeapon()) {
                         damage = Math.round(damage * lightningDamage);
-                        doLightingDamage(damage, true, true);
+                        doLightningDamage(damage, true, true);
 						if (player.statStore.hasBuff("FoxflamePelt")) layerFoxflamePeltOnThis(damage);
                     }
                     else if (isDarknessTypeWeapon()) {
@@ -6112,21 +6112,21 @@ public class Combat extends BaseContent {
 						}
                     }
                     if (player.hasStatusEffect(StatusEffects.AlchemicalThunderBuff)) {
-						doLightingDamage(Math.round(damage * 0.3), true, true);
+						doLightningDamage(Math.round(damage * 0.3), true, true);
 						if (player.statStore.hasBuff("FoxflamePelt")) layerFoxflamePeltOnThis(damage);
 					}
                     if (player.weapon == weapons.PRURUMI && player.spe >= 150) {
                         doPhysicalDamage(damage, true, true);
-                        if (player.hasStatusEffect(StatusEffects.AlchemicalThunderBuff)) doLightingDamage(Math.round(damage * 0.3), true, true);
+                        if (player.hasStatusEffect(StatusEffects.AlchemicalThunderBuff)) doLightningDamage(Math.round(damage * 0.3), true, true);
 						if (player.statStore.hasBuff("FoxflamePelt")) layerFoxflamePeltOnThis(damage);
                         if (player.spe >= 225) {
                             doPhysicalDamage(damage, true, true);
-                            if (player.hasStatusEffect(StatusEffects.AlchemicalThunderBuff)) doLightingDamage(Math.round(damage * 0.3), true, true);
+                            if (player.hasStatusEffect(StatusEffects.AlchemicalThunderBuff)) doLightningDamage(Math.round(damage * 0.3), true, true);
 							if (player.statStore.hasBuff("FoxflamePelt")) layerFoxflamePeltOnThis(damage);
                         }
                         if (player.spe >= 300) {
                             doPhysicalDamage(damage, true, true);
-                            if (player.hasStatusEffect(StatusEffects.AlchemicalThunderBuff)) doLightingDamage(Math.round(damage * 0.3), true, true);
+                            if (player.hasStatusEffect(StatusEffects.AlchemicalThunderBuff)) doLightningDamage(Math.round(damage * 0.3), true, true);
 							if (player.statStore.hasBuff("FoxflamePelt")) layerFoxflamePeltOnThis(damage);
                         }
                     }
@@ -7203,7 +7203,7 @@ public class Combat extends BaseContent {
                         doIceDamage(damage, true, true);
                         break;
                     case "lightning":
-                        doLightingDamage(damage, true, true);
+                        doLightningDamage(damage, true, true);
                         break;
                     case "darkness":
                         doDarknessDamage(damage, true, true);
@@ -7334,7 +7334,7 @@ public class Combat extends BaseContent {
 		if (player.hasPerk(PerkLib.LionHeart)) damage *= 2;
         damage *= 2;
         damage = Math.round(damage);
-        doLightingDamage(damage, true, true);
+        doLightningDamage(damage, true, true);
         if (crit1) outputText(" <b>*Critical Hit!*</b>");
         dynStats("lus", (Math.round(player.maxLust() * 0.02)), "scale", false);
         var lustDmgF:Number = 20 + rand(6);
@@ -8468,7 +8468,7 @@ public class Combat extends BaseContent {
         return damage;
     }
 
-    public function doLightingDamage(damage:Number, apply:Boolean = true, display:Boolean = false, ignoreDR:Boolean = false):Number {
+    public function doLightningDamage(damage:Number, apply:Boolean = true, display:Boolean = false, ignoreDR:Boolean = false):Number {
         MDOCount++; // for multipile attacks to prevent stupid repeating of damage messages
         damage *= doDamageReduction();
         damage = doElementalDamageMultiplier(damage);
@@ -8789,7 +8789,7 @@ public class Combat extends BaseContent {
 		var fdamage:Number = Math.round(split * fireDamageBoostedByDao());
 		var ldamage:Number = Math.round(split * lightningDamageBoostedByDao());
 		doFireDamage(fdamage, apply, display, ignoreDR);
-		doLightingDamage(ldamage, apply, display, ignoreDR);
+		doLightningDamage(ldamage, apply, display, ignoreDR);
 		return split;
 	}
 
@@ -9595,7 +9595,7 @@ public class Combat extends BaseContent {
 
             lustDmgF = Math.round(lustDmgF);
             outputText("Your opponent is struck by lightning as your lust storm rages on.")
-            damage0 = doLightingDamage(damage0, true, true);
+            damage0 = doLightningDamage(damage0, true, true);
             if (crit1) outputText(" <b>*Critical!*</b>");
             monster.teased(lustDmgF, false);
             if (crit2) outputText(" <b>Critical!</b>");
@@ -9619,7 +9619,7 @@ public class Combat extends BaseContent {
             var LustDamage:int = combat.teases.teaseBaseLustDamage();
             if (player.perkv1(IMutationsLib.MelkieLungIM) >= 2) LustDamage += scalingBonusIntelligence();
             if (player.perkv1(IMutationsLib.MelkieLungIM) >= 3) LustDamage += scalingBonusIntelligence();
-            var Randomcrit:Boolean = false;
+            var randomcrit:Boolean = false;
             //Determine if critical tease!
             var critChance4:int = 5;
             if (player.hasPerk(PerkLib.CriticalPerformance)) {
@@ -9628,7 +9628,7 @@ public class Combat extends BaseContent {
             }
             if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance4 = 0;
             if (rand(100) < critChance4) {
-                Randomcrit = true;
+                randomcrit = true;
                 LustDamage *= 1.75;
             }
             if (player.hasPerk(PerkLib.RacialParagon)) LustDamage *= combat.RacialParagonAbilityBoost();
@@ -9644,7 +9644,7 @@ public class Combat extends BaseContent {
             LustDamage = (LustDamage) * monster.lustVuln;
             LustDamage = Math.round(LustDamage);
             monster.teased(LustDamage, false);
-            if (Randomcrit) outputText(" Critical hit!");
+            if (randomcrit) outputText(" Critical hit!");
             outputText("\n\n");
             bonusExpAfterSuccesfullTease();
         }
@@ -10848,7 +10848,7 @@ public class Combat extends BaseContent {
     }
 	
 	private function repeatArcaneVenom(dmg:Number, subtype:Number, poisonele:Number):void {
-		var RandomCritAV:Boolean = false;
+		var randomCritAV:Boolean = false;
 		if (player.hasPerk(PerkLib.VegetalAffinity)) dmg *= 1.5;
 		if (player.hasPerk(PerkLib.GreenMagic)) dmg *= 2;
 		if (player.hasStatusEffect(StatusEffects.GreenCovenant)) dmg *= 2;
@@ -10860,7 +10860,7 @@ public class Combat extends BaseContent {
 		}
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChanceAV = 0;
 		if (rand(100) < critChanceAV) {
-			RandomCritAV = true;
+			randomCritAV = true;
 			dmg *= 1.75;
 		}
 		if (player.hasPerk(PerkLib.RacialParagon)) dmg *= combat.RacialParagonAbilityBoost();
@@ -10871,7 +10871,7 @@ public class Combat extends BaseContent {
 		var arve:Number = 1;
 		if (player.hasPerk(PerkLib.ArcaneVenom)) arve += AbstractSpell.stackingArcaneVenom();
 		while (arve-->0) {
-			if (RandomCritAV) repeatArcaneVenom2(dmg, 0, poisonele);
+			if (randomCritAV) repeatArcaneVenom2(dmg, 0, poisonele);
 			else repeatArcaneVenom2(dmg, 0, poisonele, false);
 		}
 	}
@@ -12625,7 +12625,7 @@ public function SingArouse(Bee:Boolean = false):void {
     var LustDamage:int = combat.teases.teaseBaseLustDamage();
     if (player.perkv1(IMutationsLib.MelkieLungIM) >= 2) LustDamage += scalingBonusIntelligence();
     if (player.perkv1(IMutationsLib.MelkieLungIM) >= 3) LustDamage += scalingBonusIntelligence();
-    var Randomcrit:Boolean = false;
+    var randomcrit:Boolean = false;
     //Determine if critical tease!
     var critChance:int = 5;
     if (player.hasPerk(PerkLib.CriticalPerformance)) {
@@ -12634,7 +12634,7 @@ public function SingArouse(Bee:Boolean = false):void {
     }
     if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
     if (rand(100) < critChance) {
-        Randomcrit = true;
+        randomcrit = true;
         LustDamage *= 1.75;
     }
     if (player.hasPerk(PerkLib.DazzlingDisplay) && rand(100) < 20) {
@@ -12652,7 +12652,7 @@ public function SingArouse(Bee:Boolean = false):void {
     LustDamage = (LustDamage) * monster.lustVuln;
     LustDamage = Math.round(LustDamage);
     monster.teased(LustDamage, false);
-    if (Randomcrit) outputText(" Critical hit!");
+    if (randomcrit) outputText(" Critical hit!");
     outputText("\n\n");
     combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
     enemyAI();
@@ -12752,14 +12752,14 @@ public function Straddle():void {
         enemyAI();
 }
 
-private var StraddleDamage:Number
-private var Randomcrit:Boolean;
+private var straddleDamage:Number
+private var randomcrit:Boolean;
 public function StraddleTease():void {
     clearOutput();
-    StraddleDamage = combat.teases.teaseBaseLustDamage();
-    if (player.perkv1(IMutationsLib.ManticoreMetabolismIM) >= 3 && player.tail.type == Tail.MANTICORE_PUSSYTAIL) StraddleDamage *= 2;
+    straddleDamage = combat.teases.teaseBaseLustDamage();
+    if (player.perkv1(IMutationsLib.ManticoreMetabolismIM) >= 3 && player.tail.type == Tail.MANTICORE_PUSSYTAIL) straddleDamage *= 2;
     //Determine if critical tease!
-    Randomcrit = false;
+    randomcrit = false;
     var critChance:int = 5;
     if (player.hasPerk(PerkLib.CriticalPerformance)) {
         if (player.lib <= 100) critChance += player.lib / 5;
@@ -12767,13 +12767,13 @@ public function StraddleTease():void {
     }
     if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
     if (rand(100) < critChance) {
-        Randomcrit = true;
-        StraddleDamage *= 1.75;
+        randomcrit = true;
+        straddleDamage *= 1.75;
         if (monster.lustVuln != 0 && player.hasPerk(PerkLib.SweepDefenses) && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.05;
     }
-    StraddleDamage = (StraddleDamage) * monster.lustVuln;
-    if (player.hasStatusEffect(StatusEffects.AlrauneEntangle)) StraddleDamage *= 2;
-    StraddleDamage = Math.round(StraddleDamage);
+    straddleDamage = (straddleDamage) * monster.lustVuln;
+    if (player.hasStatusEffect(StatusEffects.AlrauneEntangle)) straddleDamage *= 2;
+    straddleDamage = Math.round(straddleDamage);
 
     //Select the scene
     var TeaseFunctionList:Array = [RandomTeaseKiss];
@@ -12806,8 +12806,8 @@ public function StraddleTease():void {
     if (player.isAnyRace(Races.HarpylikeRaces)) TeaseFunctionList.push(RandomTeaseHarpy);
     if (player.isRaceCached(Races.KITSUNE)) TeaseFunctionList.push(RandomTeaseKitsune);
     if (player.perkv1(IMutationsLib.BlackHeartIM) > 0) TeaseFunctionList.push(RandomTeaseLustStrike);
-    var ChosenTease:Function = randomChoice(TeaseFunctionList);
-    ChosenTease();
+    var chosenTease:Function = randomChoice(TeaseFunctionList);
+    chosenTease();
     combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
     outputText("\n\n");
     if (player.hasPerk(PerkLib.DemonEnergyThirst) || player.hasPerk(PerkLib.KitsuneEnergyThirst)) {
@@ -12845,8 +12845,8 @@ public function StraddleTease():void {
 public function RandomTeaseKiss():void {
     outputText("You pull in [themonster] into a wild french kiss, forcing your tongue in as you begin to choke the protest out of [monster him]. " +
             "Your opponent starts to struggle, shoving you off his face. They stagger back, doing [monster his] best not to show how much this aroused [monster him].");
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
 public function RandomTeaseIfEnnemyCock():void {
@@ -12855,8 +12855,8 @@ public function RandomTeaseIfEnnemyCock():void {
     if (monster.hasBalls()) outputText("Your second hand is busy massaging the ball sack beneath, " +
             "intent on speeding up the inevitable and messy orgasm your skillful play will force out of [monster him]. ");
     outputText("Your opponent finally tries to fight back, forcing you to unwrap your grip on [monster his] dick momentarily. You back off, but the damage is already done.");
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
 public function RandomTeaseIfEnnemyCockIfPCNoVirgin():void {
@@ -12865,10 +12865,10 @@ public function RandomTeaseIfEnnemyCockIfPCNoVirgin():void {
             "You bounce up and down the rod, keeping your pussy tightly wrapped around [themonster]'s aching member in order to speed up the inevitable and messy orgasm your " +
             "skilled cunt will force out of [monster him]. Your opponent finally fights back, forcing you up and off [monster his] dick. You back off, but the damage is already done, your foe's arousal clear. " +
             "And you lick your lips still riding on your own pleasure.");
-    StraddleDamage *= 1.5;
-    StraddleDamage = Math.round(StraddleDamage);
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    straddleDamage *= 1.5;
+    straddleDamage = Math.round(straddleDamage);
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
     player.lust += (20 * (1 + monster.newGamePlusMod()));
 }
 
@@ -12877,8 +12877,8 @@ public function RandomTeaseStranglingTail():void {
             "pre gushing out through whatever space is left between. [themonster]'s mouth opens to let out a confused moan as you work [monster his] tool. ");
     if (monster.hasBalls()) outputText("Your hand is busy massaging the ball sack beneath, intent on speeding up the inevitable and messy orgasm your skillful play will force out of [monster him].");
     outputText("Your opponent finally fights back, forcing you to unwrap your tail from them. You back off, but the damage has already been done.");
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
 public function RandomTeaseButtfuckTail():void {
@@ -12886,24 +12886,24 @@ public function RandomTeaseButtfuckTail():void {
             "[themonster]'s eyes widen as you slowly proceed to analy tail fuck [monster him]. Ahhh such tightness in that hole. " +
             "Sadly it only lasts for a while before [monster he] finally fights back. " +
             "You give [monster a] a smirk and a wink, yanking your tail out in one go. You get back into a fighting stance, but the damage is already done.");
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
 public function RandomTeaseViolateOpponentBreast():void {
     outputText("You begin to groppe [themonster] [monster breasts] with both hands, licking the areola and smirking knowingly as the tips hardens in reaction. " +
             "[themonster] moans coax you in doubling up the attention your tongue circling a nipple then moving to the other. " +
             "It takes great effort from [themonster] to snap out and force you off [monster his] tormented chest but the blush you see on [monster his] cheeks was worth it.");
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
 public function RandomTeaseViolateOpponentPussy():void {
     outputText("You mischievously begin to finger [themonster] [monster cunt] forcing a surprised moan out of [monster him] as you attack [monster his] clitoris relentlessly. " +
             "clear, sticky pre coats your hand, a clear sign of your victim's pleasure as you rub their clit." +
             "It takes great effort from [themonster], [monster he] lets loose a cry, breaking your hold and forcing your fingers from [monster his] tormented cunt. You back off, but you see their blushing cheeks.");
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
 public function RandomTeaseLongTongue():void {
@@ -12912,8 +12912,8 @@ public function RandomTeaseLongTongue():void {
             "Your almost jerk your victim's clit with your flexible tongue, forcing out delirious moans from [themonster] as [monster his] knee goes weak from your ministration. " +
             "In desperation [monster he] punches you in the face. Your head whipped back, you're forced to pull your tongue out of [monster his] tormented cunt. You back off, but your foe is blushing madly, beads of sweat" +
             "on [monster his] forehead. Your opponent is so staggered by your expert tongueing that you easily keep [monster him] pinned. ");
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
     player.addStatusValue(StatusEffects.StraddleRoundLeft, 1, +1);
 }
 
@@ -12928,26 +12928,26 @@ public function RandomTeaseLongTongue():void {
         if (player.hasPerk(PerkLib.AlphaAndOmega)) Multiplier += 0.5;
         if (player.hasPerk(PerkLib.NaturalArsenal)) Multiplier += 0.5;
         if (player.hasPerk(PerkLib.MindbreakerBrain1toX)) Multiplier += player.perkv1(PerkLib.MindbreakerBrain1toX)*0.5;
-        StraddleDamage *= 1+(scalingBonusIntelligence()*2/100);
-        StraddleDamage *= Multiplier;
-        monster.teased(StraddleDamage, false);
+        straddleDamage *= 1+(scalingBonusIntelligence()*2/100);
+        straddleDamage *= Multiplier;
+        monster.teased(straddleDamage, false);
         monster.lustVuln += 0.05;
-        if (Randomcrit) outputText(" <b>Critical!</b>");
+        if (randomcrit) outputText(" <b>Critical!</b>");
     }
 
     public function RandomTeaseManticoreTailSpike():void {
     outputText("Taking advantage of your opponent's precarious position, you reach back and grab one of your back-spikes. " +
             "You grin widely as you bring your hand down, stabbing your opponent with your venomous spike. You bat aside their clumsy attempt at a block, stabbing them again and again. With each stab, venom frothes from the spike, and blood spills from the deep injuries." +
             "Your victim eventually rallies, blocking your wrist, then knocking the spike from your hand. You jump off them before they can strike you, but as they fight their way upright, you can tell that it was worth it");
-    if (player.perkv1(IMutationsLib.ManticoreMetabolismIM) >= 3 && player.tail.type == Tail.MANTICORE_PUSSYTAIL) StraddleDamage *= 2;
+    if (player.perkv1(IMutationsLib.ManticoreMetabolismIM) >= 3 && player.tail.type == Tail.MANTICORE_PUSSYTAIL) straddleDamage *= 2;
         var Multiplier:Number = 1;
         if (player.hasPerk(PerkLib.RacialParagon)) Multiplier += 0.5;
         if (player.hasPerk(PerkLib.Apex)) Multiplier += 0.5;
         if (player.hasPerk(PerkLib.AlphaAndOmega)) Multiplier += 0.5;
         if (player.hasPerk(PerkLib.NaturalArsenal)) Multiplier += 0.5;
-        StraddleDamage *= Multiplier;
-        monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+        straddleDamage *= Multiplier;
+        monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
     var dam4Ba:Number = 1;
     if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) dam4Ba *= 2;
     monster.statStore.addBuffObject({tou:-(dam4Ba*6)}, "Poison",{text:"Poison"});
@@ -12996,10 +12996,10 @@ public function RandomTeaseJabberwocky():void {
         monster.addStatusValue(StatusEffects.JabberwockyVenom, 3, dam4Ba);
     } else monster.createStatusEffect(StatusEffects.JabberwockyVenom, 0, 0, dam4Ba, 0);
     player.tailVenom -= player.VenomWebCost();
-    StraddleDamage *= 1+(scalingBonusToughness()*2/100);
-    StraddleDamage *= 2;
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    straddleDamage *= 1+(scalingBonusToughness()*2/100);
+    straddleDamage *= 2;
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
     monster.lustVuln += 0.05;
 }
 
@@ -13013,8 +13013,8 @@ public function RandomTeaseRaiju():void {
     outputText(" pulse");
     if (monster.hasCock() && monster.hasVagina()) outputText("s");
     outputText(" with your current at the rhythm of [themonster] owns heartbeat.");
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
     monster.lustVuln += 0.05;
 }
 
@@ -13026,8 +13026,8 @@ public function RandomTeaseHarpy():void {
             "[monster His] pre drooling [monster cockshort] twitches and strains between your plush cheeks making them slicker. " +
             "You giggle planting a few more kisses around [monster his] mouth and neck as you push [monster him] closer to the edge. " +
             "Your opponent finally fights back, forcing you to release [monster his] dick from between your cheeks. You push off, getting back into a fighting stance, almost laughing as you see [monster him] arousal.");
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
     monster.lustVuln += 0.05;
 }
 
@@ -13039,10 +13039,10 @@ public function RandomTeaseKitsune():void {
     if (monster.hasCock() && monster.hasVagina()) outputText(" and");
     if (monster.hasCock()) outputText(" [monster cockshort]");
     outputText(" with fiery lust. Your opponent eventually shakes off your magic, striking you and breaking your concentration, but they clearly enjoyed the experience. Nothing's preventing you from doing it again, after all");
-    StraddleDamage *= 1+((scalingBonusWisdom() + scalingBonusIntelligence())/100);
-    StraddleDamage = Math.round(StraddleDamage);
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    straddleDamage *= 1+((scalingBonusWisdom() + scalingBonusIntelligence())/100);
+    straddleDamage = Math.round(straddleDamage);
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
 public function RandomTeaseAlraune():void {
@@ -13056,11 +13056,11 @@ public function RandomTeaseAlraune():void {
             "begins trashing about. You hold on, but they roar, forcing [monster him]self out of your grip. You shake your head, retreating back to your previous position, and [monster him] takes a few steps back. " +
             "You will mate eventually… it's just a matter of time now.");
     //(Add a toughness modifier and double lust damage)
-    StraddleDamage *= 1+(scalingBonusToughness()*2/100);
-    StraddleDamage *= 2;
-    StraddleDamage = Math.round(StraddleDamage);
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    straddleDamage *= 1+(scalingBonusToughness()*2/100);
+    straddleDamage *= 2;
+    straddleDamage = Math.round(straddleDamage);
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
 public function RandomTeaseLiliraune():void {
@@ -13080,11 +13080,11 @@ public function RandomTeaseLiliraune():void {
             "\n\n\"We're going to give you the sweetest orgasm of your life. So sweet your eyes will probably cross thehehe...\"\n\n" +
             "You will mate eventually… it's just a matter of time now.");
     //(Add a toughness modifier and double lust damage)
-    StraddleDamage *= 1+(scalingBonusToughness()*2/100);
-    StraddleDamage *= 3;
-    StraddleDamage = Math.round(StraddleDamage);
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    straddleDamage *= 1+(scalingBonusToughness()*2/100);
+    straddleDamage *= 3;
+    straddleDamage = Math.round(straddleDamage);
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
 public function RandomTeaseLustStrike():void {
@@ -13100,11 +13100,11 @@ public function RandomTeaseLustStrike():void {
     if (monster.hasCock() && monster.hasVagina()) outputText("s");
     outputText(" with your demonic powers at the rhythm of [themonster]'s heartbeat. " +
             "The unholy transformation, even if temporary, arouses [themonster] to no end.");
-    StraddleDamage *= 1+((scalingBonusIntelligence()*2)/100);
-    //StraddleDamage *= 1+((player.intStat.core.max*2)/100);
-    StraddleDamage = Math.round(StraddleDamage);
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    straddleDamage *= 1+((scalingBonusIntelligence()*2)/100);
+    //straddleDamage *= 1+((player.intStat.core.max*2)/100);
+    straddleDamage = Math.round(straddleDamage);
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
     monster.lustVuln += 0.05;
 }
 
@@ -13115,10 +13115,10 @@ public function RandomTeaseAnemone():void {
             "insensate to [themonster] crazed moans as you attempt to force in as much pleasure as you can. " +
             "In desperation [monster he] punches you, forcing you to pull your devilish cock out of its tormented cunt. " +
             "[monster he] breathes heavily, blushing as [monster he] fights to [monster his] feet. You can tell you've rattled [monster him]");
-    StraddleDamage *= 2;
-    StraddleDamage = Math.round(StraddleDamage);
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    straddleDamage *= 2;
+    straddleDamage = Math.round(straddleDamage);
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
 public function RandomTeaseSlime():void {
@@ -13132,10 +13132,10 @@ public function RandomTeaseSlime():void {
     if (monster.hasVagina()) outputText(" inside [monster his] vagina, you begin viciously bumping into as many of [monster his] sensitive spots as you can, coaxing numerous loud moans from your partner.");
     outputText("Eventually, [monster his] forceful contractions force you back out of your opponent. They manage to get back up, but they look like they enjoyed it." +
             "Thats nice because you intend to to do it again, the first chance you get.");
-    StraddleDamage *= 1+(scalingBonusToughness()*2/100+scalingBonusLibido()*2/100);
-    StraddleDamage = Math.round(StraddleDamage);
-    monster.teased(StraddleDamage, false);
-    if (Randomcrit) outputText(" <b>Critical!</b>");
+    straddleDamage *= 1+(scalingBonusToughness()*2/100+scalingBonusLibido()*2/100);
+    straddleDamage = Math.round(straddleDamage);
+    monster.teased(straddleDamage, false);
+    if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
 public function RandomTeaseSlimeInsert():void {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -5971,10 +5971,7 @@ public class Combat extends BaseContent {
                             //Determine if critical tease!
                             var crit1:Boolean = false;
                             var critChance1:int = 5;
-                            if (player.hasPerk(PerkLib.CriticalPerformance)) {
-                                if (player.lib <= 100) critChance1 += player.lib / 5;
-                                if (player.lib > 100) critChance1 += 20;
-                            }
+                            critChance1 += teases.combatTeaseCritical();
                             if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance1 = 0;
                             if (rand(100) < critChance1) {
                                 crit1 = true;
@@ -7088,11 +7085,7 @@ public class Combat extends BaseContent {
         }
         else{
             enwa_lustCritChance = 5;
-
-            if (player.hasPerk(PerkLib.CriticalPerformance)) {
-                if (player.lib <= 100) enwa_lustCritChance += player.lib / 5;
-                if (player.lib > 100) enwa_lustCritChance += 20;
-            }
+            enwa_lustCritChance += teases.combatTeaseCritical();
         }
 
         enwa_lustPostMulti = 1;
@@ -7385,10 +7378,7 @@ public class Combat extends BaseContent {
         //Determine if critical tease!
         var crit2:Boolean = false;
         var critChance2:int = 5;
-        if (player.hasPerk(PerkLib.CriticalPerformance)) {
-            if (player.lib <= 100) critChance2 += player.lib / 5;
-            if (player.lib > 100) critChance2 += 20;
-        }
+        critChance2 += teases.combatTeaseCritical();
         if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance2 = 0;
         if (rand(100) < critChance2) {
             crit2 = true;
@@ -9580,10 +9570,7 @@ public class Combat extends BaseContent {
             //Determine if critical tease!
             var crit2:Boolean = false;
             var critChance2:int = 5;
-            if (player.hasPerk(PerkLib.CriticalPerformance)) {
-                if (player.lib <= 100) critChance2 += player.lib / 5;
-                if (player.lib > 100) critChance2 += 20;
-            }
+            critChance2 += teases.combatTeaseCritical();
             if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance2 = 0;
             if (rand(100) < critChance2) {
                 crit2 = true;
@@ -9622,10 +9609,7 @@ public class Combat extends BaseContent {
             var randomcrit:Boolean = false;
             //Determine if critical tease!
             var critChance4:int = 5;
-            if (player.hasPerk(PerkLib.CriticalPerformance)) {
-                if (player.lib <= 100) critChance4 += player.lib / 5;
-                if (player.lib > 100) critChance4 += 20;
-            }
+            critChance4 += teases.combatTeaseCritical();
             if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance4 = 0;
             if (rand(100) < critChance4) {
                 randomcrit = true;
@@ -10854,10 +10838,7 @@ public class Combat extends BaseContent {
 		if (player.hasStatusEffect(StatusEffects.GreenCovenant)) dmg *= 2;
 		//Determine if critical tease!
 		var critChanceAV:int = 5;
-		if (player.hasPerk(PerkLib.CriticalPerformance)) {
-			if (player.lib <= 100) critChanceAV += player.lib / 5;
-			if (player.lib > 100) critChanceAV += 20;
-		}
+		critChanceAV += teases.combatTeaseCritical();
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChanceAV = 0;
 		if (rand(100) < critChanceAV) {
 			randomCritAV = true;
@@ -10866,8 +10847,7 @@ public class Combat extends BaseContent {
 		if (player.hasPerk(PerkLib.RacialParagon)) dmg *= combat.RacialParagonAbilityBoost();
 		if (player.hasPerk(PerkLib.NaturalArsenal)) dmg *= 1.50;
 		if (player.hasPerk(PerkLib.LionHeart)) dmg *= 2;
-        if (player.armor == armors.ELFDRES && player.isElf()) dmg *= 2;
-        if (player.armor == armors.FMDRESS && player.isWoodElf()) dmg *= 2;
+
 		var arve:Number = 1;
 		if (player.hasPerk(PerkLib.ArcaneVenom)) arve += AbstractSpell.stackingArcaneVenom();
 		while (arve-->0) {
@@ -10879,7 +10859,7 @@ public class Combat extends BaseContent {
 		if (poisonele != 0) doPoisonDamage(poisonele, true, true);
 		dmg = Math.round(dmg * monster.lustVuln);
 		monster.teased(dmg, false);
-		if (crit) outputText(" Critical hit!");
+		if (crit) outputText(" <b>Critical!</b>" );
 		if (subtype == 1) combat.teaseXP((1 + combat.bonusExpAfterSuccesfullTease()*2));
 		else combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		if (player.hasPerk(PerkLib.VerdantLeech)) {
@@ -12628,10 +12608,7 @@ public function SingArouse(Bee:Boolean = false):void {
     var randomcrit:Boolean = false;
     //Determine if critical tease!
     var critChance:int = 5;
-    if (player.hasPerk(PerkLib.CriticalPerformance)) {
-        if (player.lib <= 100) critChance += player.lib / 5;
-        if (player.lib > 100) critChance += 20;
-    }
+    critChance += teases.combatTeaseCritical();
     if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
     if (rand(100) < critChance) {
         randomcrit = true;
@@ -12752,19 +12729,16 @@ public function Straddle():void {
         enemyAI();
 }
 
-private var straddleDamage:Number
-private var randomcrit:Boolean;
+//private var straddleDamage:Number
+//private var randomcrit:Boolean;
 public function StraddleTease():void {
     clearOutput();
-    straddleDamage = combat.teases.teaseBaseLustDamage();
+    var straddleDamage:Number = combat.teases.teaseBaseLustDamage();
     if (player.perkv1(IMutationsLib.ManticoreMetabolismIM) >= 3 && player.tail.type == Tail.MANTICORE_PUSSYTAIL) straddleDamage *= 2;
     //Determine if critical tease!
-    randomcrit = false;
+    var randomcrit:Boolean = false;
     var critChance:int = 5;
-    if (player.hasPerk(PerkLib.CriticalPerformance)) {
-        if (player.lib <= 100) critChance += player.lib / 5;
-        if (player.lib > 100) critChance += 20;
-    }
+    critChance += teases.combatTeaseCritical();
     if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
     if (rand(100) < critChance) {
         randomcrit = true;
@@ -12776,38 +12750,38 @@ public function StraddleTease():void {
     straddleDamage = Math.round(straddleDamage);
 
     //Select the scene
-    var teaseFunctionList:Array = [RandomTeaseKiss];
-    if (monster.hasBreasts()) teaseFunctionList.push(RandomTeaseViolateOpponentBreast);
+    var teaseFunctionList:Array = [randomTeaseKiss];
+    if (monster.hasBreasts()) teaseFunctionList.push(randomTeaseViolateOpponentBreast);
     if (monster.hasVagina()) {
-        teaseFunctionList.push(RandomTeaseViolateOpponentPussy);
-        if (player.tongue.type == Tongue.DEMONIC || player.tongue.type == Tongue.DRACONIC || player.tongue.type == Tongue.SNAKE) teaseFunctionList.push(RandomTeaseLongTongue);
+        teaseFunctionList.push(randomTeaseViolateOpponentPussy);
+        if (player.tongue.type == Tongue.DEMONIC || player.tongue.type == Tongue.DRACONIC || player.tongue.type == Tongue.SNAKE) teaseFunctionList.push(randomTeaseLongTongue);
     }
     if (monster.hasCock()) {
-        if (player.tail.type == Tail.DEMONIC || player.tail.type == Tail.MOUSE || player.tail.type == Tail.THUNDERBIRD || player.tail.type == Tail.HINEZUMI) teaseFunctionList.push(RandomTeaseStranglingTail);
-        if (player.tail.type == Tail.MANTICORE_PUSSYTAIL) teaseFunctionList.push(RandomTeaseManticoreTailfuckInitiate);
-        if (player.hasVagina() && !player.hasVirginVagina()) teaseFunctionList.push(RandomTeaseIfEnnemyCockIfPCNoVirgin);
-        teaseFunctionList.push(RandomTeaseIfEnnemyCock);
+        if (player.tail.type == Tail.DEMONIC || player.tail.type == Tail.MOUSE || player.tail.type == Tail.THUNDERBIRD || player.tail.type == Tail.HINEZUMI) teaseFunctionList.push(randomTeaseStranglingTail);
+        if (player.tail.type == Tail.MANTICORE_PUSSYTAIL) teaseFunctionList.push(randomTeaseManticoreTailfuckInitiate);
+        if (player.hasVagina() && !player.hasVirginVagina()) teaseFunctionList.push(randomTeaseIfEnemyCockIfPCNoVirgin);
+        teaseFunctionList.push(randomTeaseIfEnemyCock);
     }
-    if (player.tail.type == Tail.MANTICORE_PUSSYTAIL && player.tailVenom >= player.VenomWebCost()) teaseFunctionList.push(RandomTeaseManticoreTailSpike);
-    if (player.hairType == Hair.MINDBREAKERMALE) teaseFunctionList.push(RandomTeaseMindflayerCriticalOverload);
-    if (player.tail.type == Tail.LIZARD || player.tail.type == Tail.CAVE_WYRM || player.tail.type == Tail.SALAMANDER) teaseFunctionList.push(RandomTeaseButtfuckTail);
+    if (player.tail.type == Tail.MANTICORE_PUSSYTAIL && player.tailVenom >= player.VenomWebCost()) teaseFunctionList.push(randomTeaseManticoreTailSpike);
+    if (player.hairType == Hair.MINDBREAKERMALE) teaseFunctionList.push(randomTeaseMindflayerCriticalOverload);
+    if (player.tail.type == Tail.LIZARD || player.tail.type == Tail.CAVE_WYRM || player.tail.type == Tail.SALAMANDER) teaseFunctionList.push(randomTeaseButtfuckTail);
     if (player.lowerBody == LowerBody.PLANT_FLOWER || player.lowerBody == LowerBody.FLOWER_LILIRAUNE){
-        if (player.isLiliraune()) teaseFunctionList.push(RandomTeaseLiliraune);
-        else teaseFunctionList.push(RandomTeaseAlraune);
+        if (player.isLiliraune()) teaseFunctionList.push(randomTeaseLiliraune);
+        else teaseFunctionList.push(randomTeaseAlraune);
     }
-    if (player.rearBody.type == RearBody.DISPLACER_TENTACLES && !monster.hasPerk(PerkLib.EnemyConstructType)) teaseFunctionList.push(RandomTeaseDisplacerMilkingInitiate);
+    if (player.rearBody.type == RearBody.DISPLACER_TENTACLES && !monster.hasPerk(PerkLib.EnemyConstructType)) teaseFunctionList.push(randomTeaseDisplacerMilkingInitiate);
     if (player.lowerBody == LowerBody.GOO){
-        teaseFunctionList.push(RandomTeaseSlime);
-        teaseFunctionList.push(RandomTeaseSlimeInsert);
+        teaseFunctionList.push(randomTeaseSlime);
+        teaseFunctionList.push(randomTeaseSlimeInsert);
     }
-    if (player.countCocksOfType(CockTypesEnum.ANEMONE) > 0) teaseFunctionList.push(RandomTeaseAnemone);
-    if (player.hasPerk(PerkLib.ElectrifiedDesire)) teaseFunctionList.push(RandomTeaseRaiju);
-    if (player.hasPerk(PerkLib.DragonLustPoisonBreath) && player.tailVenom >= player.VenomWebCost()) teaseFunctionList.push(RandomTeaseJabberwocky);
-    if (player.isAnyRace(Races.HarpylikeRaces)) teaseFunctionList.push(RandomTeaseHarpy);
-    if (player.isRaceCached(Races.KITSUNE)) teaseFunctionList.push(RandomTeaseKitsune);
-    if (player.perkv1(IMutationsLib.BlackHeartIM) > 0) teaseFunctionList.push(RandomTeaseLustStrike);
+    if (player.countCocksOfType(CockTypesEnum.ANEMONE) > 0) teaseFunctionList.push(randomTeaseAnemone);
+    if (player.hasPerk(PerkLib.ElectrifiedDesire)) teaseFunctionList.push(randomTeaseRaiju);
+    if (player.hasPerk(PerkLib.DragonLustPoisonBreath) && player.tailVenom >= player.VenomWebCost()) teaseFunctionList.push(randomTeaseJabberwocky);
+    if (player.isAnyRace(Races.HarpylikeRaces)) teaseFunctionList.push(randomTeaseHarpy);
+    if (player.isRaceCached(Races.KITSUNE)) teaseFunctionList.push(randomTeaseKitsune);
+    if (player.perkv1(IMutationsLib.BlackHeartIM) > 0) teaseFunctionList.push(randomTeaseLustStrike);
     var chosenTease:Function = randomChoice(teaseFunctionList);
-    chosenTease();
+    chosenTease(straddleDamage, randomcrit);
     combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
     outputText("\n\n");
     if (player.hasPerk(PerkLib.DemonEnergyThirst) || player.hasPerk(PerkLib.KitsuneEnergyThirst)) {
@@ -12842,14 +12816,14 @@ public function StraddleTease():void {
     enemyAI();
 }
 
-public function RandomTeaseKiss():void {
+public function randomTeaseKiss(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You pull in [themonster] into a wild french kiss, forcing your tongue in as you begin to choke the protest out of [monster him]. " +
             "Your opponent starts to struggle, shoving you off his face. They stagger back, doing [monster his] best not to show how much this aroused [monster him].");
     monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
-public function RandomTeaseIfEnnemyCock():void {
+public function randomTeaseIfEnemyCock(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You gently and skillfully begin to stroke [themonster] [monster cockshort] giving the tip a wet kiss every now and then in order to coax the delicious pre out, " +
             "your saliva dripping from the length. [themonster] mouths open to let out a confused moan as you work [monster his] tool. ");
     if (monster.hasBalls()) outputText("Your second hand is busy massaging the ball sack beneath, " +
@@ -12859,7 +12833,7 @@ public function RandomTeaseIfEnnemyCock():void {
     if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
-public function RandomTeaseIfEnnemyCockIfPCNoVirgin():void {
+public function randomTeaseIfEnemyCockIfPCNoVirgin(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You lower yourself onto [themonster] [monster cockshort] and begin to gently gyrate your hips, " +
             "drooling from your mouth as you drink in the pleasure. [themonster] mouths open to let out a confused moan as you work [monster his] tool. " +
             "You bounce up and down the rod, keeping your pussy tightly wrapped around [themonster]'s aching member in order to speed up the inevitable and messy orgasm your " +
@@ -12872,7 +12846,7 @@ public function RandomTeaseIfEnnemyCockIfPCNoVirgin():void {
     player.lust += (20 * (1 + monster.newGamePlusMod()));
 }
 
-public function RandomTeaseStranglingTail():void {
+public function randomTeaseStranglingTail(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You wrap your prehensile tail around [themonster] [monster cockshort] and skillfully begin to stroke it, your tail tip poking inside the urethra every now and then, " +
             "pre gushing out through whatever space is left between. [themonster]'s mouth opens to let out a confused moan as you work [monster his] tool. ");
     if (monster.hasBalls()) outputText("Your hand is busy massaging the ball sack beneath, intent on speeding up the inevitable and messy orgasm your skillful play will force out of [monster him].");
@@ -12881,7 +12855,7 @@ public function RandomTeaseStranglingTail():void {
     if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
-public function RandomTeaseButtfuckTail():void {
+public function randomTeaseButtfuckTail(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You smile mischievously as you insert inch after inch of your tail into your opponent, slowly stretching that cute pucker of [monster his], " +
             "[themonster]'s eyes widen as you slowly proceed to analy tail fuck [monster him]. Ahhh such tightness in that hole. " +
             "Sadly it only lasts for a while before [monster he] finally fights back. " +
@@ -12890,7 +12864,7 @@ public function RandomTeaseButtfuckTail():void {
     if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
-public function RandomTeaseViolateOpponentBreast():void {
+public function randomTeaseViolateOpponentBreast(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You begin to groppe [themonster] [monster breasts] with both hands, licking the areola and smirking knowingly as the tips hardens in reaction. " +
             "[themonster] moans coax you in doubling up the attention your tongue circling a nipple then moving to the other. " +
             "It takes great effort from [themonster] to snap out and force you off [monster his] tormented chest but the blush you see on [monster his] cheeks was worth it.");
@@ -12898,7 +12872,7 @@ public function RandomTeaseViolateOpponentBreast():void {
     if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
-public function RandomTeaseViolateOpponentPussy():void {
+public function randomTeaseViolateOpponentPussy(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You mischievously begin to finger [themonster] [monster cunt] forcing a surprised moan out of [monster him] as you attack [monster his] clitoris relentlessly. " +
             "clear, sticky pre coats your hand, a clear sign of your victim's pleasure as you rub their clit." +
             "It takes great effort from [themonster], [monster he] lets loose a cry, breaking your hold and forcing your fingers from [monster his] tormented cunt. You back off, but you see their blushing cheeks.");
@@ -12906,7 +12880,7 @@ public function RandomTeaseViolateOpponentPussy():void {
     if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
-public function RandomTeaseLongTongue():void {
+public function randomTeaseLongTongue(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("Oh god, [themonster] had it coming as you prepare yourself to use your strongest weapon. " +
             "Your long prehensile tongue slides into [themonster] [monster cunt] like a tentacle, striking the sweet spot with unerring precision. " +
             "Your almost jerk your victim's clit with your flexible tongue, forcing out delirious moans from [themonster] as [monster his] knee goes weak from your ministration. " +
@@ -12914,51 +12888,52 @@ public function RandomTeaseLongTongue():void {
             "on [monster his] forehead. Your opponent is so staggered by your expert tongueing that you easily keep [monster him] pinned. ");
     monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
-    player.addStatusValue(StatusEffects.StraddleRoundLeft, 1, +1);
+    player.addStatusValue(StatusEffects.StraddleRoundLeft, 1, 1);
 }
 
-    public function RandomTeaseMindflayerCriticalOverload():void {
-        outputText("Immobilizing your opponent with your arms you lock [monster him] into a kiss as you insert your tentacles inside [themonster]'s head and wrap them around [monster his] brain," +
-                " giving your victim a glimpse at every depraved lewd act your body has felt and done to others and the infinite maddening pleasure your insane mind has gone through " +
-                "gifting your victim with the first hand experience of everything you have endured." +
-                " Your opponent shove you off in panic but the damage is already done and you smile knowingly as you spot telltale sign of [monster his] increased arousal.");
-        var Multiplier:Number = 1;
-        if (player.hasPerk(PerkLib.RacialParagon)) Multiplier += 0.5;
-        if (player.hasPerk(PerkLib.Apex)) Multiplier += 0.5;
-        if (player.hasPerk(PerkLib.AlphaAndOmega)) Multiplier += 0.5;
-        if (player.hasPerk(PerkLib.NaturalArsenal)) Multiplier += 0.5;
-        if (player.hasPerk(PerkLib.MindbreakerBrain1toX)) Multiplier += player.perkv1(PerkLib.MindbreakerBrain1toX)*0.5;
-        straddleDamage *= 1+(scalingBonusIntelligence()*2/100);
-        straddleDamage *= Multiplier;
-        monster.teased(straddleDamage, false);
-        monster.lustVuln += 0.05;
-        if (randomcrit) outputText(" <b>Critical!</b>");
-    }
+public function randomTeaseMindflayerCriticalOverload(straddleDamage:Number, randomcrit:Boolean):void {
+    outputText("Immobilizing your opponent with your arms you lock [monster him] into a kiss as you insert your tentacles inside [themonster]'s head and wrap them around [monster his] brain," +
+            " giving your victim a glimpse at every depraved lewd act your body has felt and done to others and the infinite maddening pleasure your insane mind has gone through " +
+            "gifting your victim with the first hand experience of everything you have endured." +
+            " Your opponent shove you off in panic but the damage is already done and you smile knowingly as you spot telltale sign of [monster his] increased arousal.");
+    var multiplier:Number = 1;
+    if (player.hasPerk(PerkLib.RacialParagon)) multiplier += RacialParagonAbilityBoost() - 1;
+    if (player.hasPerk(PerkLib.NaturalArsenal)) multiplier += 0.5;
+    if (player.hasPerk(PerkLib.MindbreakerBrain1toX)) multiplier += player.perkv1(PerkLib.MindbreakerBrain1toX)*0.5;
+    straddleDamage *= multiplier;
+    straddleDamage += scalingBonusIntelligence() * 2;
+    monster.teased(straddleDamage, false);
+    
+    if (monster.lustVuln != 0) monster.lustVuln += 0.05;
+    if (randomcrit) outputText(" <b>Critical!</b>");
+}
 
-    public function RandomTeaseManticoreTailSpike():void {
+public function randomTeaseManticoreTailSpike(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("Taking advantage of your opponent's precarious position, you reach back and grab one of your back-spikes. " +
             "You grin widely as you bring your hand down, stabbing your opponent with your venomous spike. You bat aside their clumsy attempt at a block, stabbing them again and again. With each stab, venom frothes from the spike, and blood spills from the deep injuries." +
             "Your victim eventually rallies, blocking your wrist, then knocking the spike from your hand. You jump off them before they can strike you, but as they fight their way upright, you can tell that it was worth it");
     if (player.perkv1(IMutationsLib.ManticoreMetabolismIM) >= 3 && player.tail.type == Tail.MANTICORE_PUSSYTAIL) straddleDamage *= 2;
-        var Multiplier:Number = 1;
-        if (player.hasPerk(PerkLib.RacialParagon)) Multiplier += 0.5;
-        if (player.hasPerk(PerkLib.Apex)) Multiplier += 0.5;
-        if (player.hasPerk(PerkLib.AlphaAndOmega)) Multiplier += 0.5;
-        if (player.hasPerk(PerkLib.NaturalArsenal)) Multiplier += 0.5;
-        straddleDamage *= Multiplier;
-        monster.teased(straddleDamage, false);
+    
+    var multiplier:Number = 1;
+    if (player.hasPerk(PerkLib.RacialParagon)) multiplier += RacialParagonAbilityBoost() - 1;
+    if (player.hasPerk(PerkLib.NaturalArsenal)) multiplier += 0.5;
+    straddleDamage *= multiplier;
+
+    monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
+
     var dam4Ba:Number = 1;
     if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) dam4Ba *= 2;
     monster.statStore.addBuffObject({tou:-(dam4Ba*6)}, "Poison",{text:"Poison"});
     if (monster.hasStatusEffect(StatusEffects.ManticoreVenom)) {
         monster.addStatusValue(StatusEffects.ManticoreVenom, 3, dam4Ba);
     } else monster.createStatusEffect(StatusEffects.ManticoreVenom, 0, 0, dam4Ba, 0);
+
     player.tailVenom -= player.VenomWebCost();
     flags[kFLAGS.VENOM_TIMES_USED] += 0.2;
 }
 
-public function RandomTeaseManticoreTailfuckInitiate():void {
+public function randomTeaseManticoreTailfuckInitiate(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You lick your lips and hold your victim down as you get into position,  engulfing [themonster] juicy [monster cockshort] with your tail pussy. You’re going to milk that cumpump for what its worth.");
     var DurationLeft:int = player.statusEffectv1(StatusEffects.StraddleRoundLeft);
     var BasePlugDuration:int = 1;
@@ -12968,7 +12943,7 @@ public function RandomTeaseManticoreTailfuckInitiate():void {
     monster.removeStatusEffect(StatusEffects.Straddle);
 }
 
-public function RandomTeaseDisplacerMilkingInitiate():void {
+public function randomTeaseDisplacerMilkingInitiate(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You lick your lips in anticipation as you hold your victim's arms to the ground and plug your two tentacle suckers to [monster his] breasts. " +
             "[monster he] struggles, flushing red as you flood [monster his] nipples with your lactation inducing venom and begin to force the delicious milk out of [monster his] chest. ");
     var DurationLeft:int = player.statusEffectv1(StatusEffects.StraddleRoundLeft);
@@ -12977,33 +12952,32 @@ public function RandomTeaseDisplacerMilkingInitiate():void {
     monster.removeStatusEffect(StatusEffects.Straddle);
 }
 
-public function RandomTeaseJabberwocky():void {
+public function randomTeaseJabberwocky(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You inhale deeply before forcing yourself in, kissing your foe. You force their mouth open, breathing poison directly down [monster His] throat!");
     var dam4Ba:Number = 1;
-    var Multiplier:Number = 1;
-    if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) Multiplier += 1;
-    if (player.perkv1(IMutationsLib.DrakeLungsIM) >= 1) Multiplier += 2;
-    if (player.perkv1(IMutationsLib.DrakeLungsIM) >= 2) Multiplier += 2;
-    if (player.perkv1(IMutationsLib.DrakeLungsIM) >= 3) Multiplier += 2;
-    if (player.perkv1(IMutationsLib.DrakeLungsIM) >= 4) Multiplier += 2;
-    if (player.hasPerk(PerkLib.RacialParagon)) Multiplier += 0.5;
-    if (player.hasPerk(PerkLib.Apex)) Multiplier += 0.5;
-    if (player.hasPerk(PerkLib.AlphaAndOmega)) Multiplier += 0.5;
-    if (player.hasPerk(PerkLib.NaturalArsenal)) Multiplier += 0.5;
-    dam4Ba *= Multiplier;
+    var multiplier:Number = 1;
+    if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) multiplier += 1;
+    if (player.perkv1(IMutationsLib.DrakeLungsIM) >= 1) multiplier += 2;
+    if (player.perkv1(IMutationsLib.DrakeLungsIM) >= 2) multiplier += 2;
+    if (player.perkv1(IMutationsLib.DrakeLungsIM) >= 3) multiplier += 2;
+    if (player.perkv1(IMutationsLib.DrakeLungsIM) >= 4) multiplier += 2;
+    if (player.hasPerk(PerkLib.RacialParagon)) multiplier += RacialParagonAbilityBoost() - 1;
+    if (player.hasPerk(PerkLib.NaturalArsenal)) multiplier += 0.5;
+    dam4Ba *= multiplier;
+
     monster.statStore.addBuffObject({tou:-(dam4Ba*2)}, "Poison",{text:"Poison"});
     if (monster.hasStatusEffect(StatusEffects.JabberwockyVenom)) {
         monster.addStatusValue(StatusEffects.JabberwockyVenom, 3, dam4Ba);
     } else monster.createStatusEffect(StatusEffects.JabberwockyVenom, 0, 0, dam4Ba, 0);
     player.tailVenom -= player.VenomWebCost();
-    straddleDamage *= 1+(scalingBonusToughness()*2/100);
+    straddleDamage += scalingBonusToughness() * 2;
     straddleDamage *= 2;
     monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
-    monster.lustVuln += 0.05;
+    if (monster.lustVuln != 0) monster.lustVuln += 0.05;
 }
 
-public function RandomTeaseRaiju():void {
+public function randomTeaseRaiju(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You begin gathering up electricity before discharging it into your opponent's genitals at point blank range. [monster His] ");
     if (monster.hasCock()) outputText("cock begins shooting an endless flow of cum");
     if (monster.hasCock() && monster.hasVagina()) outputText(" as [monster his]");
@@ -13013,12 +12987,16 @@ public function RandomTeaseRaiju():void {
     outputText(" pulse");
     if (monster.hasCock() && monster.hasVagina()) outputText("s");
     outputText(" with your current at the rhythm of [themonster] owns heartbeat.");
+
+    var multiplier:Number = 1;
+    if (player.hasPerk(PerkLib.RacialParagon)) multiplier += RacialParagonAbilityBoost() - 1;
+    straddleDamage *= multiplier;
     monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
-    monster.lustVuln += 0.05;
+    if (monster.lustVuln != 0) monster.lustVuln += 0.05;
 }
 
-public function RandomTeaseHarpy():void {
+public function randomTeaseHarpy(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You wrap your wings around [themonster], firmly planting your plush backside down onto [monster his] cock and slipping it between your cheeks. " +
             "Your soft ass completely engulfs [monster his] dick and hugs it tightly. " +
             "You moving your hips up and down massaging and stroking it between your warm soft flesh. You pull [themonster] into a kiss, " +
@@ -13026,12 +13004,16 @@ public function RandomTeaseHarpy():void {
             "[monster His] pre drooling [monster cockshort] twitches and strains between your plush cheeks making them slicker. " +
             "You giggle planting a few more kisses around [monster his] mouth and neck as you push [monster him] closer to the edge. " +
             "Your opponent finally fights back, forcing you to release [monster his] dick from between your cheeks. You push off, getting back into a fighting stance, almost laughing as you see [monster him] arousal.");
+    
+    var multiplier:Number = 1;
+    if (player.hasPerk(PerkLib.RacialParagon)) multiplier += RacialParagonAbilityBoost() - 1;
+    straddleDamage *= multiplier;
     monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
-    monster.lustVuln += 0.05;
+    if (monster.lustVuln != 0) monster.lustVuln += 0.05;
 }
 
-public function RandomTeaseKitsune():void {
+public function randomTeaseKitsune(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("With a mischievous grin you coat your hands and tail tips with foxfire, running the tingling flames deliciously along the length of [themonster] body");
     if (monster.hasBreasts()) outputText(", your tails tracing [monster his] [monster breasts]");
     outputText(". You finish [monster him] up by focusing your flames on [monster his] crotch bathing [monster his]");
@@ -13039,13 +13021,17 @@ public function RandomTeaseKitsune():void {
     if (monster.hasCock() && monster.hasVagina()) outputText(" and");
     if (monster.hasCock()) outputText(" [monster cockshort]");
     outputText(" with fiery lust. Your opponent eventually shakes off your magic, striking you and breaking your concentration, but they clearly enjoyed the experience. Nothing's preventing you from doing it again, after all");
-    straddleDamage *= 1+((scalingBonusWisdom() + scalingBonusIntelligence())/100);
+    
+    straddleDamage += scalingBonusWisdom() + scalingBonusIntelligence();
+    var multiplier:Number = 1;
+    if (player.hasPerk(PerkLib.RacialParagon)) multiplier += RacialParagonAbilityBoost() - 1;
+    straddleDamage *= multiplier;
     straddleDamage = Math.round(straddleDamage);
     monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
-public function RandomTeaseAlraune():void {
+public function randomTeaseAlraune(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("Now that [themonster] is nicely tied up you giggle and you pull [monster him] into a kiss, " +
             "feeding [monster him] your aphrodisiac nectar as your hand sweetly traces [monster his] cheek, one of your stamen going straight for");
     if (monster.hasVagina()) outputText(" the waiting love canal up front as another takes aim and plunge into ");
@@ -13055,15 +13041,19 @@ public function RandomTeaseAlraune():void {
     outputText("\n\nThe sex is mind melting but short lived as suddenly aware of what is going on [themonster] " +
             "begins trashing about. You hold on, but they roar, forcing [monster him]self out of your grip. You shake your head, retreating back to your previous position, and [monster him] takes a few steps back. " +
             "You will mate eventually… it's just a matter of time now.");
+    
+    var multiplier:Number = 1;
+    if (player.hasPerk(PerkLib.RacialParagon)) multiplier += RacialParagonAbilityBoost() - 1;
+    straddleDamage *= multiplier;
     //(Add a toughness modifier and double lust damage)
-    straddleDamage *= 1+(scalingBonusToughness()*2/100);
+    straddleDamage *= scalingBonusToughness() * 2;
     straddleDamage *= 2;
     straddleDamage = Math.round(straddleDamage);
     monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
-public function RandomTeaseLiliraune():void {
+public function randomTeaseLiliraune(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("With your lovely guest comfortably set in your pitcher its time for you to get to the fun part." +
             "\n\n\"Oh my! An early treat sister, look at how she/he is well tied up.\"" +
             "\n\n\"It sure gets my sap pumping.\"\n\n");
@@ -13079,15 +13069,19 @@ public function RandomTeaseLiliraune():void {
             "\n\n\"You're just delaying the inevitable you know? You should just surrender and let us take good care of your pleasure.\"" +
             "\n\n\"We're going to give you the sweetest orgasm of your life. So sweet your eyes will probably cross thehehe...\"\n\n" +
             "You will mate eventually… it's just a matter of time now.");
+    
+    var multiplier:Number = 1;
+    if (player.hasPerk(PerkLib.RacialParagon)) multiplier += RacialParagonAbilityBoost() - 1;
+    straddleDamage *= multiplier;
     //(Add a toughness modifier and double lust damage)
-    straddleDamage *= 1+(scalingBonusToughness()*2/100);
+    straddleDamage += scalingBonusToughness() * 2;
     straddleDamage *= 3;
     straddleDamage = Math.round(straddleDamage);
     monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
-public function RandomTeaseLustStrike():void {
+public function randomTeaseLustStrike(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You smile lewdly, almost moaning the syllables as you pose your hand on [themonster] crotch " +
             "waving the demonic signs and delivering your unholy magic directly into your victim's endowment. [monster His] ");
     if (monster.hasCock() > 0) outputText("cock drools black precum, swelling in size");
@@ -13100,28 +13094,32 @@ public function RandomTeaseLustStrike():void {
     if (monster.hasCock() && monster.hasVagina()) outputText("s");
     outputText(" with your demonic powers at the rhythm of [themonster]'s heartbeat. " +
             "The unholy transformation, even if temporary, arouses [themonster] to no end.");
-    straddleDamage *= 1+((scalingBonusIntelligence()*2)/100);
-    //straddleDamage *= 1+((player.intStat.core.max*2)/100);
+
+    straddleDamage += scalingBonusIntelligence() * 2;
     straddleDamage = Math.round(straddleDamage);
     monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
-    monster.lustVuln += 0.05;
+    if (monster.lustVuln != 0) monster.lustVuln += 0.05;
 }
 
-public function RandomTeaseAnemone():void {
+public function randomTeaseAnemone(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You take no time, plugging your venomous tentacled anemone cock into [themonster]'s vulnerable pussy. " +
             "The effect is instantaneous as [monster he] is stung on the entire surface of [monster his] vaginal walls, " +
             "the lips puffing up and the hole gushing with a telltale spray of girlcum. You begin to piston inside, " +
             "insensate to [themonster] crazed moans as you attempt to force in as much pleasure as you can. " +
             "In desperation [monster he] punches you, forcing you to pull your devilish cock out of its tormented cunt. " +
             "[monster he] breathes heavily, blushing as [monster he] fights to [monster his] feet. You can tell you've rattled [monster him]");
+    
+    var multiplier:Number = 1;
+    if (player.hasPerk(PerkLib.RacialParagon)) multiplier += RacialParagonAbilityBoost() - 1;
+    straddleDamage *= multiplier;
     straddleDamage *= 2;
     straddleDamage = Math.round(straddleDamage);
     monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
-public function RandomTeaseSlime():void {
+public function randomTeaseSlime(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("You take no time, violating [themonster]'s vulnerable ");
     if (monster.hasVagina()) outputText("pussy");
     if (monster.hasVagina() && monster.hasCock()) outputText(" and ");
@@ -13132,13 +13130,17 @@ public function RandomTeaseSlime():void {
     if (monster.hasVagina()) outputText(" inside [monster his] vagina, you begin viciously bumping into as many of [monster his] sensitive spots as you can, coaxing numerous loud moans from your partner.");
     outputText("Eventually, [monster his] forceful contractions force you back out of your opponent. They manage to get back up, but they look like they enjoyed it." +
             "Thats nice because you intend to to do it again, the first chance you get.");
-    straddleDamage *= 1+(scalingBonusToughness()*2/100+scalingBonusLibido()*2/100);
+    
+    var multiplier:Number = 1;
+    if (player.hasPerk(PerkLib.RacialParagon)) multiplier += RacialParagonAbilityBoost() - 1;
+    straddleDamage *= multiplier;
+    straddleDamage += (scalingBonusToughness() * 2) + (scalingBonusLibido() * 2);
     straddleDamage = Math.round(straddleDamage);
     monster.teased(straddleDamage, false);
     if (randomcrit) outputText(" <b>Critical!</b>");
 }
 
-public function RandomTeaseSlimeInsert():void {
+public function randomTeaseSlimeInsert(straddleDamage:Number, randomcrit:Boolean):void {
     outputText("Hungry for fluids you forcefully inject yourself into your opponent body, using every available orifice as an entryway. ");
     if (monster.hasCock()) outputText("Within seconds you reach the fresh cum storage of your opponent feeding straight from the tap. Your forceful entry causes [monster him] no short amount of pleasure as you mess [monster him] up inside. ");
     if (monster.hasBalls()) outputText("Your victims balls double in size the veins pulsing as your slushing presense causes them to easily triple in volume. You get a firm grip on your victim's gonads, ready to milk them for what the are worth. ");
@@ -13146,13 +13148,14 @@ public function RandomTeaseSlimeInsert():void {
     if (monster.hasVagina() && !monster.hasCock()) outputText("Once deep");
     if (monster.hasVagina()) outputText(" inside [monster his] vagina, flooding your gelatinous body all the way past the cervix, into the womb.");
     outputText("Whatever is left of you you pour straight into your victim's ass, fully flooding [monster his] innards all the way to the stomach, causing your body to bloat your opponents belly. <b>Its snacking time!</b>");
+    
     var DurationLeft:int = player.statusEffectv1(StatusEffects.StraddleRoundLeft);
     monster.createStatusEffect(StatusEffects.SlimeInsert, 2 + rand(3), DurationLeft, 0, 0);
     player.removeStatusEffect(StatusEffects.StraddleRoundLeft);
     monster.removeStatusEffect(StatusEffects.Straddle);
 }
 
-public function StraddleLeggoMyEggo():void {
+public function straddleLeggoMyEggo():void {
     clearOutput();
     outputText("You let [themonster] go, prefering to continue the fight normally.");
     monster.removeStatusEffect(StatusEffects.Straddle);
@@ -13343,10 +13346,7 @@ public function ScyllaTease():void {
             //Determine if critical tease!
             var crit:Boolean = false;
             var critChance:int = 5;
-            if (player.hasPerk(PerkLib.CriticalPerformance)) {
-                if (player.lib <= 100) critChance += player.lib / 5;
-                if (player.lib > 100) critChance += 20;
-            }
+            critChance += teases.combatTeaseCritical();
             if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
             if (rand(100) < critChance) {
                 crit = true;
@@ -13504,10 +13504,7 @@ public function SwallowTease():void {
             //Determine if critical tease!
             var crit:Boolean = false;
             var critChance:int = 5;
-            if (player.hasPerk(PerkLib.CriticalPerformance)) {
-                if (player.lib <= 100) critChance += player.lib / 5;
-                if (player.lib > 100) critChance += 20;
-            }
+            critChance += teases.combatTeaseCritical();
             if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
             if (rand(100) < critChance) {
                 crit = true;
@@ -13700,10 +13697,7 @@ public function WebTease():void {
             //Determine if critical tease!
             var crit:Boolean = false;
             var critChance:int = 5;
-            if (player.hasPerk(PerkLib.CriticalPerformance)) {
-                if (player.lib <= 100) critChance += player.lib / 5;
-                if (player.lib > 100) critChance += 20;
-            }
+            critChance += teases.combatTeaseCritical();
             if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
             if (player.armor == armors.ELFDRES && player.isElf()) damage *= 2;
             if (player.armor == armors.FMDRESS && player.isWoodElf()) damage *= 2;
@@ -13852,10 +13846,7 @@ public function GooTease():void {
             //Determine if critical tease!
             var crit:Boolean = false;
             var critChance:int = 5;
-            if (player.hasPerk(PerkLib.CriticalPerformance)) {
-                if (player.lib <= 100) critChance += player.lib / 5;
-                if (player.lib > 100) critChance += 20;
-            }
+            critChance += teases.combatTeaseCritical();
             if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
             if (rand(100) < critChance) {
                 crit = true;
@@ -14010,10 +14001,7 @@ public function ManticoreFeed():void {
         //Determine if critical tease!
         var crit:Boolean = false;
         var critChance:int = 5;
-        if (player.hasPerk(PerkLib.CriticalPerformance)) {
-            if (player.lib <= 100) critChance += player.lib / 5;
-            if (player.lib > 100) critChance += 20;
-        }
+        critChance += teases.combatTeaseCritical();
         if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
         if (rand(100) < critChance) {
             crit = true;
@@ -14120,10 +14108,7 @@ public function displacerFeedContinue():void {
         //Determine if critical tease!
         var crit:Boolean = false;
         var critChance:int = 5;
-        if (player.hasPerk(PerkLib.CriticalPerformance)) {
-            if (player.lib <= 100) critChance += player.lib / 5;
-            if (player.lib > 100) critChance += 20;
-        }
+        critChance += teases.combatTeaseCritical();
         if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
         if (rand(100) < critChance) {
             crit = true;
@@ -14230,10 +14215,7 @@ public function SlimeRapeFeed():void {
         //Determine if critical tease!
         var crit:Boolean = false;
         var critChance:int = 5;
-        if (player.hasPerk(PerkLib.CriticalPerformance)) {
-            if (player.lib <= 100) critChance += player.lib / 5;
-            if (player.lib > 100) critChance += 20;
-        }
+        critChance += teases.combatTeaseCritical();
         if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
         if (rand(100) < critChance) {
             crit = true;

--- a/classes/classes/Scenes/Combat/CombatAbility.as
+++ b/classes/classes/Scenes/Combat/CombatAbility.as
@@ -223,6 +223,7 @@ public class CombatAbility extends BaseCombatContent {
 	public var targetType:int;
 	public var timingType:int;
 	private var _tags:/*Boolean*/Array;
+	public var icon:String;
 	public var baseManaCost:Number = 0;
 	public var baseWrathCost:Number = 0;
 	public var baseSFCost:Number = 0;
@@ -422,6 +423,7 @@ public class CombatAbility extends BaseCombatContent {
 		}
 		
 		bd.hint(fullDesc,deactivating ? "Deactivate " + name : name);
+		if (icon) bd.icon(icon);
 		return bd;
 	}
 	

--- a/classes/classes/Scenes/Combat/CombatMagic.as
+++ b/classes/classes/Scenes/Combat/CombatMagic.as
@@ -820,10 +820,7 @@ public class CombatMagic extends BaseCombatContent {
 			//Determine if critical tease!
 			var crit:Boolean = false;
 			var critChance:int = 5;
-			if (player.hasPerk(PerkLib.CriticalPerformance)) {
-				if (player.lib <= 100) critChance += player.lib / 5;
-				if (player.lib > 100) critChance += 20;
-			}
+			critChance += combat.teases.combatTeaseCritical();
 			if (rand(100) < critChance) {
 				crit = true;
 				damage *= 1.75;

--- a/classes/classes/Scenes/Combat/CombatSoulskills.as
+++ b/classes/classes/Scenes/Combat/CombatSoulskills.as
@@ -714,7 +714,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		}
 		else if (combat.isLightningTypeWeapon()) {
 			damage = Math.round(damage * combat.lightningDamageBoostedByDao());
-			doLightingDamage(damage, true, true);
+			doLightningDamage(damage, true, true);
 		}
 		else if (combat.isDarknessTypeWeapon()) {
 			damage = Math.round(damage * combat.darknessDamageBoostedByDao());
@@ -803,7 +803,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		}
 		else if (combat.isLightningTypeWeapon()) {
 			damage = Math.round(damage * combat.lightningDamageBoostedByDao());
-			doLightingDamage(damage, true, true);
+			doLightningDamage(damage, true, true);
 		}
 		else if (combat.isDarknessTypeWeapon()) {
 			damage = Math.round(damage * combat.darknessDamageBoostedByDao());
@@ -1086,7 +1086,7 @@ public class CombatSoulskills extends BaseCombatContent {
 				break;
 			case "lightning":
 				damage = Math.round(damage*combat.lightningDamageBoostedByDao());
-				doLightingDamage(damage, true, true);
+				doLightningDamage(damage, true, true);
 				break;
 			case "darkness":
 				damage = Math.round(damage*combat.darknessDamageBoostedByDao());

--- a/classes/classes/Scenes/Combat/CombatTeases.as
+++ b/classes/classes/Scenes/Combat/CombatTeases.as
@@ -37,30 +37,29 @@ public class CombatTeases extends BaseCombatContent {
 		tBLD += (2 * player.teaseDmgStat.value);
 
 
-		if (player.hasPerk(PerkLib.BimboBody) || player.hasPerk(PerkLib.BroBody) || player.hasPerk(PerkLib.FutaForm)) tBLD += 15;
-		if (player.hasPerk(PerkLib.SensualLover)) tBLD += 6;
-		if (player.hasPerk(PerkLib.Seduction)) tBLD += 15;
+		if (player.hasPerk(PerkLib.BimboBody) || player.hasPerk(PerkLib.BroBody) || player.hasPerk(PerkLib.FutaForm)) tBLD *= 1.75;
+		if (player.hasPerk(PerkLib.SensualLover)) tBLD *= 1.3;
+		if (player.hasPerk(PerkLib.Seduction)) tBLD *= 1.75;
 		
 		//partial skins bonuses
 		switch (player.coatType()) {
 			case Skin.FUR:
-				tBLD += (1 + player.newGamePlusMod());
+				tBLD *= 1 + (0.01 * (1 + player.newGamePlusMod()));
 				break;
 			case Skin.SCALES:
-				tBLD += (2 * (1 + player.newGamePlusMod()));
+				tBLD *= 1 + (0.02 * (1 + player.newGamePlusMod()));
 				break;
 			case Skin.CHITIN:
-				tBLD += (3 * (1 + player.newGamePlusMod()));
+				tBLD *= 1 + (0.03 * (1 + player.newGamePlusMod()));
 				break;
 			case Skin.BARK:
-				tBLD += (4 * (1 + player.newGamePlusMod()));
+				tBLD *= 1 + (0.04 * (1 + player.newGamePlusMod()));
 				break;
 		}
-		if (player.hasPerk(PerkLib.FlawlessBody)) tBLD += 20;
+		if (player.hasPerk(PerkLib.FlawlessBody)) tBLD *= 2;
 		if (player.hasPerk(PerkLib.GracefulBeauty)) tBLD += scalingBonusSpeed() * 0.1;
 		if (player.isElf() && player.hasPerk(PerkLib.ELFElvenSpearDancingTechnique) && player.isSpearTypeWeapon()) tBLD += scalingBonusSpeed() * 0.1;
-		if (player.hasPerk(PerkLib.JobSeducer)) tBLD += player.teaseLevel * 3;
-		else tBLD += player.teaseLevel * 2;
+		tBLD *= masteryBonusDamageTease();
 		if (player.hasPerk(PerkLib.JobCourtesan) && monster.hasPerk(PerkLib.EnemyBossType)) tBLD *= 1.2;
 
 		var damagemultiplier:Number = 1;
@@ -93,14 +92,69 @@ public class CombatTeases extends BaseCombatContent {
 		return tBLD;
 	}
 
-	public function teaseAuraLustDamageBonus(monster:Monster, lustDmg:Number = 0):Number {
-		if (player.hasPerk(PerkLib.SensualLover)) lustDmg += 2;
-		if (player.hasPerk(PerkLib.Seduction)) lustDmg += 5;
+	public function masteryBonusDamageTease():Number {
+		var lustMult:Number = 1;
+		var multiplier:Number = 0.02;
+		if (player.hasPerk(PerkLib.JobSeducer)) multiplier += 0.01;
+
+		lustMult += (multiplier * player.teaseLevel);
+
+		return lustMult;
+	}
+
+	public function combatTeaseCritical():Number {
+		var critTChance:Number = 0;
+		if (player.hasPerk(PerkLib.ElvenSense) && player.inte >= 50) critTChance += 5;
+		if (player.armor == armors.R_CHANG || player.armor == armors.R_QIPAO || player.armor == armors.G_CHANG || player.armor == armors.G_QIPAO
+			 || player.armor == armors.B_CHANG || player.armor == armors.B_QIPAO || player.armor == armors.P_CHANG || player.armor == armors.P_QIPAO) critTChance += 5;
+
+		if (player.headJewelry == headjewelries.SCANGOG) critTChance += 5;
+        if (player.headJewelry == headjewelries.SATGOG) critTChance += 10;
+
+		if (player.hasPerk(PerkLib.CriticalPerformance)) {
+				if (player.lib <= 100) critTChance += player.lib / 4;
+				if (player.lib > 100) critTChance += 25;
+			}
+
+		if (player.eyesOfTheHunterAdeptBoost()) {
+			if (player.hasPerk(PerkLib.EyesOfTheHunterAdept) && player.sens >= 50) critTChance += 5;
+			if (player.hasPerk(PerkLib.EyesOfTheHunterSu) && player.sens >= 30) {
+				if (player.sens >= 500) critTChance += 95;
+				else critTChance += 2 * Math.round((player.sens - 25) / 5);
+			}
+		}
+		if (player.eyesOfTheHunterExpertBoost()) {
+			if (player.hasPerk(PerkLib.EyesOfTheHunterExpert) && player.sens >= 75) critTChance += 5;
+			if (player.hasPerk(PerkLib.EyesOfTheHunterSu) && player.sens >= 30) {
+				if (player.sens >= 500) critTChance += 95;
+				else critTChance += 2 * Math.round((player.sens - 25) / 5);
+			}
+		}
+		if (player.eyesOfTheHunterMasterBoost()) {
+			if (player.hasPerk(PerkLib.EyesOfTheHunterMaster) && player.sens >= 100) critTChance += 5;
+			if (player.hasPerk(PerkLib.EyesOfTheHunterSu) && player.sens >= 30) {
+				if (player.sens >= 500) critTChance += 95;
+				else critTChance += 2 * Math.round((player.sens - 25) / 5);
+			}
+		}
+		if (player.eyesOfTheHunterGrandMasterBoost()) {
+			if (player.hasPerk(PerkLib.EyesOfTheHunterGrandMaster) && player.sens >= 125) critTChance += 5;
+			if (player.hasPerk(PerkLib.EyesOfTheHunterSu) && player.sens >= 30) {
+				if (player.sens >= 500) critTChance += 95;
+				else critTChance += 2 * Math.round((player.sens - 25) / 5);
+			}
+		}
+
+		return critTChance;
+	}
+
+	public function teaseAuraLustDamageBonus(monster:Monster, lustDmg:Number):Number {
+		if (player.hasPerk(PerkLib.SensualLover)) lustDmg *= 1.1;
+		if (player.hasPerk(PerkLib.Seduction)) lustDmg *= 1.25;
         lustDmg += player.teaseDmgStat.value;
-		if (player.hasPerk(PerkLib.BimboBody) || player.hasPerk(PerkLib.BroBody) || player.hasPerk(PerkLib.FutaForm)) lustDmg += 5;
-		if (player.hasPerk(PerkLib.FlawlessBody)) lustDmg += 10;
-		if (player.hasPerk(PerkLib.JobSeducer)) lustDmg += player.teaseLevel * 3;
-		else lustDmg += player.teaseLevel * 2;
+		if (player.hasPerk(PerkLib.BimboBody) || player.hasPerk(PerkLib.BroBody) || player.hasPerk(PerkLib.FutaForm)) lustDmg *= 1.25;
+		if (player.hasPerk(PerkLib.FlawlessBody)) lustDmg *= 1.5;
+		lustDmg *= masteryBonusDamageTease();
 		if (player.hasPerk(PerkLib.EromancyExpert)) lustDmg *= 1.5;
 		if (player.hasPerk(PerkLib.ArcaneLash)) lustDmg *= 1.5;
 		if (player.hasPerk(PerkLib.JobCourtesan) && monster.hasPerk(PerkLib.EnemyBossType)) lustDmg *= 1.2;
@@ -1537,23 +1591,22 @@ public class CombatTeases extends BaseCombatContent {
 		}
 		//Land the hit!
 		if (rand(100) <= chance + rand(bonusChance)) {
-			damage = (damage + rand(bonusDamage));
-			damage = teaseBaseLustDamage(damage);
+			bonusDamage = (damage + rand(bonusDamage));
+			damage = teaseBaseLustDamage();
+			//Gain additional % damage based on tease choice chosen
+			damage *= 1 + (bonusDamage/100);
 			if (player.hasPerk(PerkLib.BroadSelection) && player.differentTypesOfCocks() > 1) damage *= (1 + (0.25 * player.differentTypesOfCocks()));
 			if (SceneLib.urtaQuest.isUrta()) damage *= 2;
 			damage *= monster.lustVuln;
 			damage = Math.round(damage);
-			if (player.hasPerk(PerkLib.DazzlingDisplay) && rand(100) < 20) {
+			if (player.hasPerk(PerkLib.DazzlingDisplay) && rand(100) < 20 && !monster.hasPerk(PerkLib.Resolute)) {
 				outputText("\n[themonster] is so mesmerised by your show that it stands there gawking.");
 				monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
 			}
 			//Determine if critical tease!
 			var crit:Boolean = false;
 			var critChance:int = 5;
-			if (player.hasPerk(PerkLib.CriticalPerformance)) {
-				if (player.lib <= 100) critChance += player.lib / 4;
-				if (player.lib > 100) critChance += 25;
-			}
+			critChance += combatTeaseCritical();
 			if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
 			if (rand(100) < critChance) {
 				crit = true;

--- a/classes/classes/Scenes/Combat/CombatUI.as
+++ b/classes/classes/Scenes/Combat/CombatUI.as
@@ -380,7 +380,7 @@ public class CombatUI extends BaseCombatContent {
 					button(1).disable("You are too tired to bite " + monster.a + " [monster name].");
 				}
 			}
-			addButton(4, "Release", combat.StraddleLeggoMyEggo).hint("Release your opponent.");
+			addButton(4, "Release", combat.straddleLeggoMyEggo).hint("Release your opponent.");
 		} else if (monster.hasStatusEffect(StatusEffects.ManticorePlug)) {
 			menu();
 			addButton(0, "Feed", combat.ManticoreFeed).hint("Milk your victim's cock with your powerful tail!");

--- a/classes/classes/Scenes/Combat/General/FlyingSwordSkill.as
+++ b/classes/classes/Scenes/Combat/General/FlyingSwordSkill.as
@@ -119,7 +119,7 @@ public class FlyingSwordSkill extends AbstractGeneral {
 										break;
 			case TAG_DARKNESS: 			damageFunc = doDarknessDamage;
 										break;
-			case TAG_LIGHTNING: 		damageFunc = doLightingDamage;
+			case TAG_LIGHTNING: 		damageFunc = doLightningDamage;
 										break;
 			default: 					damageFunc = doPhysicalDamage;
 										break;

--- a/classes/classes/Scenes/Combat/General/TeaseSkill.as
+++ b/classes/classes/Scenes/Combat/General/TeaseSkill.as
@@ -1,0 +1,41 @@
+package classes.Scenes.Combat.General {
+import classes.PerkLib;
+import classes.Monster;
+import classes.Scenes.Combat.Combat;
+import classes.Scenes.Combat.AbstractGeneral;
+
+public class TeaseSkill extends AbstractGeneral {
+
+    public function TeaseSkill() {
+        super(
+            "Tease",
+            "Attempt to make an enemy more aroused by striking a seductive pose and exposing parts of your body.",
+            TARGET_ENEMY,
+            TIMING_INSTANT,
+            [TAG_LUSTDMG],
+            null
+        )
+		lastAttackType = Combat.LAST_ATTACK_LUST;
+    }
+
+    override public function get isKnown():Boolean {
+        return true;
+    }
+
+	override public function describeEffectVs(target:Monster):String {
+		return "Deals ~" + numberFormat(calcLustDamage(target)) + " lust damage.";
+	}
+
+	public function calcLustDamage(monster:Monster):Number {
+		var lustDmg:Number = 10;
+        
+
+		return Math.round(lustDmg);
+	}
+
+    override public function doEffect(display:Boolean = true):void {
+    	var damage:Number = calcLustDamage(monster);
+
+    }
+}
+}

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -1321,10 +1321,7 @@ public class MagicSpecials extends BaseCombatContent {
 			//Determine if critical tease!
 			var crit:Boolean = false;
 			var critChance:int = 5;
-			if (player.hasPerk(PerkLib.CriticalPerformance)) {
-				if (player.lib <= 100) critChance += player.lib / 5;
-				if (player.lib > 100) critChance += 20;
-			}
+			critChance += combat.teases.combatTeaseCritical();
 			if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
 			if (rand(100) < critChance) {
 				crit = true;
@@ -1402,10 +1399,7 @@ public class MagicSpecials extends BaseCombatContent {
 		//Determine if critical tease!
 		var crit2:Boolean = false;
 		var critChance2:int = 5;
-		if (player.hasPerk(PerkLib.CriticalPerformance)) {
-			if (player.lib <= 100) critChance2 += player.lib / 5;
-			if (player.lib > 100) critChance2 += 20;
-		}
+		critChance2 += combat.teases.combatTeaseCritical();
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance2 = 0;
 		if (rand(100) < critChance2) {
 			crit2 = true;
@@ -1466,10 +1460,7 @@ public class MagicSpecials extends BaseCombatContent {
 		//Determine if critical tease!
 		var crit2:Boolean = false;
 		var critChance2:int = 5;
-		if (player.hasPerk(PerkLib.CriticalPerformance)) {
-			if (player.lib <= 100) critChance2 += player.lib / 5;
-			if (player.lib > 100) critChance2 += 20;
-		}
+		critChance2 += combat.teases.combatTeaseCritical();
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance2 = 0;
 		if (rand(100) < critChance2) {
 			crit2 = true;
@@ -4874,10 +4865,7 @@ public class MagicSpecials extends BaseCombatContent {
 		//Determine if critical tease!
 		var critL:Boolean = false;
 		var critChanceL:int = 5;
-		if (player.hasPerk(PerkLib.CriticalPerformance)) {
-			if (player.lib <= 100) critChanceL += player.lib / 5;
-			if (player.lib > 100) critChanceL += 20;
-		}
+		critChanceL += combat.teases.combatTeaseCritical();
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChanceL = 0;
 		if (rand(100) < critChanceL) {
 			critL = true;

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -1278,7 +1278,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.NaturalArsenal)) damage *= 1.50;
 		if (player.hasPerk(PerkLib.LionHeart)) damage *= 2;
 		damage = Math.round(damage * combat.lightningDamageBoostedByDao());
-		doLightingDamage(damage, true, true);
+		doLightningDamage(damage, true, true);
 		outputText(" damage. ");
 		if (crit1) outputText(" <b>*Critical Hit!*</b>");
 		outputText("\n\n");
@@ -1389,7 +1389,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.NaturalArsenal)) damage *= 1.50;
 		if (player.hasPerk(PerkLib.LionHeart)) damage *= 2;
 		damage = Math.round(damage * combat.lightningDamageBoostedByDao());
-		doLightingDamage(damage, true, true);
+		doLightningDamage(damage, true, true);
 		outputText(" damage. ");
 		if (crit1) outputText(" <b>*Critical Hit!*</b>");
 		dynStats("lus", (Math.round(player.maxLust() * 0.02)), "scale", false);
@@ -1483,7 +1483,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.NaturalArsenal)) lustDmgF *= 1.50;
 		lustDmgF = Math.round(lustDmgF);
 		outputText("You let electricity build up in your body before unleashing it into the ambient sky, the clouds roaring with thunder. Here comes the storm! ");
-		doLightingDamage(damage, true, true);
+		doLightningDamage(damage, true, true);
 		if (crit1) outputText(" <b>*Critical!*</b>");
 		monster.teased(lustDmgF, false);
 		if (crit2) outputText(" <b>Critical!</b>");
@@ -2296,7 +2296,7 @@ public class MagicSpecials extends BaseCombatContent {
 				else outputText("are");
 				outputText("too resolute to be stunned by your attack.</b> ");
 			}
-			doLightingDamage(damage, true, true);
+			doLightningDamage(damage, true, true);
 		}
 		outputText("\n\n");
 		checkAchievementDamage(damage);
@@ -5123,7 +5123,7 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		else outputText("begin spasming while [monster his] body is ran through by electricity");
 		damage = Math.round(damage * combat.lightningDamageBoostedByDao());
-		doLightingDamage(damage);
+		doLightningDamage(damage);
 	}
 	private function FaeStormAcid(damage:Number):void{
 		if(monster.plural) {
@@ -5806,7 +5806,7 @@ public class MagicSpecials extends BaseCombatContent {
 			case 0:
 				outputText("[Themonster] takes heavy electricity damage from the eyebeam! ");
 				damage = Math.round(damage * combat.lightningDamageBoostedByDao());
-				doLightingDamage((damage * 3), true, true);
+				doLightningDamage((damage * 3), true, true);
 				break;
 			case 1:
 				outputText("[Themonster]  starts to burn as [monster his] body catches fire from the eyebeam! ");
@@ -6404,7 +6404,7 @@ public class MagicSpecials extends BaseCombatContent {
 			outputText("too resolute to be stunned by your attack.</b>");
 		}*/
 		outputText("Your elemental charges electricity, then discharges it with a blinding bolt doing ");
-		doLightingDamage(damage, true, true);
+		doLightningDamage(damage, true, true);
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
 		enemyAI();

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -2200,10 +2200,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		//Determine if critical tease!
 		var crit:Boolean = false;
 		var critChance:int = 5;
-		if (player.hasPerk(PerkLib.CriticalPerformance)) {
-			if (player.lib <= 100) critChance += player.lib / 5;
-			if (player.lib > 100) critChance += 20;
-		}
+		critChance += combat.teases.combatTeaseCritical();
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
 		if (rand(100) < critChance) {
 			crit = true;
@@ -2991,11 +2988,8 @@ public class PhysicalSpecials extends BaseCombatContent {
 			//Determine if critical tease!
 			var crit:Boolean = false;
 			var critChance:int = 5;
-			if (player.hasPerk(PerkLib.CriticalPerformance)) {
-				if (player.lib <= 100) critChance += player.lib / 5;
-				if (player.lib > 100) critChance += 20;
-				if (player.hasPerk(PerkLib.AnatomyExpert)) critChance += 10;
-			}
+			critChance += combat.teases.combatTeaseCritical();
+			if (player.hasPerk(PerkLib.AnatomyExpert)) critChance += 10;
 			if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
 			if (rand(100) < critChance) {
 			crit = true;
@@ -6362,10 +6356,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		//Determine if critical tease!
 		var crit1:Boolean = false;
 		var critChance1:int = 5;
-		if (player.hasPerk(PerkLib.CriticalPerformance)) {
-			if (player.lib <= 100) critChance1 += player.lib / 5;
-			if (player.lib > 100) critChance1 += 20;
-		}
+		critChance1 += combat.teases.combatTeaseCritical();
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance1 = 0;
 		if (rand(100) < critChance1) {
 			crit1 = true;

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -839,7 +839,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		else if (combat.isLightningTypeWeapon()) {
 			damage = Math.round(damage * combat.lightningDamageBoostedByDao());
-			doLightingDamage(damage, true, true);
+			doLightningDamage(damage, true, true);
 		}
 		else if (combat.isDarknessTypeWeapon()) {
 			damage = Math.round(damage * combat.darknessDamageBoostedByDao());
@@ -1493,7 +1493,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 				outputText("Not satisfied with your weapon alone you also impale your target on your horns, delivering massive damage.");
 			}
 			doDamage(damage/2, true, true);
-			if (player.horns.type == Horns.KIRIN) doLightingDamage(damage/2, true, true)
+			if (player.horns.type == Horns.KIRIN) doLightningDamage(damage/2, true, true)
 			if (crit) {
 				outputText("<b>Critical!</b>");
 			}
@@ -2665,7 +2665,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 	private function golemsDunks(damage:Number):void {
 		if (player.hasStatusEffect(StatusEffects.GolemUpgrades1) && player.statusEffectv3(StatusEffects.GolemUpgrades1) > 0) {
 			if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 5) doDarknessDamage(damage, true, true);
-			else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 4) doLightingDamage(damage, true, true);
+			else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 4) doLightningDamage(damage, true, true);
 			else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 3) doIceDamage(damage, true, true);
 			else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 2) doFireDamage(damage, true, true);
 			else doDamage(damage, true, true);
@@ -2674,7 +2674,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (player.hasStatusEffect(StatusEffects.GolemUpgrades1) && player.statusEffectv1(StatusEffects.GolemUpgrades1) > 0) {
 			if (player.hasStatusEffect(StatusEffects.GolemUpgrades1) && player.statusEffectv3(StatusEffects.GolemUpgrades1) > 0) {
 				if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 5) doDarknessDamage(damage, true, true);
-				else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 4) doLightingDamage(damage, true, true);
+				else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 4) doLightningDamage(damage, true, true);
 				else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 3) doIceDamage(damage, true, true);
 				else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 2) doFireDamage(damage, true, true);
 				else doDamage(damage, true, true);
@@ -2683,7 +2683,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (player.statusEffectv1(StatusEffects.GolemUpgrades1) > 1) {
 				if (player.hasStatusEffect(StatusEffects.GolemUpgrades1) && player.statusEffectv3(StatusEffects.GolemUpgrades1) > 0) {
 					if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 5) doDarknessDamage(damage, true, true);
-					else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 4) doLightingDamage(damage, true, true);
+					else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 4) doLightningDamage(damage, true, true);
 					else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 3) doIceDamage(damage, true, true);
 					else if (player.statusEffectv3(StatusEffects.GolemUpgrades1) == 2) doFireDamage(damage, true, true);
 					else doDamage(damage, true, true);
@@ -4855,10 +4855,10 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (player.hasPerk(PerkLib.NaturalArsenal)) damage *= 1.50;
 			if (player.hasPerk(PerkLib.LionHeart)) damage *= 2;
 			doDamage(damage, true, true);
-			doLightingDamage(Math.round(damage*0.1), true, true);
+			doLightningDamage(Math.round(damage*0.1), true, true);
 			if (player.hasPerk(PerkLib.PhantomStrike)) {
 				doDamage(damage, true, true);
-				doLightingDamage(Math.round(damage*0.1), true, true);
+				doLightningDamage(Math.round(damage*0.1), true, true);
 				damage *= 2;
 			}
 			outputText(" damage.");
@@ -6141,20 +6141,20 @@ public class PhysicalSpecials extends BaseCombatContent {
 			damage *= 1.75;
 		}
 		damage = Math.round(damage);
-		doLightingDamage(damage, true, true);
+		doLightningDamage(damage, true, true);
 		if (player.keyItemvX("HB Scatter Laser", 2) > 1) {
 			if (player.keyItemvX("HB Scatter Laser", 2) == 3) {
 				if (monster.plural) {
-					doLightingDamage(damage, true, true);
-					doLightingDamage(damage, true, true);
+					doLightningDamage(damage, true, true);
+					doLightningDamage(damage, true, true);
 				}
-				doLightingDamage(damage, true, true);
-				doLightingDamage(damage, true, true);
-				doLightingDamage(damage, true, true);
+				doLightningDamage(damage, true, true);
+				doLightningDamage(damage, true, true);
+				doLightningDamage(damage, true, true);
 			}
 			else {
-				if (monster.plural) doLightingDamage(damage, true, true);
-				doLightingDamage(damage, true, true);
+				if (monster.plural) doLightningDamage(damage, true, true);
+				doLightningDamage(damage, true, true);
 			}
 		}
 		outputText(" damage! ");
@@ -6184,7 +6184,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			damage *= 1.75;
 		}
 		damage = Math.round(damage);
-		doLightingDamage(damage, true, true);
+		doLightningDamage(damage, true, true);
 		outputText(" damage! ");
 		if (crit) outputText("<b>*Critical Hit!*</b>");
 		outputText("\n\n");
@@ -6216,7 +6216,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			damage *= 0.5;
 			damage = Math.round(damage);
 			outputText("potent discharge ");
-			doLightingDamage(damage, true, true);
+			doLightningDamage(damage, true, true);
 			outputText(" damage!");
 			if (crit) outputText(" <b>*Critical Hit!*</b>");
 			monster.createStatusEffect(StatusEffects.Stunned,4,0,0,0);
@@ -6353,7 +6353,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			damage *= 1.75;
 		}
 		damage = Math.round(damage);
-		doLightingDamage(damage, true, true);
+		doLightningDamage(damage, true, true);
 		outputText(" damage! ");
 		if (crit) outputText("<b>*Critical Hit!*</b> ");
 		var lustDmg:Number = (player.inte / 5 * spellModBlack() + rand(monster.lib - monster.inte * 2 + monster.cor) / 5);

--- a/classes/classes/Scenes/Combat/Soulskills/CreateElementSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/CreateElementSkill.as
@@ -136,7 +136,7 @@ public class CreateElementSkill extends AbstractSoulSkill {
 				break;
 			case "Lightning":
 				damage = Math.round(damage*combat.lightningDamageBoostedByDao());
-				doLightingDamage(damage, true, display);
+				doLightningDamage(damage, true, display);
 				break;
 			case "Darkness":
 				damage = Math.round(damage*combat.darknessDamageBoostedByDao());

--- a/classes/classes/Scenes/Combat/Soulskills/DracoSweepSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/DracoSweepSkill.as
@@ -98,7 +98,7 @@ public class DracoSweepSkill extends AbstractSoulSkill {
 		}
 		else if (combat.isLightningTypeWeapon()) {
 			damage = Math.round(damage * combat.lightningDamageBoostedByDao());
-			doLightingDamage(damage, true, display);
+			doLightningDamage(damage, true, display);
 			if (player.statStore.hasBuff("FoxflamePelt")) combat.layerFoxflamePeltOnThis(damage);
 		}
 		else if (combat.isDarknessTypeWeapon()) {

--- a/classes/classes/Scenes/Combat/Soulskills/MultiThrustSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/MultiThrustSkill.as
@@ -109,7 +109,7 @@ public class MultiThrustSkill extends AbstractSoulSkill {
 		}
 		else if (combat.isLightningTypeWeapon()) {
 			damage = Math.round(damage * combat.lightningDamageBoostedByDao());
-			doLightingDamage(damage, true, display);
+			doLightningDamage(damage, true, display);
 			if (player.statStore.hasBuff("FoxflamePelt")) combat.layerFoxflamePeltOnThis(damage);
 		}
 		else if (combat.isDarknessTypeWeapon()) {

--- a/classes/classes/Scenes/Combat/Soulskills/StormOfSisterhoodSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/StormOfSisterhoodSkill.as
@@ -70,7 +70,7 @@ public class StormOfSisterhoodSkill extends AbstractSoulSkill {
 			outputText("You start concentrate on the wrath flowing in your body, your veins while imaging a joy of sharing storm of sisterhood with enemy. Shortly after that wrath starts to gather around your hands till it envelop your hands in ligthing.\n\n");
     		outputText("With joy, you sends a mass of ligthing toward [themonster] while mumbling about 'sharing the storm of sisterhood'. ");
 		}
-		doLightingDamage(damage, true, display);
+		doLightningDamage(damage, true, display);
 		if (display) outputText("\n\n");
     }
 }

--- a/classes/classes/Scenes/Combat/SpecialsMagic/EAspectLightningSkill.as
+++ b/classes/classes/Scenes/Combat/SpecialsMagic/EAspectLightningSkill.as
@@ -59,7 +59,7 @@ public class EAspectLightningSkill extends AbstractMagicSpecial {
         damage = Math.round(damage);
 
         if (display) outputText("Your elemental charges electricity, then discharges it with a blinding bolt doing ");
-		doLightingDamage(damage, true, display);
+		doLightningDamage(damage, true, display);
 		if (crit && display) outputText(" <b>Critical!</b>");
 		outputText("\n\n");
     }

--- a/classes/classes/Scenes/Combat/SpellsBlack/ArouseSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsBlack/ArouseSpell.as
@@ -88,17 +88,14 @@ public class ArouseSpell extends AbstractBlackSpell {
 		//Determine if critical tease!
 		var crit:Boolean   = false;
 		var critChance:int = 5;
-		if (player.hasPerk(PerkLib.CriticalPerformance)) {
-			if (player.lib <= 100) critChance += player.lib / 5;
-			if (player.lib > 100) critChance += 20;
-		}
+		critChance += combat.teases.combatTeaseCritical();
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
 		if (rand(100) < critChance) {
 			crit = true;
 			lustDmg *= 1.75;
 		}
-		monster.teased(lustDmg, false);
-		if (crit) outputText(" <b>Critical!</b>");
+		monster.teased(lustDmg, false, display);
+		if (crit && display) outputText(" <b>Critical!</b>");
 		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		if (player.hasPerk(PerkLib.VerdantLeech)) {
 			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;

--- a/classes/classes/Scenes/Combat/SpellsBlack/WaveOfEcstasySpell.as
+++ b/classes/classes/Scenes/Combat/SpellsBlack/WaveOfEcstasySpell.as
@@ -85,20 +85,17 @@ public class WaveOfEcstasySpell extends AbstractBlackSpell {
 		//Determine if critical tease!
 		var crit:Boolean   = false;
 		var critChance:int = 5;
-		if (player.hasPerk(PerkLib.CriticalPerformance)) {
-			if (player.lib <= 100) critChance += player.lib / 5;
-			if (player.lib > 100) critChance += 20;
-		}
+		critChance += combat.teases.combatTeaseCritical();
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
 		if (rand(100) < critChance) {
 			crit = true;
 			lustDmg *= 1.75;
 		}
-		monster.teased(lustDmg, false);
+		monster.teased(lustDmg, false, display);
 		if (display) {
 			outputText(" damage.");
 		}
-		if (crit) outputText(" <b>Critical!</b>");
+		if (crit && display) outputText(" <b>Critical!</b>");
 		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
 		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		if (player.hasPerk(PerkLib.VerdantLeech)) {

--- a/classes/classes/Scenes/Combat/SpellsDivine/ThunderstormSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsDivine/ThunderstormSpell.as
@@ -45,7 +45,7 @@ public class ThunderstormSpell extends AbstractDivineSpell {
 		if (display) {
 			outputText("<b>A bolt of divine lightning falls from the sky and strikes [themonster]</b>. ");
 		}
-		monster.takeLightningDamage(player.statusEffectv1(StatusEffects.Thunderstorm), display);
+		doLightningDamage(player.statusEffectv1(StatusEffects.Thunderstorm), true, display);
 		if (display) {
 			outputText("\n\n");
 		}
@@ -67,20 +67,11 @@ public class ThunderstormSpell extends AbstractDivineSpell {
 			outputText("You call upon the anger of the gods to smite your foe and they gladly answer with thunder. Lightning begins to strike down upon your opponent"+(monster.plural ? "s":"")+" with perfect precision.");
 		}
 		var damage:Number = calcDamage(monster, true, true);
-		//Determine if critical hit!
-		var crit:Boolean = false;
-		var critChance:int = 5;
-		critChance += combatMagicalCritical();
-		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-		if (rand(100) < critChance) {
-			crit = true;
-			damage *= 1.75;
-		}
+		
 		player.createStatusEffect(StatusEffects.Thunderstorm, damage, calcDuration(), 0, 0);
-		doLightingDamage(damage, true, display);
-		if (crit && display) {
-			outputText("<b>Critical Hit!</b>");
-		}
+		damage = critAndRepeatDamage(display, damage, DamageType.LIGHTNING);
+		checkAchievementDamage(damage);
+		combat.heroBaneProc(damage);
 	}
 }
 }

--- a/classes/classes/Scenes/Combat/SpellsGreen/BriarthornSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/BriarthornSpell.as
@@ -69,27 +69,24 @@ public class BriarthornSpell extends AbstractGreenSpell {
 			monster.createStatusEffect(StatusEffects.Briarthorn, 6, 0, 0, 0);
 			var arve:Number = 1;
 			if (player.hasPerk(PerkLib.ArcaneVenom)) arve += stackingArcaneVenom();
-			while (arve-->0) doSpellEffect2();
+			while (arve-->0) doSpellEffect2(display);
 			outputText("\n");
 		}
 	}
 	
-	private function doSpellEffect2():void {
+	private function doSpellEffect2(display:Boolean = true):void {
 		var lustDmg:Number = calcDamage(monster, true, true);
 		//Determine if critical tease!
 		var crit:Boolean   = false;
 		var critChance:int = 5;
-		if (player.hasPerk(PerkLib.CriticalPerformance)) {
-			if (player.lib <= 100) critChance += player.lib / 5;
-			if (player.lib > 100) critChance += 20;
-		}
+		critChance += combat.teases.combatTeaseCritical();
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
 		if (rand(100) < critChance) {
 			crit = true;
 			lustDmg *= 1.75;
 		}
-		monster.teased(lustDmg, false);
-		if (crit) outputText(" <b>Critical!</b>");
+		monster.teased(lustDmg, false, display);
+		if (crit && display) outputText(" <b>Critical!</b>");
 		combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		if (player.hasPerk(PerkLib.VerdantLeech)) {
 			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;

--- a/classes/classes/Scenes/Combat/SpellsGreen/DeathBlossomSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/DeathBlossomSpell.as
@@ -50,27 +50,24 @@ public class DeathBlossomSpell extends AbstractGreenSpell {
 			monster.createStatusEffect(StatusEffects.DeathBlossom, 5, 1, 0, 0);
 			var arve:Number = 1;
 			if (player.hasPerk(PerkLib.ArcaneVenom)) arve += stackingArcaneVenom();
-			while (arve-->0) doSpellEffect2();
+			while (arve-->0) doSpellEffect2(display);
 			outputText("\n");
 		}
 	}
 	
-	private function doSpellEffect2():void {
+	private function doSpellEffect2(display:Boolean = true):void {
 		var lustDmg:Number = calcDamage(monster, true, true);
 		//Determine if critical tease!
 		var crit:Boolean   = false;
 		var critChance:int = 5;
-		if (player.hasPerk(PerkLib.CriticalPerformance)) {
-			if (player.lib <= 100) critChance += player.lib / 5;
-			if (player.lib > 100) critChance += 20;
-		}
+		critChance += combat.teases.combatTeaseCritical();
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
 		if (rand(100) < critChance) {
 			crit = true;
 			lustDmg *= 1.75;
 		}
-		monster.teased(lustDmg, false);
-		if (crit) outputText(" <b>Critical!</b>");
+		monster.teased(lustDmg, false, display);
+		if (crit && display) outputText(" <b>Critical!</b>");
 		combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		if (player.hasPerk(PerkLib.VerdantLeech)) {
 			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;

--- a/classes/classes/Scenes/Combat/SpellsGreen/PlantGrowthSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/PlantGrowthSpell.as
@@ -61,7 +61,7 @@ public class PlantGrowthSpell extends AbstractGreenSpell {
 				player.createStatusEffect(StatusEffects.PlantGrowth, calcDuration(), 0, 0, 0);
 				var arve:Number = 1;
 				if (player.hasPerk(PerkLib.ArcaneVenom)) arve += stackingArcaneVenom();
-				while (arve-->0) doSpellEffect2();
+				while (arve-->0) doSpellEffect2(display);
 			outputText("\n");
 			}
 			else {
@@ -71,22 +71,19 @@ public class PlantGrowthSpell extends AbstractGreenSpell {
 		}
 	}
 	
-	private function doSpellEffect2():void {
+	private function doSpellEffect2(display:Boolean = true):void {
 		var lustDmg:Number = calcDamage(monster, true, true);
 		//Determine if critical tease!
 		var crit:Boolean   = false;
 		var critChance:int = 5;
-		if (player.hasPerk(PerkLib.CriticalPerformance)) {
-			if (player.lib <= 100) critChance += player.lib / 5;
-			if (player.lib > 100) critChance += 20;
-		}
+		critChance += combat.teases.combatTeaseCritical();
 		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
 		if (rand(100) < critChance) {
 			crit = true;
 			lustDmg *= 1.75;
 		}
-		monster.teased(lustDmg, false);
-		if (crit) outputText(" <b>Critical!</b>");
+		monster.teased(lustDmg, false, display);
+		if (crit && display) outputText(" <b>Critical!</b>");
 		combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		if (player.hasPerk(PerkLib.VerdantLeech)) {
 			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;

--- a/classes/classes/Scenes/Dungeons/D3/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/D3/Lethice.as
@@ -447,10 +447,10 @@ public class Lethice extends Monster
 			return adaptionDeflect(damage,"damage","true");
 		}
 
-		override protected function applyTease(lustDelta:Number):void{
+		override protected function applyTease(lustDelta:Number, display:Boolean = true):void{
 			lustDelta = adaptionDeflect(lustDelta,"lust","lust");
 			if(lustDelta>0){
-				super.applyTease(lustDelta);
+				super.applyTease(lustDelta, display);
 			}
 		}
 

--- a/classes/classes/Scenes/NPCs/Amily.as
+++ b/classes/classes/Scenes/NPCs/Amily.as
@@ -158,15 +158,15 @@ import classes.Scenes.Combat.CombatAbilities;
 
 		//(if PC uses tease/seduce after this)
 		//Deals big lust increase, despite her resistance.
-		override public function teased(lustDelta:Number, isNotSilent:Boolean = true):void
+		override public function teased(lustDelta:Number, isNotSilent:Boolean = true, display:Boolean = true):void
 		{
 			if(hasStatusEffect(StatusEffects.Concentration)) {
 				outputText("Amily flushes hotly; her concentration only makes her pay more attention to your parts!");
 				lustDelta += 25+lustDelta;
 				removeStatusEffect(StatusEffects.Concentration);
-				applyTease(lustDelta);
+				applyTease(lustDelta, display);
 			} else {
-				super.teased(lustDelta);
+				super.teased(lustDelta, isNotSilent, display);
 			}
 		}
 

--- a/classes/classes/Scenes/NPCs/Holli.as
+++ b/classes/classes/Scenes/NPCs/Holli.as
@@ -225,13 +225,13 @@ public class Holli extends Monster
 		}
 
 
-		override public function teased(lustDelta:Number, isNotSilent:Boolean = true):void
+		override public function teased(lustDelta:Number, isNotSilent:Boolean = true, display:Boolean = true):void
 		{
 			if (hasStatusEffect(StatusEffects.HolliBurning)) {
 				outputText("Holli doesn't even seem to notice, so concerned is she with defeating you before the mounting bonfire causes her any more pain.");
 				lustDelta = 0;
 			}
-			applyTease(lustDelta);
+			applyTease(lustDelta, display);
 		}
 
 		public function Holli()

--- a/classes/classes/Scenes/Places/Owca/LustyDemons.as
+++ b/classes/classes/Scenes/Places/Owca/LustyDemons.as
@@ -42,12 +42,12 @@ public class LustyDemons extends Monster
 			}
 		}
 
-		override public function teased(lustDelta:Number, isNotSilent:Boolean = true):void
+		override public function teased(lustDelta:Number, isNotSilent:Boolean = true, display:Boolean = true):void
 		{
 			if(lustDelta > 0 && lustDelta < 5) outputText("  The demons lessen somewhat in the intensity of their attack, and some even eye up your assets as they strike at you. Vapula has trouble giving her orders.");
 			if(lustDelta >= 5 && lustDelta < 10) outputText("  The demons are obviously avoiding damaging anything you might use to fuck and they're starting to leave their hands on you just a little longer after each blow.  Some are copping quick feels and you can smell the demonic lust on the air.  Vapula is starting to get frustrated as her minions are more and more reluctant to attack you, preferring to caress each other instead.");
 			if(lustDelta >= 10) outputText("  The demons are decreasingly willing to hit you and more and more willing to just stroke their hands sensuously over you.  Vapula is uncontrollably aroused herself and shivers even as she tries to maintain some semblance of offense, but most of the demons are visibly uncomfortable and some just lie on the ground, tamed by their own lust.");
-			applyTease(lustDelta);
+			applyTease(lustDelta, display);
 		}
 
 		public function LustyDemons()

--- a/classes/classes/Scenes/Quests/UrtaQuest/MilkySuccubus.as
+++ b/classes/classes/Scenes/Quests/UrtaQuest/MilkySuccubus.as
@@ -80,12 +80,12 @@ use namespace CoC;
 		}
 
 
-		override public function teased(lustDelta:Number, isNotSilent:Boolean = true):void
+		override public function teased(lustDelta:Number, isNotSilent:Boolean = true, display:Boolean = true):void
 		{
 			outputText(capitalA + short + " smiles, rubbing her hands across herself as she watches your display.  She does not seem greatly affected by your show - at least in the sense of increasing arousal.  She does seem oddly more... vital, as if she drew strength from the very display you put on.");
 			this.statStore.addBuff("str", 5, "DispelablePowerUP",{});
 			addHP(50);
-			applyTease(lustDelta);
+			applyTease(lustDelta, display);
 		}
 
 		public function MilkySuccubus()


### PR DESCRIPTION
Lust damage is now affected by damage reduction
Added option to tease function to allow for the tease number to not be displayed, similar to the other damage functions
Thunderstorm DoT now takes enemy defences, and magic modifiers into account
Corrected "doLightningDamage" spelling mistake
Add functionality to set a button's icon from the combat ability itself
Updated base tease damage and crit chance to be in line with the melee and ranged equivalent formulas
Standardized Naga Tease damage
Standardized tease crit chance for all tease spells/specials