### PR TITLE
Team Fight Fixes

### DIFF
--- a/classes/classes/Scenes/Combat/CombatUI.as
+++ b/classes/classes/Scenes/Combat/CombatUI.as
@@ -274,11 +274,11 @@ public class CombatUI extends BaseCombatContent {
 			doFlyingSwordTurn();
 		else if (isCompanionTurn(0))
 			doCompanionTurn(0);
-		else if (isCompanionTurn(1) && !player.hasStatusEffect(StatusEffects.MinoKing) && player.statusEffectv1(StatusEffects.MinoKing) != 1)
+		else if (isCompanionTurn(1))
 			doCompanionTurn(1);
-		else if (isCompanionTurn(2) && !player.hasStatusEffect(StatusEffects.MinoKing) && player.statusEffectv1(StatusEffects.MinoKing) != 2)
+		else if (isCompanionTurn(2))
 			doCompanionTurn(2);
-		else if (isCompanionTurn(3) && !player.hasStatusEffect(StatusEffects.MinoKing) && player.statusEffectv1(StatusEffects.MinoKing) != 3)
+		else if (isCompanionTurn(3))
 			doCompanionTurn(3);
 		//PC: is busy with something
 		else if (isPlayerBound()) {
@@ -783,6 +783,7 @@ public class CombatUI extends BaseCombatContent {
 	public function isCompanionTurn(num:int):Boolean {
 		var present:Boolean;
 		var acted:Boolean;
+		var occupied:Boolean = player.hasStatusEffect(StatusEffects.MinoKing) && player.statusEffectv1(StatusEffects.MinoKing) == num;
 		switch(num) {
 			case 0:
 				present = flags[kFLAGS.PLAYER_COMPANION_0] != "";
@@ -801,7 +802,7 @@ public class CombatUI extends BaseCombatContent {
 				acted = flags[kFLAGS.IN_COMBAT_PLAYER_COMPANION_3_ACTION];
 				break;
 		}
-		return present && !acted;
+		return present && !acted && !occupied;
 	}
 
 	public function doCompanionTurn(num:int, clearAndNext:Boolean = true):void {

--- a/classes/classes/Scenes/Dungeons/RiverDungeon/TwinBosses.as
+++ b/classes/classes/Scenes/Dungeons/RiverDungeon/TwinBosses.as
@@ -186,7 +186,7 @@ use namespace CoC;
 				removeStatusEffect(StatusEffects.JabberwockyVenom);
 				buff("Poison").remove();
 			}
-			SceneLib.combat.combatRoundOver();
+			doNext(SceneLib.combat.combatMenu, false);
 		}
 		
 		override public function defeated(hpVictory:Boolean):void

--- a/classes/classes/Scenes/Monsters/AngelLR.as
+++ b/classes/classes/Scenes/Monsters/AngelLR.as
@@ -52,7 +52,7 @@ public class AngelLR extends AbstractAngel
 				removeStatusEffect(StatusEffects.JabberwockyVenom);
 				buff("Poison").remove();
 			}
-			SceneLib.combat.combatRoundOver();
+			doNext(SceneLib.combat.combatMenu, false);
 		}
 		
 		private function AngelEnergyRays():void {


### PR DESCRIPTION
Fixed bug where the check for whether a companion can act due to being occupied distracting an enemy now applies regardless of whether Simplified Pre-Turn is on

The River Dungeon and Arena team fights now no longer have the chance of softlocking the user if they can instantly kill the enemy, like the Minotaur fight