### PR TITLE
Spell Fixes

### DIFF
--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -755,7 +755,7 @@ public class PerkLib
 						"]",
 				"You've chosen the 'Brutal Blows' perk, which reduces enemy armor with each hit. (+5% melee physical attacks multiplier)");
 		public static const BrutalSpells:PerkType = mk("Brutal Spells", "Brutal Spells",
-				"[if(player.int8>=75)" +
+				"[if(player.int>=75)" +
 						"Reduces enemy magic resistance with each spell. (+5% base spell strength)" +
 						"|" +
 						"<b>You are too dumb to gain benefit from this perk.</b>" +
@@ -4017,7 +4017,7 @@ public class PerkLib
 				"Corruption meter now increase lust resistance based on purity.");
 		public static const Cornucopia:PerkType = mk("Cornucopia", "Cornucopia",
 				"Vaginal and Anal capacities increased by 30.");
-		public static const CorrosiveMeltdownMastered:PerkType = mk("Raging Inferno (Mastered)", "Raging Inferno (Mastered)",
+		public static const CorrosiveMeltdownMastered:PerkType = mk("Corrosive Meltdown (Mastered)", "Corrosive Meltdown (Mastered)",
 				"Cumulative 120% damage increase for every subsequent acid spell. Each turn without cast acid spell lower damage by 40% down to normal (100%) damage. Prevent decay of cumulative damage increase bonus when channeling acid based attack. Maximum 50 stacks.");
 		public static const CraftedArrows:PerkType = mk("Crafted Arrows", "Crafted Arrows",
 				"You have personaly crafted arrows in your quiver. Depending on their type it will increase bow attack from 10% to 40%");
@@ -4028,7 +4028,7 @@ public class PerkLib
 		public static const DominantAlpha:PerkType = new DominantAlphaPerk();
 		public static const DualMind:PerkType = mk("Dual Mind", "Dual Mind",
 				"Greatly empower the tease ability.");
-		public static const EclipsingShadowMastered:PerkType = mk("Raging Inferno (Mastered)", "Raging Inferno (Mastered)",
+		public static const EclipsingShadowMastered:PerkType = mk("Eclipsing Shadow (Mastered)", "Eclipsing Shadow (Mastered)",
 				"Cumulative 120% damage increase for every subsequent darkness spell. Each turn without cast darkness spell lower damage by 40% down to normal (100%) damage. Prevent decay of cumulative damage increase bonus when channeling darkness based attack. Maximum 50 stacks.");
 		public static const ElementalBody:PerkType = mk("Elemental", "Elemental",
 				"You are currently in elemental form.");
@@ -4079,7 +4079,7 @@ public class PerkLib
 				"Grants a corrupted fire coating to your body, dealing fire damage with all feral attacks.");
 		public static const HighTideMastered:PerkType = mk("High Tide (Mastered)", "High Tide (Mastered)",
 				"Cumulative 120% damage increase for every subsequent water spell. Each turn without cast water spell lower damage by 40% down to normal (100%) damage. Prevent decay of cumulative damage increase bonus when channeling water based attack. Maximum 50 stacks.");
-		public static const HighVoltageMastered:PerkType = mk("Raging Inferno (Mastered)", "Raging Inferno (Mastered)",
+		public static const HighVoltageMastered:PerkType = mk("High Voltage (Mastered)", "High Voltage (Mastered)",
 				"Cumulative 120% damage increase for every subsequent lightning spell. Each turn without cast lightning spell lower damage by 40% down to normal (100%) damage. Prevent decay of cumulative damage increase bonus when channeling lightning based attack. Maximum 50 stacks.");
 		public static const HowlingGaleMastered:PerkType = mk("Howling Gale (Mastered)", "Howling Gale (Mastered)",
 				"Cumulative 120% damage increase for every subsequent wind spell. Each turn without cast wind spell lower damage by 40% down to normal (100%) damage. Prevent decay of cumulative damage increase bonus when channeling wind based attack. Maximum 50 stacks.");
@@ -4131,7 +4131,7 @@ public class PerkLib
 				"When slaying or purifying demons their corrupted power is purified and sent back to you.");
 		public static const RagingInfernoMastered:PerkType = mk("Raging Inferno (Mastered)", "Raging Inferno (Mastered)",
 				"Cumulative 120% damage increase for every subsequent fire spell. Each turn without cast fire spell lower damage by 40% down to normal (100%) damage. Prevent decay of cumulative damage increase bonus when channeling fire based attack. Maximum 50 stacks.");
-		public static const RumblingQuakeMastered:PerkType = mk("Raging Inferno (Mastered)", "Raging Inferno (Mastered)",
+		public static const RumblingQuakeMastered:PerkType = mk("Rumbling Quake (Mastered)", "Rumbling Quake (Mastered)",
 				"Cumulative 120% damage increase for every subsequent earth spell. Each turn without cast earth spell lower damage by 40% down to normal (100%) damage. Prevent decay of cumulative damage increase bonus when channeling earth based attack. Maximum 50 stacks.");
 		public static const SageMedicine:PerkType = mk("Sage Medicine", "Sage Medicine",
 				"Sage Medicine used for the Azazel ascension, reduces minimum corruption caused by havinng a soul Phylactery");

--- a/classes/classes/Scenes/Combat/AbstractSpell.as
+++ b/classes/classes/Scenes/Combat/AbstractSpell.as
@@ -109,9 +109,9 @@ public class AbstractSpell extends CombatAbility {
 	protected function postSpellEffect(display:Boolean = true):void {
 		MagicAddonEffect(magicAddonProcs);
 		if (player.weapon == weapons.DEMSCYT && player.cor < 90) dynStats("cor", 0.3);
-		if (hasTag(TAG_LUSTDMG)) combat.teases.fueledByDesireHeal(display);
+		if (targetType == TARGET_ENEMY && hasTag(TAG_LUSTDMG)) combat.teases.fueledByDesireHeal(display);
 		if (monster is SiegweirdBoss) (monster as SiegweirdBoss).castedSpellThisTurn = true;
-		if (player.hasPerk(PerkLib.BrutalSpells)) combat.magic.BrutalSpellsEffect();
+		if (targetType == TARGET_ENEMY && hasTag(TAG_DAMAGING) && player.hasPerk(PerkLib.BrutalSpells)) combat.magic.brutalSpellsEffect(display);
 	}
 	
 	public override function doEffect(display:Boolean = true):void {
@@ -629,7 +629,7 @@ public class AbstractSpell extends CombatAbility {
 					break;
 			}
 		}
-		dynStats("lib", .25, "lus", 15);
+		dynStats("lib", .25, "lus", Math.max(player.maxLust() * 0.01, 15));
 	}
 	
 	/**

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -547,6 +547,7 @@ public class Combat extends BaseContent {
                 if (flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID] != "") {
                     outputText("  Somehow you came away from the encounter with " + ItemType.lookupItem(flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID]).longName + ".\n\n");
                     inventory.takeItem(ItemType.lookupItem(flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID]), createCallBackFunction(camp.returnToCamp, timePasses));
+                    flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID] = "";
                 } else doNext(createCallBackFunction(camp.returnToCamp, timePasses));
 				//SF harvest
 				if (player.hasPerk(PerkLib.PrestigeJobNecromancer) && monster.soulforce > 0) {
@@ -9028,6 +9029,7 @@ public class Combat extends BaseContent {
         //Bonus loot overrides others
         if (flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID] != "") {
             itype = ItemType.lookupItem(flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID]);
+            flags[kFLAGS.BONUS_ITEM_AFTER_COMBAT_ID] = "";
         } else {
             itype = monster.dropLoot();
         }

--- a/classes/classes/Scenes/Combat/CombatMagic.as
+++ b/classes/classes/Scenes/Combat/CombatMagic.as
@@ -894,8 +894,8 @@ public class CombatMagic extends BaseCombatContent {
 		if (player.hasStatusEffect(StatusEffects.BalanceOfLife)) HPChange((player.maxHP() * numberOfProcs * 0.05), false);
 	}
 	
-	public function BrutalSpellsEffect():void {
-		if (monster.armorMDef > 0) outputText("\nYour spells are so brutal that you damage [themonster]'s magical resistance!");
+	public function brutalSpellsEffect(display:Boolean = true):void {
+		if (monster.armorMDef > 0 && display) outputText("\nYour spells are so brutal that you damage [themonster]'s magical resistance!");
         var bbc:Number = (Math.round(monster.armorMDef * 0.1) + 5);
 		if (monster.armorMDef - bbc > 0) monster.armorMDef -= bbc;
         else monster.armorMDef = 0;


### PR DESCRIPTION
Fixed text bugs related to new Brutal Spells and cumulative magic perks
Fixed bug where settings custom drops for certain enemies did not reset after dropping once 
Brutal Spell perk will now only trigger for damaging spells, not every one
Backfire lust damage will now scale will lust rather than a flat rate