### PR TITLE
Fairy Special Fixes

### DIFF
--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -4993,12 +4993,12 @@ public class MagicSpecials extends BaseCombatContent {
 			damage *= 1.75;
 		}
 		if (player.hasPerk(PerkLib.RacialParagon)) damage *= combat.RacialParagonAbilityBoost();
-		if (player.hasPerk(PerkLib.NaturalArsenal)) damage *= 1.50;
+		if (player.hasPerk(PerkLib.NaturalArsenal)) damage *= 1.5;
 		if (player.hasPerk(PerkLib.LionHeart)) damage *= 2;
 		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 3) damage *= 1.50;
 		damage = Math.round(damage);
 		doMagicDamage(damage, true, true);
-		if (crit) outputText(" <b>*Critical Hit!*</b>");
+		if (crit) outputText(" <b>*Critical Hit!*</b>. ");
 		//Randomising secondary effects
 		var EffectList:Array = [];
 		EffectList.push(FaeStormLightning);
@@ -5013,15 +5013,13 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 2) ProcChance -= 10;
 		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 3) ProcChance -= 10;
 		var procCount:int = 0;
-		var procChecks:int = 6;
+		var procChecks:int = (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4)? 12: 6;
 		for (var i:int = 0; i < procChecks; i++) {
 			if (rand(100) >= ProcChance) {
 				procCount++;
-			} else {
-				break;
 			}
 		}
-		for (i=1; i<=procCount; i++) {
+		for (i=1; i <= Math.min(procCount, 6); i++) {
 			var choice:Function = randomChoice(EffectList);
 			if(i == 1) {
 				outputText("Your opponent ");
@@ -5054,23 +5052,8 @@ public class MagicSpecials extends BaseCombatContent {
 		clearOutput();
 		useMana(80, Combat.USEMANA_MAGIC);
 		outputText("You fly above your opponent"+((monster.hasPerk(PerkLib.EnemyGroupType) || monster.hasPerk(PerkLib.EnemyLargeGroupType))?"s":"")+" and flap a cloud of magical dust at [monster him]. ");
+		combat.darkRitualCheckDamage();
 		
-		var damage:Number = (scalingBonusIntelligence() * spellMod());
-		//Determine if critical hit!
-		var crit:Boolean = false;
-		var critChance:int = 5;
-		critChance += combatMagicalCritical();
-		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-		if (rand(100) < critChance) {
-			crit = true;
-			damage *= 1.75;
-		}
-		if (player.hasPerk(PerkLib.RacialParagon)) damage *= combat.RacialParagonAbilityBoost();
-		if (player.hasPerk(PerkLib.NaturalArsenal)) damage *= 1.50;
-		if (player.hasPerk(PerkLib.LionHeart)) damage *= 2;
-		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 3) damage *= 1.50;
-		damage = Math.round(damage);
-
 		//Randomising effects
 		var EffectList:Array = [];
 		EffectList.push(FaeStormLightning);
@@ -5085,17 +5068,15 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.FairyQueenRegalia)) ProcChance -= 30;
 		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 2) ProcChance -= 10;
 		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 3) ProcChance -= 10;
-		//if (ProcChance < 0) ProcChance = 0;
+		
 		var procCount:int = 0;
-		var procChecks:int = 5;
+		var procChecks:int = (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4)? 10: 5;
 		for (var i:int = 0; i < procChecks; i++) {
 			if (rand(100) >= ProcChance) {
 				procCount++;
-			} else {
-				break;
 			}
 		}
-		for (i=1; i<=procCount; i++) {
+		for (i=1; i <= Math.min(procCount, 5); i++) {
 			var choice:Function = randomChoice(EffectList);
 			if(i == 1) {
 				outputText("Your opponent ");
@@ -5121,9 +5102,9 @@ public class MagicSpecials extends BaseCombatContent {
 
 	private function FaeStormLightning():void{
 		if(monster.plural) {
-			outputText("begin spasming while [monster his] bodies are ran through by electricity ");
+			outputText("begin spasming while [monster his] bodies are ran through by electricity");
 		}
-		else outputText("begin spasming while [monster his] body is ran through by electricity ");
+		else outputText("begin spasming while [monster his] body is ran through by electricity");
 
 		var damage:Number = (scalingBonusIntelligence() * spellMod());
 		
@@ -5131,7 +5112,6 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.NaturalArsenal)) damage *= 1.5;
 		if (player.hasPerk(PerkLib.LionHeart)) damage *= 2;
 		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 3) damage *= 1.5;
-		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) damage *= 2;
 		damage *= combat.lightningDamageBoostedByDao();
 		damage = calcVoltageMod(damage, true);
 
@@ -5145,7 +5125,6 @@ public class MagicSpecials extends BaseCombatContent {
 			damage *= 1.75;
 		}
 
-
 		doLightningDamage(damage, true, true);
 		if (crit) outputText(" <b>*Critical Hit!*</b>");
 	}
@@ -5154,10 +5133,7 @@ public class MagicSpecials extends BaseCombatContent {
 			outputText("begins screaming as [monster his] bodies is suddenly coated with acid and [monster his] armor melting");
 		}
 		else outputText("begins screaming as [monster his] body is suddenly coated with acid and [monster his] armor melting");
-		var debuffPercent:Number = 0.1;
-		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) debuffPercent *= 2;
-
-		monster.armorDef -= monster.armorDef * debuffPercent;
+		monster.armorDef *= 0.5;
 	}
 	private function FaeStormBurn():void{
 		if(monster.plural) {
@@ -5165,7 +5141,6 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		else outputText("starts to burn as [monster his] body catch fire");
 		var burnPercent:Number = 0.02;
-		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) burnPercent *= 2;
 
 		if (monster.hasStatusEffect(StatusEffects.BurnDoT)) monster.addStatusValue(StatusEffects.BurnDoT, 1, 1);
 		else monster.createStatusEffect(StatusEffects.BurnDoT, 10, burnPercent, 0, 0);
@@ -5173,16 +5148,14 @@ public class MagicSpecials extends BaseCombatContent {
 	private function FaeStormPoison():void {
 		outputText("turns green as a potent poison saps [monster his] strength");
 		var statDecrease:int = 1;
-		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) statDecrease *= 2;
 
-		monster.createOrAddStatusEffect(StatusEffects.NagaVenom, statDecrease);
+		monster.createOrAddStatusEffect(StatusEffects.NagaVenom, 1, statDecrease);
 	}
 	private function FaeStormFrozen():void{
 		outputText("shivers as [monster his] skin covers with ice, the surrounding air freezing solid");
-		var freezeDuration:int = 2;
-		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) freezeDuration *= 2;
+		var freezeDuration:int = 3;
 
-		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.FrozenSolid,freezeDuration,0,0,0);	
+		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.FrozenSolid,freezeDuration,0,0,0);
 		else outputText(". Sadly, [themonster] quickly dodges before they are completely frozen");
 		
 	}
@@ -5190,11 +5163,10 @@ public class MagicSpecials extends BaseCombatContent {
 		var lustDmg:Number = scalingBonusIntelligence() / 3;
 		lustDmg *= spellMod();
 		lustDmg = combat.teases.teaseAuraLustDamageBonus(monster, lustDmg);
-		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) lustDmg *= 2;
 		if (monster) lustDmg *= monster.lustVuln;
 
-		if(monster.plural) outputText("are magically aroused by the spell ");
-		else outputText("is magically aroused by the spell ");
+		if(monster.plural) outputText("are magically aroused by the spell");
+		else outputText("is magically aroused by the spell");
 		monster.teased(Math.round(lustDmg), false);
 	}
 	private function FaeStormSleep():void{
@@ -5202,7 +5174,6 @@ public class MagicSpecials extends BaseCombatContent {
 		else outputText("is sent straight to the dream lands by the spell’s powerful hypnotic effects");
 
 		var sleepDuration:Number = 2;
-		if (player.perkv1(IMutationsLib.FeyArcaneBloodstreamIM) >= 4) sleepDuration *= 2;
 
 		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.Sleep,sleepDuration,0,0,0);
 		else outputText(", only to quickly shake themselves awake");


### PR DESCRIPTION
Proc Check loop for Fae Storm/Pixie Dust no longer stops after first failed check

Reverted change to tier 4 fae bloodstream for those magic specials, but will now stop once the maximum number of effect procs have been reached Pixie Dust Special now has to pay  the dark ritual HP cost for its increased damage