### PR TITLE
Boss changes

### DIFF
--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -1173,84 +1173,47 @@ import classes.Scenes.Combat.CombatAbilities;
 		}
 
 		public function eBaseStrengthDamage():Number {
-			var damage:Number = 0;
-			damage += str;
-			if (str >= 21) damage += (str - 20);
-			if (str >= 41) damage += (str - 40);
-			if (str >= 61) damage += (str - 60);
-			if (str >= 81) damage += (str - 80);
-			if (str >= 101) damage += tieredBonus(str, 50, 100);
-			if (str < 10) damage = 10;
-			if (hasStatusEffect(StatusEffects.PunishingKick)) damage *= 0.5;
-			if (hasStatusEffect(StatusEffects.Provoke)) damage *= statusEffectv2(StatusEffects.Provoke);
-			//monster exclusive perks bonus
-			damage *= eBaseMultis();
-			damage = Math.round(damage);
-			return damage;
+			return eBasePhysModifier(eBaseStatDamage(str));
 		}
 
 		public function eBaseToughnessDamage():Number {
-			var damage:Number = 0;
-			damage += tou;
-			if (tou >= 21) damage += (tou - 20);
-			if (tou >= 41) damage += (tou - 40);
-			if (tou >= 61) damage += (tou - 60);
-			if (tou >= 81) damage += (tou - 80);
-			if (tou >= 101) damage += tieredBonus(tou, 50, 100);
-			if (tou < 10) damage = 10;
-			if (hasStatusEffect(StatusEffects.PunishingKick)) damage *= 0.5;
-			if (hasStatusEffect(StatusEffects.Provoke)) damage *= statusEffectv2(StatusEffects.Provoke);
-			//monster exclusive perks bonus
-			damage *= eBaseMultis();
-			damage = Math.round(damage);
-			return damage;
+			return eBasePhysModifier(eBaseStatDamage(tou));
 		}
 
 		public function eBaseSpeedDamage():Number {
-			var damage:Number = 0;
-			damage += spe;
-			if (spe >= 21) damage += (spe - 20);
-			if (spe >= 41) damage += (spe - 40);
-			if (spe >= 61) damage += (spe - 60);
-			if (spe >= 81) damage += (spe - 80);
-			if (spe >= 101) damage += tieredBonus(spe, 50, 100);
-			if (spe < 10) damage = 10;
-			if (hasStatusEffect(StatusEffects.PunishingKick)) damage *= 0.5;
-			if (hasStatusEffect(StatusEffects.Provoke)) damage *= statusEffectv2(StatusEffects.Provoke);
-			//monster exclusive perks bonus
-			damage *= eBaseMultis();
-			damage = Math.round(damage);
-			return damage;
+			return eBasePhysModifier(eBaseStatDamage(spe));
 		}
 
 		public function eBaseIntelligenceDamage():Number {
-			var damage:Number = 0;
-			damage += inte;
-			if (inte >= 21) damage += (inte - 20);
-			if (inte >= 41) damage += (inte - 40);
-			if (inte >= 61) damage += (inte - 60);
-			if (inte >= 81) damage += (inte - 80);
-			if (inte >= 101) damage += tieredBonus(inte, 50, 100);
-			if (inte < 10) damage = 10;
+			return eBaseStatDamage(inte);
+		}
+
+		public function eBaseWisdomDamage():Number {
+			return eBaseStatDamage(wis);
+		}
+
+		public function eBaseLibidoDamage():Number {
+			return eBaseStatDamage(lib);
+		}
+
+		private function eBaseStatDamage(stat:Number):Number {
+			var damage:Number = stat;
+			if (stat >= 21) damage += (stat - 20);
+			if (stat >= 41) damage += (stat - 40);
+			if (stat >= 61) damage += (stat - 60);
+			if (stat >= 81) damage += (stat - 80);
+			if (stat >= 101) damage += tieredBonus(stat, 50, 100);
+			if (stat < 10) damage = 10;
 			//monster exclusive perks bonus
 			damage *= eBaseMultis();
 			damage = Math.round(damage);
 			return damage;
 		}
 
-		public function eBaseWisdomDamage():Number {
-			var damage:Number = 0;
-			damage += wis;
-			if (wis >= 21) damage += (wis - 20);
-			if (wis >= 41) damage += (wis - 40);
-			if (wis >= 61) damage += (wis - 60);
-			if (wis >= 81) damage += (wis - 80);
-			if (wis >= 101) damage += tieredBonus(wis, 50, 100);
-			if (wis < 10) damage = 10;
-			//monster exclusive perks bonus
-			damage *= eBaseMultis();
-			damage = Math.round(damage);
-			return damage;
+		private function eBasePhysModifier(damage:Number):Number {
+			if (hasStatusEffect(StatusEffects.PunishingKick)) damage *= 0.5;
+			if (hasStatusEffect(StatusEffects.Provoke)) damage *= statusEffectv2(StatusEffects.Provoke);
+			return Math.round(damage);
 		}
 
 		private function inteligencescalingbonusMonster(stat:int):Number{
@@ -2894,7 +2857,7 @@ import classes.Scenes.Combat.CombatAbilities;
 		 * To be overwritten by child monster classes
 		 * @return statues (Array) - List of String repreenting each unique status the monster is currently under
 		 */
-		public function displaySpecialStatues():Array {
+		public function displaySpecialStatuses():Array {
 			return [];
 		}
 
@@ -3861,32 +3824,34 @@ import classes.Scenes.Combat.CombatAbilities;
 				if(flags[kFLAGS.PC_FETISH] >= 2) player.dynStats("lus", 3);
 			}
 			if(this is SecretarialSuccubus || this is MilkySuccubus) {
-				if(player.lust < (player.maxLust() * 0.45)) outputText("There is something in the air around your opponent that makes you feel warm.\n\n");
-				else if(player.lust < (player.maxLust() * 0.70)) outputText("You aren't sure why but you have difficulty keeping your eyes off your opponent's lewd form.\n\n");
-				else if(player.lust < (player.maxLust() * 0.90)) outputText("You blush when you catch yourself staring at your foe's rack, watching it wobble with every step she takes.\n\n");
-				else outputText("You have trouble keeping your greedy hands away from your groin.  It would be so easy to just lay down and masturbate to the sight of your curvy enemy.  The succubus looks at you with a sexy, knowing expression.\n\n");
-				player.takeLustDamage(1+rand(8), true);
+				if(player.lust < (player.maxLust() * 0.45)) outputText("There is something in the air around your opponent that makes you feel warm. ");
+				else if(player.lust < (player.maxLust() * 0.70)) outputText("You aren't sure why but you have difficulty keeping your eyes off your opponent's lewd form. ");
+				else if(player.lust < (player.maxLust() * 0.90)) outputText("You blush when you catch yourself staring at your foe's rack, watching it wobble with every step she takes. ");
+				else outputText("You have trouble keeping your greedy hands away from your groin.  It would be so easy to just lay down and masturbate to the sight of your curvy enemy.  The succubus looks at you with a sexy, knowing expression. ");
+				player.takeLustDamage((eBaseLibidoDamage() / 40) + rand(8), true);
+				outputText("\n\n");
 			}
 			//[LUST GAINED PER ROUND] - Omnibus
 			if(hasStatusEffect(StatusEffects.LustAura)) {
 				if (this is OmnibusOverseer || this is HeroslayerOmnibus) {
-					if(player.lust < (player.maxLust() * 0.33)) outputText("Your groin tingles warmly.  The demon's aura is starting to get to you.\n\n");
-					if(player.lust >= (player.maxLust() * 0.33) && player.lust < (player.maxLust() * 0.66)) outputText("You blush as the demon's aura seeps into you, arousing you more and more.\n\n");
+					if(player.lust < (player.maxLust() * 0.33)) outputText("Your groin tingles warmly.  The demon's aura is starting to get to you. ");
+					if(player.lust >= (player.maxLust() * 0.33) && player.lust < (player.maxLust() * 0.66)) outputText("You blush as the demon's aura seeps into you, arousing you more and more. ");
 					if(player.lust >= (player.maxLust() * 0.66)) {
 						outputText("You flush bright red with desire as the lust in the air worms its way inside you.  ");
 						temp = rand(4);
-						if(temp == 0) outputText("You have a hard time not dropping to your knees to service her right now.\n\n");
-						if(temp == 2) outputText("The urge to bury your face in her breasts and suckle her pink nipples nearly overwhelms you.\n\n");
-						if(temp == 1) outputText("You swoon and lick your lips, tasting the scent of the demon's pussy in the air.\n\n");
-						if(temp == 3) outputText("She winks at you and licks her lips, and you can't help but imagine her tongue sliding all over your body.  You regain composure moments before throwing yourself at her.  That was close.\n\n");
+						if(temp == 0) outputText("You have a hard time not dropping to your knees to service her right now. ");
+						if(temp == 2) outputText("The urge to bury your face in her breasts and suckle her pink nipples nearly overwhelms you. ");
+						if(temp == 1) outputText("You swoon and lick your lips, tasting the scent of the demon's pussy in the air. ");
+						if(temp == 3) outputText("She winks at you and licks her lips, and you can't help but imagine her tongue sliding all over your body.  You regain composure moments before throwing yourself at her.  That was close. ");
 					}
 				}
 				if (this is Alraune || this is Marae) {
-					if(player.lust < (player.maxLust() * 0.33)) outputText("The pollen in the air gradually increase your arousal.\n\n");
-					if(player.lust >= (player.maxLust() * 0.33) && player.lust < (player.maxLust() * 0.66)) outputText("The pollen in the air is getting to you.\n\n");
-					if(player.lust >= (player.maxLust() * 0.66)) outputText("You flush bright red with desire as the lust in the air worms its way inside you.\n\n");
+					if(player.lust < (player.maxLust() * 0.33)) outputText("The pollen in the air gradually increase your arousal. ");
+					if(player.lust >= (player.maxLust() * 0.33) && player.lust < (player.maxLust() * 0.66)) outputText("The pollen in the air is getting to you. ");
+					if(player.lust >= (player.maxLust() * 0.66)) outputText("You flush bright red with desire as the lust in the air worms its way inside you. ");
 				}
-				player.takeLustDamage((3 + int(player.lib/20 + player.cor/25)), true);
+				player.takeLustDamage(((eBaseLibidoDamage() / 40) + int(player.lib/20 + player.cor/25)), true);
+				outputText("\n\n");
 			}
 			//immolation DoT
 			if (hasStatusEffect(StatusEffects.ImmolationDoT)) {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -11874,7 +11874,7 @@ public class Combat extends BaseContent {
                 if (player.hasStatusEffect(StatusEffects.MonsterDig)) statusTypes.push("Underground");
                 if (combat.isEnemyInvisibleButNotUnderground) statusTypes.push("Invisible");
                 if (monster.lustVuln == 0) statusTypes.push("Lust Immune");
-                statusTypes.concat(monster.displaySpecialStatues());
+                statusTypes.push(monster.displaySpecialStatuses());
             }
             outputText("\n");
             if (player.hasPerk(PerkLib.EyesOfTheHunterNovice)){

--- a/classes/classes/Scenes/Dungeons/DeepCave/Zetaz.as
+++ b/classes/classes/Scenes/Dungeons/DeepCave/Zetaz.as
@@ -7,110 +7,72 @@ import classes.BodyParts.LowerBody;
 import classes.BodyParts.Wings;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
+import classes.GlobalFlags.kFLAGS;
 
 public class Zetaz extends Monster
 	{
-		public function zetazAI():void {
-			//Zetaz taunts.
-			zetazTaunt();
-			outputText("\n\n");
-			//If afflicted by blind or whispered and over 50% lust,
-			//burns lust and clears statuses before continuing with
-			//turn.
-			if(lust > 50 && (hasStatusEffect(StatusEffects.Fear) || hasStatusEffect(StatusEffects.Blind))) {
-				if (hasStatusEffect(StatusEffects.Fear)) this.speStat.core.value += statusEffectv2(StatusEffects.Fear);
-				removeStatusEffect(StatusEffects.Fear);
-				removeStatusEffect(StatusEffects.Blind);
-				lust -= 10;
-				outputText("Zetaz blinks and shakes his head while stroking himself.  After a second his turgid member loses some of its rigidity, but his gaze has become clear.  He's somehow consumed some of his lust to clear away your magic!");
-			}
-			
-			//STANDARD COMBAT STATUS EFFECTS HERE
-			if(hasStatusEffect(StatusEffects.Stunned)) {
-				outputText("Your foe is too dazed from your last hit to strike back!");
-				removeStatusEffect(StatusEffects.Stunned);
-				return;
-			}
-			var select:Number=1;
-			var rando:Number=1;
-			if(hasStatusEffect(StatusEffects.Constricted)) {
-				//Enemy struggles -
-				outputText("Your prey pushes at your tail, twisting and writhing in an effort to escape from your tail's tight bonds.");
-				if(statusEffectv1(StatusEffects.Constricted) <= 0) {
-					outputText("  " + capitalA + short + " proves to be too much for your tail to handle, breaking free of your tightly bound coils.");
-					removeStatusEffect(StatusEffects.Constricted);
-				}
-				addStatusValue(StatusEffects.Constricted,1,-1);
-				return;
-			}
-			//STANDARD COMBAT STATUS AFFECTS END HERE
-			//-If over 50 lust and below 50% hp
-			//--burns 20 lust to restore 20% hp.
-			if(lust > 50 && HPRatio() <= .5) {
-				outputText("The imp lord shudders from his wounds and the pulsing member that's risen from under his tattered loincloth.  He strokes it and murmurs under his breath for a few moments.  You're so busy watching the spectacle of his masturbation that you nearly miss the sight of his bruises and wounds closing!  Zetaz releases his swollen member, and it deflates slightly.  He's used some kind of black magic to convert some of his lust into health!");
-				addHP(0.25 * maxHP());
-				lust -= 20;
-				player.takeLustDamage(2, true);
+
+		public function lustHeal():void {
+			outputText("The imp lord shudders from his wounds and the pulsing member that's risen from under his tattered loincloth.  He strokes it and murmurs under his breath for a few moments.  You're so busy watching the spectacle of his masturbation that you nearly miss the sight of his bruises and wounds closing!  Zetaz releases his swollen member, and it deflates slightly.  He's used some kind of black magic to convert some of his lust into health!");
+			addHP(0.25 * maxHP());
+			lust -= maxLust() * 0.2;
+			player.takeLustDamage(eBaseDamage() / 5, true);
+			createStatusEffect(StatusEffects.AbilityCooldown1, 3, 0, 0, 0);
+		}
+
+		public function heatDraft():void {
+			//Chucks faux-heat draft ala goblins. -
+			outputText("Zetaz grabs a bottle from a drawer and hurls it in your direction!  ");
+			if(player.getEvasionRoll()) {
+				outputText("You sidestep it a moment before it shatters on the wall, soaking the tapestries with red fluid!");
 			}
 			else {
-				var attackChoice:Number = rand(3);
-				if(attackChoice == 0) {
-					//Chucks faux-heat draft ala goblins. -
-					outputText("Zetaz grabs a bottle from a drawer and hurls it in your direction!  ");
-					if(player.getEvasionRoll()) {
-						outputText("You sidestep it a moment before it shatters on the wall, soaking the tapestries with red fluid!");
-					}
-					else {
-						outputText("You try to avoid it, but the fragile glass shatters against you, coating you in sticky red liquid.  It seeps into your [skin.type] and leaves a pleasant, residual tingle in its wake.  Oh no...");
-						//[Applies: "Temporary Heat" status]
-						if(!player.hasStatusEffect(StatusEffects.TemporaryHeat)) player.createStatusEffect(StatusEffects.TemporaryHeat,0,10,0,0);
-					}
-				}
-				else if(attackChoice == 1) {
-					//'Gust' – channels a pidgy's spirit to beat
-					//his wings and kick up dust, blinding the PC
-					//next turn and dealing light damage. -
-					outputText("The imp leaps into the air with a powerful spring, beating his wings hard to suspend himself in the center of his bedchamber.  Dust kicks up into the air from the force of his flight and turns the room into a blinding tornado!  Small objects smack off of you, ");
-					//(causing little damage/
-					if(player.tou > 60) outputText("causing little damage");
-					else {
-						var dmg:Number = 1 + rand(6);
-						outputText("wounding you slightly ");
-						dmg = player.takePhysDamage(dmg, true);
-					}
-					outputText(" while the dust gets into your eyes, temporarily blinding you!");
-					if (!player.isImmuneToBlind()) player.createStatusEffect(StatusEffects.Blind,1,0,0,0);
-				}
-				//Gigarouse – A stronger version of normal imp's
-				//'arouse' spell. - copy normal arouse text and
-				//spice it up with extra wetness!
-				else {
-					gigaArouse();
-				}
+				outputText("You try to avoid it, but the fragile glass shatters against you, coating you in sticky red liquid.  It seeps into your [skin.type] and leaves a pleasant, residual tingle in its wake.  Oh no...");
+				//[Applies: "Temporary Heat" status]
+				if(!player.hasStatusEffect(StatusEffects.TemporaryHeat)) player.createStatusEffect(StatusEffects.TemporaryHeat,0,10,0,0);
 			}
+		}
+
+		public function gust():void {
+			//'Gust' – channels a pidgy's spirit to beat
+			//his wings and kick up dust, blinding the PC
+			//next turn and dealing light damage. -
+			outputText("The imp leaps into the air with a powerful spring, beating his wings hard to suspend himself in the center of his bedchamber.  Dust kicks up into the air from the force of his flight and turns the room into a blinding tornado!  Small objects smack off of you, ");
+			//(causing little damage/
+			if(player.tou > 60) outputText("causing little damage");
+			else {
+				var dmg:Number = eBaseDamage();
+				outputText("wounding you slightly");
+				dmg = player.takePhysDamage(dmg, true);
+			}
+			outputText(" while the dust gets into your eyes, temporarily blinding you!");
+			if (!player.isImmuneToBlind()) player.createStatusEffect(StatusEffects.Blind,1,0,0,0);
 		}
 		
 		public function gigaArouse():void {
 			outputText("You see " + a + short + " make familiar arcane gestures at you, but his motions seem a lot more over the top than you'd expect from an imp.\n\n");
-			player.takeLustDamage(rand(player.lib/10)+player.cor/10+15, true);
-			if(player.lust < 30) outputText("Your nethers pulse with pleasant warmth that brings to mind pleasant sexual memories.  ");
-			if(player.lust >= 30 && player.lust < 60) outputText("Blood rushes to your groin in a rush as your body is hit by a tidal-wave of arousal.  ");
-			if(player.lust >= 60) outputText("Your mouth begins to drool as you close your eyes and imagine yourself sucking off Zetaz, then riding him, letting him sate his desires in your inviting flesh.  The unnatural visions send pulses of lust through you so strongly that your body shivers.  ");
+			var lustDmg:Number = inteligencescalingbonus() / 3;
+			lustDmg *= 1 + (0.5 * (player.cor / 100));
+			lustDmg += 15;
+			
+			player.takeLustDamage(lustDmg, true);
+			if(player.lust100 < 30) outputText("Your nethers pulse with pleasant warmth that brings to mind pleasant sexual memories.  ");
+			if(player.lust100 >= 30 && player.lust100 < 60) outputText("Blood rushes to your groin in a rush as your body is hit by a tidal-wave of arousal.  ");
+			if(player.lust100 >= 60) outputText("Your mouth begins to drool as you close your eyes and imagine yourself sucking off Zetaz, then riding him, letting him sate his desires in your inviting flesh.  The unnatural visions send pulses of lust through you so strongly that your body shivers.  ");
 			if(player.cocks.length > 0) {
-				if(player.lust >= 60 && player.cocks.length > 0) outputText("You feel [eachcock] dribble pre-cum, bouncing with each beat of your heart and aching to be touched.  ");
-				if(player.lust >= 30 && player.lust < 60 && player.cocks.length == 1) outputText(player.SMultiCockDesc() + " hardens and twitches, distracting you further.  ");
+				if(player.lust100 >= 60 && player.cocks.length > 0) outputText("You feel [eachcock] dribble pre-cum, bouncing with each beat of your heart and aching to be touched.  ");
+				if(player.lust100 >= 30 && player.lust100 < 60 && player.cocks.length == 1) outputText(player.SMultiCockDesc() + " hardens and twitches, distracting you further.  ");
 			}
 			if(player.vaginas.length > 0) {
-				if(player.lust >= 60 && player.vaginas[0].vaginalWetness == VaginaClass.WETNESS_NORMAL && player.vaginas.length == 1) outputText("Your [vagina] dampens perceptibly, feeling very empty.  ");
-				if(player.lust >= 60 && player.vaginas[0].vaginalWetness == VaginaClass.WETNESS_WET && player.vaginas.length > 0) outputText("Your crotch becomes sticky with girl-lust, making it clear to " + a + short + " just how welcome your body finds the spell.  ");
-				if(player.lust >= 60 && player.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLICK && player.vaginas.length == 1) outputText("Your [vagina] becomes sloppy and wet, dribbling with desire to be mounted and fucked.  ");
-				if(player.lust >= 60 && player.vaginas[0].vaginalWetness == VaginaClass.WETNESS_DROOLING && player.vaginas.length > 0) outputText("Thick runners of girl-lube stream down the insides of your thighs as your crotch gives into the demonic magics.  You wonder what " + a + short + "'s cock would feel like inside you?  ");
-				if (player.lust >= 60 && player.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLAVERING && player.vaginas.length == 1) outputText("Your [vagina] instantly soaks your groin with the heady proof of your need.  You wonder just how slippery you could " + a + short + "'s dick when it's rammed inside you?  ");
+				if(player.lust100 >= 60 && player.vaginas[0].vaginalWetness == VaginaClass.WETNESS_NORMAL && player.vaginas.length == 1) outputText("Your [vagina] dampens perceptibly, feeling very empty.  ");
+				if(player.lust100 >= 60 && player.vaginas[0].vaginalWetness == VaginaClass.WETNESS_WET && player.vaginas.length > 0) outputText("Your crotch becomes sticky with girl-lust, making it clear to " + a + short + " just how welcome your body finds the spell.  ");
+				if(player.lust100 >= 60 && player.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLICK && player.vaginas.length == 1) outputText("Your [vagina] becomes sloppy and wet, dribbling with desire to be mounted and fucked.  ");
+				if(player.lust100 >= 60 && player.vaginas[0].vaginalWetness == VaginaClass.WETNESS_DROOLING && player.vaginas.length > 0) outputText("Thick runners of girl-lube stream down the insides of your thighs as your crotch gives into the demonic magics.  You wonder what " + a + short + "'s cock would feel like inside you?  ");
+				if (player.lust100 >= 60 && player.vaginas[0].vaginalWetness == VaginaClass.WETNESS_SLAVERING && player.vaginas.length == 1) outputText("Your [vagina] instantly soaks your groin with the heady proof of your need.  You wonder just how slippery you could " + a + short + "'s dick when it's rammed inside you?  ");
 			}
 			if(player.lust >= player.maxOverLust()) doNext(SceneLib.combat.endLustLoss);
 		}
 
-		
 		public function zetazTaunt():void {
 			if(!hasStatusEffect(StatusEffects.round)) {
 				createStatusEffect(StatusEffects.round,1,0,0,0);
@@ -132,9 +94,42 @@ public class Zetaz extends Monster
 			}
 		}
 
-		override public function doAI():void
-		{
-			zetazAI();
+		//One time heal and empowerment
+		public function zetazMight():void {
+			outputText("Zetaz flushes, drawing on his body's desires to empower his muscles and toughen his up.");
+			outputText("The rush of success and power flows through his body.  He feels like he can do anything!");
+			statStore.addBuffObject({"str.mult":0.3, "tou.mult":0.3},"ImpMight");
+			addHP(0.25 * maxHP());
+			this.mightCasted = true;
+		}
+
+		override protected function performCombatAction():void {
+			if (hasStatusEffect(StatusEffects.Blind) && lust100 > 50)
+				blindHeal();
+			
+			//Zetaz taunts.
+			zetazTaunt();
+			outputText("\n\n");
+
+			super.performCombatAction();
+		}
+
+		override protected function handleFear():Boolean {
+			if (lust100 > 50) {
+				this.speStat.core.value += statusEffectv2(StatusEffects.Fear);
+				removeStatusEffect(StatusEffects.Fear);
+				removeStatusEffect(StatusEffects.Blind);
+				outputText("Zetaz blinks and shakes his head while stroking himself.  After a second his turgid member loses some of its rigidity, but his gaze has become clear.  He's somehow consumed some of his lust to clear away your magic!\n");
+				lust -= maxLust()/10;
+				return true;
+			}
+			return super.handleFear();
+		}
+
+		public function blindHeal():void {
+			removeStatusEffect(StatusEffects.Blind);
+			outputText("Zetaz blinks and shakes his head while stroking himself.  After a second his turgid member loses some of its rigidity, but his gaze has become clear.  He's somehow consumed some of his lust to clear away your magic!\n");
+			lust -= maxLust()/10;
 		}
 		
 		override public function defeated(hpVictory:Boolean):void
@@ -150,6 +145,31 @@ public class Zetaz extends Monster
 			} else {
 				SceneLib.dungeons.deepcave.loseToZetaz();
 			}
+		}
+
+		private function buildAbilities():Array {
+			var abilities:Array = [
+				{call: lustHeal, type: ABILITY_SPECIAL, range: RANGE_SELF, condition: lustHealCheck, weight: Infinity },
+				{call: heatDraft, type: ABILITY_MAGIC, range: RANGE_RANGED},
+				{call: gigaArouse, type: ABILITY_MAGIC, range: RANGE_RANGED},
+				{call: gust, type: ABILITY_PHYSICAL, range: RANGE_RANGED},
+				{call: eAttack, type: ABILITY_PHYSICAL, range: RANGE_MELEE}
+			];
+
+			//Zetaz gains the ability to use Might under 50%HP in difficulties over Normal 
+			if (flags[kFLAGS.GAME_DIFFICULTY] > 0) {
+				abilities.push({call: zetazMight, type: ABILITY_MAGIC, range: RANGE_SELF, condition: mightCheck, weight: Infinity});
+			}
+
+			return abilities;
+		}
+
+		public function lustHealCheck():Boolean {
+			return lust100 > 50 && HPRatio() <= .5 && !hasStatusEffect(StatusEffects.AbilityCooldown1);
+		}
+
+		public function mightCheck():Boolean {
+			return HPRatio() <= .5 && !mightCasted;
 		}
 
 		public function Zetaz()
@@ -197,8 +217,11 @@ public class Zetaz extends Monster
 			this.createPerk(PerkLib.EnemyBossType, 0, 0, 0, 0);
 			this.createPerk(PerkLib.EnemyTrueDemon, 0, 0, 0, 0);
 			this.createPerk(PerkLib.OverMaxHP, 40, 0, 0, 0);
+			this.abilities = this.buildAbilities();
 			checkMonster();
 		}
+
+		private var mightCasted:Boolean = false;
 		
 	}
 

--- a/classes/classes/Scenes/Dungeons/Factory/OmnibusOverseer.as
+++ b/classes/classes/Scenes/Dungeons/Factory/OmnibusOverseer.as
@@ -35,6 +35,8 @@ public class OmnibusOverseer extends Monster
 			}
 			else {
 				createStatusEffect(StatusEffects.LustAura, 0, 0, 0, 0);
+				outputText("\nIf you don't do something, you'll quickly succumb!");
+				clearTempResolute(false);
 			}
 		}
 		

--- a/classes/classes/Scenes/Dungeons/Factory/OmnibusOverseer.as
+++ b/classes/classes/Scenes/Dungeons/Factory/OmnibusOverseer.as
@@ -31,7 +31,7 @@ public class OmnibusOverseer extends Monster
 			outputText("The demoness blinks her eyes closed and knits her eyebrows in concentration.  The red orbs open wide and she smiles, licking her lips.   The air around her grows warmer, and muskier, as if her presence has saturated it with lust.");
 			if (hasStatusEffect(StatusEffects.LustAura)) {
 				outputText("  Your eyes cross with unexpected feelings as the taste of desire in the air worms its way into you.  The intense aura quickly subsides, but it's already done its job.");
-				player.takeLustDamage((8 + int(player.lib / 20 + player.cor / 25)), true);
+				player.takeLustDamage((eBaseLibidoDamage() / 20 + int(player.lib / 20 + player.cor / 25)), true);
 			}
 			else {
 				createStatusEffect(StatusEffects.LustAura, 0, 0, 0, 0);
@@ -54,16 +54,51 @@ public class OmnibusOverseer extends Monster
 					outputText("The milk splashes into your [armor], soaking you effectively.  ");
 					if (player.cocks.length > 0) {
 						outputText("Your [cock] gets hard as the milk lubricates and stimulates it.  ");
-						player.takeLustDamage(5, true);
+						player.takeLustDamage(eBaseLibidoDamage() / 50, true);
 					}
 					if (player.vaginas.length > 0) {
 						outputText("You rub your thighs together as the milk slides between your pussy lips, stimulating you far more than it should.  ");
-						player.takeLustDamage(5, true);
+						player.takeLustDamage(eBaseLibidoDamage() / 50, true);
 					}
 				}
-				player.takeLustDamage(7 + player.effectiveSensitivity() / 20, true);
 				if (player.biggestLactation() > 1) outputText("Milk dribbles from your [allbreasts] in sympathy.");
+				player.takeLustDamage(eBaseLibidoDamage() / 30 + player.effectiveSensitivity() / 20, true);
+
 			}
+		}
+
+		override protected function handleStun():Boolean {
+			if (hasStatusEffect(StatusEffects.LustAura)) {
+				outputText("The Overseer's concentration shatters, dispelling the lust aura!\n\n");
+				removeStatusEffect(StatusEffects.LustAura);
+			}
+
+			return super.handleStun();
+		}
+
+		override protected function handleFear():Boolean {
+			if (hasStatusEffect(StatusEffects.LustAura)) {
+				outputText("The Overseer's concentration shatters, dispelling the lust aura!\n\n");
+				removeStatusEffect(StatusEffects.LustAura);
+			}
+
+			return super.handleFear();
+		}
+
+		override protected function handleConfusion():Boolean {
+			if (hasStatusEffect(StatusEffects.LustAura)) {
+				outputText("The Overseer's concentration shatters, dispelling the lust aura!\n\n");
+				removeStatusEffect(StatusEffects.LustAura);
+			}
+
+			return super.handleConfusion();
+		}
+
+		override public function displaySpecialStatuses():Array {
+			var statusArray:Array = super.displaySpecialStatuses();
+			trace("Check Called: " + hasStatusEffect(StatusEffects.LustAura));
+			if (hasStatusEffect(StatusEffects.LustAura)) statusArray.push("Lust Aura");
+			return statusArray;
 		}
 		
 		public function OmnibusOverseer()

--- a/classes/classes/Scenes/TestMenu.as
+++ b/classes/classes/Scenes/TestMenu.as
@@ -36,6 +36,10 @@ import classes.Scenes.NPCs.TyrantiaFollower;
 import classes.Scenes.NPCs.WaizAbi;
 import classes.Scenes.Places.Boat.Marae;
 import classes.Scenes.Places.HeXinDao.AdventurerGuild;
+import classes.Scenes.Dungeons.DeepCave.Zetaz;
+import classes.Scenes.Dungeons.Factory.OmnibusOverseer;
+import classes.Scenes.Dungeons.DemonLab.Incels;
+import classes.Scenes.Dungeons.EbonLabyrinth.Draculina;
 import classes.Stats.Buff;
 
 import coc.view.ButtonDataList;
@@ -56,7 +60,7 @@ public class TestMenu extends BaseContent
 		bd.add("Equip", EquipmentMenu, "For creating various equipment items for tests.");
 		bd.add("NonEquip", NonEquipmentMenu, "For creating various non-equipment items for tests.");
 		bd.add("Materials", MaterialMenu, "For creating various materials for tests.");
-		bd.add("Enemies", EnemiesMenu, "For spawning various enemies to test fight them.");
+		bd.add("Enemies", enemiesMenu, "For spawning various enemies to test fight them.");
 		bd.add("Camp NPC's", FasterOrInstantCampNPCRecruitment, "Menu to speed up recruitment of camp npc's due to testing needs.");
 		bd.add("Body State", BodyStateMenu, "For more precisely adjusting a few other body values or parts than Stats Adj option.");
 		bd.add("MetamorphFull", AllMetamorphOptionsUnlock, "Unlock all Metamorph options.").disableIf(!player.hasPerk(PerkLib.Metamorph));
@@ -1810,42 +1814,36 @@ public class TestMenu extends BaseContent
 			addButton(14, "Back", SoulforceCheats);
 		}
 	}
-	public function EnemiesMenu(page:int = 1):void {
+	public function enemiesMenu():void {
+		var buttons:ButtonDataList = new ButtonDataList();
 		menu();
-		if (page == 1) {
-			addButton(0, "FightForPearl", FightForPearl).hint("Test fight to get Sky Poison Pearl legally (aside we cheat to start fight)");
-			addButton(1, "B.Monke", FightWaizAbi).hint("You not even want to let the innocent bimbo monke free? <i>*sigh*</i>");
-			if (player.level >= 45) addButton(2, "Oculicorn", FightIridesian).hint("Test fight with Oculicorn.");
-			//3
-			addButton(4, "The Dummy", FightTheDummy).hint("Fight with The Dummy.");
-			addButton(5, "Sand Mother", FightSandMother).hint("Test fight with Sand Mother.");
-			addButton(6, "GothGirl", FightLilith).hint("Fight with devilish cute goth girl.");
-			//7
-			addButton(8, "Sonya", FightSonya).hint("Test fight with Sonya.");
-			addButton(9, "RyuBi", FightRyuBi).hint("Test fight with RyuBi.");
-			addButton(10, "Marae", FightMarae).hint("Test fight with Marae (depending on game stage she can be buffed or unbuffed).");
-			addButton(11, "SuccGard", FightSuccubusGardener).hint("Test fight with Succubus Gardener. (Also it will glitch right after fight so not start this fight if you got unsaved progress that you not wanna loose as only way to handle post fight glitch is restarting game)");
-			addButton(12, "Lethice", FightLethice).hint("Test fight with Lethice.");
-			addButton(13, "-2-", EnemiesMenu, page + 1);
-			addButton(14, "Back", SoulforceCheats);
-		}
-		if (page == 2)  {
-			addButton(0, "Galia", FightGalia).hint("Test fight with Galia.");
-			//1
-			//2
-			addButton(3, "ChaosChimera", FightChaosChimera).hint("Test fight with Chaos Chimera.");
-			addButton(4, "AnotSucc", FightCarrera).hint("Fight with probably another succubus out there...");
-			addButton(5, "LvLUP Eva", LvLUPEva).hint("LvL UP forcefully Evangeline for testing purpose up to the limit.");
-			addButton(6, "DELvL Eva", DELvLEva).hint("DE LvL forcefully Evangeline for testing purpose down toward the lvl 12.");
-			addButton(7, "LvLUP Aurora", LvLUPAurora).hint("LvL UP forcefully Aurora for testing purpose up to the limit.");
-			addButton(8, "DELvL Aurora", DELvLAurora).hint("DE LvL forcefully Aurora for testing purpose down toward the lvl 1.");
-			addButton(9, "Aria", FightAria).hint("Test fight with melkie huntress Aria.");
-			addButton(10, "SomeMalikore", FightRandomnMalikore).hint("Test fight with some malikore.");
-			addButton(11, "Pierce", FightPierce).hint("Test fight with Pierce.");
-			//12
-			addButton(13, "-1-", EnemiesMenu, page - 1);
-			addButton(14, "Back", SoulforceCheats);
-		}
+		
+		buttons.add("Overseer", curry(fightMonster, OmnibusOverseer), "Test Fight against Omnibus Overseer");
+		buttons.add("Sand Mother", FightSandMother, "Test Fight against Sand Mother");
+		buttons.add("Zetaz", curry(fightMonster, Zetaz), "Test Fight against Zetaz");
+		buttons.add("Incels", curry(fightMonster, Incels), "Test Fight against Incels");
+		buttons.add("SuccGard", FightSuccubusGardener, "Test fight with Succubus Gardener. (Also it will glitch right after fight so not start this fight if you got unsaved progress that you not wanna loose as only way to handle post fight glitch is restarting game)");
+		buttons.add("Lethice", FightLethice, "Test Fight against Lethice");
+		buttons.add("Marae", FightMarae, "Test fight with Marae (depending on game stage she can be buffed or unbuffed).");
+		buttons.add("The Dummy", FightTheDummy, "Test Fight against The Dummy");
+		buttons.add("FightForPearl", FightForPearl, "Test fight to get Sky Poison Pearl legally (aside we cheat to start fight)");
+		buttons.add("B.Monke", FightWaizAbi, "You not even want to let the innocent bimbo monke free? <i>*sigh*</i>");
+		if (player.level >= 45) buttons.add("Oculicorn", FightIridesian, "Test fight with Oculicorn.");
+		buttons.add("Draculina", curry(fightMonster, Draculina), "Test Fight against Draculina");
+		buttons.add("GothGirl", FightLilith, "Fight with devilish cute goth girl.");
+		buttons.add("Sonya", FightSonya, "Test fight with Sonya.");
+		buttons.add("RyuBi", FightRyuBi, "Test fight with RyuBi.");
+		buttons.add("Galia", FightGalia, "Test fight with Galia.");
+		buttons.add("ChaosChimera", FightChaosChimera, "Test fight with Chaos Chimera.");
+		buttons.add("AnotSucc", FightCarrera, "Fight with probably another succubus out there...");
+		buttons.add("Aria", FightAria, "Test fight with melkie huntress Aria.");
+		buttons.add("SomeMalikore", FightRandomnMalikore, "Test fight with some malikore.");
+		buttons.add("Pierce", FightPierce, "Test fight with Pierce.");
+		buttons.add("LvLUP Eva", LvLUPEva, "LvL UP forcefully Evangeline for testing purpose up to the limit.");
+		buttons.add("DELvL Eva", DELvLEva, "DE LvL forcefully Evangeline for testing purpose down toward the lvl 12.");
+		buttons.add("LvLUP Aurora", LvLUPAurora, "LvL UP forcefully Aurora for testing purpose up to the limit.");
+		buttons.add("DELvL Aurora", DELvLAurora, "DE LvL forcefully Aurora for testing purpose down toward the lvl 1.");
+		submenu(buttons, SoulforceCheats, 0, false);
 	}
 
 	public function AddRapPerk():void {
@@ -2412,6 +2410,13 @@ public class TestMenu extends BaseContent
 		statScreenRefresh();
 		curry(MaterialMenu, 1);
 	}
+	public function fightMonster(monsterClass:Class, setupFunc:Function = null):void {
+		clearOutput();
+		var monster:Monster = new monsterClass();
+		if (setupFunc != null) setupFunc(monster);
+		outputText("Entering battle with " + monster.short + "! Enjoy ^^");
+		startCombat(monster);
+	}
 	public function FightForPearl():void {
 		clearOutput();
 		outputText("Entering battle with Deep Sea Kraken Boss! Enjoy ^^");
@@ -2483,22 +2488,22 @@ public class TestMenu extends BaseContent
 	public function LvLUPAurora():void {
 		outputText("\n\n<b>Aurora get stronger! (cheat stop working when she reach max possible lvl for now (atm it's lvl 73))</b>");
 		if (flags[kFLAGS.AURORA_LVL] < 13) flags[kFLAGS.AURORA_LVL]++;
-		EnemiesMenu(2);
+		enemiesMenu();
 	}
 	public function DELvLAurora():void {
 		outputText("\n\n<b>Aurora get weaker! (cheat stop working when she reach lvl 1)</b>");
 		if (flags[kFLAGS.AURORA_LVL] > 1) flags[kFLAGS.AURORA_LVL]--;
-		EnemiesMenu(2);
+		enemiesMenu();
 	}
 	public function LvLUPEva():void {
 		outputText("\n\n<b>Evangeline get stronger! (cheat stop working when she reach max possible lvl for now (atm it's lvl 42))</b>");
 		if (flags[kFLAGS.EVANGELINE_LVL_UP] < 17) flags[kFLAGS.EVANGELINE_LVL_UP]++;
-		EnemiesMenu(1);
+		enemiesMenu();
 	}
 	public function DELvLEva():void {
 		outputText("\n\n<b>Evangeline get weaker! (cheat stop working when she reach lvl 12)</b>");
 		if (flags[kFLAGS.EVANGELINE_LVL_UP] > 6) flags[kFLAGS.EVANGELINE_LVL_UP]--;
-		EnemiesMenu(1);
+		enemiesMenu();
 	}
 	public function RevertCabinProgress():void {
 		flags[kFLAGS.CAMP_CABIN_PROGRESS] = 2;


### PR DESCRIPTION
Modified Zetaz AI to use inbuilt functions
Added Might spell to Zetaz that can be used once on difficulties higher than normal
Added monster damage function based off of libido
Cleaned up cheat menu for fighting test bosses
Fixed bug relating to showing special statuses for bosses
Added "GigaWhitefire" spell to Zetaz
"zetazMight" now causes Zetaz to start flying
Zetaz's "Gust" attack is not used if the enemy is already blinded
Omnibus Overseer's "lust aura" and "milk attack" moves now deal scaling damage. "Lust Aura" DoT now deals scaling libido damage
Stunning/Confusing/Fearing the Overseer will disrupt their Lust Aura
Added message to Omnibus Overseer Lust Aura, to signal that they should try disrupting the boss to cancel the aura