### PR TITLE
Soulskill Invisibility Check

### DIFF
--- a/classes/classes/Scenes/Combat/AbstractSpell.as
+++ b/classes/classes/Scenes/Combat/AbstractSpell.as
@@ -90,9 +90,6 @@ public class AbstractSpell extends CombatAbility {
 			if (monster.hasStatusEffect(StatusEffects.Dig)) {
 				return "You can only use buff magic while underground."
 			}
-			if (combat.isEnemyInvisible) {
-				return "You cannot use offensive spells against an opponent you cannot see or target."
-			}
 		}
 		
 		if (player.wrath < wrathCost()) {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -874,7 +874,9 @@ public class Combat extends BaseContent {
 		if (player.isFlying()) {
 			if (player.statusEffectv2(StatusEffects.Flying) == 1) buttons.add("Land", landAfterUsingFlyingSword);
 			if (player.statusEffectv2(StatusEffects.Flying) == 2) buttons.add("Land", landAfterUsingSoulforce);
-            buttons.add("Great Dive", greatDive).hint("Make a Great Dive to deal TONS of damage!");
+            buttons.add("Great Dive", greatDive)
+            .hint("Make a Great Dive to deal TONS of damage!")
+            .disableIf(isEnemyInvisible, "You cannot use offensive skills against an opponent you cannot see or target.");
         }
         if (CombatAbilities.FlamesOfLove.isKnown) {
             buttons.append(CombatAbilities.FlamesOfLove.createButton(monster));

--- a/classes/classes/Scenes/Combat/CombatAbility.as
+++ b/classes/classes/Scenes/Combat/CombatAbility.as
@@ -229,7 +229,10 @@ public class CombatAbility extends BaseCombatContent {
 	public var baseSFCost:Number = 0;
 	public var baseFatigueCost:Number = 0;
 	public var processPostCallback:Boolean = true;
+	//Used to tell the system the type of damage the last used ability inflicted
 	protected var lastAttackType:int = 0;
+	//Custom toggle to allow an ability to hit an invisible enemy 
+	protected var affectsInvisible:Boolean = false;
 	
 	public function CombatAbility(
 			name:String,
@@ -582,6 +585,11 @@ public class CombatAbility extends BaseCombatContent {
 		} else if (ccd == -2) {
 			return "This ability can only be used once per day."
 		}
+
+		if (!affectsInvisible && targetType == TARGET_ENEMY && combat.isEnemyInvisible) {
+            return "You cannot use offensive skills against an opponent you cannot see or target."
+        }
+
 		return "";
 	}
 	

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -664,6 +664,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		var isEnemyInvisible:Boolean = combat.isEnemyInvisible;
 		if (!player.isInGoblinMech() && !player.isInNonGoblinMech()) {
 			bd = buttons.add("Great Dive", combat.greatDive).hint("Make a Great Dive to deal TONS of damage!");
+			if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 			if (player.isRaceCached(Races.FAIRY, 2) || player.isRaceCached(Races.FAERIEDRAGON)) bd.disable("You cannot use Great Dive due to been too small.");
 			//Embrace
 			if ((player.arms.type == Arms.BAT || player.wings.type == Wings.VAMPIRE) && !monster.hasPerk(PerkLib.EnemyGroupType) && !monster.hasPerk(PerkLib.EnemyLargeGroupType)) {


### PR DESCRIPTION
Added toggle to CombatAbility that allows abilities to override enemy invisibility targetting restriction if needed
Damaging Soulskills now cannot hit invisible targets 
Great Dive now cannot hit invisible targets