### PR TITLE
Bug Fixes

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -56,7 +56,7 @@ jobs:
         uses: joshtynjala/setup-apache-flex-action@v2
         with:
           flex-version: "4.16.1"
-          air-version: "33.1.1.935"
+          air-version: "33.1.1.345"
           accept-air-license: true
 
       # this is where the build happens. A separate build is started for every entry in the matrix element

--- a/build.xml
+++ b/build.xml
@@ -61,12 +61,12 @@
                 <arg line="-target apk-captive-runtime" />
                 <arg line="-arch @{architecture}"/>
                 <arg line="-storetype pkcs12" />
-                <arg line="-keystore ${basedir}/coc.keystore" />
+                <arg line="-keystore '${basedir}'/coc.keystore" />
                 <arg line="-storepass 123456" />
-                <arg line="${build.dir}/CoC-Mobile-@{special-postfix}.apk" />
-                <arg line="${basedir}/CoC-Android-@{swf-name-postfix}.xml" />
-                <arg line="-C ${build.dir} CoC-Mobile-@{swf-name-postfix}.swf" />
-                <arg line="-C ${basedir}" />
+                <arg line="'${build.dir}'/CoC-Mobile-@{special-postfix}.apk" />
+                <arg line="'${basedir}'/CoC-Android-@{swf-name-postfix}.xml" />
+                <arg line="-C '${build.dir}' CoC-Mobile-@{swf-name-postfix}.swf" />
+                <arg line="-C '${basedir}'" />
                 <arg line="devTools/icons" />
             </exec>
         </sequential>

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -2026,10 +2026,14 @@ import classes.Scenes.Combat.CombatAbilities;
 			}
 			if (hasTempResolute()) {
 				var currentDuration:int = getPerkValue(PerkLib.Resolute, 4);
-				if (currentDuration <= 0) {
-					clearTempResolute();
-				} else {
-					setPerkValue(PerkLib.Resolute, 4, currentDuration - 1);
+				var decayResolute:int = getPerkValue(PerkLib.Resolute, 3);
+				//Only start to decay temp resolute duration once the enemy can actually move again
+				if (decayResolute == 1) {
+					if (currentDuration <= 0) {
+						clearTempResolute();
+					} else {
+						setPerkValue(PerkLib.Resolute, 4, currentDuration - 1);
+					}
 				}
 			}
 			if (hasStatusEffect(StatusEffects.Lustzerking)) {
@@ -2096,6 +2100,9 @@ import classes.Scenes.Combat.CombatAbilities;
 					return;
 				}
 			}
+
+			//Only start temp resolute decay once monster is no longer incapacitated
+			if (hasTempResolute() && getPerkValue(PerkLib.Resolute, 3) == 2) setPerkValue(PerkLib.Resolute, 3, 1);
 			performCombatAction();
 		}
 
@@ -2381,7 +2388,7 @@ import classes.Scenes.Combat.CombatAbilities;
 
 		public function handleStunEnd(effect:StatusEffectType):void {
 			if (hasStatusEffect(effect) && canGainTempStunImmunity()) {
-				createPerk(PerkLib.Resolute, 0, 0, 1, resoluteBuffDuration);
+				createPerk(PerkLib.Resolute, 0, 0, 2, resoluteBuffDuration);
 				outputText("<b>[Themonster] is now temporarily resistant to being stunned!</b>\n\n");
 			}
 			removeStatusEffect(effect);
@@ -2392,14 +2399,17 @@ import classes.Scenes.Combat.CombatAbilities;
 		}
 
 		public function clearTempResolute(display:Boolean = true):void {
-			if (hasPerk(PerkLib.Resolute) && getPerkValue(PerkLib.Resolute, 3) == 1) {
+			if (hasTempResolute()) {
 				removePerk(PerkLib.Resolute);
 				if (display) outputText("<b>[Themonster] is no longer resistant to being stunned!</b>\n\n");
 			}
 		}
 
+		/**
+		 * Temp Resolute duration will only start to degrade once it's v3 value is set to 1
+		 */
 		public function hasTempResolute():Boolean {
-			return hasPerk(PerkLib.Resolute) && getPerkValue(PerkLib.Resolute, 3) == 1;
+			return hasPerk(PerkLib.Resolute) && (getPerkValue(PerkLib.Resolute, 3) == 1 || getPerkValue(PerkLib.Resolute, 3) == 2);
 		}
 
 		/**

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -1546,6 +1546,7 @@ public class PlayerEvents extends BaseContent implements TimeAwareInterface {
 				EngineCore.changeFatigue(-(100 + (player.spe*2)));
 				outputText("You feel energised and empowered by the energy drained out of the cum of your recent fuck. What a meal!");
 				player.removeStatusEffect(StatusEffects.DemonEnergyThirstFeed);
+				player.addPerkValue(PerkLib.DemonEnergyThirst, 1, 1);
 			}
 			//DarkCharm
 			needNext ||= player.gainOrLosePerk(PerkLib.DarkCharm, player.isAnyRaceCached(Races.DEMON, Races.IMP, Races.DRACULA) || player.hasMutation(IMutationsLib.BlackHeartIM), "You feel a strange sensation in your body. With you looking like a demon, you have unlocked the potential to use demonic charm attacks!", "With some of your demon-like traits gone, so does your ability to use charm attacks.", player.perkv4(PerkLib.DarkCharm) == 0);

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -5145,7 +5145,8 @@ public class MagicSpecials extends BaseCombatContent {
 	}
 	private function FaeStormFrozen(damage:Number):void{
 		outputText(" shivers as [monster his] skin covers with ice, the surrounding air freezing solid");
-		monster.createStatusEffect(StatusEffects.FrozenSolid,3,0,0,0);
+		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.FrozenSolid,3,0,0,0);
+		else outputText(". [Themonster] quickly moves before they are frozen");
 	}
 	private function FaeStormLust(damage:Number):void{
 		var lustDmg:Number = combat.lustDamageCalc();
@@ -5156,7 +5157,8 @@ public class MagicSpecials extends BaseCombatContent {
 	private function FaeStormSleep(damage:Number):void{
 		if (monster.plural) outputText("are sent straight to the dream lands by the spell’s powerful hypnotic effects");
 		else outputText("is sent straight to the dream lands by the spell’s powerful hypnotic effects");
-		monster.createStatusEffect(StatusEffects.Sleep,2,0,0,0);
+		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.Sleep,2,0,0,0);
+		else outputText(" only to quickly shake off the effects");
 	}
 
 	public function BalefulPolymorph():void {
@@ -5832,8 +5834,12 @@ public class MagicSpecials extends BaseCombatContent {
 				outputText("[Themonster]  skin is covered with ice from the eyebeam as the air surrounding [monster him] freezes solid! ");
 				damage = Math.round(damage * combat.iceDamageBoostedByDao());
 				doIceDamage(damage, true, true);
-				if (monster.hasStatusEffect(StatusEffects.Stunned)) monster.addStatusValue(StatusEffects.Stunned, 1, 1);
-				else monster.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
+				if (!monster.hasPerk(PerkLib.Resolute)) {
+					if (monster.hasStatusEffect(StatusEffects.Stunned)) monster.addStatusValue(StatusEffects.Stunned, 1, 1);
+					else monster.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
+				} else {
+					output("However, [themonster] is able to quickly break themselves free! ")
+				}
 				break;
 			case 4:
 				outputText("[Themonster]  takes heavy cold damage! ");
@@ -5849,13 +5855,21 @@ public class MagicSpecials extends BaseCombatContent {
 				break;
 			case 6:
 				outputText("The eyebeam’s powerful hypnotic effects send your target straight to the dream lands! ");
-				if (monster.hasStatusEffect(StatusEffects.Sleep)) monster.addStatusValue(StatusEffects.Sleep, 1, 1);
-				else monster.createStatusEffect(StatusEffects.Sleep,2,0,0,0);
+				if (!monster.hasPerk(PerkLib.Resolute)) {
+					if (monster.hasStatusEffect(StatusEffects.Sleep)) monster.addStatusValue(StatusEffects.Sleep, 1, 1);
+					else monster.createStatusEffect(StatusEffects.Sleep,2,0,0,0);
+				} else {
+					outputText("However, [themonster] was able to quickly shake themselves awake! ");
+				}
 				break;
 			case 7:
 				outputText("[Themonster] is turned to stone by the petrification ray shooting from your eyestalk! It's going to be immobile for a while. ");
-				if (monster.hasStatusEffect(StatusEffects.Stunned)) monster.addStatusValue(StatusEffects.Stunned, 1, 1);
-				else monster.createStatusEffect(StatusEffects.Stunned, 3, 0, 0, 0);
+				if (!monster.hasPerk(PerkLib.Resolute)) {
+					if (monster.hasStatusEffect(StatusEffects.Stunned)) monster.addStatusValue(StatusEffects.Stunned, 1, 1);
+					else monster.createStatusEffect(StatusEffects.Stunned, 3, 0, 0, 0);
+				} else {
+					outputText("However, [themonster] was able to quickly shake off the effect! ");
+				}
 				break;
 			case 8:
 				outputText("[Themonster] takes heavy fire damage being seared by the ray shooting from one of your eyestalks! ");

--- a/classes/classes/Scenes/Combat/SpellsBlack/PolarMidnightSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsBlack/PolarMidnightSpell.as
@@ -72,10 +72,10 @@ public class PolarMidnightSpell extends AbstractBlackSpell {
 		}
 		var damage:Number = calcDamage(monster, true, true);
 		damage = critAndRepeatDamage(display, damage, DamageType.ICE);
-		if (display) {
-			outputText("\n\n[Monster A] [monster name] is encased in a thick layer of ice.\n\n");
+		if (!monster.hasPerk(PerkLib.Resolute)) {
+			if (display) outputText("\n\n[Monster A] [monster name] is encased in a thick layer of ice.\n\n");
+			monster.createStatusEffect(StatusEffects.FrozenSolid, 5, 0, 0, 0);
 		}
-		monster.createStatusEffect(StatusEffects.FrozenSolid, 5, 0, 0, 0);
 		checkAchievementDamage(damage);
 		combat.heroBaneProc(damage);
 	}

--- a/classes/classes/Scenes/Monsters/WeresharkScene.as
+++ b/classes/classes/Scenes/Monsters/WeresharkScene.as
@@ -83,7 +83,8 @@ public function lostToWereshark():void {
 			outputText("His erection is pulsating within you as he picks up the tempo eagerly to catch his release. Unable to take it any longer, your thoughts swimming in the lack of air, you clench down fervently."+(player.hasCock()?" With a heavy moan, your erection thrums as it grinds against his abs before you cum, shooting several ropes of your seed into the open water.":"")+" ");
 			outputText("You clench your ass tighter on his member as the height of your orgasm rocks through you. He heaves a low growl as his chest heaves, brushing up against you as he cums, forcing you to take in wave after wave of his warm seed, contrasting the cool ocean.\n\n");
 		}
-		tfIntoWereshark();
+		if (!player.blockingBodyTransformations())
+			tfIntoWereshark();
 		outputText("Spent, he slowly loosens his grasp on you, allowing you to float back to the surface. Not without giving you a final, mocking lick across your face, he swims away, leaving you to float back to shore.\n\n");
 	}
 	cleanupAfterCombat();


### PR DESCRIPTION
Enemy Temp Resolute buff will now no longer decay while the enemy is still incapacitated in some way (e.g. Straddle/ Fear)
Losing to a Wereshark while in a perm TF will no longer override it with the Wereshark TF
Reverted Air SDK version used in GitHub workflow to 33.1.1.345 (Should hopefully fix problem with new perk screen on some phones) 
Imp Tome scene should start having the chance to trigger after absorbing energy from sex 26 times (from when this update is added)