### PR TITLE
Bug Fixes

### DIFF
--- a/classes/classes/IMutations/FeyArcaneBloodstreamMutation.as
+++ b/classes/classes/IMutations/FeyArcaneBloodstreamMutation.as
@@ -28,7 +28,7 @@ public class FeyArcaneBloodstreamMutation extends IMutationPerkType
                 descS += ", and increase said damage by 50%";
             }
             if (pTier >= 4){
-                descS += ". When using an ability with random effects the spell now attempts to activate each effect twice";
+                descS += ". When using an ability with random effects, the impact of the effects are doubled";
             }
             if (descS != "")descS += ".";
             return descS;

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -4148,6 +4148,66 @@ import classes.Scenes.Combat.CombatAbilities;
 					}
 				}
 			}
+			//Venom damage calculation
+			var venomLustDmg:Number = 0;
+			var damage1B:Number = 0;
+			//Snake Venom
+        	if (hasStatusEffect(StatusEffects.NagaVenom)) {
+				statStore.addBuffObject({str:-statusEffectv1(StatusEffects.NagaVenom), spe:-statusEffectv1(StatusEffects.NagaVenom)}, "Poison",{text:"Poison"});
+				if (statusEffectv3(StatusEffects.NagaVenom) >= 1) venomLustDmg += statusEffectv3(StatusEffects.NagaVenom);
+			}
+			//Apophis Venom
+        	if (hasStatusEffect(StatusEffects.ApophisVenom)) {
+				damage1B = SceneLib.combat.teases.teaseBaseLustDamage();
+				if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) {
+					damage1B *= 2;
+				}
+				venomLustDmg += damage1B;
+				SceneLib.combat.teaseXP(1 + SceneLib.combat.bonusExpAfterSuccesfullTease());
+				statStore.addBuffObject({str:-statusEffectv1(StatusEffects.ApophisVenom)*2, spe:-statusEffectv1(StatusEffects.ApophisVenom)*2, tou:-statusEffectv1(StatusEffects.ApophisVenom)*2}, "Poison",{text:"Poison"});
+				if (statusEffectv3(StatusEffects.ApophisVenom) >= 1) venomLustDmg += statusEffectv3(StatusEffects.ApophisVenom);
+			}
+			//Bee Venom
+        	if (hasStatusEffect(StatusEffects.BeeVenom)) {
+				damage1B = SceneLib.combat.teases.teaseBaseLustDamage();
+				if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) {
+					damage1B *= 2;
+				}
+				venomLustDmg += damage1B;
+				SceneLib.combat.teaseXP(1 + SceneLib.combat.bonusExpAfterSuccesfullTease());
+				if (lustVuln != 0) lustVuln += 0.05;
+				statStore.addBuffObject({tou:-statusEffectv1(StatusEffects.ManticoreVenom)*2}, "Poison",{text:"Poison"});
+
+				if (statusEffectv3(StatusEffects.BeeVenom) >= 1) venomLustDmg += statusEffectv3(StatusEffects.BeeVenom);
+			}
+			//Jabberwocky Poison Breath
+        	if (hasStatusEffect(StatusEffects.JabberwockyVenom)) {
+				 damage1B = SceneLib.combat.teases.teaseBaseLustDamage();
+				if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) {
+					damage1B *= 2;
+				}
+				venomLustDmg += damage1B;
+				SceneLib.combat.teaseXP(1 + SceneLib.combat.bonusExpAfterSuccesfullTease());
+				if (lustVuln != 0) lustVuln += 0.05;
+				statStore.addBuffObject({tou:-statusEffectv1(StatusEffects.JabberwockyVenom)*2}, "Poison",{text:"Poison"});
+				if (statusEffectv3(StatusEffects.JabberwockyVenom) >= 1) venomLustDmg += statusEffectv3(StatusEffects.JabberwockyVenom);
+			}
+			//Manticore Venom
+       		if (hasStatusEffect(StatusEffects.ManticoreVenom)) {
+				damage1B = SceneLib.combat.teases.teaseBaseLustDamage();
+				if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) {
+					damage1B *= 2;
+				}
+				venomLustDmg += damage1B;
+				SceneLib.combat.teaseXP(1 + SceneLib.combat.bonusExpAfterSuccesfullTease());
+				statStore.addBuffObject({tou:-statusEffectv1(StatusEffects.ManticoreVenom)*2}, "Poison",{text:"Poison"});
+				if (statusEffectv3(StatusEffects.ManticoreVenom) >= 1) venomLustDmg += statusEffectv3(StatusEffects.ManticoreVenom);
+			}
+			if (venomLustDmg > 0 && lustVuln != 0) {
+				outputText("[Themonster] is aroused from the poison coursing through them ");
+				teased(venomLustDmg * lustVuln, false, true);
+				outputText("\n\n");
+			}
 			if (hasStatusEffect(StatusEffects.Maleficium)) {
 				if (statusEffectv1(StatusEffects.Maleficium) <= 0) {
 					removeStatusEffect(StatusEffects.Maleficium);

--- a/classes/classes/Scenes/Combat/AbstractSpell.as
+++ b/classes/classes/Scenes/Combat/AbstractSpell.as
@@ -211,7 +211,7 @@ public class AbstractSpell extends CombatAbility {
 				lustDmg *= 5;
 			}
 		}
-		if(player.hasPerk(PerkLib.ArcaneLash)) lustDmg *= 1.5;
+		if(player.hasPerk(PerkLib.ArcaneLash) && player.isWhipTypeWeapon()) lustDmg *= 1.5;
 		if(player.hasStatusEffect(StatusEffects.AlvinaTraining2)) lustDmg *= 1.2;
 		if (monster != null) {
 			if (player.hasPerk(PerkLib.HexKnowledge) && monster.cor < 34) lustDmg *= 1.2;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -11924,9 +11924,6 @@ public class Combat extends BaseContent {
                     outputText("You notice [monster he] is obviously affected by your venom, [monster his] movements become unsure, and [monster his] balance begins to fade. Sweat is beginning to roll on [monster his] skin. You wager [monster he] is probably beginning to regret provoking you.  ");
                 }
             }
-            monster.statStore.addBuffObject({str:-monster.statusEffectv1(StatusEffects.NagaVenom), spe:-monster.statusEffectv1(StatusEffects.NagaVenom)}, "Poison",{text:"Poison"});
-            if (monster.statusEffectv3(StatusEffects.NagaVenom) >= 1 && monster.lustVuln > 0) monster.lust += monster.statusEffectv3(StatusEffects.NagaVenom);
-            if (combatIsOver()) return;
         }
         //Apophis Venom
         if (monster.hasStatusEffect(StatusEffects.ApophisVenom)) {
@@ -11945,15 +11942,6 @@ public class Combat extends BaseContent {
                     outputText("You notice [monster he] is obviously affected by your venom, [monster his] movements become unsure, and [monster his] balance begins to fade. Sweat is beginning to roll on [monster his] skin. You wager [monster he] is probably beginning to regret provoking you.  ");
                 }
             }
-            damage1B = combat.teases.teaseBaseLustDamage() * monster.lustVuln;
-            if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) {
-                damage1B *= 2;
-            }
-            monster.teased(damage1B);
-            combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-            monster.statStore.addBuffObject({str:-monster.statusEffectv1(StatusEffects.ApophisVenom)*2, spe:-monster.statusEffectv1(StatusEffects.ApophisVenom)*2, tou:-monster.statusEffectv1(StatusEffects.ApophisVenom)*2}, "Poison",{text:"Poison"});
-            if (monster.statusEffectv3(StatusEffects.ApophisVenom) >= 1 && monster.lustVuln > 0) monster.lust += monster.statusEffectv3(StatusEffects.ApophisVenom);
-            if (combatIsOver()) return;
         }
         //Bee Venom
         if (monster.hasStatusEffect(StatusEffects.BeeVenom)) {
@@ -11972,17 +11960,6 @@ public class Combat extends BaseContent {
                     outputText("You notice [monster he] is obviously affected by your venom, [monster his] movements become unsure, and [monster his] balance begins to fade. Sweat is beginning to roll on [monster his] skin. You wager [monster he] is probably beginning to regret provoking you.  ");
                 }
             }
-            damage1B = combat.teases.teaseBaseLustDamage() * monster.lustVuln;
-            if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) {
-                damage1B *= 2;
-            }
-            monster.teased(damage1B);
-            combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-            monster.lustVuln += 0.05;
-            monster.statStore.addBuffObject({tou:-monster.statusEffectv1(StatusEffects.ManticoreVenom)*2}, "Poison",{text:"Poison"});
-
-            if (monster.statusEffectv3(StatusEffects.BeeVenom) >= 1 && monster.lustVuln > 0) monster.lust += monster.statusEffectv3(StatusEffects.BeeVenom);
-            if (combatIsOver()) return;
         }
         //Jabberwocky Poison Breath
         if (monster.hasStatusEffect(StatusEffects.JabberwockyVenom)) {
@@ -12001,16 +11978,6 @@ public class Combat extends BaseContent {
                     outputText("You notice [monster he] is obviously affected by your venom, [monster his] movements become unsure, and [monster his] balance begins to fade. Sweat is beginning to roll on [monster his] skin. You wager [monster he] is probably beginning to regret provoking you.  ");
                 }
             }
-            damage1B = combat.teases.teaseBaseLustDamage() * monster.lustVuln;
-            if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) {
-                damage1B *= 2;
-            }
-            monster.teased(damage1B);
-            combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-            monster.lustVuln += 0.05;
-            monster.statStore.addBuffObject({tou:-monster.statusEffectv1(StatusEffects.JabberwockyVenom)*2}, "Poison",{text:"Poison"});
-            if (monster.statusEffectv3(StatusEffects.JabberwockyVenom) >= 1 && monster.lustVuln > 0) monster.lust += monster.statusEffectv3(StatusEffects.JabberwockyVenom);
-            if (combatIsOver()) return;
         }
         //Manticore Venom
         if (monster.hasStatusEffect(StatusEffects.ManticoreVenom)) {
@@ -12029,15 +11996,6 @@ public class Combat extends BaseContent {
                     outputText("You notice [monster he] is obviously affected by your venom, [monster his] movements become unsure, and [monster his] balance begins to fade. Sweat is beginning to roll on [monster his] skin. You wager [monster he] is probably beginning to regret provoking you.  ");
                 }
             }
-            damage1B = combat.teases.teaseBaseLustDamage() * monster.lustVuln;
-            if (player.hasPerk(PerkLib.ImprovedVenomGlandSu)) {
-                damage1B *= 2;
-            }
-            monster.teased(damage1B);
-            combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-            monster.statStore.addBuffObject({tou:-monster.statusEffectv1(StatusEffects.ManticoreVenom)*2}, "Poison",{text:"Poison"});
-            if (monster.statusEffectv3(StatusEffects.ManticoreVenom) >= 1 && monster.lustVuln > 0) monster.lust += monster.statusEffectv3(StatusEffects.ManticoreVenom);
-            if (combatIsOver()) return;
         }
         if (monster is Harpy) {
             //(Enemy slightly aroused)

--- a/classes/classes/Scenes/Combat/CombatTeases.as
+++ b/classes/classes/Scenes/Combat/CombatTeases.as
@@ -138,7 +138,7 @@ public class CombatTeases extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.FlawlessBody)) lustDmg *= 1.5;
 		lustDmg *= masteryBonusDamageTease();
 		if (player.hasPerk(PerkLib.EromancyExpert)) lustDmg *= 1.5;
-		if (player.hasPerk(PerkLib.ArcaneLash)) lustDmg *= 1.5;
+		if (player.hasPerk(PerkLib.ArcaneLash) && player.isWhipTypeWeapon()) lustDmg *= 1.5;
 		if (player.hasPerk(PerkLib.JobCourtesan) && monster && monster.hasPerk(PerkLib.EnemyBossType)) lustDmg *= 1.2;
 		if (player.hasPerk(PerkLib.SluttySimplicity) && player.armor.hasTag(ItemTags.A_REVEALING)) lustDmg *= (1 + ((10 + rand(11)) / 100));
 		if (player.hasPerk(PerkLib.ElectrifiedDesire)) lustDmg *= (1 + (player.lust100 * 0.01));

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -2598,7 +2598,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(i == 6) {
 				outputText(". Just as you thought you couldn’t get luckier [monster he] ");
 			}
-			choice(damage);
+			choice();
 			EffectList.splice(EffectList.indexOf(choice), 1)
 		}
 		outputText("\n\n");
@@ -5013,7 +5013,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 2) ProcChance -= 10;
 		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 3) ProcChance -= 10;
 		var procCount:int = 0;
-		var procChecks:int = (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4 ? 12:6)
+		var procChecks:int = 6;
 		for (var i:int = 0; i < procChecks; i++) {
 			if (rand(100) >= ProcChance) {
 				procCount++;
@@ -5041,7 +5041,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(i == 6) {
 				outputText(". Just as you thought you couldn’t get luckier [monster he] ");
 			}
-			choice(damage);
+			choice();
 			EffectList.splice(EffectList.indexOf(choice), 1)
 		}
 		outputText(".\n\n");
@@ -5087,7 +5087,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 3) ProcChance -= 10;
 		//if (ProcChance < 0) ProcChance = 0;
 		var procCount:int = 0;
-		var procChecks:int = (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4 ? 10:5)
+		var procChecks:int = 5;
 		for (var i:int = 0; i < procChecks; i++) {
 			if (rand(100) >= ProcChance) {
 				procCount++;
@@ -5112,55 +5112,100 @@ public class MagicSpecials extends BaseCombatContent {
 			if(i == 5) {
 				outputText(". Finally [monster he] ");
 			}
-			choice(damage);
+			choice();
 			EffectList.splice(EffectList.indexOf(choice), 1)
 		}
 		outputText(".\n\n");
 		enemyAI();
 	}
 
-	private function FaeStormLightning(damage:Number):void{
+	private function FaeStormLightning():void{
 		if(monster.plural) {
-			outputText("begin spasming while [monster his] bodies are ran through by electricity");
+			outputText("begin spasming while [monster his] bodies are ran through by electricity ");
 		}
-		else outputText("begin spasming while [monster his] body is ran through by electricity");
-		damage = Math.round(damage * combat.lightningDamageBoostedByDao());
-		doLightningDamage(damage);
+		else outputText("begin spasming while [monster his] body is ran through by electricity ");
+
+		var damage:Number = (scalingBonusIntelligence() * spellMod());
+		
+		if (player.hasPerk(PerkLib.RacialParagon)) damage *= combat.RacialParagonAbilityBoost();
+		if (player.hasPerk(PerkLib.NaturalArsenal)) damage *= 1.5;
+		if (player.hasPerk(PerkLib.LionHeart)) damage *= 2;
+		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 3) damage *= 1.5;
+		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) damage *= 2;
+		damage *= combat.lightningDamageBoostedByDao();
+		damage = calcVoltageMod(damage, true);
+
+		//Determine if critical hit!
+		var crit:Boolean = false;
+		var critChance:int = 5;
+		critChance += combatMagicalCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			damage *= 1.75;
+		}
+
+
+		doLightningDamage(damage, true, true);
+		if (crit) outputText(" <b>*Critical Hit!*</b>");
 	}
-	private function FaeStormAcid(damage:Number):void{
+	private function FaeStormAcid():void{
 		if(monster.plural) {
 			outputText("begins screaming as [monster his] bodies is suddenly coated with acid and [monster his] armor melting");
 		}
 		else outputText("begins screaming as [monster his] body is suddenly coated with acid and [monster his] armor melting");
-		monster.armorDef *= 0.5;
+		var debuffPercent:Number = 0.1;
+		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) debuffPercent *= 2;
+
+		monster.armorDef -= monster.armorDef * debuffPercent;
 	}
-	private function FaeStormBurn(damage:Number):void{
+	private function FaeStormBurn():void{
 		if(monster.plural) {
 			outputText("starts to burn as [monster his] bodies catch fire");
 		}
 		else outputText("starts to burn as [monster his] body catch fire");
-		monster.createStatusEffect(StatusEffects.BurnDoT, 10, 0.02, 0, 0);
+		var burnPercent:Number = 0.02;
+		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) burnPercent *= 2;
+
+		if (monster.hasStatusEffect(StatusEffects.BurnDoT)) monster.addStatusValue(StatusEffects.BurnDoT, 1, 1);
+		else monster.createStatusEffect(StatusEffects.BurnDoT, 10, burnPercent, 0, 0);
 	}
-	private function FaeStormPoison(damage:Number):void {
+	private function FaeStormPoison():void {
 		outputText("turns green as a potent poison saps [monster his] strength");
-		monster.createStatusEffect(StatusEffects.NagaVenom, 1, 1, 0, 0);
+		var statDecrease:int = 1;
+		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) statDecrease *= 2;
+
+		monster.createOrAddStatusEffect(StatusEffects.NagaVenom, statDecrease);
 	}
-	private function FaeStormFrozen(damage:Number):void{
-		outputText(" shivers as [monster his] skin covers with ice, the surrounding air freezing solid");
-		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.FrozenSolid,3,0,0,0);
-		else outputText(". [Themonster] quickly moves before they are frozen");
+	private function FaeStormFrozen():void{
+		outputText("shivers as [monster his] skin covers with ice, the surrounding air freezing solid");
+		var freezeDuration:int = 2;
+		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) freezeDuration *= 2;
+
+		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.FrozenSolid,freezeDuration,0,0,0);	
+		else outputText(". Sadly, [themonster] quickly dodges before they are completely frozen");
+		
 	}
-	private function FaeStormLust(damage:Number):void{
-		var lustDmg:Number = combat.lustDamageCalc();
-		if(monster.plural) outputText("are magically aroused by the spell");
-		else outputText("is magically aroused by the spell");
+	private function FaeStormLust():void{
+		var lustDmg:Number = scalingBonusIntelligence() / 3;
+		lustDmg *= spellMod();
+		lustDmg = combat.teases.teaseAuraLustDamageBonus(monster, lustDmg);
+		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) lustDmg *= 2;
+		if (monster) lustDmg *= monster.lustVuln;
+
+		if(monster.plural) outputText("are magically aroused by the spell ");
+		else outputText("is magically aroused by the spell ");
 		monster.teased(Math.round(lustDmg), false);
 	}
-	private function FaeStormSleep(damage:Number):void{
+	private function FaeStormSleep():void{
 		if (monster.plural) outputText("are sent straight to the dream lands by the spell’s powerful hypnotic effects");
 		else outputText("is sent straight to the dream lands by the spell’s powerful hypnotic effects");
-		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.Sleep,2,0,0,0);
-		else outputText(" only to quickly shake off the effects");
+
+		var sleepDuration:Number = 2;
+		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) sleepDuration *= 2;
+
+		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.Sleep,sleepDuration,0,0,0);
+		else outputText(", only to quickly shake themselves awake");
 	}
 
 	public function BalefulPolymorph():void {


### PR DESCRIPTION
Changed highest tier of Fae Bloodstream to double effects of fae magic effects, rather than doubling the number of procs (Same effect but cleaner code)

Moved venom applications from correct "combatstatusupdate" function, to prevent it being called outside of a new round. Venom ticks cannot increase the lust vulnerability of lust immune enemies