### PR TITLE
Upgrade soulskills

### DIFF
--- a/classes/classes/Items/ConsumableLib.as
+++ b/classes/classes/Items/ConsumableLib.as
@@ -248,10 +248,6 @@ public final class ConsumableLib extends AlchemyLib
 		public const CEB_MAN: Consumable = mk("CEB_MAN", "CEBManual", "a manual for Create Element (Basic)", 100, "This manual would teach you how to use Create Element (Basic) soulskill. (Mag)", m.createelementmanual1);
 		public const CEA_MAN: Consumable = mk("CEA_MAN", "CEAManual", "a manual for Create Element (Advanced)", 400, "This manual would teach you how to use Create Element (Advanced) soulskill. (Mag)", m.createelementmanual2);
 		//public const YYB_MAN: Consumable = mk("YYB_MAN", "YYBlastManual", "a manual for Yin Yang Blast", x, "This manual would teach you how to use Yin Yang Blast combination soulskill and it components Yin Palm and Yang Fist soulskills.", m.xxx);
-		public const FOLLMAN: Consumable = mk("FOLLMAN", "FOLLManual", "a manual for Flames of Love (Low Rank) Soulskill", 100, "This manual would teach you how to use Flames of Love (Low Rank) soulskill.", m.flamesoflovemanuallowrank);
-		public const IOLLMAN: Consumable = mk("IOLLMAN", "IOLLManual", "a manual for Icicles of Love (Low Rank) Soulskill", 100, "This manual would teach you how to use Icicles of Love (Low Rank) soulskill.", m.iciclesoflovemanuallowrank);
-		public const SOSLMAN: Consumable = mk("SOSLMAN", "SOSLManual", "a manual for Storm of Sisterhood (Low Rank) Soulskill", 100, "This manual would teach you how to use Storm of Sisterhood (Low Rank) soulskill.", m.stormofsisterhoodmanuallowrank);
-		public const NOBLMAN: Consumable = mk("NOBLMAN", "NOBLManual", "a manual for Night of Brotherhood (Low Rank) Soulskill", 100, "This manual would teach you how to use Night of Brotherhood (Low Rank) soulskill.", m.nightofbrotherhoodmanuallowrank);
 	/*	public const FOLXMAN: Consumable = mk("MAN", "Manual", "a manual for Flames of Love () Soulskill", x, "This manual would teach you how to use Flames of Love (... Rank) soulskill.", m.xxx);
 		public const IOLXMAN: Consumable = mk("MAN", "Manual", "a manual for Icicles of Love () Soulskill", x, ".", m.xxx);
 		public const SOSXMAN: Consumable = mk("MAN", "Manual", "a manual for Storm of Sisterhood () Soulskill", x, ".", m.xxx);

--- a/classes/classes/Scenes/Combat/CombatAbility.as
+++ b/classes/classes/Scenes/Combat/CombatAbility.as
@@ -503,7 +503,6 @@ public class CombatAbility extends BaseCombatContent {
 	 */
 	public function setDuration():void {
 		var duration:int = calcDuration();
-		if (duration > 0) duration++;
 		player.durations[id] = duration;
 	}
 	

--- a/classes/classes/Scenes/Combat/CombatAbility.as
+++ b/classes/classes/Scenes/Combat/CombatAbility.as
@@ -492,7 +492,9 @@ public class CombatAbility extends BaseCombatContent {
 	// "Use ablity" = setCooldown() + useResources() + doEffect()
 	
 	public function setCooldown():void {
-		player.cooldowns[id] = calcCooldown();
+		var cooldown:int = calcCooldown();
+		if (cooldown > 0) cooldown++;
+		player.cooldowns[id] = cooldown;
 	}
 
 	/**
@@ -500,7 +502,9 @@ public class CombatAbility extends BaseCombatContent {
 	 * Must be manually called as part of doEffect()
 	 */
 	public function setDuration():void {
-		player.durations[id] = calcDuration();
+		var duration:int = calcDuration();
+		if (duration > 0) duration++;
+		player.durations[id] = duration;
 	}
 	
 	/**

--- a/classes/classes/Scenes/Combat/Soulskills/FlamesOfLoveSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/FlamesOfLoveSkill.as
@@ -5,6 +5,7 @@ import classes.Monster;
 import classes.Scenes.Combat.Combat;
 import classes.internals.SaveableState;
 import classes.PerkLib;
+import classes.Saves;
 
 public class FlamesOfLoveSkill extends AbstractSoulSkill implements SaveableState {
 	private var uses:int = 0;
@@ -19,7 +20,7 @@ public class FlamesOfLoveSkill extends AbstractSoulSkill implements SaveableStat
             StatusEffects.KnowsFlamesOfLove
         )
 		lastAttackType = Combat.LAST_ATTACK_SPELL;
-		baseSFCost = 100;
+		Saves.registerSaveableState(this);
     }
 
 	public function loadFromObject(o:Object, ignoreErrors:Boolean):void
@@ -73,7 +74,9 @@ public class FlamesOfLoveSkill extends AbstractSoulSkill implements SaveableStat
 					break;
 			case 2: desc += "Effective against groups.\nRank: Low Rank";
 					break;
-			case 3: desc += "Highly effective against groups.\nRank: High Rank";
+			case 3: desc += "Highly effective against groups.\nRank: Mid Rank";
+					break;
+			case 4: desc += "Highly effective against groups.\nRank: High Rank";
 					break;
 		}
 
@@ -94,23 +97,12 @@ public class FlamesOfLoveSkill extends AbstractSoulSkill implements SaveableStat
     }
 
 	override public function calcCooldown():int {
-		return  Math.round(player.statusEffectv1(StatusEffects.KnowsFlamesOfLove));
-	}
-
-	override public function sfCost():int {
-		var currentLevel:int = player.statusEffectv1(knownCondition);
-		var cost:int = baseSFCost;
-
-		cost *= Math.pow(2, currentLevel - 1);
-
-		cost *= soulskillCost() * soulskillcostmulti();
-		return Math.round(cost);
+		return  Math.max(0, player.statusEffectv1(knownCondition) - 1);
 	}
 
 	private function calcLustRestore():Number {
 		var restoreAmount:Number = 0;
-		var restoreMult:Number = Math.pow(2, player.statusEffectv1(StatusEffects.KnowsFlamesOfLove) - 1);
-		restoreAmount += Math.round(player.lust * (restoreMult * 0.1));
+		restoreAmount += Math.round(player.lust * (player.statusEffectv1(knownCondition) * 0.1));
 		return restoreAmount;
 	}
 
@@ -154,8 +146,8 @@ public class FlamesOfLoveSkill extends AbstractSoulSkill implements SaveableStat
 
     private function levelUpCheck(increment:Boolean = true, display:Boolean = true):void {
 		var currentLevel:int = player.statusEffectv1(knownCondition);
-		var nextLevelUp:int = (currentLevel == 2)? 20: 5;
-		var maxLevel:int = 3;
+		var nextLevelUp:int = (currentLevel > 1)? 10: 5;
+		var maxLevel:int = 4;
 		if (currentLevel <= 0 || currentLevel >= maxLevel) return;
 
 		if (increment && uses < nextLevelUp) uses++;
@@ -168,18 +160,27 @@ public class FlamesOfLoveSkill extends AbstractSoulSkill implements SaveableStat
 		if (currentLevel == 1 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulApprentice)) {
 			if (display) {
 				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
-				outputText("<b>\"" + name + " rank has increased from (Rankless) to (Low Rank)!</b>\n\n");
+				outputText("<b>\"" + name + "\" rank has increased from (Rankless) to (Low Rank)!</b>\n\n");
 			}
 			player.changeStatusValue(knownCondition, 1, 2);
 			uses = 0;
 		}
 
-		if (currentLevel == 2 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulScholar)) {
+		if (currentLevel == 2 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulWarrior)) {
 			if (display) {
 				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
-				outputText("<b>\"" + name + " rank has increased from (Low Rank) to (High Rank)!</b>\n\n");
+				outputText("<b>\"" + name + "\" rank has increased from (Low Rank) to (Mid Rank)!</b>\n\n");
 			}
 			player.changeStatusValue(knownCondition, 1, 3);
+			uses = 0;
+		}
+
+		if (currentLevel == 3 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulScholar)) {
+			if (display) {
+				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
+				outputText("<b>\"" + name + "\" rank has increased from (Mid Rank) to (High Rank)!</b>\n\n");
+			}
+			player.changeStatusValue(knownCondition, 1, 4);
 			uses = 0;
 		}
 	}

--- a/classes/classes/Scenes/Combat/Soulskills/FlamesOfLoveSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/FlamesOfLoveSkill.as
@@ -3,23 +3,50 @@ import classes.Scenes.Combat.AbstractSoulSkill;
 import classes.StatusEffects;
 import classes.Monster;
 import classes.Scenes.Combat.Combat;
+import classes.internals.SaveableState;
+import classes.PerkLib;
 
-public class FlamesOfLoveSkill extends AbstractSoulSkill {
+public class FlamesOfLoveSkill extends AbstractSoulSkill implements SaveableState {
+	private var uses:int = 0;
+	private var skillIcon:String = "I_FOLBMAN";
     public function FlamesOfLoveSkill() {
         super(
             "Flames of Love",
             "Enfuse your magic with your burning lust, transfering it to your enemy as a barrage of flames.",
             TARGET_ENEMY,
             TIMING_INSTANT,
-            [TAG_DAMAGING, TAG_FIRE, TAG_RECOVERY, TAG_MAGICAL, TAG_AOE],
+            [TAG_DAMAGING, TAG_FIRE, TAG_RECOVERY, TAG_MAGICAL],
             StatusEffects.KnowsFlamesOfLove
         )
 		lastAttackType = Combat.LAST_ATTACK_SPELL;
+		baseSFCost = 100;
     }
 
-	override public function get buttonName():String {
-		return "Flames of Love";
-	}
+	public function loadFromObject(o:Object, ignoreErrors:Boolean):void
+    {
+    	if (o) {
+			uses = o["uses"];
+		} else {
+			resetState();
+		}
+    }
+
+	public function saveToObject():Object
+    {
+    	return {
+			"uses": uses 
+		}
+    }
+
+    public function stateObjectName():String
+    {
+    	return "FlamesOfLove";
+    }
+
+    public function resetState():void
+    {
+    	uses = 0;
+    }
 
 	override protected function usabilityCheck():String {
         var uc:String =  super.usabilityCheck();
@@ -37,25 +64,74 @@ public class FlamesOfLoveSkill extends AbstractSoulSkill {
 		return "~" + numberFormat(calcDamage(target, lustRestore)) + " fire damage, restores ~" + numberFormat(lustRestore) + " lust";
 	}
 
+	override public function get description():String {
+		var desc:String = super.description;
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+
+		switch (currentLevel) {
+			case 1: desc += "\nRank: Rankless";
+					break;
+			case 2: desc += "Effective against groups.\nRank: Low Rank";
+					break;
+			case 3: desc += "Highly effective against groups.\nRank: High Rank";
+					break;
+		}
+
+		return desc;
+	} 
+
+	override public function presentTags():Array {
+        var result:Array = super.presentTags();
+        var currentLevel:int = player.statusEffectv1(knownCondition);
+        if (currentLevel > 1) result.push(TAG_AOE);
+
+        return result;
+    }
+
+    override public function hasTag(tag:int):Boolean {
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+        return super.hasTag(tag) || (currentLevel > 1 && (tag == TAG_AOE));
+    }
+
 	override public function calcCooldown():int {
 		return  Math.round(player.statusEffectv1(StatusEffects.KnowsFlamesOfLove));
 	}
 
-	public function flamesOfLoveLC():Number {
-    	return 10 * player.statusEffectv1(StatusEffects.KnowsFlamesOfLove);
+	override public function sfCost():int {
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+		var cost:int = baseSFCost;
+
+		cost *= Math.pow(2, currentLevel - 1);
+
+		cost *= soulskillCost() * soulskillcostmulti();
+		return Math.round(cost);
 	}
 
 	private function calcLustRestore():Number {
 		var restoreAmount:Number = 0;
-		restoreAmount += Math.round(player.lust * (flamesOfLoveLC() * 0.01));
+		var restoreMult:Number = Math.pow(2, player.statusEffectv1(StatusEffects.KnowsFlamesOfLove) - 1);
+		restoreAmount += Math.round(player.lust * (restoreMult * 0.1));
 		return restoreAmount;
 	}
 
 	public function calcDamage(monster:Monster, baseDamage: Number):Number {
-		var damage:Number = baseDamage * (5 * player.statusEffectv1(StatusEffects.KnowsFlamesOfLove));
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+		var damage:Number = baseDamage * (5 * currentLevel);
 
+		if (currentLevel > 1) {
+			damage += scalingBonusWisdom() * 0.5;
+
+			damage *= soulskillMagicalMod();
+		}
+		
 		//group enemies bonus
-		if (monster && monster.plural) damage *= 5;
+		if (monster && monster.plural) {
+			if (currentLevel > 2) {
+				damage *= 5;
+			} else if (currentLevel > 1) {
+				damage *= 2;
+			}
+		}
 
 		damage *= combat.fireDamageBoostedByDao();
 		return Math.round(damage);
@@ -73,6 +149,39 @@ public class FlamesOfLoveSkill extends AbstractSoulSkill {
 		}
 		doFireDamage(damage, true, display);
 		if (display) outputText("\n\n");
+		levelUpCheck(true, display);
     }
+
+    private function levelUpCheck(increment:Boolean = true, display:Boolean = true):void {
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+		var nextLevelUp:int = (currentLevel == 2)? 20: 5;
+		var maxLevel:int = 3;
+		if (currentLevel <= 0 || currentLevel >= maxLevel) return;
+
+		if (increment && uses < nextLevelUp) uses++;
+
+		if (isFinite(nextLevelUp)) {
+            notificationView.popupProgressBar2(skillIcon,skillIcon,
+                    name + " Mastery", (uses-1)/nextLevelUp, uses/nextLevelUp);
+        }
+
+		if (currentLevel == 1 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulApprentice)) {
+			if (display) {
+				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
+				outputText("<b>\"" + name + " rank has increased from (Rankless) to (Low Rank)!</b>\n\n");
+			}
+			player.changeStatusValue(knownCondition, 1, 2);
+			uses = 0;
+		}
+
+		if (currentLevel == 2 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulScholar)) {
+			if (display) {
+				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
+				outputText("<b>\"" + name + " rank has increased from (Low Rank) to (High Rank)!</b>\n\n");
+			}
+			player.changeStatusValue(knownCondition, 1, 3);
+			uses = 0;
+		}
+	}
 }
 }

--- a/classes/classes/Scenes/Combat/Soulskills/FlamesOfLoveSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/FlamesOfLoveSkill.as
@@ -102,7 +102,20 @@ public class FlamesOfLoveSkill extends AbstractSoulSkill implements SaveableStat
 
 	private function calcLustRestore():Number {
 		var restoreAmount:Number = 0;
-		restoreAmount += Math.round(player.lust * (player.statusEffectv1(knownCondition) * 0.1));
+
+		var restoreMult:Number = 0;
+		switch (player.statusEffectv1(knownCondition)) {
+			case 1: restoreMult = 0.1;
+					break;
+			case 2: restoreMult = 0.2;
+					break;
+			case 3: restoreMult = 0.25;
+					break;
+			case 4: restoreMult = 0.3;
+					break;
+		}
+		restoreAmount += Math.round(player.lust * restoreMult);
+
 		return restoreAmount;
 	}
 

--- a/classes/classes/Scenes/Combat/Soulskills/IciclesOfLoveSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/IciclesOfLoveSkill.as
@@ -6,6 +6,7 @@ import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.Combat.Combat;
 import classes.internals.SaveableState;
 import classes.PerkLib;
+import classes.Saves;
 
 public class IciclesOfLoveSkill extends AbstractSoulSkill implements SaveableState {
 	private var uses:int = 0;
@@ -20,7 +21,7 @@ public class IciclesOfLoveSkill extends AbstractSoulSkill implements SaveableSta
             StatusEffects.KnowsIciclesOfLove
         )
 		lastAttackType = Combat.LAST_ATTACK_SPELL;
-		baseSFCost = 100;
+		Saves.registerSaveableState(this);
     }
 
 	public function loadFromObject(o:Object, ignoreErrors:Boolean):void
@@ -74,12 +75,14 @@ public class IciclesOfLoveSkill extends AbstractSoulSkill implements SaveableSta
 					break;
 			case 2: desc += "Effective against groups.\nRank: Low Rank";
 					break;
-			case 3: desc += "Highly effective against groups.\nRank: High Rank";
+			case 3: desc += "Highly effective against groups.\nRank: Mid Rank";
+					break;
+			case 4: desc += "Highly effective against groups.\nRank: High Rank";
 					break;
 		}
 
 		return desc;
-	} 
+	}
 
 	override public function presentTags():Array {
         var result:Array = super.presentTags();
@@ -95,23 +98,12 @@ public class IciclesOfLoveSkill extends AbstractSoulSkill implements SaveableSta
     }
 
 	override public function calcCooldown():int {
-		return  Math.round(player.statusEffectv1(StatusEffects.KnowsIciclesOfLove));
-	}
-
-	override public function sfCost():int {
-		var currentLevel:int = player.statusEffectv1(knownCondition);
-		var cost:int = baseSFCost;
-
-		cost *= Math.pow(2, currentLevel - 1);
-
-		cost *= soulskillCost() * soulskillcostmulti();
-		return Math.round(cost);
+		return  Math.max(0, player.statusEffectv1(knownCondition) - 1);
 	}
 
 	private function calcLustRestore():Number {
 		var restoreAmount:Number = 0;
-		var restoreMult:Number = Math.pow(2, player.statusEffectv1(StatusEffects.KnowsIciclesOfLove) - 1);
-		restoreAmount += Math.round(player.lust * (restoreMult * 0.1));
+		restoreAmount += Math.round(player.lust * (player.statusEffectv1(knownCondition) * 0.1));
 		return restoreAmount;
 	}
 
@@ -154,8 +146,8 @@ public class IciclesOfLoveSkill extends AbstractSoulSkill implements SaveableSta
 
 	private function levelUpCheck(increment:Boolean = true, display:Boolean = true):void {
 		var currentLevel:int = player.statusEffectv1(knownCondition);
-		var nextLevelUp:int = (currentLevel == 2)? 20: 5;
-		var maxLevel:int = 3;
+		var nextLevelUp:int = (currentLevel > 1)? 10: 5;
+		var maxLevel:int = 4;
 		if (currentLevel <= 0 || currentLevel >= maxLevel) return;
 
 		if (increment && uses < nextLevelUp) uses++;
@@ -168,18 +160,27 @@ public class IciclesOfLoveSkill extends AbstractSoulSkill implements SaveableSta
 		if (currentLevel == 1 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulApprentice)) {
 			if (display) {
 				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
-				outputText("<b>\"" + name + " rank has increased from (Rankless) to (Low Rank)!</b>\n\n");
+				outputText("<b>\"" + name + "\" rank has increased from (Rankless) to (Low Rank)!</b>\n\n");
 			}
 			player.changeStatusValue(knownCondition, 1, 2);
 			uses = 0;
 		}
 
-		if (currentLevel == 2 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulScholar)) {
+		if (currentLevel == 2 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulWarrior)) {
 			if (display) {
 				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
-				outputText("<b>\"" + name + " rank has increased from (Low Rank) to (High Rank)!</b>\n\n");
+				outputText("<b>\"" + name + "\" rank has increased from (Low Rank) to (Mid Rank)!</b>\n\n");
 			}
 			player.changeStatusValue(knownCondition, 1, 3);
+			uses = 0;
+		}
+
+		if (currentLevel == 3 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulScholar)) {
+			if (display) {
+				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
+				outputText("<b>\"" + name + "\" rank has increased from (Mid Rank) to (High Rank)!</b>\n\n");
+			}
+			player.changeStatusValue(knownCondition, 1, 4);
 			uses = 0;
 		}
 	}

--- a/classes/classes/Scenes/Combat/Soulskills/IciclesOfLoveSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/IciclesOfLoveSkill.as
@@ -4,23 +4,50 @@ import classes.StatusEffects;
 import classes.Monster;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.Combat.Combat;
+import classes.internals.SaveableState;
+import classes.PerkLib;
 
-public class IciclesOfLoveSkill extends AbstractSoulSkill {
+public class IciclesOfLoveSkill extends AbstractSoulSkill implements SaveableState {
+	private var uses:int = 0;
+	private var skillIcon:String = "I_IOLBMAN";
     public function IciclesOfLoveSkill() {
         super(
             "Icicles of Love",
             "Weaponize your lust, crystalizing it into cold, sharp icicles.",
             TARGET_ENEMY,
             TIMING_INSTANT,
-            [TAG_DAMAGING, TAG_ICE, TAG_RECOVERY, TAG_MAGICAL, TAG_AOE],
+            [TAG_DAMAGING, TAG_ICE, TAG_RECOVERY, TAG_MAGICAL],
             StatusEffects.KnowsIciclesOfLove
         )
 		lastAttackType = Combat.LAST_ATTACK_SPELL;
+		baseSFCost = 100;
     }
 
-	override public function get buttonName():String {
-		return "Icicles of Love";
-	}
+	public function loadFromObject(o:Object, ignoreErrors:Boolean):void
+    {
+    	if (o) {
+			uses = o["uses"];
+		} else {
+			resetState();
+		}
+    }
+
+	public function saveToObject():Object
+    {
+    	return {
+			"uses": uses 
+		}
+    }
+
+    public function stateObjectName():String
+    {
+    	return "IciclesOfLove";
+    }
+
+    public function resetState():void
+    {
+    	uses = 0;
+    }
 
 	override protected function usabilityCheck():String {
         var uc:String =  super.usabilityCheck();
@@ -38,25 +65,74 @@ public class IciclesOfLoveSkill extends AbstractSoulSkill {
 		return "~" + numberFormat(calcDamage(target, lustRestore)) + " ice damage, restores ~" + numberFormat(lustRestore) + " lust";
 	}
 
+	override public function get description():String {
+		var desc:String = super.description;
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+
+		switch (currentLevel) {
+			case 1: desc += "\nRank: Rankless";
+					break;
+			case 2: desc += "Effective against groups.\nRank: Low Rank";
+					break;
+			case 3: desc += "Highly effective against groups.\nRank: High Rank";
+					break;
+		}
+
+		return desc;
+	} 
+
+	override public function presentTags():Array {
+        var result:Array = super.presentTags();
+        var currentLevel:int = player.statusEffectv1(knownCondition);
+        if (currentLevel > 1) result.push(TAG_AOE);
+
+        return result;
+    }
+
+    override public function hasTag(tag:int):Boolean {
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+        return super.hasTag(tag) || (currentLevel > 1 && (tag == TAG_AOE));
+    }
+
 	override public function calcCooldown():int {
 		return  Math.round(player.statusEffectv1(StatusEffects.KnowsIciclesOfLove));
 	}
 
-	public function iciclesOfLoveLC():Number {
-    	return 10 * player.statusEffectv1(StatusEffects.KnowsIciclesOfLove);
+	override public function sfCost():int {
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+		var cost:int = baseSFCost;
+
+		cost *= Math.pow(2, currentLevel - 1);
+
+		cost *= soulskillCost() * soulskillcostmulti();
+		return Math.round(cost);
 	}
 
 	private function calcLustRestore():Number {
 		var restoreAmount:Number = 0;
-		restoreAmount += Math.round(player.lust * (iciclesOfLoveLC() * 0.01));
+		var restoreMult:Number = Math.pow(2, player.statusEffectv1(StatusEffects.KnowsIciclesOfLove) - 1);
+		restoreAmount += Math.round(player.lust * (restoreMult * 0.1));
 		return restoreAmount;
 	}
 
 	public function calcDamage(monster:Monster, baseDamage: Number):Number {
-		var damage:Number = baseDamage * (5 * player.statusEffectv1(StatusEffects.KnowsIciclesOfLove));
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+		var damage:Number = baseDamage * (5 * currentLevel);
 
+		if (currentLevel > 1) {
+			damage += scalingBonusWisdom() * 0.5;
+
+			damage *= soulskillMagicalMod();
+		}
+		
 		//group enemies bonus
-		if (monster && monster.plural) damage *= 5;
+		if (monster && monster.plural) {
+			if (currentLevel > 2) {
+				damage *= 5;
+			} else if (currentLevel > 1) {
+				damage *= 2;
+			}
+		}
 
 		damage *= combat.iceDamageBoostedByDao();
 		return Math.round(damage);
@@ -75,5 +151,37 @@ public class IciclesOfLoveSkill extends AbstractSoulSkill {
 		doIceDamage(damage, true, display);
 		if (display) outputText("\n\n");
     }
+
+	private function levelUpCheck(increment:Boolean = true, display:Boolean = true):void {
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+		var nextLevelUp:int = (currentLevel == 2)? 20: 5;
+		var maxLevel:int = 3;
+		if (currentLevel <= 0 || currentLevel >= maxLevel) return;
+
+		if (increment && uses < nextLevelUp) uses++;
+
+		if (isFinite(nextLevelUp)) {
+            notificationView.popupProgressBar2(skillIcon,skillIcon,
+                    name + " Mastery", (uses-1)/nextLevelUp, uses/nextLevelUp);
+        }
+
+		if (currentLevel == 1 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulApprentice)) {
+			if (display) {
+				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
+				outputText("<b>\"" + name + " rank has increased from (Rankless) to (Low Rank)!</b>\n\n");
+			}
+			player.changeStatusValue(knownCondition, 1, 2);
+			uses = 0;
+		}
+
+		if (currentLevel == 2 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulScholar)) {
+			if (display) {
+				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
+				outputText("<b>\"" + name + " rank has increased from (Low Rank) to (High Rank)!</b>\n\n");
+			}
+			player.changeStatusValue(knownCondition, 1, 3);
+			uses = 0;
+		}
+	}
 }
 }

--- a/classes/classes/Scenes/Combat/Soulskills/IciclesOfLoveSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/IciclesOfLoveSkill.as
@@ -103,7 +103,20 @@ public class IciclesOfLoveSkill extends AbstractSoulSkill implements SaveableSta
 
 	private function calcLustRestore():Number {
 		var restoreAmount:Number = 0;
-		restoreAmount += Math.round(player.lust * (player.statusEffectv1(knownCondition) * 0.1));
+
+		var restoreMult:Number = 0;
+		switch (player.statusEffectv1(knownCondition)) {
+			case 1: restoreMult = 0.1;
+					break;
+			case 2: restoreMult = 0.2;
+					break;
+			case 3: restoreMult = 0.25;
+					break;
+			case 4: restoreMult = 0.3;
+					break;
+		}
+		restoreAmount += Math.round(player.lust * restoreMult);
+		
 		return restoreAmount;
 	}
 

--- a/classes/classes/Scenes/Combat/Soulskills/NightOfBrotherhoodSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/NightOfBrotherhoodSkill.as
@@ -4,29 +4,56 @@ import classes.StatusEffects;
 import classes.Monster;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.Combat.Combat;
+import classes.internals.SaveableState;
+import classes.PerkLib;
 
-public class NightOfBrotherhoodSkill extends AbstractSoulSkill {
+public class NightOfBrotherhoodSkill extends AbstractSoulSkill implements SaveableState {
+	private var uses:int = 0;
+	private var skillIcon:String = "I_NOBBMAN";
     public function NightOfBrotherhoodSkill() {
         super(
             "Night of Brotherhood",
             "Condense your wrath into a wreath of shadows, filled with the hate of your brotherhood.",
             TARGET_ENEMY,
             TIMING_INSTANT,
-            [TAG_DAMAGING, TAG_DARKNESS, TAG_RECOVERY, TAG_MAGICAL, TAG_AOE],
+            [TAG_DAMAGING, TAG_DARKNESS, TAG_RECOVERY, TAG_MAGICAL],
             StatusEffects.KnowsNightOfBrotherhood
         )
 		lastAttackType = Combat.LAST_ATTACK_SPELL;
+		baseSFCost = 100;
     }
 
-	override public function get buttonName():String {
-		return "Night of Brotherhood";
-	} 
+	public function loadFromObject(o:Object, ignoreErrors:Boolean):void
+    {
+    	if (o) {
+			uses = o["uses"];
+		} else {
+			resetState();
+		}
+    }
+
+	public function saveToObject():Object
+    {
+    	return {
+			"uses": uses 
+		}
+    }
+
+    public function stateObjectName():String
+    {
+    	return "NightOfBrotherhood";
+    }
+
+    public function resetState():void
+    {
+    	uses = 0;
+    }
 
 	override protected function usabilityCheck():String {
         var uc:String =  super.usabilityCheck();
         if (uc) return uc;
 
-        if (player.wrath < 50) {
+        if (player.wrath < 250) {
 			return "Your current wrath is too low.";
 		}
 
@@ -38,25 +65,74 @@ public class NightOfBrotherhoodSkill extends AbstractSoulSkill {
 		return "~" + numberFormat(calcDamage(target, wrathRestore)) + " darkness damage, restores ~" + numberFormat(wrathRestore) + " wrath";
 	}
 
+	override public function get description():String {
+		var desc:String = super.description;
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+
+		switch (currentLevel) {
+			case 1: desc += "\nRank: Rankless";
+					break;
+			case 2: desc += "Effective against groups.\nRank: Low Rank";
+					break;
+			case 3: desc += "Highly effective against groups.\nRank: High Rank";
+					break;
+		}
+
+		return desc;
+	} 
+
+	override public function presentTags():Array {
+        var result:Array = super.presentTags();
+        var currentLevel:int = player.statusEffectv1(knownCondition);
+        if (currentLevel > 1) result.push(TAG_AOE);
+
+        return result;
+    }
+
+    override public function hasTag(tag:int):Boolean {
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+        return super.hasTag(tag) || (currentLevel > 1 && (tag == TAG_AOE));
+    }
+
 	override public function calcCooldown():int {
 		return  Math.round(player.statusEffectv1(StatusEffects.KnowsNightOfBrotherhood));
 	}
 
-	public function nightOfBrotherhoodWC():Number {
-    	return 10 * player.statusEffectv1(StatusEffects.KnowsNightOfBrotherhood);
+	override public function sfCost():int {
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+		var cost:int = baseSFCost;
+
+		cost *= Math.pow(2, currentLevel - 1);
+
+		cost *= soulskillCost() * soulskillcostmulti();
+		return Math.round(cost);
 	}
 
 	private function calcWrathRestore():Number {
 		var restoreAmount:Number = 0;
-		restoreAmount += Math.round(player.wrath * (nightOfBrotherhoodWC() * 0.01));
+		var restoreMult:Number = Math.pow(2, player.statusEffectv1(StatusEffects.KnowsNightOfBrotherhood) - 1);
+		restoreAmount += Math.round(player.wrath * (restoreMult * 0.1));
 		return restoreAmount;
 	}
 
 	public function calcDamage(monster:Monster, baseDamage: Number):Number {
-		var damage:Number = baseDamage * (5 * player.statusEffectv1(StatusEffects.KnowsNightOfBrotherhood));
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+		var damage:Number = baseDamage * (5 * currentLevel);
 
+		if (currentLevel > 1) {
+			damage += scalingBonusWisdom() * 0.5;
+
+			damage *= soulskillMagicalMod();
+		}
+		
 		//group enemies bonus
-		if (monster && monster.plural) damage *= 5;
+		if (monster && monster.plural) {
+			if (currentLevel > 2) {
+				damage *= 5;
+			} else if (currentLevel > 1) {
+				damage *= 2;
+			}
+		}
 
 		damage *= combat.darknessDamageBoostedByDao();
 		return Math.round(damage);
@@ -75,5 +151,37 @@ public class NightOfBrotherhoodSkill extends AbstractSoulSkill {
 		doDarknessDamage(damage, true, display);
 		if (display) outputText("\n\n");
     }
+
+	private function levelUpCheck(increment:Boolean = true, display:Boolean = true):void {
+		var currentLevel:int = player.statusEffectv1(knownCondition);
+		var nextLevelUp:int = (currentLevel == 2)? 20: 5;
+		var maxLevel:int = 3;
+		if (currentLevel <= 0 || currentLevel >= maxLevel) return;
+
+		if (increment && uses < nextLevelUp) uses++;
+
+		if (isFinite(nextLevelUp)) {
+            notificationView.popupProgressBar2(skillIcon,skillIcon,
+                    name + " Mastery", (uses-1)/nextLevelUp, uses/nextLevelUp);
+        }
+
+		if (currentLevel == 1 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulApprentice)) {
+			if (display) {
+				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
+				outputText("<b>\"" + name + " rank has increased from (Rankless) to (Low Rank)!</b>\n\n");
+			}
+			player.changeStatusValue(knownCondition, 1, 2);
+			uses = 0;
+		}
+
+		if (currentLevel == 2 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulScholar)) {
+			if (display) {
+				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
+				outputText("<b>\"" + name + " rank has increased from (Low Rank) to (High Rank)!</b>\n\n");
+			}
+			player.changeStatusValue(knownCondition, 1, 3);
+			uses = 0;
+		}
+	}
 }
 }

--- a/classes/classes/Scenes/Combat/Soulskills/NightOfBrotherhoodSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/NightOfBrotherhoodSkill.as
@@ -103,7 +103,20 @@ public class NightOfBrotherhoodSkill extends AbstractSoulSkill implements Saveab
 
 	private function calcWrathRestore():Number {
 		var restoreAmount:Number = 0;
-		restoreAmount += Math.round(player.wrath * (player.statusEffectv1(knownCondition) * 0.1));
+
+		var restoreMult:Number = 0;
+		switch (player.statusEffectv1(knownCondition)) {
+			case 1: restoreMult = 0.1;
+					break;
+			case 2: restoreMult = 0.2;
+					break;
+			case 3: restoreMult = 0.25;
+					break;
+			case 4: restoreMult = 0.3;
+					break;
+		}
+		restoreAmount += Math.round(player.wrath * restoreMult);
+		
 		return restoreAmount;
 	}
 

--- a/classes/classes/Scenes/Combat/Soulskills/NightOfBrotherhoodSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/NightOfBrotherhoodSkill.as
@@ -6,6 +6,7 @@ import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.Combat.Combat;
 import classes.internals.SaveableState;
 import classes.PerkLib;
+import classes.Saves;
 
 public class NightOfBrotherhoodSkill extends AbstractSoulSkill implements SaveableState {
 	private var uses:int = 0;
@@ -20,7 +21,7 @@ public class NightOfBrotherhoodSkill extends AbstractSoulSkill implements Saveab
             StatusEffects.KnowsNightOfBrotherhood
         )
 		lastAttackType = Combat.LAST_ATTACK_SPELL;
-		baseSFCost = 100;
+		Saves.registerSaveableState(this);
     }
 
 	public function loadFromObject(o:Object, ignoreErrors:Boolean):void
@@ -74,12 +75,14 @@ public class NightOfBrotherhoodSkill extends AbstractSoulSkill implements Saveab
 					break;
 			case 2: desc += "Effective against groups.\nRank: Low Rank";
 					break;
-			case 3: desc += "Highly effective against groups.\nRank: High Rank";
+			case 3: desc += "Highly effective against groups.\nRank: Mid Rank";
+					break;
+			case 4: desc += "Highly effective against groups.\nRank: High Rank";
 					break;
 		}
 
 		return desc;
-	} 
+	}
 
 	override public function presentTags():Array {
         var result:Array = super.presentTags();
@@ -95,23 +98,12 @@ public class NightOfBrotherhoodSkill extends AbstractSoulSkill implements Saveab
     }
 
 	override public function calcCooldown():int {
-		return  Math.round(player.statusEffectv1(StatusEffects.KnowsNightOfBrotherhood));
-	}
-
-	override public function sfCost():int {
-		var currentLevel:int = player.statusEffectv1(knownCondition);
-		var cost:int = baseSFCost;
-
-		cost *= Math.pow(2, currentLevel - 1);
-
-		cost *= soulskillCost() * soulskillcostmulti();
-		return Math.round(cost);
+		return  Math.max(0, player.statusEffectv1(knownCondition) - 1);
 	}
 
 	private function calcWrathRestore():Number {
 		var restoreAmount:Number = 0;
-		var restoreMult:Number = Math.pow(2, player.statusEffectv1(StatusEffects.KnowsNightOfBrotherhood) - 1);
-		restoreAmount += Math.round(player.wrath * (restoreMult * 0.1));
+		restoreAmount += Math.round(player.wrath * (player.statusEffectv1(knownCondition) * 0.1));
 		return restoreAmount;
 	}
 
@@ -154,8 +146,8 @@ public class NightOfBrotherhoodSkill extends AbstractSoulSkill implements Saveab
 
 	private function levelUpCheck(increment:Boolean = true, display:Boolean = true):void {
 		var currentLevel:int = player.statusEffectv1(knownCondition);
-		var nextLevelUp:int = (currentLevel == 2)? 20: 5;
-		var maxLevel:int = 3;
+		var nextLevelUp:int = (currentLevel > 1)? 10: 5;
+		var maxLevel:int = 4;
 		if (currentLevel <= 0 || currentLevel >= maxLevel) return;
 
 		if (increment && uses < nextLevelUp) uses++;
@@ -168,18 +160,27 @@ public class NightOfBrotherhoodSkill extends AbstractSoulSkill implements Saveab
 		if (currentLevel == 1 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulApprentice)) {
 			if (display) {
 				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
-				outputText("<b>\"" + name + " rank has increased from (Rankless) to (Low Rank)!</b>\n\n");
+				outputText("<b>\"" + name + "\" rank has increased from (Rankless) to (Low Rank)!</b>\n\n");
 			}
 			player.changeStatusValue(knownCondition, 1, 2);
 			uses = 0;
 		}
 
-		if (currentLevel == 2 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulScholar)) {
+		if (currentLevel == 2 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulWarrior)) {
 			if (display) {
 				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
-				outputText("<b>\"" + name + " rank has increased from (Low Rank) to (High Rank)!</b>\n\n");
+				outputText("<b>\"" + name + "\" rank has increased from (Low Rank) to (Mid Rank)!</b>\n\n");
 			}
 			player.changeStatusValue(knownCondition, 1, 3);
+			uses = 0;
+		}
+
+		if (currentLevel == 3 && uses >= nextLevelUp && player.hasPerk(PerkLib.SoulScholar)) {
+			if (display) {
+				outputText("Your skill at using the \"" + name + "\" soulskill has progressed!\n");
+				outputText("<b>\"" + name + "\" rank has increased from (Mid Rank) to (High Rank)!</b>\n\n");
+			}
+			player.changeStatusValue(knownCondition, 1, 4);
 			uses = 0;
 		}
 	}

--- a/classes/classes/Scenes/Combat/Soulskills/StormOfSisterhoodSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/StormOfSisterhoodSkill.as
@@ -103,7 +103,20 @@ public class StormOfSisterhoodSkill extends AbstractSoulSkill implements Saveabl
 
 	private function calcWrathRestore():Number {
 		var restoreAmount:Number = 0;
-		restoreAmount += Math.round(player.wrath * (player.statusEffectv1(knownCondition) * 0.1));
+
+		var restoreMult:Number = 0;
+		switch (player.statusEffectv1(knownCondition)) {
+			case 1: restoreMult = 0.1;
+					break;
+			case 2: restoreMult = 0.2;
+					break;
+			case 3: restoreMult = 0.25;
+					break;
+			case 4: restoreMult = 0.3;
+					break;
+		}
+		restoreAmount += Math.round(player.wrath * restoreMult);
+		
 		return restoreAmount;
 	}
 


### PR DESCRIPTION
Flames Of Love/ Icicles Of Love/ Night Of Brotherhood/ Storm Of SisterHood Skills now have 4 levels: Rankless, Low Rank, Mid Rank, High Rank

Level 2 adds AOE (x2), wisdom and magical soulskill scaling, increases restore amount to 20%, and cooldown to 1 turn
Level 3 increases AOE scaling (x5), increases restore amount to 25% and cooldown to 2 turns
Level 4  increases restore amount to 30% and cooldown to 3 turns

Level up requirements:
Low Rank requires Soul Apprentice perk and 5 uses
Mid Rank requires Soul Warrior perk and 10 uses
High Rank requires Soul Scholar perk and 10 uses