### PR TITLE
Legendary tag

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -2304,13 +2304,14 @@ import classes.Scenes.Combat.CombatAbility;
 			}
 			else {
 				addButton(btn, "ORTRTA Rank" + tier.toString(), perkRPConfirm, tier, PerkLib.AscensionOneRaceToRuleThemAllX, pCost, 
-					"Acquire One Race To Rule Them All Rank " + tier.toString() + ".\n\nIncreases the number of stat points earned per level, and racial skill power.");
+					"Acquire One Race To Rule Them All Rank " + tier.toString() + ".\n\nIncreases the number of stat points earned per level, and racial skill power.\n"
+					+ "Cost: " + tier * pCost);
 			}
 		}
 		
 		private function perkHerosBirthrightCheck(tier:int, btn:int):void {
 			var pCost:int = 10;
-			if (tier > 3) {
+			if (tier > 6) {
 				addButtonDisabled(btn, "B. right Rank "+ (tier-1).toString(),"You have the highest tier already.");
 			}
 			else if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] < tier) {
@@ -2321,7 +2322,8 @@ import classes.Scenes.Combat.CombatAbility;
 			}
 			else {
 				addButton(btn, "B. right Rank " + tier.toString(), perkRPConfirm, tier, PerkLib.AscensionHerosBirthrightRankX, pCost, 
-					"Acquire Hero's Birthright Rank " + tier.toString() + ".\n\nReduces the level needed to equip legendary items.");
+					"Acquire Hero's Birthright Rank " + tier.toString() + ".\n\nReduces the level needed to equip legendary items by 9.\n"
+					+ "Cost: " + tier * pCost);
 			}
 		}
 
@@ -2330,7 +2332,7 @@ import classes.Scenes.Combat.CombatAbility;
 			if (tier == 1) player.createPerk(perk,1,0,0,1);
 			else player.setPerkValue(perk,1,player.perkv1(perk) + 1);
 			clearOutput();
-			outputText("You have acquired " + perk.name() + "!");
+			outputText("You have acquired " + perk.name() + "!\n\n" + perk.desc());
 			if (RPP == 1) doNext(rarePerks1);
 			else doNext(rarePerks2);
 		}

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -2222,6 +2222,12 @@ import classes.Scenes.Combat.CombatAbility;
 				perkOneRaceToRuleThemAllCheck(1, btn);
 			}
 			btn++
+			if (player.hasPerk(PerkLib.AscensionHerosBirthrightRankX)){
+				perkHerosBirthrightCheck(player.perkv1(PerkLib.AscensionHerosBirthrightRankX) + 1, btn);
+			} else {
+				perkHerosBirthrightCheck(1, btn);
+			}
+			btn++
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] >= 2 && player.hasPerk(PerkLib.AscensionHerosLineage)) {
 				if (player.ascensionPerkPoints >= 25 && !player.hasPerk(PerkLib.AscensionHerosLegacy)) addButton(btn, "HeroLegacy", perkHerosLegacy).hint("Perk giving you an additional 1 perk point, 1 super perk point and 5 stat points at the start of the game (scaling with current NG tier, for super perk points amount is reduced by 2).\n\nCost: 25 points");
 				else if (player.ascensionPerkPoints < 25) button(btn).disable("You do not have enough ascension perk points!");
@@ -2297,7 +2303,25 @@ import classes.Scenes.Combat.CombatAbility;
 				addButtonDisabled(btn, "ORTRTA Rank "+ tier.toString(),"You do not have enough points.");
 			}
 			else {
-				addButton(btn, "ORTRTA Rank" + tier.toString(), perkRPConfirm, tier, PerkLib.AscensionOneRaceToRuleThemAllX, pCost, "Acquire One Race To Rule Them All Rank " + tier.toString());
+				addButton(btn, "ORTRTA Rank" + tier.toString(), perkRPConfirm, tier, PerkLib.AscensionOneRaceToRuleThemAllX, pCost, 
+					"Acquire One Race To Rule Them All Rank " + tier.toString() + ".\n\nIncreases the number of stat points earned per level, and racial skill power.");
+			}
+		}
+		
+		private function perkHerosBirthrightCheck(tier:int, btn:int):void {
+			var pCost:int = 10;
+			if (tier > 3) {
+				addButtonDisabled(btn, "B. right Rank "+ (tier-1).toString(),"You have the highest tier already.");
+			}
+			else if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] < tier) {
+				addButtonDisabled(btn, "B. right Rank "+ tier.toString(),"You need to ascend once more.");
+			}
+			else if (player.ascensionPerkPoints < pCost * tier) {
+				addButtonDisabled(btn, "B. right Rank "+ tier.toString(),"You do not have enough points.");
+			}
+			else {
+				addButton(btn, "B. right Rank " + tier.toString(), perkRPConfirm, tier, PerkLib.AscensionHerosBirthrightRankX, pCost, 
+					"Acquire Hero's Birthright Rank " + tier.toString() + ".\n\nReduces the level needed to equip legendary items.");
 			}
 		}
 
@@ -2306,7 +2330,7 @@ import classes.Scenes.Combat.CombatAbility;
 			if (tier == 1) player.createPerk(perk,1,0,0,1);
 			else player.setPerkValue(perk,1,player.perkv1(perk) + 1);
 			clearOutput();
-			outputText("You have acquired "+ perk.name() + "!");
+			outputText("You have acquired " + perk.name() + "!");
 			if (RPP == 1) doNext(rarePerks1);
 			else doNext(rarePerks2);
 		}

--- a/classes/classes/Items/Armor.as
+++ b/classes/classes/Items/Armor.as
@@ -109,5 +109,9 @@ public class Armor extends Equipable
 			game.player.removePerk(PerkLib.BulgeArmor); //Exgartuan check
 			if (game.player.modArmorName.length > 0) game.player.modArmorName = "";
 		}
+
+		override public function getLegItemEquipFailureMessage():String {
+			return "You try to equip the legendary armor, but to your disappointment the item simply refuses to stay on your body. It seems you still lack the right to wear this item.";
+		}
 	}
 }

--- a/classes/classes/Items/ArmorLib.as
+++ b/classes/classes/Items/ArmorLib.as
@@ -10,9 +10,9 @@ import classes.PerkLib;
 public final class ArmorLib extends ItemConstants
 	{
 		public function Legendary():Array {
-			return LegendaryPure().concat(LegendaryCorrupt());
+			return legendaryPure().concat(LegendaryCorrupt());
 		}
-		public function LegendaryPure():Array {
+		public function legendaryPure():Array {
 			return [
 				BMARMOR,
 				IBKIMO,

--- a/classes/classes/Items/ArmorLib.as
+++ b/classes/classes/Items/ArmorLib.as
@@ -34,7 +34,8 @@ public final class ArmorLib extends ItemConstants
 				TCKIMO,
 				OTKIMO,
 				CTBGUAR,
-				CGUNSLI
+				CGUNSLI,
+				DEATHPGA
 			];
 		}
 

--- a/classes/classes/Items/Armors/BattleMaidenArmor.as
+++ b/classes/classes/Items/Armors/BattleMaidenArmor.as
@@ -13,6 +13,7 @@ import classes.Items.ItemTags;
 		{
 			super("BMArmor", "BMArmor", "Battle maiden armor", "a Battle maiden armor", 80, 40, 4800, "The purified original maiden armor recovered its former property. It fully protect the virginity of its wielder even going so far as to progressively clear the fog of lust from her mind.", "Light", false, false);
 			withTag(ItemTags.A_REVEALING);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get def():Number{
@@ -30,10 +31,6 @@ import classes.Items.ItemTags;
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
 			if (!super.canEquip(doOutput)) return false;
-			if (game.player.level < 54) {
-				if (doOutput) outputText("You try and wear the legendary armor, but, to your disapointment, the item simply refuses to stay on your body. It would seem you lack the power and right to wield this item yet.");
-				return false;
-			}
 			return LustyMaidensArmor.canUseStatic(doOutput);
 		}
 	}

--- a/classes/classes/Items/Armors/CentaurBlackguardArmor.as
+++ b/classes/classes/Items/Armors/CentaurBlackguardArmor.as
@@ -1,6 +1,7 @@
 package classes.Items.Armors
 {
 	import classes.Items.Armor;
+	import classes.Items.ItemTags;
 	import classes.Scenes.NPCs.CelessScene;
 	/**
 	 * ...
@@ -11,14 +12,12 @@ package classes.Items.Armors
 		
 		public function CentaurBlackguardArmor()
 		{
-			super("TaurBAr","Taur B. Armor","some taur blackguard armor","a set of taur blackguard armor",40,20,1698,"A suit of blackguard's armor for centaurs.","Heavy")
+			super("TaurBAr","Taur B. Armor","some taur blackguard armor","a set of taur blackguard armor",40,20,1698,"A suit of blackguard's armor for centaurs.","Heavy");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.isTaur() && game.player.level >= 54) return super.canEquip(doOutput)
-			if (doOutput) {
-				if (game.player.level >= 54) outputText("You try and wear the legendary armor but to your disapointment the item simply refuse to stay on your body. It would seem you yet lack the power and right to wield this item.");
-				else outputText("The blackguard's armor is designed for centaurs, so it doesn't really fit you. You place the armor back in your inventory");
-			}
+			if (game.player.isTaur()) return super.canEquip(doOutput)
+			if (doOutput) outputText("The blackguard's armor is designed for centaurs, so it doesn't really fit you. You place the armor back in your inventory");
 			return false;
 		}
 		

--- a/classes/classes/Items/Armors/CentaurPaladinArmor.as
+++ b/classes/classes/Items/Armors/CentaurPaladinArmor.as
@@ -1,6 +1,7 @@
 package classes.Items.Armors
 {
 	import classes.Items.Armor;
+	import classes.Items.ItemTags;
 	import classes.Scenes.NPCs.CelessScene;
 	/**
 	 * ...
@@ -11,14 +12,12 @@ package classes.Items.Armors
 		
 		public function CentaurPaladinArmor() 
 		{
-			super("TaurHPAr","Taur HP. Armor","some taur paladin armor","a set of taur paladin armor",40,20,1698,"A suit of paladin's armor for centaurs.","Heavy")
+			super("TaurHPAr","Taur HP. Armor","some taur paladin armor","a set of taur paladin armor",40,20,1698,"A suit of paladin's armor for centaurs.","Heavy");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.isTaur() && game.player.level >= 54) return super.canEquip(doOutput)
-			if (doOutput) {
-				if (game.player.level >= 54) outputText("You try and wear the legendary armor but to your disapointment the item simply refuse to stay on your body. It would seem you yet lack the power and right to wield this item.");
-				else outputText("The paladin's armor is designed for centaurs, so it doesn't really fit you. You place the armor back in your inventory");
-			}
+			if (game.player.isTaur()) return super.canEquip(doOutput)
+			if (doOutput) outputText("The paladin's armor is designed for centaurs, so it doesn't really fit you. You place the armor back in your inventory");
 			return false;
 		}
 		

--- a/classes/classes/Items/Armors/CowGunslingerOutfit.as
+++ b/classes/classes/Items/Armors/CowGunslingerOutfit.as
@@ -21,6 +21,7 @@ import classes.StatusEffects;
 			withTag(ItemTags.A_AGILE);
 			withPerk(PerkLib.CowGunslingerOutfit,0,0,0,0);
 			withTag(ItemTags.A_REVEALING);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get def():Number{
@@ -32,12 +33,6 @@ import classes.StatusEffects;
 			var mod:int = 0;
 			mod += game.player.cor/10;
 			return 10 + mod;
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wear the legendary armor but to your disapointment the item simply refuse to stay on your body. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 }

--- a/classes/classes/Items/Armors/DeathPrinceGoldenArmor.as
+++ b/classes/classes/Items/Armors/DeathPrinceGoldenArmor.as
@@ -5,6 +5,7 @@ package classes.Items.Armors
 {
 	import classes.Items.Armor;
 	import classes.StatusEffects;
+	import classes.Items.ItemTags;
 	
 	public class DeathPrinceGoldenArmor extends Armor
 	{
@@ -12,6 +13,7 @@ package classes.Items.Armors
 		public function DeathPrinceGoldenArmor() 
 		{
 			super("DeathPGA","DeathPrinceGoldenArmor","Death Prince Golden Armor","a Death Prince Golden Armor",20,40,19200,"A set of golden armor worn by Anubi lords, both a symbol of status and power. These armors are generally granted to an anubis who has acquired a sizable amount of slaves. (empowers Anubi ability by 50%, +200% Magic Soulskill power, grants 5% regeneration when soulforce is above half)","Medium")
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function afterEquip(doOutput:Boolean):void {
@@ -37,13 +39,6 @@ package classes.Items.Armors
 			mod += game.player.cor/5;
 			return 20 + mod;
 		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wear the legendary armor but to your disapointment the item simply refuse to stay on your body. It would seem you yet lack the power and right to wield this item.");
-			return false;
-		}
-		
 	}
 
 }

--- a/classes/classes/Items/Armors/InariBlessedKimono.as
+++ b/classes/classes/Items/Armors/InariBlessedKimono.as
@@ -21,13 +21,9 @@ import classes.StatusEffects;
 			});
 			withPerk(PerkLib.InariBlessedKimono,0,0,0,0);
 			withTag(ItemTags.A_REVEALING);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wear the legendary armor but to your disapointment the item simply refuse to stay on your body. It would seem you yet lack the power and right to wield this item.");
-			return false;
-		}
 		override public function get def():Number{
 			var mod:int = (100-game.player.cor)/20;
 			return 5 + mod;

--- a/classes/classes/Items/Armors/OniEnlightenedKimono.as
+++ b/classes/classes/Items/Armors/OniEnlightenedKimono.as
@@ -16,15 +16,13 @@ import classes.Player;
 		{
 			super("OE Kimo", "OniEnlightenedKimono", "Oni Noble kimono", "a oni noble kimono", 30, 50, 27000, "This deceptively sturdy kimono belonged to a beloved shogun amonst oni nobility. Despite their natural predisposition for domination over smaller races, some oni lords decides to rule as benevolent rulers rather then slavemasters. These benevolent oni lords more often then not are in search of the so called drunken enlightment.", "Light");
 			withTag(ItemTags.A_AGILE);
-			withPerk(PerkLib.OniEnlightenedKimono, 0, 0, 0, 0)
+			withPerk(PerkLib.OniEnlightenedKimono, 0, 0, 0, 0);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.tallness >= 80 || game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) {
-				if (game.player.level >= 54) outputText("You try and wear the legendary armor but to your disapointment the item simply refuse to stay on your body. It would seem you yet lack the power and right to wield this item.");
-				else outputText("You aren't tall enough to wear this kimono!  ");
-			}
+			if (game.player.tallness >= 80) return super.canEquip(doOutput);
+			if (doOutput) outputText("You aren't tall enough to wear this kimono!  ");
 			return false;
 		}
 		override public function get def():Number{

--- a/classes/classes/Items/Armors/OniTyrantKimono.as
+++ b/classes/classes/Items/Armors/OniTyrantKimono.as
@@ -16,15 +16,13 @@ import classes.Player;
 		{
 			super("OT Kimo", "OniTyrantKimono", "Oni Tyrant kimono", "a oni tyrant kimono", 30, 50, 27000, "This deceptively sturdy kimono belonged to a tyrant amonst oni nobility. In their homeland oni rules over lesser race with an iron fist. Might makes right or so they say.", "Light");
 			withTag(ItemTags.A_AGILE);
-			withPerk(PerkLib.OniTyrantKimono, 0, 0, 0, 0)
+			withTag(ItemTags.I_LEGENDARY);
+			withPerk(PerkLib.OniTyrantKimono, 0, 0, 0, 0);
 		}
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.tallness >= 80 || game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) {
-				if (game.player.level >= 54) outputText("You try and wear the legendary armor but to your disapointment the item simply refuse to stay on your body. It would seem you yet lack the power and right to wield this item.");
-				else outputText("You aren't tall enough to wear this kimono!  ");
-			}
+			if (game.player.tallness >= 80) return super.canEquip(doOutput);
+			if (doOutput) outputText("You aren't tall enough to wear this kimono!");
 			return false;
 		}
 		override public function get def():Number{

--- a/classes/classes/Items/Armors/SuccubusArmor.as
+++ b/classes/classes/Items/Armors/SuccubusArmor.as
@@ -16,6 +16,7 @@ import classes.PerkLib;
 			super("S.Armor", "S.Armor", "Succubus armor", "a Succubus armor", 50, 25, 3000, "The fully corrupted maiden armor became an armor fit for a succubus. It incite its owner to sex and rewards it for debauching herself. It's already suggestive design became downright obscene as the metal and clothes color turned black as night.", "Light", false, false);
 			withBuffs({'teasedmg':10, 'minlustx': 0.3});
 			withTag(ItemTags.A_REVEALING);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get def():Number {
@@ -33,10 +34,6 @@ import classes.PerkLib;
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
 			if (!super.canEquip(doOutput)) return false;
-			if (game.player.level < 54) {
-				if (doOutput) outputText("You try and wear the legendary armor, but, to your disapointment, the item simply refuses to stay on your body. It would seem you lack the power and right to wield this item yet.");
-				return false;
-			}
 			return LustyMaidensArmor.canUseStatic(doOutput);
 		}
 		

--- a/classes/classes/Items/Armors/TamamoNoMaeCursedKimono.as
+++ b/classes/classes/Items/Armors/TamamoNoMaeCursedKimono.as
@@ -21,13 +21,9 @@ import classes.StatusEffects;
 			});
 			withPerk(PerkLib.TamamoNoMaeCursedKimono,0,0,0,0);
 			withTag(ItemTags.A_REVEALING);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wear the legendary armor but to your disapointment the item simply refuse to stay on your body. It would seem you yet lack the power and right to wield this item.");
-			return false;
-		}
 		override public function get def():Number{
 			var mod:int = game.player.cor/20;
 			return 5 + mod;

--- a/classes/classes/Items/Equipable.as
+++ b/classes/classes/Items/Equipable.as
@@ -138,7 +138,7 @@ public class Equipable extends Useable {
 
 	public function getLegendaryEquipLevel():int {
 		var equipLevel:int = 54;
-		equipLevel -= game.player.perkv1(PerkLib.AscensionHerosBirthrightRankX) * 20;
+		equipLevel -= game.player.perkv1(PerkLib.AscensionHerosBirthrightRankX) * 9;
 		if (equipLevel < 0) equipLevel = 0;
 		return equipLevel;
 	}

--- a/classes/classes/Items/Equipable.as
+++ b/classes/classes/Items/Equipable.as
@@ -8,6 +8,7 @@ import classes.PerkClass;
 import classes.PerkType;
 import classes.Stats.StatUtils;
 import classes.internals.Utils;
+import classes.PerkLib;
 
 /**
  * Superclass for items that could be equipped by player (armor, weapon, jewelry, ...).
@@ -136,7 +137,10 @@ public class Equipable extends Useable {
 	}
 
 	public function getLegendaryEquipLevel():int {
-		return 54;
+		var equipLevel:int = 54;
+		equipLevel -= game.player.perkv1(PerkLib.AscensionHerosBirthrightRankX) * 20;
+		if (equipLevel < 0) equipLevel = 0;
+		return equipLevel;
 	}
 
 	public function getLegItemEquipFailureMessage():String {

--- a/classes/classes/Items/Equipable.as
+++ b/classes/classes/Items/Equipable.as
@@ -134,15 +134,27 @@ public class Equipable extends Useable {
 		CoC_Settings.errorAMC("Equipable("+id+")", "slots");
 		return [];
 	}
+
+	public function getLegendaryEquipLevel():int {
+		return 54;
+	}
+
+	public function getLegItemEquipFailureMessage():String {
+		return "You try to equip the legendary item, but to your disapointment the item simply refuses to stay on your body. It seems you still lack the right to use this item.";
+	}
 	
 	/**
 	 * Test if player can equip the item.
 	 * Should NOT check empty target slot (but can check other slots).
 	 * (ex. equipping large weapon can check for no shield but shouldn't check for no weapon)
 	 * @param doOutput Player tries equipping the item, if fails, print why. And do any side effects related to failed equip attempt.
-	 * @return
+	 * @return true if the player can wear the item
 	 */
 	public function canEquip(doOutput:Boolean):Boolean {
+		if(hasTag(ItemTags.I_LEGENDARY) && game.player.level < getLegendaryEquipLevel()) {
+			if (doOutput) outputText(getLegItemEquipFailureMessage());
+			return false;
+		}
 		return true;
 	}
 	

--- a/classes/classes/Items/ItemTags.as
+++ b/classes/classes/Items/ItemTags.as
@@ -11,15 +11,19 @@ public class ItemTags {
      * For armors that display a lot of skin and thus count as naked for tease purpose and perks such as naked truth
      * Value: none.
      */
-    public static const A_REVEALING:String = "revealing";
+    public static const A_REVEALING:String      = "Revealing";
     /**
      * For armors that are flexible or nearly as flexible as if wearing nothing
      * Value: none.
      */
-    public static const A_AGILE:String = "agile";
+    public static const A_AGILE:String          = "Agile";
     /**
      * For consumables that trigger a transformation
      */
-    public static const U_TF:String    = "tf";
+    public static const U_TF:String             = "tf";
+    /**
+     * To legendary items, which will have a level requirement to equip
+     */
+    public static const I_LEGENDARY:String     = "Legendary";
 }
 }

--- a/classes/classes/Items/Shield.as
+++ b/classes/classes/Items/Shield.as
@@ -92,7 +92,7 @@ public class Shield extends Equipable
 		}
 
 		override public function getLegItemEquipFailureMessage():String {
-			return "You try to equip the legendary shield, but to your disapointment the item simply refuses to stay in your hands. It seems you still lack the right to wield this item.";
+			return "You try to equip the legendary shield, but to your disappointment the item simply refuses to stay in your hands. It seems you still lack the right to wield this item.";
 		}
 	}
 }

--- a/classes/classes/Items/Shield.as
+++ b/classes/classes/Items/Shield.as
@@ -90,5 +90,9 @@ public class Shield extends Equipable
 			}
 			super.afterEquip(doOutput);
 		}
+
+		override public function getLegItemEquipFailureMessage():String {
+			return "You try to equip the legendary shield, but to your disapointment the item simply refuses to stay in your hands. It seems you still lack the right to wield this item.";
+		}
 	}
 }

--- a/classes/classes/Items/ShieldLib.as
+++ b/classes/classes/Items/ShieldLib.as
@@ -13,9 +13,9 @@ import classes.Races;
 public final class ShieldLib extends ItemConstants
 	{
 		public function Legendary():Array {
-			return LegendaryPure().concat(LegendaryCorrupt());
+			return legendaryPure().concat(LegendaryCorrupt());
 		}
-		public function LegendaryPure():Array {
+		public function legendaryPure():Array {
 			return [
 				SANCTYL
 			];

--- a/classes/classes/Items/Shields/DarkAegis.as
+++ b/classes/classes/Items/Shields/DarkAegis.as
@@ -5,6 +5,7 @@
 package classes.Items.Shields
 {
 import classes.Items.Shield;
+import classes.Items.ItemTags;
 import classes.PerkLib;
 
 	public class DarkAegis extends Shield
@@ -16,6 +17,7 @@ import classes.PerkLib;
 					"Gleaming in black metal and obsidian plates, this legendary shield is said to heal and protect a fallen knight. Demonic ornaments cover most of its obsidian-carved surface.",
 					"Large");
 			withPerk(PerkLib.Sanctuary, 2, 0, 0, 0);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get block():Number {
@@ -43,12 +45,6 @@ import classes.PerkLib;
 			}
 			block += Math.round(game.player.cor / scal);
 			return (2 + block);
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary shield but to your disapointment the item simply refuse to stay put in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 }

--- a/classes/classes/Items/Shields/Sanctuary.as
+++ b/classes/classes/Items/Shields/Sanctuary.as
@@ -5,6 +5,7 @@
 package classes.Items.Shields
 {
 import classes.Items.Shield;
+import classes.Items.ItemTags;
 import classes.PerkLib;
 
 	public class Sanctuary extends Shield
@@ -16,6 +17,7 @@ import classes.PerkLib;
 					"Shining in snow-white ivory with a silver trim, this legendary shield is said to heal and protect a knight of pure heart. Embellishments carved on the ivory cover most of its surface.",
 					"Large");
 			withPerk(PerkLib.Sanctuary, 1, 0, 0, 0);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get block():Number {
@@ -43,12 +45,6 @@ import classes.PerkLib;
 			}
 			block += Math.round((100 - game.player.cor) / 5);
 			return (2 + block);
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary shield but to your disapointment the item simply refuse to stay put in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 }

--- a/classes/classes/Items/Weapon.as
+++ b/classes/classes/Items/Weapon.as
@@ -112,7 +112,7 @@ public class Weapon extends Equipable
 				if (doOutput) outputText("You would very like to equip this item but your body stiffness prevents you from doing so.");
 				return false;
 			}
-			return true;
+			return super.canEquip(doOutput);
 		}
 		
 		override public function beforeEquip(doOutput:Boolean):Equipable {
@@ -144,6 +144,14 @@ public class Weapon extends Equipable
 			if (game.flags[kFLAGS.FERAL_COMBAT_MODE] == 1 && !game.player.isFeralCombat()) game.flags[kFLAGS.FERAL_COMBAT_MODE] = 0;
 			
 			return super.beforeEquip(doOutput);
+		}
+
+		override public function getLegItemEquipFailureMessage():String {
+			var weaponType:String = _type.split(", ")[0];
+			if (weaponType == ItemConstants.WT_MACE_HAMMER) weaponType = "Mace";
+			if (weaponType == ItemConstants.WT_DUELING || weaponType == ItemConstants.WT_EXOTIC) weaponType = "Weapon";
+			return "You try to equip the legendary " + weaponType.toLowerCase() + ", but to your disappointment the item simply refuses to stay in your hands." + 
+				" It seems you still lack the right to wear this item.";
 		}
 	}
 }

--- a/classes/classes/Items/Weapon.as
+++ b/classes/classes/Items/Weapon.as
@@ -149,7 +149,7 @@ public class Weapon extends Equipable
 		override public function getLegItemEquipFailureMessage():String {
 			var weaponType:String = _type.split(", ")[0];
 			if (weaponType == ItemConstants.WT_MACE_HAMMER) weaponType = "Mace";
-			if (weaponType == ItemConstants.WT_DUELING || weaponType == ItemConstants.WT_EXOTIC) weaponType = "Weapon";
+			if (weaponType == ItemConstants.WT_DUELING || weaponType == ItemConstants.WT_EXOTIC || !weaponType) weaponType = "Weapon";
 			return "You try to equip the legendary " + weaponType.toLowerCase() + ", but to your disappointment the item simply refuses to stay in your hands." + 
 				" It seems you still lack the right to wear this item.";
 		}

--- a/classes/classes/Items/WeaponLib.as
+++ b/classes/classes/Items/WeaponLib.as
@@ -39,7 +39,8 @@ public final class WeaponLib extends ItemConstants
 				ARMAGED,
 				OCCULUS,
 				EXCALIB,
-				DEXCALI
+				DEXCALI,
+				ASTERIUS
 			];
 		}
 		public function LegendaryCorrupt():Array {
@@ -56,7 +57,8 @@ public final class WeaponLib extends ItemConstants
 				B_WIDOW,
 				DOCDEST,
 				CHAOSEA,
-				ECLIPSE
+				ECLIPSE,
+				NEXUS
 			];
 		}
 		

--- a/classes/classes/Items/WeaponLib.as
+++ b/classes/classes/Items/WeaponLib.as
@@ -21,7 +21,7 @@ public final class WeaponLib extends ItemConstants
 		}
 
 		public function Legendary():Array {
-			return legendaryPure().concat(LegendaryCorrupt());
+			return legendaryPure().concat(LegendaryCorrupt()).concat(NEXUS);
 		}
 		public function legendaryPure():Array {
 			return [
@@ -57,8 +57,7 @@ public final class WeaponLib extends ItemConstants
 				B_WIDOW,
 				DOCDEST,
 				CHAOSEA,
-				ECLIPSE,
-				NEXUS
+				ECLIPSE
 			];
 		}
 		

--- a/classes/classes/Items/WeaponLib.as
+++ b/classes/classes/Items/WeaponLib.as
@@ -21,9 +21,9 @@ public final class WeaponLib extends ItemConstants
 		}
 
 		public function Legendary():Array {
-			return LegendaryPure().concat(LegendaryCorrupt());
+			return legendaryPure().concat(LegendaryCorrupt());
 		}
-		public function LegendaryPure():Array {
+		public function legendaryPure():Array {
 			return [
 				NPHBLDE,
 				T_HEART,
@@ -38,7 +38,8 @@ public final class WeaponLib extends ItemConstants
 				POCDEST,
 				ARMAGED,
 				OCCULUS,
-				EXCALIB
+				EXCALIB,
+				DEXCALI
 			];
 		}
 		public function LegendaryCorrupt():Array {

--- a/classes/classes/Items/WeaponRange.as
+++ b/classes/classes/Items/WeaponRange.as
@@ -75,12 +75,15 @@ public class WeaponRange extends Equipable
 		}
 
 		override public function getLegItemEquipFailureMessage():String {
-			var itemType:String = "bow";
+			var itemType:String = _perk;
 			if ([ItemConstants.WT_PISTOL, ItemConstants.WT_RIFLE, ItemConstants.WT_2H_FIREARM, ItemConstants.WT_DUAL_FIREARMS, ItemConstants.WT_DUAL_2H_FIREARMS].indexOf(_perk) > -1) {
 				itemType = "firearm";
+			} else if (_perk == ItemConstants.WT_THROWING || !itemType) {
+				itemType = "weapon";
 			}
 
-			return "You try to equip the legendary " + itemType + ", but to your disapointment the item simply refuses to stay in your hands. It seems you still lack the right to wield this item.";
+			return "You try to equip the legendary " + itemType.toLowerCase() + 
+				", but to your disappointment the item simply refuses to stay in your hands. It seems you still lack the right to wield this item.";
 		}
 	}
 }

--- a/classes/classes/Items/WeaponRange.as
+++ b/classes/classes/Items/WeaponRange.as
@@ -7,6 +7,7 @@ package classes.Items
 
 import classes.PerkLib;
 import classes.Scenes.SceneLib;
+import classes.Items.ItemConstants;
 
 import coc.view.IconLib;
 
@@ -71,6 +72,15 @@ public class WeaponRange extends Equipable
 				SceneLib.inventory.unequipShield();
 			}
 			return super.beforeEquip(doOutput);
+		}
+
+		override public function getLegItemEquipFailureMessage():String {
+			var itemType:String = "bow";
+			if ([ItemConstants.WT_PISTOL, ItemConstants.WT_RIFLE, ItemConstants.WT_2H_FIREARM, ItemConstants.WT_DUAL_FIREARMS, ItemConstants.WT_DUAL_2H_FIREARMS].indexOf(_perk) > -1) {
+				itemType = "firearm";
+			}
+
+			return "You try to equip the legendary " + itemType + ", but to your disapointment the item simply refuses to stay in your hands. It seems you still lack the right to wield this item.";
 		}
 	}
 }

--- a/classes/classes/Items/WeaponRangeLib.as
+++ b/classes/classes/Items/WeaponRangeLib.as
@@ -11,9 +11,9 @@ import classes.PerkLib;
 public final class WeaponRangeLib extends ItemConstants
 	{
 		public function Legendary():Array {
-			return LegendaryPure().concat(LegendaryCorrupt());
+			return legendaryPure().concat(LegendaryCorrupt());
 		}
-		public function LegendaryPure():Array {
+		public function legendaryPure():Array {
 			return [
 				ARTEMIS,
 				KSLHARP,

--- a/classes/classes/Items/Weapons/ArmageddonBlade.as
+++ b/classes/classes/Items/Weapons/ArmageddonBlade.as
@@ -5,6 +5,7 @@
 package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 	import classes.Player;
 	import classes.PerkLib;
 	import classes.StatusEffects;
@@ -14,6 +15,7 @@ package classes.Items.Weapons
 		public function ArmageddonBlade()
 		{
 			super("Armaged", "ArmageddonBlade", "Armageddon Blade", "an Armageddon Blade", "slash", 410, 65600, "Re-forged with Divine Power, the Armageddon Blade is the only weapon powerful enough to slay Lethice. Requires 500 strength to fully unleash it power.", "Massive, MGWrath", "Sword");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {
@@ -56,11 +58,8 @@ package classes.Items.Weapons
 		}
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.hasPerk(PerkLib.GigantGrip) && game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) {
-				if (game.player.level < 54) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-				else outputText("You aren't skilled in handling massive weapons, even when using both hands to use this sword.  ");
-			}
+			if (game.player.hasPerk(PerkLib.GigantGrip)) return super.canEquip(doOutput);
+			if (doOutput) outputText("You aren't skilled enough in handling massive weapons, even when using both hands to use this sword.  ");
 			return false;
 		}
 	}

--- a/classes/classes/Items/Weapons/AsteriusRage.as
+++ b/classes/classes/Items/Weapons/AsteriusRage.as
@@ -5,12 +5,14 @@
 package classes.Items.Weapons
 {
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 import classes.PerkLib;
 
 public class AsteriusRage extends Weapon {
 		
 		public function AsteriusRage() {
 			super("A.R", "A.R", "Asterius Rage", "Asterius Rage", "cleaves", 200, 20000, "This pair of massive axes once belonged to Asterius the god of the minotaurs.  It'd be hard for anyone smaller than a giant to wield effectively and as a mather of fact seems to work best in the hand of someone of truly titanic strength.  Those axes are double-bladed and deadly-looking.  Requires height of 6'6 or above\".", [WP_DUAL_MASSIVE,WP_MGWRATH].join(", "), WT_AXE);
+			withTag(ItemTags.I_LEGENDARY);		
 		}
 		
 		override public function get attack():Number {
@@ -33,21 +35,15 @@ public class AsteriusRage extends Weapon {
 		}
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54){
-				if (game.player.hasPerk(PerkLib.DualWield) && (game.player.hasPerk(PerkLib.TitanGrip) || (game.player.hasPerk(PerkLib.GigantGripSu) && game.player.playerHasFourArms()))) return super.canEquip(doOutput);
-				if (doOutput) {
-					if (!game.player.hasPerk(PerkLib.TitanGrip)) outputText("You aren't skilled enough to handle this pair of weapons with only two hands!  Unless you want to hurt yourself instead of your enemies when trying to use them...  ");
-					else {
-						if (game.player.playerHasFourArms()) outputText("You aren't skilled enough to handle this pair of weapons!  Unless you want to hurt yourself instead of your enemies when trying to use them...  ");
-						else outputText("You lack second pair of arms!  ");
-					}
+			if (game.player.hasPerk(PerkLib.DualWield) && (game.player.hasPerk(PerkLib.TitanGrip) || (game.player.hasPerk(PerkLib.GigantGripSu) && game.player.playerHasFourArms()))) return super.canEquip(doOutput);
+			if (doOutput) {
+				if (!game.player.hasPerk(PerkLib.TitanGrip)) outputText("You aren't skilled enough to handle this pair of weapons with only two hands!  Unless you want to hurt yourself instead of your enemies when trying to use them...  ");
+				else {
+					if (game.player.playerHasFourArms()) outputText("You aren't skilled enough to handle this pair of weapons!  Unless you want to hurt yourself instead of your enemies when trying to use them...  ");
+					else outputText("You lack second pair of arms!  ");
 				}
-				return false;
 			}
-			else{
-				if(doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-				return false;
-			}
+			return false;
 		}
 	}
 }

--- a/classes/classes/Items/Weapons/BFTHSword.as
+++ b/classes/classes/Items/Weapons/BFTHSword.as
@@ -26,7 +26,7 @@ package classes.Items.Weapons
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
 			if (game.player.hasPerk(PerkLib.GigantGrip)) return super.canEquip(doOutput);
-			if (doOutput) outputText("You aren't skilled in handling massive weapons, even when using both hands to use this sword. Just face that truth you not able to fix your tiny e-pen complex yet...  ");
+			if (doOutput) outputText("You aren't skilled enough in handling massive weapons, even when using both hands to use this sword. Just face that truth you not able to fix your tiny e-pen complex yet...  ");
 			return false;
 		}
 	}

--- a/classes/classes/Items/Weapons/BlackWidow.as
+++ b/classes/classes/Items/Weapons/BlackWidow.as
@@ -3,6 +3,7 @@ package classes.Items.Weapons
 import classes.CoC;
 import classes.GlobalFlags.kFLAGS;
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 
 public class BlackWidow extends Weapon
 	{
@@ -12,6 +13,7 @@ public class BlackWidow extends Weapon
 			super("BWidow", "B. Widow", "black widow rapier", "a black widow rapier", "slash", 80, 9600,
 					"A rapier that used to belong a deceitful noblewoman, made in a strange, purple metal. Its pommel design looks similar to that of a spiderweb, while the blade and hilt are decorated with amethysts and arachnid-looking engravings.", WP_AP100, WT_DUELING
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number{
 			var boost:int = 0;
@@ -29,11 +31,6 @@ public class BlackWidow extends Weapon
 			if (CoC.instance.flags[kFLAGS.RAPHAEL_RAPIER_TRANING] < 2) boost += CoC.instance.flags[kFLAGS.RAPHAEL_RAPIER_TRANING] * 2;
 			else boost += 4 + (CoC.instance.flags[kFLAGS.RAPHAEL_RAPIER_TRANING] - 2);
 			return (20 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 

--- a/classes/classes/Items/Weapons/BloodLetter.as
+++ b/classes/classes/Items/Weapons/BloodLetter.as
@@ -1,6 +1,7 @@
 package classes.Items.Weapons 
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 	import classes.Player;
 
 	public class BloodLetter extends Weapon
@@ -12,6 +13,7 @@ package classes.Items.Weapons
 				"BLDLetter","Blood Letter","bloodletter katana","a bloodletter katana","slash",132,10560,
 				"This dark blade is as beautiful as it is deadly, made in black metal and decorated with crimson ruby gemstones. Lending its power to a corrupt warrior, it will strike with an unholy force, albeit, draining some blood from its wielder on the process.", "Large", "Dueling"
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number {
 			var boost:int = 0;
@@ -27,12 +29,6 @@ package classes.Items.Weapons
 			boost += Math.round(game.player.cor / scal);
 			return (12 + (3 * boost)); 
 		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
-		}
-		
 	}
 
 }

--- a/classes/classes/Items/Weapons/ChaosBlade.as
+++ b/classes/classes/Items/Weapons/ChaosBlade.as
@@ -1,6 +1,7 @@
 package classes.Items.Weapons
 {
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 import classes.Player;
 
 public class ChaosBlade extends Weapon
@@ -12,6 +13,8 @@ public class ChaosBlade extends Weapon
                 "ChaosBlade","Chaos Blade","Chaos Blade","a Chaos Blade","slash",135,10800,
                 "This dark blade is as beautiful as it is deadly, made in black metal and decorated with a single crimson ruby gemstones. Lending its power to a corrupt warrior, it will strike with an unholy force, albeit, draining some blood from its wielder on the process as this weapon is not meant to be wielded by mortals.", "Hybrid", "Dueling"
         );
+		withTag(ItemTags.I_LEGENDARY);
+
     }
     override public function get attack():Number {
         var boost:int = 0;
@@ -26,11 +29,6 @@ public class ChaosBlade extends Weapon
 		}
 		boost += Math.round(game.player.cor / scal);
         return (15 + (3 * boost));
-    }
-    override public function canEquip(doOutput:Boolean):Boolean {
-        if (game.player.level >= 54) return super.canEquip(doOutput);
-        if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-        return false;
     }
 }
 }

--- a/classes/classes/Items/Weapons/Chaoseater.as
+++ b/classes/classes/Items/Weapons/Chaoseater.as
@@ -5,6 +5,7 @@
 package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 	import classes.Player;
 	import classes.PerkLib;
 	import classes.StatusEffects;
@@ -14,6 +15,7 @@ package classes.Items.Weapons
 		public function Chaoseater()
 		{
 			super("Chaosea", "Chaoseater", "Chaoseater", "a Chaoseater", "slash", 410, 65600, "It's incredibly large blade with jagged edges on both sides along with the skulls engraved within the middle of the blade. Requires 500 strength to fully unleash it power.", "Massive, MGWrath", "Sword");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {
@@ -56,11 +58,8 @@ package classes.Items.Weapons
 		}
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.hasPerk(PerkLib.GigantGrip) && game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) {
-				if (game.player.level < 54) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-				else outputText("You aren't skilled in handling massive weapons, even when using both hands to use this sword.  ");
-			}
+			if (game.player.hasPerk(PerkLib.GigantGrip)) return super.canEquip(doOutput);
+			if (doOutput) outputText("You aren't skilled enough in handling massive weapons, even when using both hands to use this sword.");
 			return false;
 		}
 	}

--- a/classes/classes/Items/Weapons/DefiledOniChieftainDestroyer.as
+++ b/classes/classes/Items/Weapons/DefiledOniChieftainDestroyer.as
@@ -6,6 +6,7 @@ package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
 	import classes.Player;
+	import classes.Items.ItemTags;
 
 	public class DefiledOniChieftainDestroyer extends Weapon
 	{
@@ -13,6 +14,7 @@ package classes.Items.Weapons
 		public function DefiledOniChieftainDestroyer()
 		{
 			super("DOCDest", "DOCDestroyer", "Defiled Oni Chieftain Destroyer", "a Defiled Oni Chieftain Destroyer", "smash", 210, 16800, "This unrealistically large two handed mace was clearly made for some legendary oni chieftain to wield. Even bigger than the standard oni tetsubo this thing could topple buildings. You likely will need some absurd strength just to lift it.", "Large, Whirlwind, LGWrath, Stun15", "Mace/Hammer ,Tetsubo");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {
@@ -32,11 +34,6 @@ package classes.Items.Weapons
 			}
 			boost += Math.round(game.player.cor / scal);
 			return (10 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 }

--- a/classes/classes/Items/Weapons/DemonSnakespear.as
+++ b/classes/classes/Items/Weapons/DemonSnakespear.as
@@ -1,6 +1,7 @@
 package classes.Items.Weapons
 {
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 
 public class DemonSnakespear extends Weapon
 	{
@@ -11,6 +12,7 @@ public class DemonSnakespear extends Weapon
 				"A dark steel spear imbued with corruption. Along the handle is a snake-like decoration with ruby eyes, from the mouth of which the spear tip emerges. The spear head is poisoned with an unknown venom.",
 				WP_AP100, WT_SPEAR
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number {
 			var boost:int = 0;
@@ -25,11 +27,6 @@ public class DemonSnakespear extends Weapon
 			}
 			boost += Math.round(game.player.cor / scal);
 			return (20 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 

--- a/classes/classes/Items/Weapons/DemonicGreataxe.as
+++ b/classes/classes/Items/Weapons/DemonicGreataxe.as
@@ -1,6 +1,7 @@
 package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 	/**
 	 * ...
 	 * @author Liadri
@@ -14,6 +15,7 @@ package classes.Items.Weapons
 					"A greataxe made in black metal and imbued with unholy power. Its shaft is wrapped in bat wings made of darkened bronze. Its deadly blade seems to always aim for the enemy necks.",
 					"Large", "Axe"
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number{
 			var boost:int = 0;
@@ -28,11 +30,6 @@ package classes.Items.Weapons
 			}
 			boost += Math.round(game.player.cor / scal);
 			return (20 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 }

--- a/classes/classes/Items/Weapons/DorcSouls.as
+++ b/classes/classes/Items/Weapons/DorcSouls.as
@@ -5,6 +5,7 @@
 package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 	import classes.PerkLib;
 	import classes.Player;
 	
@@ -12,6 +13,7 @@ package classes.Items.Weapons
 		
 		public function DorcSouls() {
 			super("DorSoul", "DorcSouls", "Dorc Souls", "a Dorc Souls", "slash", 180, 14400, "Said to have been the favored weapon of a mad god named Dorc these corrupted swords heals the wielder on swings.", "Dual Large, LGWrath", "Sword");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {
@@ -42,13 +44,10 @@ package classes.Items.Weapons
 		}
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
-			if (((game.player.hasPerk(PerkLib.DualWield) && (game.player.hasPerk(PerkLib.GigantGrip) || game.player.hasPerk(PerkLib.AntyDexterity))) || (game.player.hasPerk(PerkLib.GigantGrip) && game.player.hasPerk(PerkLib.AntyDexterity))) && game.player.level >= 54) return super.canEquip(doOutput);
+			if (((game.player.hasPerk(PerkLib.DualWield) && (game.player.hasPerk(PerkLib.GigantGrip) || game.player.hasPerk(PerkLib.AntyDexterity))) || (game.player.hasPerk(PerkLib.GigantGrip) && game.player.hasPerk(PerkLib.AntyDexterity)))) return super.canEquip(doOutput);
 			if (doOutput) {
-				if (game.player.level < 54) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-				else {
-					if (game.player.hasPerk(PerkLib.GigantGrip) || game.player.hasPerk(PerkLib.AntyDexterity)) outputText("You aren't skilled in handling large weapons with one hand yet to effectively use those swords. Unless you want to hurt yourself instead of your enemies when trying to use them...  ");
-					else outputText("You aren't skilled enough to handle this pair of weapons!  ");
-				}
+				if (game.player.hasPerk(PerkLib.GigantGrip) || game.player.hasPerk(PerkLib.AntyDexterity)) outputText("You aren't skilled in handling large weapons with one hand yet to effectively use those swords. Unless you want to hurt yourself instead of your enemies when trying to use them...  ");
+				else outputText("You aren't skilled enough to handle this pair of weapons!  ");
 			}
 			return false;
 		}

--- a/classes/classes/Items/Weapons/DualExcalibur.as
+++ b/classes/classes/Items/Weapons/DualExcalibur.as
@@ -5,6 +5,7 @@
 package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 	import classes.PerkLib;
 	import classes.Player;
 	import classes.GlobalFlags.*;
@@ -15,6 +16,7 @@ package classes.Items.Weapons
 		public function DualExcalibur() 
 		{
 			super("DExcalib", "DualExcalibur", "Dual Excalibur", "a Dual Excalibur", "slash", 40, 1600, "A legendary dual swords said to have been made by Marae for her champion. Those weapon radiates divine power, purifying its wielder and protecting them from impurity.", "Dual", "Sword");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {

--- a/classes/classes/Items/Weapons/EbonyDestroyer.as
+++ b/classes/classes/Items/Weapons/EbonyDestroyer.as
@@ -1,6 +1,7 @@
 package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 
 	public class EbonyDestroyer extends Weapon
 	{
@@ -11,6 +12,7 @@ package classes.Items.Weapons
 				"This massive weapon, made of the darkest metal seems to seethe with unseen malice. Its desire to destroy and hurt the pure is so strong that it’s wielder must be wary, lest the blade take control of their body to fulfill its gruesome desires.",
 				"Large, LGWrath", "Sword"
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number {
 			var boost:int = 0;
@@ -37,11 +39,6 @@ package classes.Items.Weapons
 			}
 			boost += Math.round(game.player.cor / scal);
 			return (10 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 

--- a/classes/classes/Items/Weapons/Eclipse.as
+++ b/classes/classes/Items/Weapons/Eclipse.as
@@ -2,6 +2,7 @@ package classes.Items.Weapons
 {
 import classes.EventParser;
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 import classes.PerkLib;
 import classes.TimeAwareInterface;
 
@@ -27,6 +28,7 @@ public class Eclipse extends Weapon implements TimeAwareInterface
 					"Created using the blood and bones of a titan for material Eclipse as it is now called constantly craves for oblivion. As a corrupted sentient weapon it constantly craves death and suffering but more then anything the life of its owner for Eclipse obeys no master and seeks to destroy everything indescriminately. Due to its nature as an item infused with the essense of annihilation Eclipse weakens the power of healing spells.",
 					"Wand, Weakens healing spell, Spellpower bonus for corruption", WT_WAND);
 			withBuff('spellpower', +1.0);
+			withTag(ItemTags.I_LEGENDARY);
 			EventParser.timeAwareClassAdd(this);
 		}
 		
@@ -70,12 +72,6 @@ public class Eclipse extends Weapon implements TimeAwareInterface
 			}
 			boost += Math.round((100 - game.player.cor) / scal);
 			return (1 + boost); 
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay put in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 
 		override public function get description():String {

--- a/classes/classes/Items/Weapons/Excalibur.as
+++ b/classes/classes/Items/Weapons/Excalibur.as
@@ -5,6 +5,7 @@
 package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 	import classes.PerkLib;
 	import classes.Player;
 	import classes.GlobalFlags.*;
@@ -15,6 +16,7 @@ package classes.Items.Weapons
 		public function Excalibur()
 		{
 			super("Excalib", "Excalibur", "Excalibur", "an Excalibur", "slash", 40, 800, "A legendary sword said to have been made by Marae for her champion. This weapon radiates divine power, purifying its wielder and protecting them from impurity.", "", "Sword");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {

--- a/classes/classes/Items/Weapons/GiantShuriken.as
+++ b/classes/classes/Items/Weapons/GiantShuriken.as
@@ -26,7 +26,7 @@ package classes.Items.Weapons
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
 			if (game.player.hasPerk(PerkLib.GigantGrip)) return super.canEquip(doOutput);
-			if (doOutput) outputText("You aren't skilled in handling massive weapons, even when using both hands to use this sword.  ");
+			if (doOutput) outputText("You aren't skilled enough in handling massive weapons, even when using both hands to use this sword.  ");
 			return false;
 		}
 	}

--- a/classes/classes/Items/Weapons/Hellraiser.as
+++ b/classes/classes/Items/Weapons/Hellraiser.as
@@ -1,6 +1,7 @@
 package classes.Items.Weapons 
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 	import classes.PerkLib;
 	/**
 	 * ...
@@ -16,6 +17,7 @@ package classes.Items.Weapons
 					"Large, Whirlwind, Bleed10", "Scythe, StaffPart"
 			);
 			withBuff('spellpower', +2);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {
@@ -31,11 +33,6 @@ package classes.Items.Weapons
 			}
 			boost += Math.round(game.player.cor / scal);
 			return (40 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 

--- a/classes/classes/Items/Weapons/KarmicTouch.as
+++ b/classes/classes/Items/Weapons/KarmicTouch.as
@@ -6,6 +6,8 @@ package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
 	import classes.Player;
+	import classes.Items.ItemTags;
+
 
 	public class KarmicTouch extends Weapon
 	{
@@ -14,12 +16,7 @@ package classes.Items.Weapons
 		{
 			super("KarmTou", "KarmicTouch", "karmic gloves", "a pair of karmic gloves", "punch", 0, 400, "A pair of gauntlets, ordinary at first glance save by its immaculate appearance in shining metal and snow-white cloth.Their touch brings waste into the wicked flesh, punishing them in the form of blows more painful then should be.", "Stun50", WT_GAUNTLET);
 			withBuffs({ 'psoulskillpower': +1.5 });
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 	}

--- a/classes/classes/Items/Weapons/LifehuntScythe.as
+++ b/classes/classes/Items/Weapons/LifehuntScythe.as
@@ -2,6 +2,7 @@ package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
 	import classes.PerkLib;
+	import classes.Items.ItemTags;
 	/**
 	 * ...
 	 * @author Oxdeception
@@ -16,6 +17,7 @@ package classes.Items.Weapons
 					"Large, Whirlwind, Bleed25", "Scythe, StaffPart"
 			);
 			withBuff('spellpower', +1.0);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {
@@ -31,11 +33,6 @@ package classes.Items.Weapons
 			}
 			boost += Math.round((100 - game.player.cor) / scal);
 			return (40 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 

--- a/classes/classes/Items/Weapons/Masamune.as
+++ b/classes/classes/Items/Weapons/Masamune.as
@@ -1,6 +1,7 @@
 package classes.Items.Weapons 
 {
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 
 public class Masamune extends Weapon
 	{
@@ -11,6 +12,7 @@ public class Masamune extends Weapon
 				"masamune","Masamune","masamune katana","a masamune katana","slash",112,8960,
 				"This blessed katana is made in shining steel and heavily decorated with silver and blue sapphires. When used by a pure-hearted knight, the divine will within guides each strike, making it much deadlier.", "Large", "Dueling"
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number {
 			var boost:int = 0;
@@ -25,11 +27,6 @@ public class Masamune extends Weapon
 			}
 			boost += Math.round((100 - game.player.cor) / scal);
 			return (12 + (2 * boost)); 
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	
 	}

--- a/classes/classes/Items/Weapons/MoonlitSnow.as
+++ b/classes/classes/Items/Weapons/MoonlitSnow.as
@@ -1,6 +1,7 @@
 package classes.Items.Weapons
 {
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 
 public class MoonlitSnow extends Weapon
 	{
@@ -11,6 +12,7 @@ public class MoonlitSnow extends Weapon
 				"Moonlit Snow","Moonlit Snow","Moonlit Snow","a Moonlit Snow","slash",115,9200,
 				"This blessed katana is made in shining steel and heavily decorated with silver and blue sapphires. When used by a pure-hearted knight, the divine will within guides each strike, making it much deadlier.", "Hybrid", "Dueling"
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number {
 			var boost:int = 0;
@@ -25,11 +27,6 @@ public class MoonlitSnow extends Weapon
 			}
 			boost += Math.round((100 - game.player.cor) / scal);
 			return (15 + (2 * boost));
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 

--- a/classes/classes/Items/Weapons/NephilimBlade.as
+++ b/classes/classes/Items/Weapons/NephilimBlade.as
@@ -1,6 +1,7 @@
 package classes.Items.Weapons
 {
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 
 public class NephilimBlade extends Weapon
 	{
@@ -12,6 +13,7 @@ public class NephilimBlade extends Weapon
 				"A long lost sword, made in a shining metal, that once belonged to the demigod Nephilim. This masterfully crafted blade seeks and destroys corruption wherever it might find it, and will periodically cleanse their user body and soul.",
 				"Large, LGWrath", "Sword"
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number {
 			var boost:int = 0;
@@ -38,11 +40,6 @@ public class NephilimBlade extends Weapon
 			}
 			boost += Math.round((100 - game.player.cor) / scal);
 			return (10 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 

--- a/classes/classes/Items/Weapons/Nexus.as
+++ b/classes/classes/Items/Weapons/Nexus.as
@@ -2,6 +2,7 @@ package classes.Items.Weapons
 {
 import classes.EventParser;
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 import classes.PerkLib;
 import classes.TimeAwareInterface;
 
@@ -28,6 +29,7 @@ public class Nexus extends Weapon implements TimeAwareInterface
 					"Wand, Increase spell resistance by 20%, Increases Spellpower based on neutrality", WT_WAND
 			);
 			withBuff('spellpower', +0.6);
+			withTag(ItemTags.I_LEGENDARY);
 			EventParser.timeAwareClassAdd(this);
 		}
 
@@ -64,12 +66,6 @@ public class Nexus extends Weapon implements TimeAwareInterface
             else
                 return _description;
         }
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay put in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
-		}
 
 		override public function get description():String {
 			updateWizardsMult(); //To display *correct* values

--- a/classes/classes/Items/Weapons/NocturnusStaff.as
+++ b/classes/classes/Items/Weapons/NocturnusStaff.as
@@ -2,6 +2,7 @@ package classes.Items.Weapons
 {
 import classes.EventParser;
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 import classes.PerkLib;
 import classes.TimeAwareInterface;
 
@@ -27,6 +28,7 @@ public class NocturnusStaff extends Weapon implements TimeAwareInterface
 					"This corrupted staff is made in black ebonwood and decorated with a bat ornament in bronze. Malice seems to seep through the item, devouring the wielder’s mana to channel its unholy power.",
 					"Large, Staff, +200% Spell cost, Spellpower bonus for corruption", WT_STAFF);
 			withBuff('spellpower', +1.0);
+			withTag(ItemTags.I_LEGENDARY);
 			EventParser.timeAwareClassAdd(this);
 		}
 		
@@ -75,12 +77,6 @@ public class NocturnusStaff extends Weapon implements TimeAwareInterface
             else
                 return _description;
         }
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay put in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
-		}
 
 		override public function get description():String {
 			updateWizardsMult(); //To display *correct* values

--- a/classes/classes/Items/Weapons/Nodachi.as
+++ b/classes/classes/Items/Weapons/Nodachi.as
@@ -26,7 +26,7 @@ package classes.Items.Weapons
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
 			if (game.player.hasPerk(PerkLib.GigantGrip)) return super.canEquip(doOutput);
-			if (doOutput) outputText("You aren't skilled in handling massive weapons, even when using both hands to use this sword.  ");
+			if (doOutput) outputText("You aren't skilled enough in handling massive weapons, even when using both hands to use this sword.  ");
 			return false;
 		}
 	}

--- a/classes/classes/Items/Weapons/Occulus.as
+++ b/classes/classes/Items/Weapons/Occulus.as
@@ -2,6 +2,7 @@ package classes.Items.Weapons
 {
 import classes.EventParser;
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 import classes.PerkLib;
 import classes.TimeAwareInterface;
 
@@ -28,6 +29,7 @@ public class Occulus extends Weapon implements TimeAwareInterface
 					"Wand, greatly empowers healing spells, increases Spellpower based on purity", WT_WAND
 			);
 			withBuff('spellpower', +1.0);
+			withTag(ItemTags.I_LEGENDARY);
 			EventParser.timeAwareClassAdd(this);
 		}
 
@@ -71,12 +73,6 @@ public class Occulus extends Weapon implements TimeAwareInterface
 			}
 			boost += Math.round(game.player.cor / scal);
 			return (1 + boost); 
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay put in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 
 		override public function get description():String {

--- a/classes/classes/Items/Weapons/PurifiedOniChieftainDestroyer.as
+++ b/classes/classes/Items/Weapons/PurifiedOniChieftainDestroyer.as
@@ -5,6 +5,7 @@
 package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 	import classes.Player;
 
 	public class PurifiedOniChieftainDestroyer extends Weapon
@@ -13,6 +14,7 @@ package classes.Items.Weapons
 		public function PurifiedOniChieftainDestroyer()
 		{
 			super("POCDest", "POCDestroyer", "Purified Oni Chieftain Destroyer", "a Purified Oni Chieftain Destroyer", "smash", 210, 16800, "This unrealistically large two handed mace was clearly made for some legendary oni chieftain to wield. Even bigger than the standard oni tetsubo this thing could topple buildings. You likely will need some absurd strength just to lift it.", "Large, Whirlwind, LGWrath, Stun15", "Mace/Hammer, Tetsubo");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {
@@ -32,13 +34,6 @@ package classes.Items.Weapons
 			}
 			boost += Math.round((100 - game.player.cor) / scal);
 			return (10 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) {
-				outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			}
-			return false;
 		}
 	}
 }

--- a/classes/classes/Items/Weapons/QueensGuard.as
+++ b/classes/classes/Items/Weapons/QueensGuard.as
@@ -3,6 +3,7 @@ package classes.Items.Weapons
 import classes.CoC;
 import classes.GlobalFlags.kFLAGS;
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 
 public class QueensGuard extends Weapon
 	{
@@ -12,6 +13,7 @@ public class QueensGuard extends Weapon
 			super("Q.Guard", "Q. Guard", "queen's guard rapier", "a queen's guard rapier", "slash", 80, 9600,
 					" An elegant rapier made in brass and gold, with the seal of Mareth’s former nobility. The ruby gemstones running among the blade and the intricate engravings in gold identify it as belonging to the old kingdom knighthoods orders.", WP_AP100, WT_DUELING
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number{
 			var boost:int = 0;
@@ -29,11 +31,6 @@ public class QueensGuard extends Weapon
 			if (CoC.instance.flags[kFLAGS.RAPHAEL_RAPIER_TRANING] < 2) boost += CoC.instance.flags[kFLAGS.RAPHAEL_RAPIER_TRANING] * 2;
 			else boost += 4 + (CoC.instance.flags[kFLAGS.RAPHAEL_RAPIER_TRANING] - 2);
 			return (20 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 

--- a/classes/classes/Items/Weapons/SeraphicSpear.as
+++ b/classes/classes/Items/Weapons/SeraphicSpear.as
@@ -1,6 +1,7 @@
 package classes.Items.Weapons
 {
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 
 public class SeraphicSpear extends Weapon
 	{
@@ -11,6 +12,7 @@ public class SeraphicSpear extends Weapon
 				"A silvery spear imbued with holy power and decorated with blue sapphire gemstones. Engraved in the handle is an ancient runic spell made to ward evil. This blessed equipment seems to slowly heal its wielder’s wounds.",
 				WP_AP100, WT_SPEAR
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number {
 			var boost:int = 0;
@@ -25,11 +27,6 @@ public class SeraphicSpear extends Weapon
 			}
 			boost += Math.round((100 - game.player.cor) / scal);
 			return (20 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 

--- a/classes/classes/Items/Weapons/TrullHeart.as
+++ b/classes/classes/Items/Weapons/TrullHeart.as
@@ -5,6 +5,7 @@
 package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 	import classes.PerkLib;
 	import classes.Player;
 	
@@ -12,6 +13,7 @@ package classes.Items.Weapons
 		
 		public function TrullHeart() {
 			super("T.Heart", "T.Heart", "Trull Heart", "a Trull Heart", "slash", 180, 14400, "This pair of oversized swords is said to have once belonged to a legendary giant. The owner wounds seems to recover when those pure blades are used.", "Dual Large, LGWrath", "Sword");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {
@@ -42,13 +44,10 @@ package classes.Items.Weapons
 		}
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
-			if (((game.player.hasPerk(PerkLib.DualWield) && (game.player.hasPerk(PerkLib.GigantGrip) || game.player.hasPerk(PerkLib.AntyDexterity))) || (game.player.hasPerk(PerkLib.GigantGrip) && game.player.hasPerk(PerkLib.AntyDexterity))) && game.player.level >= 54) return super.canEquip(doOutput);
+			if (((game.player.hasPerk(PerkLib.DualWield) && (game.player.hasPerk(PerkLib.GigantGrip) || game.player.hasPerk(PerkLib.AntyDexterity))) || (game.player.hasPerk(PerkLib.GigantGrip) && game.player.hasPerk(PerkLib.AntyDexterity)))) return super.canEquip(doOutput);
 			if (doOutput) {
-				if (game.player.level < 54) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-				else {
-					if (game.player.hasPerk(PerkLib.GigantGrip) || game.player.hasPerk(PerkLib.AntyDexterity)) outputText("You aren't skilled in handling large weapons with one hand yet to effectively use those swords. Unless you want to hurt yourself instead enemies when trying to use them...  ");
-					else outputText("You aren't skilled enough to handle this pair of weapons!  ");
-				}
+				if (game.player.hasPerk(PerkLib.GigantGrip) || game.player.hasPerk(PerkLib.AntyDexterity)) outputText("You aren't skilled in handling large weapons with one hand yet to effectively use those swords. Unless you want to hurt yourself instead enemies when trying to use them...  ");
+				else outputText("You aren't skilled enough to handle this pair of weapons!  ");
 			}
 			return false;
 		}

--- a/classes/classes/Items/Weapons/UndefeatedKingDestroyer.as
+++ b/classes/classes/Items/Weapons/UndefeatedKingDestroyer.as
@@ -26,7 +26,7 @@ package classes.Items.Weapons
 		
 		override public function canEquip(doOutput:Boolean):Boolean {
 			if (game.player.hasPerk(PerkLib.GigantGrip)) return super.canEquip(doOutput);
-			if (doOutput) outputText("You aren't skilled in handling massive weapons, even when using both hands to use this mace. Just face that truth you not even close to Undefeated King level yet...  ");
+			if (doOutput) outputText("You aren't skilled enough in handling massive weapons, even when using both hands to use this mace. Just face that truth you not even close to Undefeated King level yet...  ");
 			return false;
 		}
 	}

--- a/classes/classes/Items/Weapons/UnicornStaff.as
+++ b/classes/classes/Items/Weapons/UnicornStaff.as
@@ -2,6 +2,7 @@ package classes.Items.Weapons
 {
 import classes.EventParser;
 import classes.Items.Weapon;
+import classes.Items.ItemTags;
 import classes.PerkLib;
 import classes.TimeAwareInterface;
 
@@ -28,6 +29,7 @@ public class UnicornStaff extends Weapon implements TimeAwareInterface
 					"Large, Staff, Spell Cost -50%, increases Spellpower based on purity", WT_STAFF
 			);
 			withBuff('spellpower', +1.0);
+			withTag(ItemTags.I_LEGENDARY);
 			EventParser.timeAwareClassAdd(this);
 		}
 
@@ -76,12 +78,6 @@ public class UnicornStaff extends Weapon implements TimeAwareInterface
             else
                 return _description;
         }
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay put in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
-		}
 
 		override public function get description():String {
 			updateWizardsMult(); //To display *correct* values

--- a/classes/classes/Items/Weapons/WingedGreataxe.as
+++ b/classes/classes/Items/Weapons/WingedGreataxe.as
@@ -1,6 +1,7 @@
 package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
+	import classes.Items.ItemTags;
 	/**
 	 * ...
 	 * @author Liadri
@@ -14,6 +15,7 @@ package classes.Items.Weapons
 					"A greataxe made in untarnished steel and imbued with holy power. Its shaft is wrapped in feathery wings made of brass and gold. This holy artifact was created to execute demonic fiends, always finding their weakest spot.",
 					"Large", "Axe"
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number{
 			var boost:int = 0;
@@ -28,11 +30,6 @@ package classes.Items.Weapons
 			}
 			boost += Math.round((100 - game.player.cor) / scal);
 			return (20 + boost);
-		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 }

--- a/classes/classes/Items/Weapons/YamaRajaGrasp.as
+++ b/classes/classes/Items/Weapons/YamaRajaGrasp.as
@@ -6,6 +6,7 @@ package classes.Items.Weapons
 {
 	import classes.Items.Weapon;
 	import classes.Player;
+	import classes.Items.ItemTags;
 
 	public class YamaRajaGrasp extends Weapon
 	{
@@ -14,12 +15,7 @@ package classes.Items.Weapons
 		{
 			super("YamaRG", "YamaRajaGrasp", "Yama-Raja gloves", "a pair of Yama-Raja gloves", "punch", 0, 1600, "These black gloves are made in black leather and an ebony alloy. Their corrupt touch seeks to destroy the pure and innocent. As such, it will seek the weak points of its victims when striking.", "", WT_GAUNTLET);
 			withBuffs({ 'psoulskillpower': +1.5 });
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if (doOutput) outputText("You try and wield the legendary weapon but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 	}

--- a/classes/classes/Items/WeaponsRange/Artemis.as
+++ b/classes/classes/Items/WeaponsRange/Artemis.as
@@ -1,6 +1,7 @@
 package classes.Items.WeaponsRange 
 {
 	import classes.Items.WeaponRange;
+	import classes.Items.ItemTags;
 	import classes.Player;
 	
 	/**
@@ -16,6 +17,7 @@ package classes.Items.WeaponsRange
 					"The white sandalwood of this blessed bow seems to draw light in. The radiant arrows fired with this holy weapon strike true as if guided by divine hands.",
 					"Bow"
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number{
 			var boost:int = 0;
@@ -30,12 +32,6 @@ package classes.Items.WeaponsRange
 			}
 			boost += Math.round((100 - game.player.cor) / scal);
 			return (27 + boost);
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary bow but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 		
 	}

--- a/classes/classes/Items/WeaponsRange/BadOmen.as
+++ b/classes/classes/Items/WeaponsRange/BadOmen.as
@@ -5,6 +5,7 @@
 package classes.Items.WeaponsRange 
 {
 	import classes.Items.WeaponRange;
+	import classes.Items.ItemTags;
 	import classes.GlobalFlags.kFLAGS;
 	
 	public class BadOmen extends WeaponRange {
@@ -12,6 +13,7 @@ package classes.Items.WeaponsRange
 		public function BadOmen() 
 		{
 			super("BadOmen", "BadOmen", "Bad Omen", "a Bad Omen", "shot", 150, 7500, "A single 22mm, four-round revolver, the Bad Omen has even largest bullets than desert eagle. Its shots are deadly and precise through the gun has one hell of a recoil. Requires 200 strength to fully unleash it power.", "Pistol")
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number{
@@ -31,12 +33,6 @@ package classes.Items.WeaponsRange
 			}
 			boost += Math.round(game.player.cor / scal);
 			return (10 + boost);
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary firearm but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 		
 	}

--- a/classes/classes/Items/WeaponsRange/GoodSamaritan.as
+++ b/classes/classes/Items/WeaponsRange/GoodSamaritan.as
@@ -5,6 +5,7 @@
 package classes.Items.WeaponsRange 
 {
 	import classes.Items.WeaponRange;
+	import classes.Items.ItemTags;
 	import classes.GlobalFlags.kFLAGS;
 	
 	public class GoodSamaritan extends WeaponRange {
@@ -12,6 +13,7 @@ package classes.Items.WeaponsRange
 		public function GoodSamaritan() 
 		{
 			super("GoodSam", "GoodSamaritan", "Good Samaritan", "a Good Samaritan", "shot", 150, 7500, "A single 22mm, four-round revolver, the Good Samaritan has even largest bullets than desert eagle. Its shots are deadly and precise through the gun has one hell of a recoil. Requires 200 strength to fully unleash it power.", "Pistol")
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number{
@@ -31,12 +33,6 @@ package classes.Items.WeaponsRange
 			}
 			boost += Math.round((100-game.player.cor) / scal);
 			return (10 + boost);
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary firearm but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 		
 	}

--- a/classes/classes/Items/WeaponsRange/KrakenSlayerHarpoons.as
+++ b/classes/classes/Items/WeaponsRange/KrakenSlayerHarpoons.as
@@ -5,6 +5,7 @@
 package classes.Items.WeaponsRange 
 {
 	import classes.Items.WeaponRange;
+	import classes.Items.ItemTags;
 	import classes.GlobalFlags.kFLAGS;
 	
 	public class KrakenSlayerHarpoons extends WeaponRange
@@ -13,6 +14,7 @@ package classes.Items.WeaponsRange
 		public function KrakenSlayerHarpoons() 
 		{
 			super("KSlHarp", "Kraken Slayer Harpoons", "kraken slayer harpoons", "a kraken slayer harpoons", "shot", 140, 7000, "A set of ornamented harpoons engraved with design of sea animals. This magical weapon replenish ammunition in its stack naturally allowing the hunter to fight unimpeded and smite the corrupt.", "Throwing");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {
@@ -29,12 +31,6 @@ package classes.Items.WeaponsRange
 			}
 			boost += Math.round((100 - game.player.cor) / scal);
 			return (27 + boost);
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary harpoons but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 }

--- a/classes/classes/Items/WeaponsRange/LeviathanHarpoons.as
+++ b/classes/classes/Items/WeaponsRange/LeviathanHarpoons.as
@@ -5,6 +5,7 @@
 package classes.Items.WeaponsRange 
 {
 	import classes.Items.WeaponRange;
+	import classes.Items.ItemTags;
 	import classes.GlobalFlags.kFLAGS;
 	
 	public class LeviathanHarpoons extends WeaponRange
@@ -13,6 +14,7 @@ package classes.Items.WeaponsRange
 		public function LeviathanHarpoons() 
 		{
 			super("LevHarp", "LeviathanHarpoons", "leviathan harpoons", "a leviathan harpoons", "shot", 140, 7000, "A set of ornamented harpoons engraved with design of sea animals. This magical weapon replenish ammunition in its stack naturally allowing the hunter to fight unimpeded and decimate the pure.", "Throwing");
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		
 		override public function get attack():Number {
@@ -29,12 +31,6 @@ package classes.Items.WeaponsRange
 			}
 			boost += Math.round(game.player.cor / scal);
 			return (27 + boost);
-		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary harpoons but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
 		}
 	}
 }

--- a/classes/classes/Items/WeaponsRange/WildHunt.as
+++ b/classes/classes/Items/WeaponsRange/WildHunt.as
@@ -1,6 +1,7 @@
 package classes.Items.WeaponsRange 
 {
 	import classes.Items.WeaponRange;
+	import classes.Items.ItemTags;
 	import classes.Player;
 	
 	/**
@@ -16,6 +17,7 @@ package classes.Items.WeaponsRange
 					"The ebony wood of this corrupt bow seems to ignore light. Arrows fired with this weapon seem to have a malignant mind of their own, striking down the weak with brutal efficiency.",
 					"Bow"
 			);
+			withTag(ItemTags.I_LEGENDARY);
 		}
 		override public function get attack():Number{
 			var boost:int = 0;
@@ -31,13 +33,6 @@ package classes.Items.WeaponsRange
 			boost += Math.round(game.player.cor / scal);
 			return (27 + boost);
 		}
-		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.level >= 54) return super.canEquip(doOutput);
-			if(doOutput) outputText("You try and wield the legendary bow but to your disapointment the item simply refuse to stay in your hands. It would seem you yet lack the power and right to wield this item.");
-			return false;
-		}
-		
 	}
 
 }

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -85,6 +85,7 @@ public class PerkLib
 		public static const AscensionBuildingPrestigeX:PerkType = new AscensionBuildPrestigeX();
 		public static const AscensionTrancendentalGeneticMemoryStageX:PerkType = new AscensionTrancendentGenMemX();
 		public static const AscensionOneRaceToRuleThemAllX:PerkType = new AscensionOneRaceToRuleThemX();
+		public static const AscensionHerosBirthrightRankX:PerkType = new AscensionHerosBirthrightX();
 		public static const AscensionAdvTrainingX:PerkType = new AscensionAdvancedTrainingX();
 
 		public static const AscensionBloodlineHeritage:PerkType = mk("Ascension: Bloodline Heritage", "Ascension: Bloodline Heritage",

--- a/classes/classes/Perks/AscensionAdvancedTrainingX.as
+++ b/classes/classes/Perks/AscensionAdvancedTrainingX.as
@@ -23,7 +23,7 @@ public class AscensionAdvancedTrainingX extends PerkType
     }
 
     public function AscensionAdvancedTrainingX() {
-		super("Ascension Advanced Training", "Ascension Advanced Training",
+		super("Ascension Advanced Training", "Ascension: Advanced Training",
                 ".");
 	}
 

--- a/classes/classes/Perks/AscensionBuildPrestigeX.as
+++ b/classes/classes/Perks/AscensionBuildPrestigeX.as
@@ -23,7 +23,7 @@ public class AscensionBuildPrestigeX extends PerkType
     }
 
     public function AscensionBuildPrestigeX() {
-        super("Ascension Building Prestige Stage", "Ascension Building Prestige Stage",
+        super("Ascension Building Prestige Stage", "Ascension: Building Prestige Stage",
                 ".");
     }
 

--- a/classes/classes/Perks/AscensionHerosBirthrightX.as
+++ b/classes/classes/Perks/AscensionHerosBirthrightX.as
@@ -13,8 +13,8 @@ public class AscensionHerosBirthrightX extends PerkType
     override public function desc(params:PerkClass = null):String {
         if (!player) return _desc;
         var pVal:Number = player.perkv1(PerkLib.AscensionHerosBirthrightRankX);
-        if (pVal < 3)
-            return "The level needed to use legendary items has been reduced by " + (20 * pVal).toString() + ", making the minimum level " + (54 - (20 * pVal)).toString() + ".";
+        if (pVal < 6)
+            return "The level needed to use legendary items has been reduced by " + (9 * pVal).toString() + ", making the minimum level " + (54 - (9 * pVal)).toString() + ".";
         else   
             return "There is no longer a minimum level needed to use legendary items.";
     }
@@ -26,7 +26,7 @@ public class AscensionHerosBirthrightX extends PerkType
     }
 
     public function AscensionHerosBirthrightX() {
-        super("Ascension Hero's Birthright", "Ascension Hero's Birthright",
+        super("Ascension Hero's Birthright", "Ascension: Hero's Birthright",
                 ".");
     }
 

--- a/classes/classes/Perks/AscensionHerosBirthrightX.as
+++ b/classes/classes/Perks/AscensionHerosBirthrightX.as
@@ -1,0 +1,37 @@
+/**
+ * Created by Demojay on 24.12.23.
+ */
+package classes.Perks
+{
+import classes.PerkClass;
+import classes.PerkType;
+import classes.PerkLib;
+
+public class AscensionHerosBirthrightX extends PerkType
+{
+
+    override public function desc(params:PerkClass = null):String {
+        if (!player) return _desc;
+        var pVal:Number = player.perkv1(PerkLib.AscensionHerosBirthrightRankX);
+        if (pVal < 3)
+            return "The level needed to use legendary items has been reduced by " + (20 * pVal).toString() + ", making the minimum level " + (54 - (20 * pVal)).toString() + ".";
+        else   
+            return "There is no longer a minimum level needed to use legendary items.";
+    }
+    
+    override public function name(params:PerkClass=null):String {
+        if (!player) return _name;
+        var sufval:String = player.perkv1(PerkLib.AscensionHerosBirthrightRankX).toString();
+        return "Ascension: Hero's Birthright " + sufval;
+    }
+
+    public function AscensionHerosBirthrightX() {
+        super("Ascension Hero's Birthright", "Ascension Hero's Birthright",
+                ".");
+    }
+
+    override public function keepOnAscension(respec:Boolean = false):Boolean {
+        return true;
+    }
+}
+}

--- a/classes/classes/Perks/AscensionOneRaceToRuleThemX.as
+++ b/classes/classes/Perks/AscensionOneRaceToRuleThemX.as
@@ -11,9 +11,9 @@ public class AscensionOneRaceToRuleThemX extends PerkType
 {
 
     override public function desc(params:PerkClass = null):String {
-        if (!player || !params) return _desc;
+        if (!player) return _desc;
         var pVal:Number = player.perkv1(PerkLib.AscensionOneRaceToRuleThemAllX);
-        return "Your racial paragon boost is increased. +" + (2*pVal).toString() + " to each stat per level and increase racial skill power by " + (25*pVal).toString() + "%.";
+        return "Your racial paragon boost is increased. +" + (2*pVal).toString() + " to each stat per level and increases racial skill power by " + (25*pVal).toString() + "%.";
     }
     
     override public function name(params:PerkClass=null):String {
@@ -23,7 +23,7 @@ public class AscensionOneRaceToRuleThemX extends PerkType
     }
 
     public function AscensionOneRaceToRuleThemX() {
-        super("Ascension One Race To Rule Them All", "Ascension One Race To Rule Them All",
+        super("Ascension One Race To Rule Them All", "Ascension: One Race To Rule Them All",
                 ".");
     }
 

--- a/classes/classes/Perks/AscensionOrganMutationX.as
+++ b/classes/classes/Perks/AscensionOrganMutationX.as
@@ -23,7 +23,7 @@ public class AscensionOrganMutationX extends PerkType
     }
 
     public function AscensionOrganMutationX() {
-        super("Ascension Additional Organ Mutation", "Ascension Additional Organ Mutation",
+        super("Ascension Additional Organ Mutation", "Ascension: Additional Organ Mutation",
                 ".");
     }
 

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -5889,19 +5889,19 @@ use namespace CoC;
 		}
 
 		public function hasPureLegendaryItem():Boolean {
-			for each (var item:ItemType in CoC.instance.weapons.LegendaryPure())
+			for each (var item:ItemType in CoC.instance.weapons.legendaryPure())
 				for each (var itemSlot:ItemSlotClass in itemSlots){
 					if (itemSlot.itype == item) return true
 				}
-			for each (item in CoC.instance.weaponsrange.LegendaryPure())
+			for each (item in CoC.instance.weaponsrange.legendaryPure())
 				for each (itemSlot in itemSlots){
 					if (itemSlot.itype == item) return true
 				}
-			for each (item in CoC.instance.shields.LegendaryPure())
+			for each (item in CoC.instance.shields.legendaryPure())
 				for each (itemSlot in itemSlots){
 					if (itemSlot.itype == item) return true
 				}
-			for each (item in CoC.instance.armors.LegendaryPure())
+			for each (item in CoC.instance.armors.legendaryPure())
 				for each (itemSlot in itemSlots){
 					if (itemSlot.itype == item) return true
 				}
@@ -5909,19 +5909,19 @@ use namespace CoC;
 		}
 		public function allPureLegendaryItems():Array {
 			var list: Array = [];
-			for each (var item:ItemType in CoC.instance.weapons.LegendaryPure())
+			for each (var item:ItemType in CoC.instance.weapons.legendaryPure())
 				for each (var itemSlot:ItemSlotClass in itemSlots){
 					if (itemSlot.itype == item) list.push(item);
 				}
-			for each (item in CoC.instance.weaponsrange.LegendaryPure())
+			for each (item in CoC.instance.weaponsrange.legendaryPure())
 				for each (itemSlot in itemSlots){
 					if (itemSlot.itype == item) list.push(item);
 				}
-			for each (item in CoC.instance.shields.LegendaryPure())
+			for each (item in CoC.instance.shields.legendaryPure())
 				for each (itemSlot in itemSlots){
 					if (itemSlot.itype == item) list.push(item);
 				}
-			for each (item in CoC.instance.armors.LegendaryPure())
+			for each (item in CoC.instance.armors.legendaryPure())
 				for each (itemSlot in itemSlots){
 					if (itemSlot.itype == item) list.push(item);
 				}


### PR DESCRIPTION
Made level check function for handling legendary items tied to a "Legendary" Tag, for easy identification of legendary items
Added "Death Prince Golden Armor", "Asterius Rage" and "Nexus" to legendary lists
Added Ascension Perk Line: Hero's Birthright - reduces level needed to equip legendary items to 34 (Rank 1, NG0), 14 (Rank 2, NG1) and 0 (Rank 3, NG2)

