### PR TITLE
Blind spell fix and general fixes

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -4807,5 +4807,21 @@ public class Creature extends Utils
 				}
 			}
 		}
+
+		/**
+		 * Function called when a statuseffect is added to a creature, to allow for additional functionality
+		 * @param Status Effect Instance being attached
+		 */
+		public function onStatusAttach(sec:StatusEffectClass):void {
+			//Do nothing
+		}
+
+		/**
+		 * Function called when a statuseffect is removed from a creature, to allow for additional functionality
+		 * @param Status Effect Instance being removed
+		 */
+		public function onStatusRemove(sec:StatusEffectClass):void {
+			//Do nothing
+		}
 	}
 }

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -255,7 +255,7 @@ import classes.Scenes.Combat.CombatAbilities;
 		 * Called after monster was affected by player's ability.
 		 * @param ability
 		 */
-		public function postPlayerAbility(ability:CombatAbility):void {
+		public function postPlayerAbility(ability:CombatAbility, display:Boolean = true):void {
 			// default - do nothing
 		}
 

--- a/classes/classes/Scenes/Areas/Lake/GooGirl.as
+++ b/classes/classes/Scenes/Areas/Lake/GooGirl.as
@@ -17,10 +17,11 @@ public class GooGirl extends Monster
 		 */
 		
 		
-		override public function postPlayerAbility(ability:CombatAbility):void {
+		override public function postPlayerAbility(ability:CombatAbility, display:Boolean = true):void {
 			//[Using fire attacks on the goo]
 			if (ability.hasTag(CombatAbility.TAG_DAMAGING) && ability.hasTag(CombatAbility.TAG_FIRE)) {
-				outputText("  Your flames lick the girl's body and she opens her mouth in pained protest as you evaporate much of her moisture. When the fire passes, she seems a bit smaller and her slimy " + bodyColor + " skin has lost some of its shimmer.");
+				if (display) outputText("  Your flames lick the girl's body and she opens her mouth in pained protest as you evaporate much of her moisture." + 
+					" When the fire passes, she seems a bit smaller and her slimy " + bodyColor + " skin has lost some of its shimmer.");
 				if(!hasPerk(PerkLib.Acid)) createPerk(PerkLib.Acid,0,0,0,0);
 			}
 		}

--- a/classes/classes/Scenes/Combat/CombatAbility.as
+++ b/classes/classes/Scenes/Combat/CombatAbility.as
@@ -474,7 +474,7 @@ public class CombatAbility extends BaseCombatContent {
 		}
 		if (!interceptable || !monster.interceptPlayerAbility(this)) {
 			doEffect(output);
-			monster.postPlayerAbility(this);
+			monster.postPlayerAbility(this, output);
 		}
 	}
 	

--- a/classes/classes/Scenes/Combat/Soulskills/CleansingPalmSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/CleansingPalmSkill.as
@@ -89,7 +89,7 @@ public class CleansingPalmSkill extends AbstractSoulSkill {
 		}
 		if (monster is LivingStatue) {
 			if (display) {
-				outputText("You thrust your palm forward, causing a blast of pure energy to slam against the giant stone statue- to no effect!");		
+				outputText("You thrust your palm forward, causing a blast of pure energy to slam against the giant stone statue - to no effect!");		
 			}
 			combat.enemyAIAndResources();
 			return;

--- a/classes/classes/Scenes/Combat/SpellsWhite/BlindSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsWhite/BlindSpell.as
@@ -29,6 +29,10 @@ public class BlindSpell extends AbstractWhiteSpell{
 	override protected function usabilityCheck():String {
 		var uc:String = super.usabilityCheck();
 
+		if (monster.hasStatusEffect(StatusEffects.Blind)) {
+			return "[Themonster] is already blinded!";
+		}
+
 		//You can still use Blind if Draculina is the monster invisible
 		if (uc == "You cannot use offensive skills against an opponent you cannot see or target.") {
 			if (monster && monster is Draculina) {
@@ -50,39 +54,19 @@ public class BlindSpell extends AbstractWhiteSpell{
 					
 					outputText("\n\n<i>\"Damn you, fight!\"</i> Lethice screams, grabbing her whip and lashing out at the back-most demons, driving them forward -- and causing the middle bunch to be crushed between competing forces of retreating demons! <i>\"Fight, or you'll be in the submission tanks for the rest of your miserable lives!\"</i>");
 				}
+			} else if (monster is LivingStatue) {
+				if (display) {
+					outputText("Sadly, blindness means nothing to a statue!");
+				}
 			} else {
 				if (display) {
 					outputText("You glare at [themonster] and point at [monster him].  A bright flash erupts before [monster him]!\n");
-				}
-			}
-			if (monster is LivingStatue) {
-				// noop
-			} else if(rand(3) != 0) {
-				if (display) {
-					outputText(" <b>[Themonster] ");
+					outputText("<b>[Themonster] ");
+
 					if (monster.plural && monster.short != "imp horde") outputText("are blinded!</b>");
 					else outputText("is blinded!</b>");
 				}
-				monster.createStatusEffect(StatusEffects.Blind, 2 + player.inte / 20,0,0,0);
-				if(monster is Diva){
-					(monster as Diva).handlePlayerSpell("blind");
-				} else if(monster is Draculina){
-					(monster as Draculina).handlePlayerSpell("blind");
-				} else if(monster.short == "Isabella") {
-					if (display) {
-						if (SceneLib.isabellaFollowerScene.isabellaAccent()) outputText("\n\n\"<i>Nein! I cannot see!</i>\" cries Isabella.");
-						else outputText("\n\n\"<i>No! I cannot see!</i>\" cries Isabella.");
-					}
-				} else if(monster.short == "Kiha") {
-					if (display) {
-						outputText("\n\n\"<i>You think blindness will slow me down?  Attacks like that are only effective on those who don't know how to see with their other senses!</i>\" Kiha cries defiantly.");
-					}
-				} else if(monster.short == "plain girl") {
-					if (display) {
-						outputText("  Remarkably, it seems as if your spell has had no effect on her, and you nearly get clipped by a roundhouse as you stand, confused. The girl flashes a radiant smile at you, and the battle continues.");
-					}
-					monster.removeStatusEffect(StatusEffects.Blind);
-				}
+				monster.createStatusEffect(StatusEffects.Blind, Math.min(2 + player.inte / 20, 10),0,0,0);
 			}
 		} else {
 			if (display) {

--- a/classes/classes/Scenes/Combat/SpellsWhite/WhitefireSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsWhite/WhitefireSpell.as
@@ -65,7 +65,6 @@ public class WhitefireSpell extends AbstractWhiteSpell {
 				outputText("You narrow your eyes, focusing your mana into your thumb and middle finger.  You let the heat build, flowing from your mind and down your arm, until you raise your hand. You snap your fingers, releasing your power and the heat in an instant. [themonster] is enveloped in a flash of white flames.\n");
 			}
 		}
-		if(monster is Diva){(monster as Diva).handlePlayerSpell("whitefire");}
 		var damage:Number = calcDamage(monster, true, true);
 		damage = critAndRepeatDamage(display, damage, DamageType.FIRE);
 		if (ex) awardAchievement("Edgy Caster", kACHIEVEMENTS.COMBAT_EDGY_CASTER);

--- a/classes/classes/Scenes/Combat/SpellsWhite/WhitefireSwiftcastSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsWhite/WhitefireSwiftcastSpell.as
@@ -49,7 +49,6 @@ public class WhitefireSwiftcastSpell extends AbstractWhiteSpell {
 				outputText("You narrow your eyes, focusing your mana into your thumb and middle finger.  You let the heat build, flowing from your mind and down your arm, until you raise your hand. You snap your fingers, releasing your power and the heat in an instant. [themonster] is enveloped in a flash of white flames.\n");
 			}
 		}
-		if(monster is Diva){(monster as Diva).handlePlayerSpell("whitefire");}
 		var damage:Number = calcDamage(monster, true, true);
 		damage = critAndRepeatDamage(display, damage, DamageType.FIRE);
 		checkAchievementDamage(damage);

--- a/classes/classes/Scenes/Dungeons/D3/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/D3/Lethice.as
@@ -494,9 +494,10 @@ public class Lethice extends Monster
 			}
 		}
 
-		override public function postPlayerAbility(ability:CombatAbility):void {
+		override public function postPlayerAbility(ability:CombatAbility, display:Boolean = true):void {
 			if (fightPhase == 3 && ability is AbstractSpell && ability.hasTag(CombatAbility.TAG_DAMAGING)) {
-				outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
+				if (display) outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her." + 
+					" <i>\"How will you beat me without your magics?\"</i>\n\n");
 				createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
 			}
 		}

--- a/classes/classes/Scenes/Dungeons/DemonLab/ProjectNightwalker.as
+++ b/classes/classes/Scenes/Dungeons/DemonLab/ProjectNightwalker.as
@@ -155,17 +155,6 @@ public class ProjectNightwalker extends Monster {
         }
     }
 
-    public function handlePlayerSpell(spell:String = ""):void {
-        if (spell == "whitefire" && player.hasStatusEffect(StatusEffects.Blind)) {
-            player.removeStatusEffect(StatusEffects.Blind);
-            outputText("The room lights back as the flame dispels the shadow.");
-        }
-        if (spell == "blind" && this.hasStatusEffect(StatusEffects.Blind)) {
-            outputText("[Themonster] recoils in pain as the bright light strikes her like a hammer, temporarily pinning her to the ground and stunning her.");
-            this.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
-        }
-    }
-
     public override function isFlying():Boolean {
         return !hasStatusEffect(StatusEffects.Stunned);
     }

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/Draculina.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/Draculina.as
@@ -37,7 +37,7 @@ use namespace CoC;
 		}
 		
 		private function draculinaEmbrace():void {
-			if (rand(120) >= (player.spe > 80) ? player.spe : 80) {
+			if (!player.getEvasionRoll()) {
 				player.createStatusEffect(StatusEffects.NagaBind, 0, 0, 0, 0);
 				outputText("The arch vampire closes her wings, blurring with speed as she arrows towards you. Her body collides with you, the impact sending you reeling, and she wraps her limbs around you, locking you in a cold embrace!");
 				if (EngineCore.silly()) outputText("  Bad touch, bad touch!");
@@ -71,7 +71,9 @@ use namespace CoC;
 				player.takeLustDamage(10 + rand(9), true);
 				if (!player.hasStatusEffect(StatusEffects.AlterBindScroll3)) {
 					var drain:Number = Math.round(player.touStat.max * 0.05);
+					player.saveHPRatio();
 					player.buff("Bat bites").addStats({"tou":-drain}).withText("Bat bites!").combatPermanent();
+					player.restoreHPRatio();
 					showStatDown( 'tou' );
 					if (player.tou <= 1) {
 						doNext(SceneLib.combat.endHpLoss);
@@ -176,10 +178,9 @@ use namespace CoC;
             this.gems = mod > 20 ? 0 : Math.floor((1500 + rand(300)) * Math.exp(0.3*mod));
             this.additionalXP = mod > 20 ? 0 : Math.floor(6500 * Math.exp(0.3*mod));
             
-			this.a = " ";
+			this.a = "";
 			this.short = "Draculina";
 			this.long = "";
-			// this.plural = false;
 			this.createVagina(false, VaginaClass.WETNESS_SLAVERING, VaginaClass.LOOSENESS_NORMAL);
 			this.createStatusEffect(StatusEffects.BonusVCapacity, 40, 0, 0, 0);
 			createBreastRow(Appearance.breastCupInverse("C"));

--- a/classes/classes/Scenes/NPCs/Ceraph.as
+++ b/classes/classes/Scenes/NPCs/Ceraph.as
@@ -312,6 +312,7 @@ public class Ceraph extends Monster
 			this.special2 = ceraphSpecial2;
 			this.special3 = ceraphSpecial3;
 			this.createPerk(PerkLib.UniqueNPC, 0, 0, 0, 0);
+			this.createPerk(PerkLib.EnemyTrueDemon, 0, 0, 0, 0);
 			checkMonster();
 		}
 

--- a/classes/classes/Scenes/NPCs/Diva.as
+++ b/classes/classes/Scenes/NPCs/Diva.as
@@ -10,6 +10,9 @@ import classes.PerkLib;
 import classes.StatusEffects;
 import classes.VaginaClass;
 import classes.internals.ChainedDrop;
+import classes.Scenes.Combat.SpellsWhite.WhitefireSpell;
+import classes.Scenes.Combat.SpellsWhite.BlindSpell;
+import classes.Scenes.Combat.CombatAbility;
 
 public class Diva extends Monster {
     private var _biteCounter:int = 0;
@@ -96,6 +99,19 @@ public class Diva extends Monster {
         if (spell == "blind" && this.hasStatusEffect(StatusEffects.Blind)) {
             outputText("Diva recoils in pain as the bright light strikes her like a hammer, temporarily pinning her to the ground and stunning her.");
             this.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
+        }
+    }
+
+    override public function postPlayerAbility(ability:CombatAbility, display:Boolean = true):void {
+        if (ability is BlindSpell && hasStatusEffect(StatusEffects.Blind)) {
+            if (display) {
+                outputText("Diva recoils in pain as the bright light strikes her like a hammer, temporarily pinning her to the ground and stunning her.");
+            }
+            this.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
+        } else if (ability is WhitefireSpell && hasStatusEffect(StatusEffects.Blind)) {
+            if (display) {
+                outputText("The room lights back as the flame dispels the shadow.");
+            }
         }
     }
 

--- a/classes/classes/Scenes/NPCs/Holli.as
+++ b/classes/classes/Scenes/NPCs/Holli.as
@@ -28,9 +28,9 @@ public class Holli extends Monster
 //attack noun: lash
 		
 		
-		override public function postPlayerAbility(ability:CombatAbility):void {
+		override public function postPlayerAbility(ability:CombatAbility, display:Boolean = true):void {
 			if (ability.hasTag(CombatAbility.TAG_DAMAGING) && ability.hasTag(CombatAbility.TAG_FIRE)) {
-				if(!hasStatusEffect(StatusEffects.HolliBurning)) lightHolliOnFireMagically();
+				if(!hasStatusEffect(StatusEffects.HolliBurning)) lightHolliOnFireMagically(display);
 			}
 		}
 		
@@ -101,11 +101,11 @@ public class Holli extends Monster
 		}
 
 //if player uses whitefire/firebreath successfully, suppress these, go to 'Fire Lit' EOR events, and output additional line after the attack:
-		public function lightHolliOnFireMagically():void
+		public function lightHolliOnFireMagically(display:Boolean = true):void
 		{
 			if (hasStatusEffect(StatusEffects.JojoIsAssisting)) {
 				if (!hasStatusEffect(StatusEffects.HolliBurning)) {
-					outputText("The magical fire effectively ignites a wide swath of Jojo's tinder, and the demon howls in rage.  Seeing this, Jojo drops the burning torch he carries and turns back toward the forest to fetch more tinder.\n\n");
+					if (display) outputText("The magical fire effectively ignites a wide swath of Jojo's tinder, and the demon howls in rage.  Seeing this, Jojo drops the burning torch he carries and turns back toward the forest to fetch more tinder.\n\n");
 					createStatusEffect(StatusEffects.HolliBurning, 0, 0, 0, 0);
 				}
 			}

--- a/classes/classes/Scenes/NPCs/Isabella.as
+++ b/classes/classes/Scenes/NPCs/Isabella.as
@@ -6,6 +6,8 @@ import classes.BodyParts.Hips;
 import classes.BodyParts.Tail;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.SceneLib;
+import classes.Scenes.Combat.CombatAbility;
+import classes.Scenes.Combat.SpellsWhite.BlindSpell;
 
 public class Isabella extends Monster
 	{
@@ -118,6 +120,13 @@ public class Isabella extends Monster
 			else HP += 100;
 			lust += 5;
 			player.takeLustDamage((10+player.lib/20), true);
+		}
+
+		override public function postPlayerAbility(ability:CombatAbility, display:Boolean = true):void {
+			if (ability is BlindSpell && hasStatusEffect(StatusEffects.Blind) && display) {
+				if (SceneLib.isabellaFollowerScene.isabellaAccent()) outputText("\n\n\"<i>Nein! I cannot see!</i>\" cries Isabella.");
+				else outputText("\n\n\"<i>No! I cannot see!</i>\" cries Isabella.");
+			}
 		}
 
 		override protected function performCombatAction():void

--- a/classes/classes/Scenes/NPCs/Kiha.as
+++ b/classes/classes/Scenes/NPCs/Kiha.as
@@ -11,6 +11,8 @@ import classes.GlobalFlags.kFLAGS;
 import classes.IMutations.*;
 import classes.Scenes.SceneLib;
 import classes.internals.ChainedDrop;
+import classes.Scenes.Combat.CombatAbility;
+import classes.Scenes.Combat.SpellsWhite.BlindSpell;
 
 public class Kiha extends Monster
 	{
@@ -89,6 +91,13 @@ public class Kiha extends Monster
 				outputText("\n");
 			}
 		}
+
+		override public function postPlayerAbility(ability:CombatAbility, display:Boolean = true):void {
+			if (ability is BlindSpell && hasStatusEffect(StatusEffects.Blind) && display) {
+				outputText("\n\n\"<i>You think blindness will slow me down?  Attacks like that are only effective on those who don't know how to see with their other senses!</i>\" Kiha cries defiantly.");
+			}
+		}
+
 		/*
 		Special 2: Kiha lifts her axe overhead and then hurls it at you in a surprising feat of speed and strength. Not keen on getting cleaved in two, you sidestep the jagged metal.
 		Hit: But when your attention refocuses on the dragoness, you realize she's right in front of you! She hits you in the face with a vicious straight punch, knocking you on your back.

--- a/classes/classes/Scenes/NPCs/Shouldra.as
+++ b/classes/classes/Scenes/NPCs/Shouldra.as
@@ -5,6 +5,8 @@ import classes.BodyParts.Butt;
 import classes.BodyParts.Hips;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
+import classes.Scenes.Combat.CombatAbility;
+import classes.Scenes.Combat.SpellsWhite.BlindSpell;
 
 /**
 	 * ...
@@ -74,9 +76,20 @@ import classes.internals.*;
 			outputText("\n");
 		}
 
+		override public function postPlayerAbility(ability:CombatAbility, display:Boolean = true):void {
+			if (ability is BlindSpell && hasStatusEffect(StatusEffects.Blind)) {
+				if (display) {
+					outputText("\n\nRemarkably however, it seems as if your spell has had no effect on her, and you nearly get clipped by a roundhouse as you stand, confused." + 
+						" The girl flashes a radiant smile at you, and the battle continues.");
+				}
+				removeStatusEffect(StatusEffects.Blind);
+			}
+		}
+
 		override public function midDodge():void{
 			outputText("You wait patiently for your opponent to drop her guard. She ducks in and throws a right cross, which you roll away from before smacking your [weapon] against her side. Astonishingly, the attack appears to phase right through her, not affecting her in the slightest. You glance down to your [weapon] as if betrayed.\n");
 		}
+
 		override protected function performCombatAction():void
 		{
 			var attack:Number = rand(3);

--- a/classes/classes/StatusEffectClass.as
+++ b/classes/classes/StatusEffectClass.as
@@ -77,12 +77,18 @@ public class StatusEffectClass extends Utils
 		_host = null;
 	}
 	public function removedFromHostList(fireEvent:Boolean):void {
-		if (fireEvent) onRemove();
+		if (fireEvent) {
+			onRemove();
+			_host.onStatusRemove(this);
+		}
 		_host = null;
 	}
 	public function addedToHostList(host:Creature,fireEvent:Boolean):void {
 		_host = host;
-		if (fireEvent) onAttach();
+		if (fireEvent) {
+			onAttach();
+			_host.onStatusAttach(this);
+		}
 	}
 	public function attach(host:Creature/*,fireEvent:Boolean = true*/):void {
 		if (_host == host) return;


### PR DESCRIPTION
Blind Spell no longer has a random chance of not working, even after passing the success check

Added "onStatusAttach" and "onStatusRemove" functions to Creature class, to allow for custom code to be ran when adding/removing a status effect on a per-monster basis
"postPlayerAbility" function now takes the display parameter into account
Moved post blind monster reactions into their actual Monster classes, rather than the spell
Blind now cannot be used if the monster is already blinded
Fixed bug where Draculina Embrace will always hit
Ceraph is now classed as a proper True Demon