### PR TITLE
Green Magic Fixes and Changes

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -1126,7 +1126,7 @@ public class Creature extends Utils
 			if (applyRes) lustDmg *= lustPercent()/100; //the same as dynStats("lus", lustDmg, applyRes);
 			var ldi:int = int(lustDmg);
 			dynStats("lus", ldi);
-			SceneLib.combat.CommasForDigits(ldi, true);
+			if (display) SceneLib.combat.CommasForDigits(ldi, true);
 			return ldi;
 		}
 		/**

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -3016,9 +3016,9 @@ import classes.Scenes.Combat.CombatAbilities;
 			lustDelta = Math.round(lustDelta);
 			lust += lustDelta;
 			if (display) SceneLib.combat.CommasForDigits(lustDelta, true);//outputText(" <b>([font-lust]" + Utils.formatNumber(lustDelta) + "</font>)</b>");
-			if (player.armor == armors.ELFDRES && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0 && lustDelta >= 1) {
-				outputText(" You cool down a little bit ");
-				player.takeLustDamage(Math.round(-lustDelta)/20);
+			if (player.armor == armors.ELFDRES && player.isElf() && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0 && lustDelta >= 1) {
+				if (display) outputText(" You cool down a little bit ");
+				player.takeLustDamage(Math.round(-(player.maxLust() * 0.01)), display, true);
 			}
 		}
 

--- a/classes/classes/Scenes/Combat/AbstractSpell.as
+++ b/classes/classes/Scenes/Combat/AbstractSpell.as
@@ -109,6 +109,7 @@ public class AbstractSpell extends CombatAbility {
 	protected function postSpellEffect(display:Boolean = true):void {
 		MagicAddonEffect(magicAddonProcs);
 		if (player.weapon == weapons.DEMSCYT && player.cor < 90) dynStats("cor", 0.3);
+		if (hasTag(TAG_LUSTDMG)) combat.teases.fueledByDesireHeal(display);
 		if (monster is SiegweirdBoss) (monster as SiegweirdBoss).castedSpellThisTurn = true;
 	}
 	
@@ -210,6 +211,7 @@ public class AbstractSpell extends CombatAbility {
 		}
 		if(player.hasPerk(PerkLib.ArcaneLash) && player.isWhipTypeWeapon()) lustDmg *= 1.5;
 		if(player.hasStatusEffect(StatusEffects.AlvinaTraining2)) lustDmg *= 1.2;
+		lustDmg = combat.teases.fueledByDesireDamageBonus(lustDmg);
 		if (monster != null) {
 			if (player.hasPerk(PerkLib.HexKnowledge) && monster.cor < 34) lustDmg *= 1.2;
 			lustDmg *= corruptMagicPerkFactor(monster);

--- a/classes/classes/Scenes/Combat/AbstractSpell.as
+++ b/classes/classes/Scenes/Combat/AbstractSpell.as
@@ -197,7 +197,8 @@ public class AbstractSpell extends CombatAbility {
 			baseDamage:Number,
 			monster:Monster,
 			category:int,
-			randomize:Boolean=true
+			randomize:Boolean=true,
+			applyOmnicaster:Boolean = true
 	): Number {
 		var lustDmg:Number = baseDamage;
 		lustDmg *= spellModByCat(category);
@@ -218,6 +219,11 @@ public class AbstractSpell extends CombatAbility {
 		}
 		if (player.armor == armors.ELFDRES && player.isElf()) lustDmg *= 2;
 		if (player.armor == armors.FMDRESS && player.isWoodElf()) lustDmg *= 2;
+
+		if (applyOmnicaster && (category != CAT_SPELL_GREEN || !player.hasPerk(PerkLib.ArcaneVenom))) {
+			lustDmg *= omnicasterDamageFactor();
+		}
+
 		return Math.round(lustDmg);
 	}
 	
@@ -458,6 +464,68 @@ public class AbstractSpell extends CombatAbility {
 		var bAB:Number = 1;
 		if (player.hasPerk(PerkLib.BloodAffinity)) bAB += 1;
 		return bAB;
+	}
+
+	/**
+	 * Award tease exp if nessecary, and apply verdent leech effects
+	 * @param hits (int) - number of hits applied by the lust spell
+	 */
+	protected function postLustSpellEffect(hits:int):void {
+		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP((1 + combat.bonusExpAfterSuccesfullTease()) * hits);
+		if (player.hasPerk(PerkLib.VerdantLeech)) {
+			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += hits * 0.025;
+			HPChange(Math.round(player.maxHP() * 0.01 * hits), false);
+		}
+	}
+
+	/**
+	 * Do a crit roll and apply crit multiplier.
+	 * Deal damage once or repeatedly (if Omnicaster and param set). Does NOT apply Omnicaster damage downscale!
+	 * Also prints "Monster takes N N N N damage. Critical Hit!"
+	 * @param lustDmg Lust damage to deal
+	 * @param Spell category (e.g. CAT_SPELL_GREEN)
+	 * @param omnicaterRepeat Determine if spell should hit multiple times
+	 * @return {Array} [Total damage dealt (int), number of hits (int), crit or not (boolean)]
+	 */
+	protected function critAndRepeatLust(
+			display:Boolean,
+			lustDmg:Number,
+			category:int,
+			displayDamageOnly:Boolean=false,
+			omnicasterRepeat:Boolean=true
+	):Array {
+		
+		//Determine if critical hit!
+		var crit:Boolean = false;
+		var critChance:int = 5 + combat.teases.combatTeaseCritical();
+        if (player.perkv1(IMutationsLib.ElvishPeripheralNervSysIM) >= 4) critChance += 10;
+		if (player.perkv1(IMutationsLib.GazerEyesIM) >= 3) critChance += 10;
+		if (player.perkv1(IMutationsLib.GazerEyesIM) >= 4) critChance += 25;
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (critChance > 0 && rand(100) < critChance) {
+			crit = true;
+			lustDmg *= 1.75;
+		}
+
+		var repeats:int = 1;
+		if (omnicasterRepeat) {
+			if (category == CAT_SPELL_GREEN && player.hasPerk(PerkLib.ArcaneVenom)) {
+				repeats += stackingArcaneVenom();
+			} else {
+				repeats = omnicasterRepeatCount();
+			}
+		}
+
+		var i:int = repeats;
+		while (i-->0) {
+			if (display) outputText(" ");
+			monster.teased(lustDmg, false, display || displayDamageOnly);
+		}
+		if (display) {
+			if (crit) outputText(" <b>*Critical Hit!*</b>");
+		}
+
+		return [lustDmg * repeats, repeats, crit];
 	}
 	
 	/**

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -7040,11 +7040,6 @@ public class Combat extends BaseContent {
         if (player.armor == armors.FMDRESS && player.isWoodElf()) damage *= 2;
         if (player.hasMutation(IMutationsLib.HellhoundFireBallsIM) && player.perkv1(IMutationsLib.HellhoundFireBallsIM) >= 2) damage *= (0.05* player.cumQ());
         if (player.hasMutation(IMutationsLib.HellhoundFireBallsIM) && player.perkv1(IMutationsLib.HellhoundFireBallsIM) >= 3) damage *= (0.05* player.cumQ());
-        if (player.hasPerk(PerkLib.FueledByDesire) && player.lust100 >= 50 && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0) {
-            outputText("\nYou use your own lust against the enemy, cooling off a bit in the process.");
-            player.takeLustDamage(Math.round(-damage)/40, true);
-            damage *= 1.2;
-        }
         return monster.lustVuln * damage;
     }
 
@@ -10961,7 +10956,7 @@ public class Combat extends BaseContent {
 		else combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		if (player.hasPerk(PerkLib.VerdantLeech)) {
 			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;
-			HPChange(Math.round(player.maxHP() * 0.05), false);
+			HPChange(Math.round(player.maxHP() * 0.01), false);
 		}
 	}
 
@@ -12834,6 +12829,7 @@ public function StraddleTease():void {
     clearOutput();
     var straddleDamage:Number = combat.teases.teaseBaseLustDamage();
     if (player.perkv1(IMutationsLib.ManticoreMetabolismIM) >= 3 && player.tail.type == Tail.MANTICORE_PUSSYTAIL) straddleDamage *= 2;
+    straddleDamage = combat.teases.fueledByDesireDamageBonus(straddleDamage);
     //Determine if critical tease!
     var randomcrit:Boolean = false;
     var critChance:int = 5;
@@ -12883,6 +12879,7 @@ public function StraddleTease():void {
     chosenTease(straddleDamage, randomcrit);
     combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
     outputText("\n\n");
+    combat.teases.fueledByDesireHeal();
     if (player.hasPerk(PerkLib.DemonEnergyThirst) || player.hasPerk(PerkLib.KitsuneEnergyThirst)) {
         outputText("You gasp in delight as you drink on your victim's energy to replenish your own, feeding of [monster his] pleasure. ");
         if (player.hunger < player.maxHunger())
@@ -13442,6 +13439,7 @@ public function ScyllaTease():void {
             if (player.hasStatusEffect(StatusEffects.ControlFreak)) damagemultiplier += (2 - player.statusEffectv1(StatusEffects.ControlFreak));
             if (player.hasPerk(PerkLib.Sadomasochism)) damage *= player.sadomasochismBoost();
             damage *= damagemultiplier;
+            damage = combat.teases.fueledByDesireDamageBonus(damage);
             //Determine if critical tease!
             var crit:Boolean = false;
             var critChance:int = 5;
@@ -13463,6 +13461,7 @@ public function ScyllaTease():void {
             outputText("\n[Themonster] seems unimpressed.");
         }
         outputText("\n\n");
+        combat.teases.fueledByDesireHeal();
         if (monster.lust >= monster.maxOverLust()) {
             doNext(endLustVictory);
             return;
@@ -13600,6 +13599,7 @@ public function SwallowTease():void {
             if (player.hasStatusEffect(StatusEffects.ControlFreak)) damagemultiplier += (2 - player.statusEffectv1(StatusEffects.ControlFreak));
             if (player.hasPerk(PerkLib.Sadomasochism)) damage *= player.sadomasochismBoost();
             damage *= damagemultiplier;
+            damage = combat.teases.fueledByDesireDamageBonus(damage);
             //Determine if critical tease!
             var crit:Boolean = false;
             var critChance:int = 5;
@@ -13624,6 +13624,7 @@ public function SwallowTease():void {
             outputText("\n[Themonster] seems unimpressed.");
         }
         outputText("\n\n");
+        combat.teases.fueledByDesireHeal();
         if (monster.lust >= monster.maxOverLust()) {
             doNext(endLustVictory);
             return;
@@ -13758,6 +13759,7 @@ public function WebTease():void {
             if (player.hasStatusEffect(StatusEffects.ControlFreak)) damagemultiplier += (2 - player.statusEffectv1(StatusEffects.ControlFreak));
             if (player.hasPerk(PerkLib.Sadomasochism)) damage *= player.sadomasochismBoost();
             damage *= damagemultiplier;
+            damage = combat.teases.fueledByDesireDamageBonus(damage);
             //Determine if critical tease!
             var crit:Boolean = false;
             var critChance:int = 5;
@@ -13779,6 +13781,7 @@ public function WebTease():void {
             outputText("\n[Themonster] seems unimpressed.");
         }
         outputText("\n\n");
+        combat.teases.fueledByDesireHeal();
         if (monster.lust >= monster.maxOverLust()) {
             doNext(endLustVictory);
             return;
@@ -13866,7 +13869,8 @@ public function GooTease():void {
             if (player.hasPerk(PerkLib.UnbreakableBind)) damagemultiplier += 1;
             if (player.hasStatusEffect(StatusEffects.ControlFreak)) damagemultiplier += (2 - player.statusEffectv1(StatusEffects.ControlFreak));
 			damage *= damagemultiplier;
-
+            damage = combat.teases.fueledByDesireDamageBonus(damage);
+            
             if (player.hasPerk(PerkLib.Sadomasochism)) damage *= player.sadomasochismBoost();
 			if (player.perkv1(IMutationsLib.SlimeMetabolismIM) >= 2) damage *= (1 + (0.25 * player.perkv1(IMutationsLib.SlimeMetabolismIM)));
 
@@ -13890,6 +13894,7 @@ public function GooTease():void {
             outputText("\n[Themonster] seems unimpressed.");
         }
         outputText("\n\n");
+        combat.teases.fueledByDesireHeal();
         if (monster.lust >= monster.maxOverLust()) {
             doNext(endLustVictory);
             return;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -9761,7 +9761,7 @@ public class Combat extends BaseContent {
         //Plant Growth
         if (player.hasStatusEffect(StatusEffects.PlantGrowth) && monster.lustVuln > 0) {
             outputText("The vine slithers around [monster him] before groping at [monster his] erogenous zones, enticing them as their focus and grip on combat weakens.");
-			var damagePG:Number = scalingBonusIntelligence() * 0.05 * spellModWhite();
+			var damagePG:Number = scalingBonusIntelligence() * 0.1 * spellModWhite();
             repeatArcaneVenom(damagePG, 1, 0);
 			outputText("\n\n");
         }
@@ -9776,17 +9776,17 @@ public class Combat extends BaseContent {
 		//Briarthorn
 		if (monster.hasStatusEffect(StatusEffects.Briarthorn) && monster.lustVuln > 0) {
 			outputText("The poison inflicted by the thorns gnaws at your opponent countenance.");
-			var damageB:Number = scalingBonusIntelligence() * 0.075 * spellModWhite();
+			var damageB:Number = scalingBonusIntelligence() * 0.15 * spellModWhite();
 			repeatArcaneVenom(damageB, 0, 0);
 			outputText("\n\n");
 		}
 		//Death Blossom
 		if (monster.hasStatusEffect(StatusEffects.DeathBlossom)) {
 			outputText("The airborne poisons and aphrodisiacs spread by the blossoming flowers thickens.\n");
-			var damageDBH:Number = scalingBonusIntelligence() * 0.1 * spellModWhite() * monster.statusEffectv2(StatusEffects.DeathBlossom);
+			var damageDBH:Number = scalingBonusIntelligence() * 0.2 * spellModWhite() * monster.statusEffectv2(StatusEffects.DeathBlossom);
 			damageDBH = Math.round(damageDBH * poisonDamageBoostedByDao());
 			var damageDBL:Number = 0;
-			if (monster.lustVuln > 0) damageDBL += scalingBonusIntelligence() * 0.015 * spellModWhite() * monster.statusEffectv2(StatusEffects.DeathBlossom);
+			if (monster.lustVuln > 0) damageDBL += scalingBonusIntelligence() * 0.03 * spellModWhite() * monster.statusEffectv2(StatusEffects.DeathBlossom);
 			repeatArcaneVenom(damageDBL, 0, damageDBH);
 			outputText("\n\n");
 		}

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -4454,15 +4454,16 @@ public class Combat extends BaseContent {
         var lustChange:Number;
         doNext(combatMenu);
         clearOutput();
+        var baseLustDmg:Number = teases.teaseBaseLustDamage();
         if (monster is FrostGiant && (player.hasStatusEffect(StatusEffects.GiantBoulder))) {
-            lustChange = 20 + rand(player.lib / 4 + player.cor / 5);
+            lustChange = baseLustDmg + rand(player.lib / 4 + player.cor / 5);
             dynStats("lus", lustChange, "scale", false);
             (monster as FrostGiant).giantBoulderFantasize();
             enemyAI();
             return;
         }
         if (monster is YoungFrostGiant && (player.hasStatusEffect(StatusEffects.GiantBoulder))) {
-            lustChange = 10 + rand(player.lib / 5 + player.cor / 8);
+            lustChange = baseLustDmg / 2 + rand(player.lib / 5 + player.cor / 8);
             dynStats("lus", lustChange, "scale", false);
             (monster as YoungFrostGiant).youngGiantBoulderFantasize();
             enemyAI();
@@ -4472,22 +4473,22 @@ public class Combat extends BaseContent {
             outputText("As you fantasize, you feel Valeria rubbing her gooey body all across your sensitive skin");
             if (player.gender > 0) outputText(" and genitals");
             outputText(", arousing you even further.\n");
-            lustChange = 25 + rand(player.lib / 8 + player.cor / 8)
+            lustChange = baseLustDmg * 1.25 + rand(player.lib / 8 + player.cor / 8)
         } else if (player.hasBalls() && player.ballSize >= 10 && rand(2) == 0) {
             outputText("You daydream about fucking [themonster], feeling your balls swell with seed as you prepare to fuck [monster him] full of cum.\n");
-            lustChange = 5 + rand(player.lib / 8 + player.cor / 8);
+            lustChange = baseLustDmg / 4 + rand(player.lib / 8 + player.cor / 8);
             outputText("You aren't sure if it's just the fantasy, but your [balls] do feel fuller than before...\n");
             player.hoursSinceCum += 50;
         } else if (player.biggestTitSize() >= 6 && rand(2) == 0) {
             outputText("You fantasize about grabbing [themonster] and shoving [monster him] in between your jiggling mammaries, nearly suffocating [monster him] as you have your way.\n");
-            lustChange = 5 + rand(player.lib / 8 + player.cor / 8)
+            lustChange = baseLustDmg  / 4 + rand(player.lib / 8 + player.cor / 8)
         } else if (player.biggestLactation() >= 6 && rand(2) == 0) {
             outputText("You fantasize about grabbing [themonster] and forcing [monster him] against a " + nippleDescript(0) + ", and feeling your milk let down.  The desire to forcefeed SOMETHING makes your nipples hard and moist with milk.\n");
-            lustChange = 5 + rand(player.lib / 8 + player.cor / 8)
+            lustChange = baseLustDmg / 4 + rand(player.lib / 8 + player.cor / 8)
         } else {
             clearOutput();
             outputText("You fill your mind with perverted thoughts about [themonster], picturing [monster him] in all kinds of perverse situations with you.\n");
-            lustChange = 10 + rand(player.lib / 5 + player.cor / 8);
+            lustChange = baseLustDmg / 2 + rand(player.lib / 5 + player.cor / 8);
         }
         if (lustChange >= 20) outputText("The fantasy is so vivid and pleasurable you wish it was happening now.  You wonder if [themonster] can tell what you were thinking.\n\n");
         else outputText("\n");
@@ -9452,17 +9453,17 @@ public class Combat extends BaseContent {
         }
         //Arousing Aura
         if (player.hasPerk(PerkLib.ArousingAura) && monster.lustVuln > 0 && player.cor >= 70 && !flags[kFLAGS.DISABLE_AURAS]) {
-            if (monster.lust < (monster.maxLust() * 0.5)) outputText("Your aura seeps into [themonster] but does not have any visible effects just yet.\n\n");
+            if (monster.lust < (monster.maxLust() * 0.5)) outputText("Your aura seeps into [themonster] but does not have any visible effects just yet. ");
             else if (monster.lust < (monster.maxLust() * 0.6)) {
-                if (!monster.plural) outputText("[Themonster] starts to squirm a little from your unholy presence.\n\n");
-                else outputText("[Themonster] start to squirm a little from your unholy presence.\n\n");
-            } else if (monster.lust < (monster.maxLust() * 0.75)) outputText("Your arousing aura seems to be visibly affecting [themonster], making [monster him] squirm uncomfortably.\n\n");
+                if (!monster.plural) outputText("[Themonster] starts to squirm a little from your unholy presence. ");
+                else outputText("[Themonster] start to squirm a little from your unholy presence. ");
+            } else if (monster.lust < (monster.maxLust() * 0.75)) outputText("Your arousing aura seems to be visibly affecting [themonster], making [monster him] squirm uncomfortably. ");
             else if (monster.lust < (monster.maxLust() * 0.85)) {
-                if (!monster.plural) outputText("[Themonster]'s skin colors red as [monster he] inadvertently basks in your presence.\n\n");
-                else outputText("[Themonster]' skin colors red as [monster he] inadvertently bask in your presence.\n\n");
+                if (!monster.plural) outputText("[Themonster]'s skin colors red as [monster he] inadvertently basks in your presence. ");
+                else outputText("[Themonster]' skin colors red as [monster he] inadvertently bask in your presence. ");
             } else {
-                if (!monster.plural) outputText("The effects of your aura are quite pronounced on [themonster] as [monster he] begins to shake and steal glances at your body.\n\n");
-                else outputText("The effects of your aura are quite pronounced on [themonster] as [monster he] begin to shake and steal glances at your body.\n\n");
+                if (!monster.plural) outputText("The effects of your aura are quite pronounced on [themonster] as [monster he] begins to shake and steal glances at your body. ");
+                else outputText("The effects of your aura are quite pronounced on [themonster] as [monster he] begin to shake and steal glances at your body. ");
             }
 
             var lustAADmg:Number = (scalingBonusLibido() * 0.5);
@@ -9470,7 +9471,8 @@ public class Combat extends BaseContent {
             lustAADmg *= monster.lustVuln;
             lustAADmg = combat.fixPercentLust(lustAADmg);
             monster.teased(Math.round(lustAADmg), false);
-            bonusExpAfterSuccesfullTease();
+            outputText("\n\n");
+            if (player.hasPerk(PerkLib.EromancyMaster)) teaseXP(1 + bonusExpAfterSuccesfullTease());
         }
         //Alraune Nectar
         if (player.hasPerk(PerkLib.AlrauneNectar) && monster.lustVuln > 0 && !flags[kFLAGS.DISABLE_AURAS]) {
@@ -9494,7 +9496,7 @@ public class Combat extends BaseContent {
             lustANDmg = combat.fixPercentLust(lustANDmg);
             monster.teased(Math.round(lustANDmg), false);
             outputText("\n\n");
-            bonusExpAfterSuccesfullTease();
+            if (player.hasPerk(PerkLib.EromancyMaster)) teaseXP(1 + bonusExpAfterSuccesfullTease());
         }
         //Perfume
         if (player.hasStatusEffect(StatusEffects.ArousalPotion) && monster.lustVuln > 0) {
@@ -9516,13 +9518,13 @@ public class Combat extends BaseContent {
             power *= monster.lustVuln;
             monster.teased(Math.round(power), false);
             outputText("\n\n");
-            bonusExpAfterSuccesfullTease();
+            if (player.hasPerk(PerkLib.EromancyMaster)) teaseXP(1 + bonusExpAfterSuccesfullTease());
         }
         //Unicorn and Bicorn aura
         //Unicorn
         if ((player.hasPerk(PerkLib.AuraOfPurity)|| Forgefather.purePearlEaten) && !flags[kFLAGS.DISABLE_AURAS]) {
             if (monster.cor > 20) {
-                var damage:Number = (scalingBonusIntelligence() * 1);
+                var damage:Number = scalingBonusIntelligence();
                 //Determine if critical hit!
                 var crit:Boolean = false;
                 var critChance:int = 5;
@@ -9577,10 +9579,23 @@ public class Combat extends BaseContent {
             lustDmg = combat.fixPercentLust(lustDmg);
             monster.teased(Math.round(lustDmg), false);
             outputText("\n\n");
-            bonusExpAfterSuccesfullTease();
+            if (player.hasPerk(PerkLib.EromancyMaster)) teaseXP(1 + bonusExpAfterSuccesfullTease());
         }
         //Alraune Pollen
         if (player.hasStatusEffect(StatusEffects.AlraunePollen) && monster.lustVuln > 0) {
+            if (monster.lust < (monster.maxLust() * 0.5)) outputText("[Themonster] breathes in your pollen but does not have any visible effects yet. ");
+            else if (monster.lust < (monster.maxLust() * 0.6)) {
+                if (!monster.plural) outputText("[Themonster] start to squirm a little. Your pollen's starting to get to them. ");
+                else outputText("[Themonster] starts to squirm a little from your pollen. ");
+            } else if (monster.lust < (monster.maxLust() * 0.75)) outputText("Your pollen seems to be visibly affecting [themonster], making [monster him] squirm uncomfortably. ");
+            else if (monster.lust < (monster.maxLust() * 0.85)) {
+                if (!monster.plural) outputText("[Themonster]'s skin flushes red, blood in their cheeks as [monster he] inadvertently breathes in your pollen. ");
+                else outputText("[Themonster]' skin blushes red as [monster he] inadvertently breathes in your pollen. ");
+            } else {
+                if (!monster.plural) outputText("The effects of your pollen are quite pronounced on [themonster] as [monster he] begin to shake, occasionally stealing glances at your body. ");
+                else outputText("The effects of your pollen are quite pronounced on [themonster] as [monster he] begin to shake, stealing glances at your body. ");
+            }
+            
             var lustDmgA:Number = (scalingBonusLibido() * 0.5);
             lustDmgA = teases.teaseAuraLustDamageBonus(monster, lustDmgA);
             if (player.hasPerk(PerkLib.RacialParagon)) lustDmgA *= RacialParagonAbilityBoost();
@@ -9594,24 +9609,11 @@ public class Combat extends BaseContent {
                 lustDmgA *= 1.3;
             }
 
-            if (monster.lust < (monster.maxLust() * 0.5)) outputText("[Themonster] breathes in your pollen but does not have any visible effects yet. ");
-            else if (monster.lust < (monster.maxLust() * 0.6)) {
-                if (!monster.plural) outputText("[Themonster] start to squirm a little. Your pollen's starting to get to them. ");
-                else outputText("[Themonster] starts to squirm a little from your pollen. ");
-            } else if (monster.lust < (monster.maxLust() * 0.75)) outputText("Your pollen seems to be visibly affecting [themonster], making [monster him] squirm uncomfortably. ");
-            else if (monster.lust < (monster.maxLust() * 0.85)) {
-                if (!monster.plural) outputText("[Themonster]'s skin flushes red, blood in their cheeks as [monster he] inadvertently breathes in your pollen. ");
-                else outputText("[Themonster]' skin blushes red as [monster he] inadvertently breathes in your pollen. ");
-            } else {
-                if (!monster.plural) outputText("The effects of your pollen are quite pronounced on [themonster] as [monster he] begin to shake, occasionally stealing glances at your body. ");
-                else outputText("The effects of your pollen are quite pronounced on [themonster] as [monster he] begin to shake, stealing glances at your body. ");
-            }
-
             lustDmgA *= monster.lustVuln;
             lustDmgA = combat.fixPercentLust(lustDmgA);
             monster.teased(Math.round(lustDmgA), false);
             outputText("\n\n");
-            bonusExpAfterSuccesfullTease();
+            if (player.hasPerk(PerkLib.EromancyMaster)) teaseXP(1 + bonusExpAfterSuccesfullTease());
         }
         //Lust storm
         if (player.hasStatusEffect(StatusEffects.lustStorm)) {
@@ -9632,29 +9634,12 @@ public class Combat extends BaseContent {
             damage0 = Math.round(damage0);
             dynStats("lus", (Math.round(player.maxLust() * 0.02)), "scale", false);
             
-            var lustDmgF:Number = 20 + rand(6);
-            var lustBoostToLustDmg:Number = 0;
-            lustDmgF += scalingBonusLibido() * 0.1;
-            switch (player.coatType()) {
-                case Skin.FUR:
-                    lustDmgF += (1 + player.newGamePlusMod());
-                    break;
-                case Skin.SCALES:
-                    lustDmgF += (2 * (1 + player.newGamePlusMod()));
-                    break;
-                case Skin.CHITIN:
-                    lustDmgF += (3 * (1 + player.newGamePlusMod()));
-                    break;
-                case Skin.BARK:
-                    lustDmgF += (4 * (1 + player.newGamePlusMod()));
-                    break;
-            }
+            var lustDmgF:Number = (scalingBonusLibido() * 0.1 + scalingBonusIntelligence() * 0.1);
+            var lustBoostToLustDmg:Number = lustDmgF * 0.01;
             
             lustDmgF = teases.teaseAuraLustDamageBonus(monster, lustDmgF);
             if (player.hasPerk(PerkLib.RacialParagon)) lustDmgF *= RacialParagonAbilityBoost();
             
-            lustBoostToLustDmg += lustDmgF * 0.01;
-            lustDmgF *= 0.2;
             if (player.lust100 * 0.01 >= 0.9) lustDmgF += (lustBoostToLustDmg * 140);
             else if (player.lust100 * 0.01 < 0.2) lustDmgF += (lustBoostToLustDmg * 140);
             else lustDmgF += (lustBoostToLustDmg * 2 * (20 - (player.lust100 * 0.01)));
@@ -9670,8 +9655,6 @@ public class Combat extends BaseContent {
             }
 
             lustDmgF = lustDmgF * monster.lustVuln;
-            lustDmgF = lustDmgF/2;
-
             lustDmgF = Math.round(lustDmgF);
             outputText("Your opponent is struck by lightning as your lust storm rages on.")
             damage0 = doLightningDamage(damage0, true, true);
@@ -9680,8 +9663,7 @@ public class Combat extends BaseContent {
             if (crit2) outputText(" <b>Critical!</b>");
             outputText(" as a bolt falls from the sky!\n\n");
 
-            combat.bonusExpAfterSuccesfullTease();
-            if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
+            if (player.hasPerk(PerkLib.EromancyMaster)) teaseXP(1 + bonusExpAfterSuccesfullTease());
             if (player.perkv1(IMutationsLib.HeartOfTheStormIM) >= 3){
                 if (rand(100) < 10) {
                     if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.Stunned,2,0,0,0);
@@ -9722,7 +9704,7 @@ public class Combat extends BaseContent {
             monster.teased(LustDamage, false);
             if (randomcrit) outputText(" Critical hit!");
             outputText("\n\n");
-            bonusExpAfterSuccesfullTease();
+            if (player.hasPerk(PerkLib.EromancyMaster)) teaseXP(1 + bonusExpAfterSuccesfullTease());
         }
         //Black Frost Aura
         if (player.hasPerk(PerkLib.IceQueenGown) && player.isRaceCached(Races.YUKIONNA) && !flags[kFLAGS.DISABLE_AURAS]) {
@@ -12122,6 +12104,15 @@ public class Combat extends BaseContent {
 		var teaseEXPgogo:Number = XP;
         if (player.armor == armors.SCANSC) teaseEXPgogo += 1;
 		if (player.hasMutation(IMutationsLib.HumanVersatilityIM) && player.racialScore(Races.HUMAN) > 17) teaseEXPgogo += player.perkv1(IMutationsLib.HumanVersatilityIM);
+        if (monster is TrainingDummy && flags[kFLAGS.CAMP_UPGRADES_SPARING_RING] > 1) {
+            var bMXPMulti:Number = 1;
+            if (flags[kFLAGS.CAMP_UPGRADES_SPARING_RING] > 2) bMXPMulti += 1.5;
+            if (flags[kFLAGS.CAMP_UPGRADES_SPARING_RING] > 3) bMXPMulti += 2;
+            if (flags[kFLAGS.CAMP_UPGRADES_SPARING_RING] > 4) bMXPMulti += 2.5;
+            if (flags[kFLAGS.CAMP_UPGRADES_SPARING_RING] > 5) bMXPMulti += 3;
+            if (flags[kFLAGS.CAMP_UPGRADES_SPARING_RING] > 6) bMXPMulti += 5;
+			teaseEXPgogo *= bMXPMulti;
+        }
         player.SexXP(teaseEXPgogo);
     }
 

--- a/classes/classes/Scenes/Combat/CombatAbilities.as
+++ b/classes/classes/Scenes/Combat/CombatAbilities.as
@@ -230,12 +230,14 @@ public class CombatAbilities {
 	];
 	
 	public static const PlantGrowth:PlantGrowthSpell     = new PlantGrowthSpell();
+	public static const PlantBloom:PlantBloomSpell     	 = new PlantBloomSpell();
 	public static const Entangle:EntangleSpell           = new EntangleSpell();
 	public static const Briarthorn:BriarthornSpell       = new BriarthornSpell();
 	public static const DeathBlossom:DeathBlossomSpell   = new DeathBlossomSpell();
 
 	public static const ALL_GREEN_SPELLS:/*CombatAbility*/Array = [
 		PlantGrowth,
+		PlantBloom,
 		Entangle,
 		Briarthorn,
 		DeathBlossom

--- a/classes/classes/Scenes/Combat/CombatMagic.as
+++ b/classes/classes/Scenes/Combat/CombatMagic.as
@@ -829,6 +829,7 @@ public class CombatMagic extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.ControlFreak)) damagemultiplier += (2 - player.statusEffectv1(StatusEffects.ControlFreak));
 			damage *= damagemultiplier;
 			if (player.hasPerk(PerkLib.Sadomasochism)) damage *= player.sadomasochismBoost();
+			damage = combat.teases.fueledByDesireDamageBonus(damage);
 			
 			//Determine if critical tease!
 			var crit:Boolean = false;
@@ -840,15 +841,11 @@ public class CombatMagic extends BaseCombatContent {
 			}
 			if (monster.hasStatusEffect(StatusEffects.HypnosisNaga)) damage *= 0.5;
 			if (player.hasPerk(PerkLib.RacialParagon)) damage *= combat.RacialParagonAbilityBoost();
-			if (player.hasPerk(PerkLib.FueledByDesire) && player.lust100 >= 50 && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0) {
-				outputText("\nYou use your own lust against the enemy, cooling off a bit in the process.");
-				player.takeLustDamage(Math.round(-damage)/40, true);
-				damage *= 1.2;
-			}
 			monster.teased(Math.round(monster.lustVuln * damage));
-			if (crit) outputText(" <b>Critical!</b>");
+			if (crit && display) outputText(" <b>Critical!</b>");
 			SceneLib.combat.teaseXP(1 + SceneLib.combat.bonusExpAfterSuccesfullTease());
 			outputText("\n\n");
+			combat.teases.fueledByDesireHeal(display);
 		}
 	}
 

--- a/classes/classes/Scenes/Combat/CombatMagic.as
+++ b/classes/classes/Scenes/Combat/CombatMagic.as
@@ -819,7 +819,7 @@ public class CombatMagic extends BaseCombatContent {
 					outputText("[Themonster], stunned by the sudden change in your bearing and…manhood, gives you more than enough time to finish your spell. ");
 				}
 				if (player.perkv1(PerkLib.ImpNobility) > 0) {
-					outputText("  Your imp cohorts assist you spellcasting adding their diagrams to your own.");
+					outputText("  Your imp cohorts assist your spellcasting, adding their diagrams to your own.");
 				}
 			}
 			var damage:Number = 0;

--- a/classes/classes/Scenes/Combat/CombatTeases.as
+++ b/classes/classes/Scenes/Combat/CombatTeases.as
@@ -59,11 +59,6 @@ public class CombatTeases extends BaseCombatContent {
 
 		if (player.hasPerk(PerkLib.ChiReflowLust)) tBLD *= UmasShop.NEEDLEWORK_LUST_TEASE_DAMAGE_MULTI;
 		if (player.hasPerk(PerkLib.ArouseTheAudience) && (monster.hasPerk(PerkLib.EnemyGroupType) || monster.hasPerk(PerkLib.EnemyLargeGroupType))) tBLD *= 1.5;
-		if (player.hasPerk(PerkLib.FueledByDesire) && player.lust100 >= 50 && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0) {
-			outputText("\nYou use your own lust against the enemy, cooling off a bit in the process.");
-			player.takeLustDamage(Math.round(-tBLD)/40, true);
-			tBLD *= 1.2;
-		}
 		if (player.perkv1(PerkLib.ImpNobility) > 0) {
 			tBLD *= (100 + player.perkv1(PerkLib.ImpNobility))/100;
 		}
@@ -72,6 +67,23 @@ public class CombatTeases extends BaseCombatContent {
 		}
 		if (SceneLib.urtaQuest.isUrta()) tBLD *= 2;
 		return tBLD;
+	}
+
+	public function fueledByDesireDamageBonus(damage:Number): Number {
+		if (player.hasPerk(PerkLib.FueledByDesire) && player.lust100 >= 50 && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0) {
+			damage *= 1.2;
+		}
+		return damage;
+	}
+
+	public function fueledByDesireHeal(display:Boolean = true):Boolean {
+		if (player.hasPerk(PerkLib.FueledByDesire) && player.lust100 >= 50 && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0) {
+			if (display) outputText("\nYou use your own lust against the enemy, cooling off a bit in the process.");
+			player.takeLustDamage(-Math.round(player.maxLust() * 0.1), display, false);
+			if (display) outputText("\n");
+			return true;
+		}
+		return false;
 	}
 
 	public function masteryBonusDamageTease():Number {

--- a/classes/classes/Scenes/Combat/General/TeaseSkill.as
+++ b/classes/classes/Scenes/Combat/General/TeaseSkill.as
@@ -72,6 +72,7 @@ public class TeaseSkill extends AbstractGeneral {
 	public function calcLustDamage(monster:Monster):Number {
 		var lustDmg:Number = combat.teases.teaseBaseLustDamage();
         if (player.hasPerk(PerkLib.BroadSelection) && player.differentTypesOfCocks() > 1) lustDmg *= (1 + (0.25 * player.differentTypesOfCocks()));
+		lustDmg = combat.teases.fueledByDesireDamageBonus(lustDmg);
 		if (SceneLib.urtaQuest.isUrta()) lustDmg *= 2;
 		if (monster) lustDmg *= monster.lustVuln;
 
@@ -138,6 +139,7 @@ public class TeaseSkill extends AbstractGeneral {
 			if (monster.handleTease(lustDmg, true, display)) {
 				monster.teased(lustDmg, false, display);
 				if (crit && display) outputText(" <b>Critical!</b>");
+				combat.teases.fueledByDesireHeal(display);
 			}
 
             if (flags[kFLAGS.PC_FETISH] >= 1 && !SceneLib.urtaQuest.isUrta()) {

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -4876,11 +4876,6 @@ public class MagicSpecials extends BaseCombatContent {
 		lustDmgF = lustDmgF * monster.lustVuln;
 		if (player.hasPerk(PerkLib.RacialParagon)) lustDmgF *= combat.RacialParagonAbilityBoost();
 		if (player.hasPerk(PerkLib.NaturalArsenal)) lustDmgF *= 1.50;
-		if (player.hasPerk(PerkLib.FueledByDesire) && player.lust100 >= 50 && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0) {
-			outputText("\nYou use your own lust against the enemy, cooling off a bit in the process.");
-			player.takeLustDamage(Math.round(-lustDmgF)/40, true);
-			lustDmgF *= 1.2;
-		}
 		lustDmgF = Math.round(monster.lustVuln * lustDmgF);
 		monster.teased(lustDmgF);
 		if (critL) outputText(" <b>Critical!</b>");
@@ -5258,11 +5253,6 @@ public class MagicSpecials extends BaseCombatContent {
 			enemyAI();
 			return;
 		}
-		if (player.hasPerk(PerkLib.FueledByDesire) && player.lust100 >= 50 && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0) {
-			outputText("\nYou use your own lust against the enemy, cooling off a bit in the process.");
-			player.takeLustDamage(Math.round(-lustDmg)/40, true);
-			lustDmg *= 1.2;
-		}
 		if(monster.lust < (monster.maxLust() * 0.3)) outputText("[Themonster] squirms as the magic affects [monster him].  ");
 		if(monster.lust >= (monster.maxLust() * 0.3) && monster.lust < (monster.maxLust() * 0.6)) {
 			if(monster.plural) outputText("[Themonster] stagger, suddenly weak and having trouble focusing on staying upright.  ");
@@ -5327,11 +5317,6 @@ public class MagicSpecials extends BaseCombatContent {
 		if(player.armorName == "Scandalous Succubus Clothing") lustDmg *= 1.25;
 		if (player.armor == armors.ELFDRES && player.isElf()) lustDmg *= 2;
 		if (player.armor == armors.FMDRESS && player.isWoodElf()) lustDmg *= 2;
-		if (player.hasPerk(PerkLib.FueledByDesire) && player.lust100 >= 50 && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0) {
-			outputText("\nYou use your own lust against the enemy, cooling off a bit in the process.");
-			player.takeLustDamage(Math.round(-lustDmg)/40, true);
-			lustDmg *= 1.2;
-		}
 		if (player.perkv1(IMutationsLib.BlackHeartIM) >= 4) lustDmg += combat.teases.teaseBaseLustDamage();
 		monster.teased(Math.round(monster.lustVuln * lustDmg));
 		outputText("\n\n");
@@ -5460,11 +5445,6 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.isRaceCached(Races.POLTERGEIST,3)) {
 				damage += Math.round(player.lust * 0.1);
 				player.lust -= Math.round(player.lust * 0.1);
-			}
-			if (player.hasPerk(PerkLib.FueledByDesire) && player.lust100 >= 50 && flags[kFLAGS.COMBAT_TEASE_HEALING] == 0) {
-				outputText("\nYou use your own lust against the enemy, cooling off a bit in the process.");
-				player.takeLustDamage(Math.round(-damage)/40, true);
-				damage *= 1.2;
 			}
 			monster.teased(Math.round(monster.lustVuln * damage));
 			outputText("\n\n");

--- a/classes/classes/Scenes/Combat/SpellsBlack/ArouseSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsBlack/ArouseSpell.as
@@ -21,18 +21,18 @@ public class ArouseSpell extends AbstractBlackSpell {
 	}
 	
 	override public function describeEffectVs(target:Monster):String {
-		return "~" + calcDamage(target, false, false) + " lust damage"
+		return "~" + numberFormat(calcDamage(target, false, false)) + " lust damage"
 	}
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
-		return adjustLustDamage(scalingBonusIntelligence() / 3, monster, CAT_SPELL_BLACK, randomize);
+		return adjustLustDamage((scalingBonusIntelligence() * 0.75 + scalingBonusLibido() * 0.75), monster, CAT_SPELL_BLACK, randomize);
 	}
 	
 	override protected function doSpellEffect(display:Boolean = true):void {
 		if (display) {
 			outputText("You make a series of arcane gestures, drawing on your own lust to inflict it upon your foe!\n");
 			if (player.perkv1(PerkLib.ImpNobility) > 0) {
-				outputText("  Your imp cohorts assist you spellcasting adding their diagrams to your own.\n");
+				outputText("  Your imp cohorts assist your spellcasting, adding their diagrams to your own.\n");
 			}
 		}
 		if (monster is WormMass) {
@@ -70,37 +70,23 @@ public class ArouseSpell extends AbstractBlackSpell {
 			}
 			if (monster.vaginas.length > 0 && monster.lust100 >= 60) {
 				if (monster.plural) {
-					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_NORMAL) outputText("[Themonster]'s [monster vagina]s dampen perceptibly.  ");
-					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_WET) outputText("[Themonster]'s crotches become sticky with girl-lust.  ");
-					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLICK) outputText("[Themonster]'s [monster vagina]s become sloppy and wet.  ");
-					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_DROOLING) outputText("Thick runners of girl-lube stream down the insides of [themonster]'s thighs.  ");
-					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLAVERING) outputText("[Themonster]'s [monster vagina]s instantly soak [monster him] groin.  ");
+					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_NORMAL) outputText("[Themonster]'s [monster vagina]s dampen perceptibly.");
+					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_WET) outputText("[Themonster]'s crotches become sticky with girl-lust.");
+					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLICK) outputText("[Themonster]'s [monster vagina]s become sloppy and wet.");
+					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_DROOLING) outputText("Thick runners of girl-lube stream down the insides of [themonster]'s thighs.");
+					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLAVERING) outputText("[Themonster]'s [monster vagina]s instantly soak [monster him] groin.");
 				} else {
-					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_NORMAL) outputText("[Themonster]'s [monster vagina] dampens perceptibly.  ");
-					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_WET) outputText("[Themonster]'s crotch becomes sticky with girl-lust.  ");
-					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLICK) outputText("[Themonster]'s [monster vagina] becomes sloppy and wet.  ");
-					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_DROOLING) outputText("Thick runners of girl-lube stream down the insides of [themonster]'s thighs.  ");
-					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLAVERING) outputText("[Themonster]'s [monster vagina] instantly soaks her groin.  ");
+					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_NORMAL) outputText("[Themonster]'s [monster vagina] dampens perceptibly.");
+					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_WET) outputText("[Themonster]'s crotch becomes sticky with girl-lust.");
+					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLICK) outputText("[Themonster]'s [monster vagina] becomes sloppy and wet.");
+					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_DROOLING) outputText("Thick runners of girl-lube stream down the insides of [themonster]'s thighs.");
+					if (monster.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLAVERING) outputText("[Themonster]'s [monster vagina] instantly soaks her groin.");
 				}
 			}
 		}
 		
-		//Determine if critical tease!
-		var crit:Boolean   = false;
-		var critChance:int = 5;
-		critChance += combat.teases.combatTeaseCritical();
-		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-		if (rand(100) < critChance) {
-			crit = true;
-			lustDmg *= 1.75;
-		}
-		monster.teased(lustDmg, false, display);
-		if (crit && display) outputText(" <b>Critical!</b>");
-		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-		if (player.hasPerk(PerkLib.VerdantLeech)) {
-			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;
-			HPChange(Math.round(player.maxHP() * 0.05), false);
-		}
+		var resultArray:Array = critAndRepeatLust(display, lustDmg, CAT_SPELL_BLACK);
+		postLustSpellEffect(resultArray[1]);
 	}
 }
 }

--- a/classes/classes/Scenes/Combat/SpellsBlack/WaveOfEcstasySpell.as
+++ b/classes/classes/Scenes/Combat/SpellsBlack/WaveOfEcstasySpell.as
@@ -26,29 +26,27 @@ public class WaveOfEcstasySpell extends AbstractBlackSpell {
 	}
 	
 	override public function calcCooldown():int {
-		var calcC:int = 3;
-		calcC += spellGenericCooldown();
-		return calcC;
+		return spellBlackCooldown();
 	}
 	
 	override public function describeEffectVs(target:Monster):String {
-		return "~" + calcDamage(target, false), false + " lust damage"
+		return "~" + numberFormat(calcDamage(target, false, false)) + " lust damage"
 	}
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
 		return adjustLustDamage(
-				scalingBonusIntelligence(),
+				(scalingBonusIntelligence() + scalingBonusLibido()),
 				monster,
 				CAT_SPELL_BLACK,
 				randomize
-		) * 0.5;
+		);
 	}
 	
 	override protected function doSpellEffect(display:Boolean = true):void {
 		if (display) {
 			outputText("You almost moan in pleasure as you draw on this spell, sending forth your lust like a shockwave. ");
 			if (player.perkv1(PerkLib.ImpNobility) > 0) {
-				outputText("Your imp cohorts assist you spellcasting adding their diagrams to your own.  ");
+				outputText("Your imp cohorts assist your spellcasting, adding their diagrams to your own.  ");
 			}
 		}
 		if (monster is WormMass) {
@@ -79,29 +77,11 @@ public class WaveOfEcstasySpell extends AbstractBlackSpell {
 			} else {
 				outputText("Unable to evade it [themonster] is struck squarely by the pleasure wave");
 			}
-			outputText(" for ");
 		}
 		
-		//Determine if critical tease!
-		var crit:Boolean   = false;
-		var critChance:int = 5;
-		critChance += combat.teases.combatTeaseCritical();
-		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-		if (rand(100) < critChance) {
-			crit = true;
-			lustDmg *= 1.75;
-		}
-		monster.teased(lustDmg, false, display);
-		if (display) {
-			outputText(" damage.");
-		}
-		if (crit && display) outputText(" <b>Critical!</b>");
+		var resultArray:Array = critAndRepeatLust(display, lustDmg, CAT_SPELL_BLACK);
 		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
-		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-		if (player.hasPerk(PerkLib.VerdantLeech)) {
-			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;
-			HPChange(Math.round(player.maxHP() * 0.05), false);
-		}
+		postLustSpellEffect(resultArray[1]);
 	}
 }
 }

--- a/classes/classes/Scenes/Combat/SpellsDivine/ExorciseSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsDivine/ExorciseSpell.as
@@ -19,7 +19,7 @@ public class ExorciseSpell extends AbstractDivineSpell {
 	}
 	
 	override public function describeEffectVs(target:Monster):String {
-		return "~"+calcDamage(target, false, false)+" magical damage";
+		return "~"+numberFormat(calcDamage(target, false, false))+" magical damage";
 	}
 	
 	override public function get isKnown():Boolean {

--- a/classes/classes/Scenes/Combat/SpellsDivine/ThunderstormSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsDivine/ThunderstormSpell.as
@@ -22,7 +22,7 @@ public class ThunderstormSpell extends AbstractDivineSpell {
 	}
 	
 	override public function describeEffectVs(target:Monster):String {
-		return "~"+calcDamage(target, false, false)+" lightning damage for "+numberOfThings(calcDuration(),"round");
+		return "~"+numberFormat(calcDamage(target, false, false))+" lightning damage for "+numberOfThings(calcDuration(),"round");
 	}
 	
 	override public function isActive():Boolean {

--- a/classes/classes/Scenes/Combat/SpellsGreen/BriarthornSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/BriarthornSpell.as
@@ -59,7 +59,7 @@ public class BriarthornSpell extends AbstractGreenSpell {
 	}
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
-		var baseDamage:Number = (3 * scalingBonusIntelligence(randomize));
+		var baseDamage:Number = (6 * scalingBonusIntelligence(randomize));
 		return adjustLustDamage(baseDamage, monster, CAT_SPELL_GREEN, randomize);
 	}
 	

--- a/classes/classes/Scenes/Combat/SpellsGreen/BriarthornSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/BriarthornSpell.as
@@ -59,7 +59,7 @@ public class BriarthornSpell extends AbstractGreenSpell {
 	}
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
-		var baseDamage:Number = (6 * scalingBonusIntelligence(randomize));
+		var baseDamage:Number = ((scalingBonusIntelligence() + scalingBonusLibido()));
 		return adjustLustDamage(baseDamage, monster, CAT_SPELL_GREEN, randomize);
 	}
 	
@@ -70,30 +70,13 @@ public class BriarthornSpell extends AbstractGreenSpell {
 			return;
 		}
 		monster.createStatusEffect(StatusEffects.Briarthorn, calcDuration(), 0, 0, 0);
-		var arve:Number = 1;
-		if (player.hasPerk(PerkLib.ArcaneVenom)) arve += stackingArcaneVenom();
-		while (arve-->0) doSpellEffect2(display);
+
+		var lustDmg:Number = calcDamage(monster, true, true);
+		var resultArray:Array = critAndRepeatLust(display, lustDmg, CAT_SPELL_GREEN);
+		postLustSpellEffect(resultArray[1]);
+		
 		if (display) outputText("\n");
 	}
 	
-	private function doSpellEffect2(display:Boolean = true):void {
-		var lustDmg:Number = calcDamage(monster, true, true);
-		//Determine if critical tease!
-		var crit:Boolean   = false;
-		var critChance:int = 5;
-		critChance += combat.teases.combatTeaseCritical();
-		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-		if (rand(100) < critChance) {
-			crit = true;
-			lustDmg *= 1.75;
-		}
-		monster.teased(lustDmg, false, display);
-		if (crit && display) outputText(" <b>Critical!</b>");
-		combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-		if (player.hasPerk(PerkLib.VerdantLeech)) {
-			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;
-			HPChange(Math.round(player.maxHP() * 0.01), false);
-		}
-	}
 }
 }

--- a/classes/classes/Scenes/Combat/SpellsGreen/BriarthornSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/BriarthornSpell.as
@@ -10,8 +10,8 @@ public class BriarthornSpell extends AbstractGreenSpell {
 			"While entangling, vines grows sharp thorns that rend the opponent's flesh and deliver a deadly poison that rend vitality. This spell also Inflict heavy bleed and poison damage.",
 			TARGET_ENEMY,
 			TIMING_INSTANT,
-			[TAG_LUSTDMG]);
-		baseManaCost = 20;
+			[TAG_LUSTDMG, TAG_TIER1]);
+		baseManaCost = 40;
 	}
 	
 	override public function get isKnown():Boolean {
@@ -19,11 +19,17 @@ public class BriarthornSpell extends AbstractGreenSpell {
 	}
 	
 	override public function describeEffectVs(target:Monster):String {
-		return "~" + calcDamage(target, false, false) + " lust poison damage and bleeding DoT"
+		return "~" + numberFormat(calcDamage(target, false, false)) + " lust poison damage and bleeding DoT"
 	}
 	
 	override public function calcCooldown():int {
 		return spellWhiteCooldown();
+	}
+
+	override public function calcDuration():int {
+		var dura:Number = 6;
+		if (player.hasPerk(PerkLib.GreenMagic)) dura *= 2;
+		return dura;
 	}
 	
 	override public function isActive():Boolean {
@@ -35,7 +41,7 @@ public class BriarthornSpell extends AbstractGreenSpell {
 		if (uc) return uc;
 		
 		if (!monster.hasStatusEffect(StatusEffects.Entangled)) {
-			return "Briarthorn require to have enemy/ies entangled by the vines.";
+			return "Briarthorn require to have the enemy entangled by vines.";
 		}
 		
 		return "";
@@ -53,25 +59,21 @@ public class BriarthornSpell extends AbstractGreenSpell {
 	}
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
-		var baseDamage:Number = (combat.teases.teaseBaseLustDamage() * 3);
+		var baseDamage:Number = (3 * scalingBonusIntelligence(randomize));
 		return adjustLustDamage(baseDamage, monster, CAT_SPELL_GREEN, randomize);
 	}
 	
 	override protected function doSpellEffect(display:Boolean = true):void {
-		if (display) {
-			outputText("You concentrate on the vines causing them to grow vicious thorns that tear through your opponent's flesh delivering a noxious poison.");
-			if (monster.lustVuln == 0) {
-				if (display) {
-					outputText("\nIt has no effect!  Your foe clearly does not experience lust in the same way as you.\n");
-				}
-				return;
-			}
-			monster.createStatusEffect(StatusEffects.Briarthorn, 6, 0, 0, 0);
-			var arve:Number = 1;
-			if (player.hasPerk(PerkLib.ArcaneVenom)) arve += stackingArcaneVenom();
-			while (arve-->0) doSpellEffect2(display);
-			outputText("\n");
+		if (display) outputText("You concentrate on the vines causing them to grow vicious thorns that tear through your opponent's flesh delivering a noxious poison.");
+		if (monster.lustVuln == 0) {
+			if (display) outputText("\nIt has no effect!  Your foe clearly does not experience lust in the same way as you.\n");
+			return;
 		}
+		monster.createStatusEffect(StatusEffects.Briarthorn, calcDuration(), 0, 0, 0);
+		var arve:Number = 1;
+		if (player.hasPerk(PerkLib.ArcaneVenom)) arve += stackingArcaneVenom();
+		while (arve-->0) doSpellEffect2(display);
+		if (display) outputText("\n");
 	}
 	
 	private function doSpellEffect2(display:Boolean = true):void {
@@ -90,7 +92,7 @@ public class BriarthornSpell extends AbstractGreenSpell {
 		combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		if (player.hasPerk(PerkLib.VerdantLeech)) {
 			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;
-			HPChange(Math.round(player.maxHP() * 0.05), false);
+			HPChange(Math.round(player.maxHP() * 0.01), false);
 		}
 	}
 }

--- a/classes/classes/Scenes/Combat/SpellsGreen/DeathBlossomSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/DeathBlossomSpell.as
@@ -12,7 +12,7 @@ public class DeathBlossomSpell extends AbstractGreenSpell {
 			"Deliver deadly poison and strong aphrodisiac by causing nearby vegetation to bloom corrupted flowers which inflicts their poison each round for 3 rounds. Deals severe tease and poison damage over time intensifying every round by 20%.",
 			TARGET_ENEMY,
 			TIMING_INSTANT,
-			[TAG_LUSTDMG]);
+			[TAG_LUSTDMG, TAG_TIER2]);
 		baseManaCost = 100;
 		}
 	
@@ -21,7 +21,7 @@ public class DeathBlossomSpell extends AbstractGreenSpell {
 	}
 	
 	override public function describeEffectVs(target:Monster):String {
-		return "~" + calcDamage(target, false, false) + " lust poison damage and poison DoT intensifying every round by 20%"
+		return "~" + numberFormat(calcDamage(target, false, false)) + " lust poison damage and poison DoT intensifying every round by 20%"
 	}
 	
 	override public function calcCooldown():int {
@@ -40,19 +40,17 @@ public class DeathBlossomSpell extends AbstractGreenSpell {
 	}
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
-		var baseDamage:Number = (combat.teases.teaseBaseLustDamage() * 3);
+		var baseDamage:Number = (5 * scalingBonusIntelligence(randomize));
 		return adjustLustDamage(baseDamage, monster, CAT_SPELL_GREEN, randomize);
 	}
 	
 	override protected function doSpellEffect(display:Boolean = true):void {
-		if (display) {
-			outputText("You concentrate your desire on the nearby plants causing their flowers to spontaneously bloom in a cloud of corrupted pollen.\n");
-			monster.createStatusEffect(StatusEffects.DeathBlossom, 5, 1, 0, 0);
-			var arve:Number = 1;
-			if (player.hasPerk(PerkLib.ArcaneVenom)) arve += stackingArcaneVenom();
-			while (arve-->0) doSpellEffect2(display);
-			outputText("\n");
-		}
+		if (display) outputText("You concentrate your desire on the nearby plants causing their flowers to spontaneously bloom in a cloud of corrupted pollen.\n");
+		monster.createStatusEffect(StatusEffects.DeathBlossom, 5, 1, 0, 0);
+		var arve:Number = 1;
+		if (player.hasPerk(PerkLib.ArcaneVenom)) arve += stackingArcaneVenom();
+		while (arve-->0) doSpellEffect2(display);
+		if (display) outputText("\n");
 	}
 	
 	private function doSpellEffect2(display:Boolean = true):void {
@@ -71,7 +69,7 @@ public class DeathBlossomSpell extends AbstractGreenSpell {
 		combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		if (player.hasPerk(PerkLib.VerdantLeech)) {
 			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;
-			HPChange(Math.round(player.maxHP() * 0.05), false);
+			HPChange(Math.round(player.maxHP() * 0.01), false);
 		}
 	}
 }

--- a/classes/classes/Scenes/Combat/SpellsGreen/DeathBlossomSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/DeathBlossomSpell.as
@@ -40,7 +40,7 @@ public class DeathBlossomSpell extends AbstractGreenSpell {
 	}
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
-		var baseDamage:Number = (5 * scalingBonusIntelligence(randomize));
+		var baseDamage:Number = (10 * scalingBonusIntelligence(randomize));
 		return adjustLustDamage(baseDamage, monster, CAT_SPELL_GREEN, randomize);
 	}
 	

--- a/classes/classes/Scenes/Combat/SpellsGreen/EntangleSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/EntangleSpell.as
@@ -10,7 +10,7 @@ public class EntangleSpell extends AbstractGreenSpell {
 			"Entangle your opponent with vines. Does not hinder other elven spellcasting.",
 			TARGET_ENEMY,
 			TIMING_LASTING,
-			[TAG_LUSTDMG]);
+			[TAG_DEBUFF, TAG_TIER2]);
 		baseManaCost = 100;
 	}
 	
@@ -19,12 +19,7 @@ public class EntangleSpell extends AbstractGreenSpell {
 	}
 	
 	override public function describeEffectVs(target:Monster):String {
-		return "~"+calcDamage(target, false, false)+" lust poison damage for "+numberOfThings(calcDuration(),"round");
-	}
-	
-	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
-		var baseDamage:Number = (combat.teases.teaseBaseLustDamage() * 3);
-		return adjustLustDamage(baseDamage, monster, CAT_SPELL_GREEN, randomize);
+		return "Constricts the enemy with vines";
 	}
 	
 	override public function calcCooldown():int {

--- a/classes/classes/Scenes/Combat/SpellsGreen/PlantBloomSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/PlantBloomSpell.as
@@ -39,7 +39,7 @@ public class PlantBloomSpell extends AbstractGreenSpell {
 	}
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
-		var baseDamage:Number = (4 * scalingBonusIntelligence(randomize));
+		var baseDamage:Number = ((scalingBonusIntelligence() + scalingBonusLibido()));
 		return adjustLustDamage(baseDamage, monster, CAT_SPELL_GREEN, randomize);
 	}
 	
@@ -57,32 +57,13 @@ public class PlantBloomSpell extends AbstractGreenSpell {
 				return;
 			}
 			player.createStatusEffect(StatusEffects.PlantGrowth, calcDuration(), 0, 0, 0);
-			var arve:Number = 1;
-			if (player.hasPerk(PerkLib.ArcaneVenom)) arve += stackingArcaneVenom();
-			while (arve-->0) doSpellEffect2(display);
+
+			var lustDmg:Number = calcDamage(monster, true, true);
+			var resultArray:Array = critAndRepeatLust(display, lustDmg, CAT_SPELL_GREEN);
+			postLustSpellEffect(resultArray[1]);
 			if (display) outputText("\n");
 		}
 		
-	}
-	
-	private function doSpellEffect2(display:Boolean = true):void {
-		var lustDmg:Number = calcDamage(monster, true, true);
-		//Determine if critical tease!
-		var crit:Boolean   = false;
-		var critChance:int = 5;
-		critChance += combat.teases.combatTeaseCritical();
-		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-		if (rand(100) < critChance) {
-			crit = true;
-			lustDmg *= 1.75;
-		}
-		monster.teased(lustDmg, false, display);
-		if (crit && display) outputText(" <b>Critical!</b>");
-		combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-		if (player.hasPerk(PerkLib.VerdantLeech)) {
-			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;
-			HPChange(Math.round(player.maxHP() * 0.01), false);
-		}
 	}
 }
 }

--- a/classes/classes/Scenes/Combat/SpellsGreen/PlantBloomSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/PlantBloomSpell.as
@@ -39,7 +39,7 @@ public class PlantBloomSpell extends AbstractGreenSpell {
 	}
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
-		var baseDamage:Number = (2 * scalingBonusIntelligence(randomize));
+		var baseDamage:Number = (4 * scalingBonusIntelligence(randomize));
 		return adjustLustDamage(baseDamage, monster, CAT_SPELL_GREEN, randomize);
 	}
 	

--- a/classes/classes/Scenes/Combat/SpellsGreen/PlantBloomSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/PlantBloomSpell.as
@@ -1,0 +1,88 @@
+package classes.Scenes.Combat.SpellsGreen {
+import classes.Monster;
+import classes.PerkLib;
+import classes.Scenes.Combat.AbstractGreenSpell;
+import classes.StatusEffects;
+import classes.CoC;
+
+public class PlantBloomSpell extends AbstractGreenSpell {
+	public function PlantBloomSpell() {
+		super("Plant Bloom",
+			"Cause nearby plants to turn into invasive vines, inflicting lust damage.",
+			TARGET_ENEMY,
+			TIMING_INSTANT,
+			[TAG_LUSTDMG, TAG_TIER1]);
+		baseManaCost = 40;
+	}
+	
+	override public function get isKnown():Boolean {
+		return player.hasStatusEffect(StatusEffects.KnowsPlantGrowth) && (!CoC.instance.inCombat || combat.isNearPlants());
+	}
+	
+	override public function describeEffectVs(target:Monster):String {
+		return "~" + numberFormat(calcDamage(target, false, false)) + " lust poison damage"
+	}
+	
+	override public function calcCooldown():int {
+		return (1+spellWhiteCooldown());
+	}
+	
+	override public function advance(display:Boolean):void {
+		if (player.hasStatusEffect(StatusEffects.PlantGrowth)) {
+			if (player.statusEffectv1(StatusEffects.PlantGrowth) <= 0) {
+				player.removeStatusEffect(StatusEffects.PlantGrowth);
+				if (display) outputText("<b>Plant Growth effect wore off!</b>\n\n");
+			} else {
+				player.addStatusValue(StatusEffects.PlantGrowth, 1, -1);
+			}
+		}
+	}
+	
+	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
+		var baseDamage:Number = (2 * scalingBonusIntelligence(randomize));
+		return adjustLustDamage(baseDamage, monster, CAT_SPELL_GREEN, randomize);
+	}
+	
+	override public function calcDuration():int {
+		var dura:Number = 4;
+		if (player.hasPerk(PerkLib.GreenMagic)) dura *= 2;
+		return dura;
+	}
+	
+	override protected function doSpellEffect(display:Boolean = true):void {
+		if (combat.isNearPlants()) {
+			if (display) outputText("You focus your intent on the flora around you, infusing them with the power of your emotions. The onslaught of lust causes flowers to bloom into a pollen cloud as vine surges from the canopy and darts to your opponent.");
+			if (monster.lustVuln == 0) {
+				if (display) outputText("\nIt has no effect!  Your foe clearly does not experience lust in the same way as you.\n");
+				return;
+			}
+			player.createStatusEffect(StatusEffects.PlantGrowth, calcDuration(), 0, 0, 0);
+			var arve:Number = 1;
+			if (player.hasPerk(PerkLib.ArcaneVenom)) arve += stackingArcaneVenom();
+			while (arve-->0) doSpellEffect2(display);
+			if (display) outputText("\n");
+		}
+		
+	}
+	
+	private function doSpellEffect2(display:Boolean = true):void {
+		var lustDmg:Number = calcDamage(monster, true, true);
+		//Determine if critical tease!
+		var crit:Boolean   = false;
+		var critChance:int = 5;
+		critChance += combat.teases.combatTeaseCritical();
+		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
+		if (rand(100) < critChance) {
+			crit = true;
+			lustDmg *= 1.75;
+		}
+		monster.teased(lustDmg, false, display);
+		if (crit && display) outputText(" <b>Critical!</b>");
+		combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
+		if (player.hasPerk(PerkLib.VerdantLeech)) {
+			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;
+			HPChange(Math.round(player.maxHP() * 0.01), false);
+		}
+	}
+}
+}

--- a/classes/classes/Scenes/Combat/SpellsGreen/PlantGrowthSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGreen/PlantGrowthSpell.as
@@ -3,92 +3,35 @@ import classes.Monster;
 import classes.PerkLib;
 import classes.Scenes.Combat.AbstractGreenSpell;
 import classes.StatusEffects;
+import classes.CoC;
 
 public class PlantGrowthSpell extends AbstractGreenSpell {
 	public function PlantGrowthSpell() {
-		super("Plant growth",
-			"Grow plants around the caster. If plants are already present, turn them into invasive vines to deal lust damage.",
-			TARGET_ENEMY,
+		super("Plant Growth",
+			"Grow plants around the caster.",
+			TARGET_SELF,
 			TIMING_INSTANT,
-			[TAG_LUSTDMG]);
-		baseManaCost = 20;
+			[TAG_BUFF]);
+		baseManaCost = 50;
 	}
 	
 	override public function get isKnown():Boolean {
-		return player.hasStatusEffect(StatusEffects.KnowsPlantGrowth);
+		return player.hasStatusEffect(StatusEffects.KnowsPlantGrowth) && (!CoC.instance.inCombat || !combat.isNearPlants());
 	}
 	
 	override public function describeEffectVs(target:Monster):String {
-		return "~" + calcDamage(target, false, false) + " lust poison damage"
+		return "Allows the use of Green Magic spells";
 	}
 	
 	override public function calcCooldown():int {
 		return (1+spellWhiteCooldown());
 	}
 	
-	override public function advance(display:Boolean):void {
-		if (player.hasStatusEffect(StatusEffects.PlantGrowth)) {
-			if (player.statusEffectv1(StatusEffects.PlantGrowth) <= 0) {
-				player.removeStatusEffect(StatusEffects.PlantGrowth);
-				if (display) outputText("<b>Plant Growth effect wore off!</b>\n\n");
-			} else {
-				player.addStatusValue(StatusEffects.PlantGrowth, 1, -1);
-			}
-		}
-	}
-	
-	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
-		var baseDamage:Number = (combat.teases.teaseBaseLustDamage() * 1.5);
-		return adjustLustDamage(baseDamage, monster, CAT_SPELL_GREEN, randomize);
-	}
-	
-	override public function calcDuration():int {
-		var dura:Number = 4;
-		if (player.hasPerk(PerkLib.GreenMagic)) dura *= 2;
-		return dura;
-	}
-	
 	override protected function doSpellEffect(display:Boolean = true):void {
-		if (display) {
-			if (combat.isNearPlants()) {
-				outputText("You focus your intent on the flora around you, infusing them with the power of your emotions. The onslaught of lust causes flowers to bloom into a pollen cloud as vine surges from the canopy and darts to your opponent.");
-				if (monster.lustVuln == 0) {
-					if (display) {
-						outputText("\nIt has no effect!  Your foe clearly does not experience lust in the same way as you.\n");
-					}
-					return;
-				}
-				player.createStatusEffect(StatusEffects.PlantGrowth, calcDuration(), 0, 0, 0);
-				var arve:Number = 1;
-				if (player.hasPerk(PerkLib.ArcaneVenom)) arve += stackingArcaneVenom();
-				while (arve-->0) doSpellEffect2(display);
-			outputText("\n");
-			}
-			else {
-				outputText("You focus your energy on the world around you causing vegetation to surge out of the ground at an accelerated rate into a verdant patch of vines and other tentacle greenery.\n");
-				player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
-			}
-		}
-	}
-	
-	private function doSpellEffect2(display:Boolean = true):void {
-		var lustDmg:Number = calcDamage(monster, true, true);
-		//Determine if critical tease!
-		var crit:Boolean   = false;
-		var critChance:int = 5;
-		critChance += combat.teases.combatTeaseCritical();
-		if (monster.isImmuneToCrits() && !player.hasPerk(PerkLib.EnableCriticals)) critChance = 0;
-		if (rand(100) < critChance) {
-			crit = true;
-			lustDmg *= 1.75;
-		}
-		monster.teased(lustDmg, false, display);
-		if (crit && display) outputText(" <b>Critical!</b>");
-		combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-		if (player.hasPerk(PerkLib.VerdantLeech)) {
-			if (monster.lustVuln != 0 && !monster.hasPerk(PerkLib.EnemyTrueAngel)) monster.lustVuln += 0.025;
-			HPChange(Math.round(player.maxHP() * 0.05), false);
-		}
+		if (display) 
+			outputText("You focus your energy on the world around you, causing vegetation to surge out of the ground at an accelerated rate into a verdant patch of vines and other tentacle greenery.\n");
+		player.createStatusEffect(StatusEffects.NearbyPlants, 0, 0, 0, 0);
+			
 	}
 }
 }

--- a/classes/classes/Scenes/Combat/SpellsHex/ConsumingDarknessSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsHex/ConsumingDarknessSpell.as
@@ -25,7 +25,7 @@ public class ConsumingDarknessSpell extends AbstractHexSpell {
 	}
 	
 	override public function describeEffectVs(target:Monster):String {
-		return "" + calcDamage(target, false, false) + " darkness damage over "+
+		return "" + numberFormat(calcDamage(target, false, false)) + " darkness damage over "+
 				numberOfThings(calcDuration(),"round") +
 				"; " + calcBackfirePercent() + "% backfire"
 	}

--- a/classes/classes/Scenes/Combat/SpellsHex/CurseOfDesireSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsHex/CurseOfDesireSpell.as
@@ -12,7 +12,7 @@ public class CurseOfDesireSpell extends AbstractHexSpell {
 			"Arouse yourself and curse the target with lewd thoughts, weakening its resistance to lust and forcing it to take low lust damage each round for 8 rounds.",
 			TARGET_ENEMY,
 			TIMING_LASTING,
-			[TAG_DEBUFF,TAG_LUSTDMG]
+			[TAG_DEBUFF,TAG_LUSTDMG, TAG_TIER3]
 		);
 		baseManaCost = 400;
 		useManaType = Combat.USEMANA_BLACK;
@@ -27,7 +27,7 @@ public class CurseOfDesireSpell extends AbstractHexSpell {
 		var lrr:Number = calcLustResReduction(target);
 		return "" +
 				(lrr > 0 ? Math.round(-lrr * 100) + "% lust vuln., " : "") +
-				calcLustDamage(target, false) + " lust damage over " +
+				numberFormat(calcLustDamage(target, false)) + " lust damage over " +
 				numberOfThings(calcDuration(),"round") +
 				"; +" + calcSelfLustDamage() + " own lust" +
 				"; " + calcBackfirePercent() + "% backfire"
@@ -46,10 +46,7 @@ public class CurseOfDesireSpell extends AbstractHexSpell {
 	}
 	
 	override public function calcCooldown():int {
-		var calcC:int = 12;
-		calcC += spellGenericCooldown();
-		if (player.hasPerk(PerkLib.Necromancy)) calcC -= 1;
-		return calcC;
+		return spellBlackTier3Cooldown();
 	}
 	
 	override public function advance(display:Boolean):void {
@@ -60,19 +57,17 @@ public class CurseOfDesireSpell extends AbstractHexSpell {
 			monster.removeStatusEffect(StatusEffects.CurseOfDesire);
 		} else {
 			monster.addStatusValue(StatusEffects.CurseOfDesire, 1, -1);
-			var lustDmg3:Number = 0;
-			lustDmg3 += monster.statusEffectv2(StatusEffects.CurseOfDesire);
-			lustDmg3 *= 0.2;
+			var lustDmg3:Number = monster.statusEffectv2(StatusEffects.CurseOfDesire);
 			if (player.hasPerk(PerkLib.Necromancy)) lustDmg3 *= 1.5;
 			if (lustDmg3 < 1) lustDmg3 = 1;
 			else lustDmg3 = Math.round(lustDmg3);
 			if (display) {
-				outputText("The curse of desire slowly sap at your victim's resolve and countenance. ");
+				outputText("The curse of desire slowly saps at your victim's resolve and countenance. ");
 				if (player.perkv1(PerkLib.ImpNobility) > 0) {
-					outputText("Your imp cohorts assist you spellcasting adding their diagrams to your own. ");
+					outputText("Your imp cohorts assist your spellcasting, adding their diagrams to your own. ");
 				}
 			}
-			monster.teased(Math.round(monster.lustVuln * lustDmg3), false, display);
+			monster.teased(Math.round(lustDmg3), false, display);
 			if (display) {
 				outputText("\n\n");
 			}
@@ -80,18 +75,16 @@ public class CurseOfDesireSpell extends AbstractHexSpell {
 	}
 	
 	public function calcLustDamage(monster:Monster, randomize:Boolean =true):Number {
-		var lustDmg:Number = adjustLustDamage(
-				player.inte / 5,
-				monster,
-				CAT_SPELL_HEX,
-				randomize
+		return adjustLustDamage(
+			(scalingBonusIntelligence() * 0.75 + scalingBonusLibido() * 0.75), 
+			monster, 
+			CAT_SPELL_HEX, 
+			randomize
 		);
-		if (lustDmg < 1) lustDmg = 1;
-		return lustDmg;
 	}
 	
 	public function calcSelfLustDamage():Number {
-		return 10;
+		return player.maxLust() * 0.01;
 	}
 	
 	public function calcLustResReduction(monster:Monster):Number {
@@ -108,7 +101,7 @@ public class CurseOfDesireSpell extends AbstractHexSpell {
 		if (display) {
 			outputText("You focus on your magic, trying to draw on it without enhancing your own arousal.\n");
 			if (player.perkv1(PerkLib.ImpNobility) > 0) {
-				outputText("  Your imp cohorts assist you spellcasting adding their diagrams to your own.\n");
+				outputText("  Your imp cohorts assist your spellcasting, adding their diagrams to your own.\n");
 			}
 		}
 		if (!backfired(display)) {
@@ -117,12 +110,13 @@ public class CurseOfDesireSpell extends AbstractHexSpell {
 			if (display) {
 				outputText("You moan in pleasure as you curse your target with lewd thoughts. [Themonster] pants in arousal, unable to stop the encroaching fantasies you forced on [monster him] from having their desired effect. ");
 				if (player.perkv1(PerkLib.ImpNobility) > 0) {
-					outputText("Your imp cohorts assist you spellcasting adding their diagrams to your own.");
+					outputText("Your imp cohorts assist your spellcasting, adding their diagrams to your own.");
 				}
 			}
 			var lustDmg:Number = calcLustDamage(monster);
-			monster.createStatusEffect(StatusEffects.CurseOfDesire, calcDuration(), lustDmg, llr, 0);
-			monster.teased(lustDmg, false, display);
+			var resultArray:Array = critAndRepeatLust(display, lustDmg, CAT_SPELL_BLACK);
+			monster.createStatusEffect(StatusEffects.CurseOfDesire, calcDuration(), resultArray[0], llr, 0);
+			postLustSpellEffect(resultArray[1]);
 			dynStats("lus", calcSelfLustDamage());
 		}
 	}

--- a/classes/classes/Scenes/Combat/SpellsHex/CurseOfWeepingSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsHex/CurseOfWeepingSpell.as
@@ -26,7 +26,7 @@ public class CurseOfWeepingSpell extends AbstractHexSpell {
 	
 	override public function describeEffectVs(target:Monster):String {
 		return "" +
-				calcDamage(target, false, false) + " damage over "+
+				numberFormat(calcDamage(target, false, false)) + " damage over "+
 				numberOfThings(calcDuration(),"round") +
 				"; " + calcBackfirePercent() + "% backfire"
 	}

--- a/classes/classes/Scenes/Combat/SpellsHex/LifeSiphonSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsHex/LifeSiphonSpell.as
@@ -20,7 +20,7 @@ public class LifeSiphonSpell extends AbstractHexSpell {
 	}
 	
 	override public function describeEffectVs(target:Monster):String {
-		return "" + calcDamage(target, false, false) + " HP leech for "+
+		return "" + numberFormat(calcDamage(target, false, false)) + " HP leech for "+
 				numberOfThings(calcDuration(),"round") +
 				"; " + calcBackfirePercent() + "% backfire"
 	}

--- a/classes/classes/Scenes/Combat/SpellsHex/LifetapSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsHex/LifetapSpell.as
@@ -20,7 +20,7 @@ public class LifetapSpell extends AbstractHexSpell {
 	}
 	
 	override public function describeEffectVs(target:Monster):String {
-		return "" + hpCost() + " HP to mana; " + calcBackfirePercent() + "% backfire"
+		return "" + numberFormat(hpCost()) + " HP to mana; " + calcBackfirePercent() + "% backfire"
 	}
 	
 	override public function get isKnown():Boolean {


### PR DESCRIPTION
player.takeLustDamage now uses the display parameter is to determine if the damage number should be shown

Elf Villager dress cooldown effect only works if the player is an elf, and is changed to be a 1% percentage reduction instead of lustDmg/20 (since it is triggered for every single lust tick, making elves near immune to lust) 
Fixed bug where "Fueled By Desire" triggered outside of actual tease actions of lust spells being used 
Reduced lust heal from "Fueled By Desire" from lustDmg/40 to 10% (to prevent Elves from being near-immune to lust loss) Reduced HP heal from Verdent Leech for Green Magic from 5% to 1% (since they have Arcane Venom to trigger the effect multiple times per turn, making Green Magic better at healing that White Heals) 
Split "Plant Growth" spell into "Plant Growth" and "Plant Bloom" to make it more explicit when the spell will deal lust damage, and when it will set up plants 
Briarthorn's DoT Duration is now affected by the "Green Magic" perk 
Green Magic now has the proper Tier Tags applied to them 
Green Magic now properly scales from Intelligence rather than Tease damage, to prevent duplicate damage bonuses such as from the elf villager dress