### PR TITLE
Resource regen

### DIFF
--- a/classes/classes/Scenes/Areas/Desert/NagaScene.as
+++ b/classes/classes/Scenes/Areas/Desert/NagaScene.as
@@ -1021,10 +1021,9 @@ public function nagaTease():void {
 		if (monster.hasStatusEffect(StatusEffects.NagaVenom)) outputText("You attempt to stimulate [themonster] by rubbing [monster his] nether regions, but [monster he] seems too affected by your poison to react.\n\n");
 		if (monster.gender == 0) outputText("You look over [themonster], but can't figure out how to tease such an unusual foe.\n\n");
 		if (monster.lustVuln == 0) outputText("You attempt to stimulate [themonster] by rubbing [monster his] nether regions, but it has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
-        combat.enemyAIAndResources();
+        enemyAI();
         return;
 	}
-	recoveryOfResources();
 	var damage:Number;
     var chance:Number = 70;
     var bimbo:Boolean = false;

--- a/classes/classes/Scenes/Areas/Mountain/WormsScene.as
+++ b/classes/classes/Scenes/Areas/Mountain/WormsScene.as
@@ -176,7 +176,7 @@ public class WormsScene extends BaseContent
 			if(player.fatigue + combat.physicalCost(40) > player.maxFatigue()) {
 				outputText("You try to summon up an orgasm, but you're too tired and waste your time trying!");
 				fatigue(60);
-				combat.enemyAIAndResources();
+				enemyAI();
 				return;
 			}
 
@@ -198,7 +198,7 @@ public class WormsScene extends BaseContent
 				outputText("You expose yourself and attempt to focus on expelling your squirming pets toward [sheilaname] but as you picture launching a flood of parasites from [eachCock], the fantasy she sent returns to you, breaking your concentration!  Your hand darts automatically to your crotch, stroking [oneCock] as you imagine unloading into her cunt... only with effort do you pull it away!\n\n");
 				outputText("\"<i>Oh, my,</i>\" the demon teases.  \"<i>You don't have to masturbate yourself, [name]... I'll be happy to do it for you.</i>\"\n\n");
 				dynStats("lus", 5 + player.effectiveSensitivity()/10, "scale", false);
-				combat.enemyAIAndResources();
+				enemyAI();
 				return;
 			}
 			fatigue(40, USEFATG_PHYSICAL);
@@ -233,7 +233,7 @@ public class WormsScene extends BaseContent
 			}
 			awardAchievement("Cum Cannon", kACHIEVEMENTS.COMBAT_CUM_CANNON);
 			dynStats("lus", -20, "scale", false);
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 
 

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -783,7 +783,6 @@ public class Combat extends BaseContent {
         if (newRound) combatStatusesUpdate(); //Update Combat Statuses
         display();
         statScreenRefresh();
-        if (newRound) combatRoundOver();
         if (combatIsOver()) return;
         ui.mainMenu();
         //Modify menus.
@@ -12173,8 +12172,7 @@ public function unarmedCombatXP(XP:Number = 0):void  	{player.gainCombatXP(MASTE
 //VICTORY OR DEATH?
 // Called after the monster's action. Increments round counter. Setups doNext to win/loss/combat menu
 public function combatRoundOver():void {
-    var HPPercent:Number;
-    HPPercent = player.HP/player.maxHP();
+    player.saveHPRatio();
     combatRound++;
     player.statStore.advanceTime(Buff.RATE_ROUNDS,1);
     monster.statStore.advanceTime(Buff.RATE_ROUNDS,1);
@@ -12193,9 +12191,10 @@ public function combatRoundOver():void {
         if (player.hasPerk(PerkLib.SelfbuffsProficiencyEx) && player.mana >= CombatAbilities.Blink.manaCost()) CombatAbilities.Blink.autocast();
         else EngineCore.outputText("\nYour speeds wanes as your Blink spell ends.\n");
     }
+    player.restoreHPRatio();
+    recoveryOfResourcesImpl();
     statScreenRefresh();
     flags[kFLAGS.ENEMY_CRITICAL] = 0;
-    player.HP = HPPercent*player.maxHP();
     combatIsOver();
 }
 
@@ -13907,7 +13906,7 @@ public function spiderBiteAttack():void {
     WrathGenerationPerHit2(5);
     player.tailVenom -= player.VenomWebCost() * 5;
     flags[kFLAGS.VENOM_TIMES_USED] += 1;
-    if (!combatIsOver()) enemyAIAndResources();
+    enemyAIAndResources();
 }
 
 public function ManticoreFeed():void {

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -639,7 +639,7 @@ public class Combat extends BaseContent {
         clearOutput();
         outputText("You close the distance between you and [themonster] as quickly as possible.\n\n");
         player.removeStatusEffect(StatusEffects.KnockedBack);
-		enemyAIAndResources();
+		enemyAIImpl();
     }
 
     public function get isEnemyInvisible():Boolean {
@@ -1827,7 +1827,7 @@ public class Combat extends BaseContent {
 						addButton(0, "Next", combatMenu, false);
 					}
 				}
-				else enemyAIAndResources();
+				else enemyAIImpl();
 			}
         } else {
             //If monster is dead, prevent further elemental attack calls
@@ -1855,12 +1855,12 @@ public class Combat extends BaseContent {
             if (monster is ChaosChimera) outputText("Curse");
             else outputText("The kitsune's seals");
             outputText(" have made normal melee attacks impossible!  Maybe you could try something else?\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         if (player.hasStatusEffect(StatusEffects.Sealed2) && player.statusEffectv2(StatusEffects.Sealed2) == 0) {
             outputText("You attempt to attack, but at the last moment your mech wrenches away, preventing you from even coming close to landing a blow!  Recent enemy actions have made normal melee attack impossible!  Maybe you could try something else?\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
 		if (checkConcentration()) return; //Amily concentration
@@ -1898,7 +1898,7 @@ public class Combat extends BaseContent {
         if ((monster is FrostGiant || monster is YoungFrostGiant) && player.hasStatusEffect(StatusEffects.GiantBoulder)) {
             if (monster as FrostGiant) (monster as FrostGiant).giantBoulderHit(0);
             if (monster as YoungFrostGiant) (monster as YoungFrostGiant).youngGiantBoulderHit(0);
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         //Worms are special
@@ -1922,7 +1922,7 @@ public class Combat extends BaseContent {
                 attack();
                 return;
             }
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         //Determine if dodged!
@@ -1936,7 +1936,7 @@ public class Combat extends BaseContent {
             } else {
                 if (player.isInGoblinMech()) outputText("You activate the mech’s saw blade, intent on slicing your opponent in half. [Themonster] avoids the blade as best as it can.\n\n");
             }
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         //BLOCKED ATTACK:
@@ -1946,7 +1946,7 @@ public class Combat extends BaseContent {
                 attack();
                 return;
             } else outputText("\n");
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         baseMechMeleeAttacksDamage();
@@ -2094,7 +2094,7 @@ public class Combat extends BaseContent {
             return;
         }
         outputText("\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
     }
 
     public function packAttack():void {
@@ -2154,7 +2154,6 @@ public class Combat extends BaseContent {
     internal function wait():void {
         var skipMonsterAction:Boolean = false; // If false, enemyAI() will be called. If true, combatRoundOver()
         flags[kFLAGS.IN_COMBAT_USE_PLAYER_WAITED_FLAG] = 1;
-        recoveryOfResources();
         if (monster.hasStatusEffect(StatusEffects.PCTailTangle)) {
             (monster as Kitsune).kitsuneWait();
             skipMonsterAction = true;
@@ -2306,7 +2305,7 @@ public class Combat extends BaseContent {
         if (skipMonsterAction) {
             combatRoundOver();
         } else {
-            enemyAIAndResources();
+            enemyAIImpl();
         }
     }
 
@@ -2317,7 +2316,6 @@ public class Combat extends BaseContent {
         if (monster is Alraune) {
             (monster as Alraune).alrauneStruggle();
         }
-        recoveryOfResources();
         combatRoundOver();
     }
 
@@ -2529,7 +2527,7 @@ public class Combat extends BaseContent {
         if (skipMonsterAction) {
             combatRoundOver();
         } else {
-            enemyAIAndResources();
+            enemyAIImpl();
         }
     }
 
@@ -2537,8 +2535,7 @@ public class Combat extends BaseContent {
         clearOutput();
         outputText("You boldly approach your enemy. instead of attacking, you simply pick up some of your thrown weapons.");
 		player.ammo += 5;
-        recoveryOfResources();
-        combatRoundOver();
+        enemyAI();
     }
 
     //unused for now function - maybe use later for some other attacks accuracy or maybe spells? xD
@@ -2850,7 +2847,7 @@ public class Combat extends BaseContent {
         //Incubus Scientist
         if (monster is IncubusScientist && (monster as IncubusScientist).ShieldHits > 0) {
             (monster as IncubusScientist).ShieldsHitRanged();
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         flags[kFLAGS.LAST_ATTACK_TYPE] = LAST_ATTACK_BOW;
@@ -2930,7 +2927,7 @@ public class Combat extends BaseContent {
         if (checkConcentration("[monster name] easily glides around your attack" + (flags[kFLAGS.MULTIPLE_ARROWS_STYLE] >= 2 ? "s" : "") + " thanks to [monster his] complete concentration on your movements.\n\n")) return; //Amily concentration
         if (monster.hasStatusEffect(StatusEffects.Sandstorm) && rand(10) > 1) {
             outputText("Your attack" + (flags[kFLAGS.MULTIPLE_ARROWS_STYLE] >= 2 ? "s" : "") + " is blown off target by the tornado of sand and wind.  Damn!\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         //[Bow Response]
@@ -2943,30 +2940,30 @@ public class Combat extends BaseContent {
             if (SceneLib.isabellaFollowerScene.isabellaAccent())
                 outputText("\"<i>You remind me of ze horse-people.  Zey cannot deal vith mein shield either!</i>\" cheers Isabella.\n\n");
             else outputText("\"<i>You remind me of the horse-people.  They cannot deal with my shield either!</i>\" cheers Isabella.\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         //worms are immune
         if (monster is WormMass) {
             outputText("The " + ammoWord + (flags[kFLAGS.MULTIPLE_ARROWS_STYLE] >= 2 ? "s" : "") +" slips between the worms, sticking into the ground.\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         //Vala miss chance!
         if (monster is Vala && rand(10) < 7 && !monster.hasStatusEffect(StatusEffects.Stunned)) {
             outputText("Vala flaps her wings and twists her body. Between the sudden gust of wind and her shifting of position, the " + ammoWord + (flags[kFLAGS.MULTIPLE_ARROWS_STYLE] >= 2 ? "s" : "") +" goes wide.\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         //Blind miss chance
         if (player.playerIsBlinded()) {
             outputText("The " + ammoWord + (flags[kFLAGS.MULTIPLE_ARROWS_STYLE] >= 2 ? "s" : "") +" hits something, but blind as you are, you don't have a chance in hell of hitting anything with a " + player.weaponRangeName + ".\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         if (monster is Lethice && monster.hasStatusEffect(StatusEffects.Shell)) {
             outputText("Your " + ammoWord + (flags[kFLAGS.MULTIPLE_ARROWS_STYLE] >= 2 ? "s" : "") +" pings of the side of the shield and spins end over end into the air. Useless.\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         if (player.isBowTypeWeapon() || player.isCrossbowTypeWeapon()) {
@@ -3348,7 +3345,7 @@ public class Combat extends BaseContent {
                 monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
             }
             if (MSGControll) outputText("\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
         }
         if (monster.HP <= monster.minHP()) {
             doNext(endHpVictory);
@@ -3684,7 +3681,7 @@ public class Combat extends BaseContent {
             return;
         }
 		outputText(" It's clearly very painful.\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
     }
 
     /**
@@ -3768,7 +3765,7 @@ public class Combat extends BaseContent {
         if (hasCritAtLeastOnce) outputText(" <b>ne or more of your projectile hit a weak point!*</b>");
         if (player.ammo == 0) {
             if (player.ammo == 0) outputText("\n\n<b>You're out of weapons to throw in this fight!</b>\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
         }
         if (monster.HP <= monster.minHP()) {
             doNext(endHpVictory);
@@ -3896,7 +3893,7 @@ public class Combat extends BaseContent {
                 monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
             }
             if (player.ammo == 0) outputText("\n\n<b>You're out of weapons to throw in this fight!</b>\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
         }
         if (monster.HP <= monster.minHP()) {
             doNext(endHpVictory);
@@ -4265,7 +4262,7 @@ public class Combat extends BaseContent {
                 if (player.weaponRange == weaponsrange.LBLASTR) outputText("<b>Your milk tank is empty.</b>\n\n");
                 else outputText("<b>Your firearm clip is empty.</b>\n\n");
                 reloadWeapon2();
-            } else enemyAIAndResources();
+            } else enemyAIImpl();
         }
     }
 
@@ -4324,7 +4321,7 @@ public class Combat extends BaseContent {
         if (player.fatigue + (oneBulletReloadCost() * player.ammo) > player.maxFatigue()) {
             outputText(" You are too tired to act in this round after reloading your weapon.\n\n");
             player.fatigue += (oneBulletReloadCost() * player.ammo);
-            enemyAIAndResources();
+            enemyAIImpl();
         } else {
             fatigue(oneBulletReloadCost() * player.ammo);
             if (player.hasPerk(PerkLib.RapidReload)) {
@@ -4332,7 +4329,7 @@ public class Combat extends BaseContent {
                 doNext(combatMenu, false);
             } else {
                 outputText("Reloading took some time. Your opponent takes advantage of this.\n\n");
-                enemyAIAndResources();
+                enemyAIImpl();
             }
         }
     }
@@ -4342,7 +4339,7 @@ public class Combat extends BaseContent {
         if (player.fatigue + (oneBulletReloadCost() * player.ammo) > player.maxFatigue()) {
             outputText("You are too tired to keep shooting in this round after reloading your weapon.\n\n");
             player.fatigue += (oneBulletReloadCost() * player.ammo);
-            enemyAIAndResources();
+            enemyAIImpl();
         } else {
             fatigue(oneBulletReloadCost() * player.ammo);
             if (player.hasPerk(PerkLib.LightningReload) && flags[kFLAGS.MULTIPLE_ARROWS_STYLE] > 1) {
@@ -4354,7 +4351,7 @@ public class Combat extends BaseContent {
                 if (player.weaponRange != weaponsrange.M1CERBE && player.weaponRange != weaponsrange.TM1CERB && player.weaponRange != weaponsrange.TRFATBI && player.weaponRange != weaponsrange.HARPGUN && player.weaponRange != weaponsrange.SNIPPLE && player.weaponRange != weaponsrange.TOUHOM3 && player.weaponRange != weaponsrange.DERPLAU && player.weaponRange != weaponsrange.DUEL_P_
                         && player.weaponRange != weaponsrange.FLINTLK && player.weaponRange != weaponsrange.HARKON1 && player.weaponRange != weaponsrange.HARKON2) outputText(" Due to slow reloading you spent rest of your round on it and can't act until next turn.");
                 outputText("\n\n");
-                enemyAIAndResources();
+                enemyAIImpl();
             }
         }
     }
@@ -4426,14 +4423,14 @@ public class Combat extends BaseContent {
             lustChange = baseLustDmg + rand(player.lib / 4 + player.cor / 5);
             dynStats("lus", lustChange, "scale", false);
             (monster as FrostGiant).giantBoulderFantasize();
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         if (monster is YoungFrostGiant && (player.hasStatusEffect(StatusEffects.GiantBoulder))) {
             lustChange = baseLustDmg / 2 + rand(player.lib / 5 + player.cor / 8);
             dynStats("lus", lustChange, "scale", false);
             (monster as YoungFrostGiant).youngGiantBoulderFantasize();
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         if (player.armor == armors.GOOARMR) {
@@ -4470,7 +4467,7 @@ public class Combat extends BaseContent {
                 return;
             }
         }
-        enemyAIAndResources();
+        enemyAIImpl();
     }
 
     public function goboLustnadeLauncher():void {
@@ -4521,7 +4518,7 @@ public class Combat extends BaseContent {
         }
         outputText("\n\n")
         if (monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
-        enemyAIAndResources();
+        enemyAIImpl();
     }
 
     public function defendpose():void {
@@ -4533,7 +4530,7 @@ public class Combat extends BaseContent {
             manaregeneration1();
             soulforceregeneration1();
         }
-		enemyAIAndResources();
+		enemyAIImpl();
     }
 
     public static function playerWaitsOrDefends():Boolean {
@@ -4551,7 +4548,7 @@ public class Combat extends BaseContent {
         fatigue((player.maxFatigue() - player.fatigue) / 2);
         player.createStatusEffect(StatusEffects.SecondWindRegen, 10, 0, 0, 0);
         player.createStatusEffect(StatusEffects.CooldownSecondWind, 0, 0, 0, 0);
-        enemyAIAndResources();
+        enemyAIImpl();
     }
 
     public function surrenderByHP():void {
@@ -6524,7 +6521,6 @@ public class Combat extends BaseContent {
             outputText("\nThe pain makes your target snap out of the trance, causing them to realise what is going on.\n");
             player.removeStatusEffect(StatusEffects.HypnosisNaga);
         }
-        recoveryOfResources();
     }
 	
 	public function layerFoxflamePeltOnThis(damage:Number, display:Boolean = true):void {
@@ -7327,7 +7323,6 @@ public class Combat extends BaseContent {
 			}
 			if (player.perkv1(IMutationsLib.SlimeFluidIM) >= 4 && player.HP < player.maxHP()) monster.teased(combat.teases.teaseBaseLustDamage() * monster.lustVuln, false);
         }
-        //recoveryOfResources();
     }
 
     public function flyingSwordAttackModifier(damage:Number):Number {
@@ -8932,13 +8927,8 @@ public class Combat extends BaseContent {
         if (player.fatigue < 0) player.fatigue = 0;
         statScreenRefresh();
     }
-	
-	public function enemyAIAndResources():void {
-		recoveryOfResources();
-		enemyAI();
-	}
 
-//ENEMYAI!
+    //ENEMYAI!
     public function enemyAIImpl():void {
         if (monster.HP <= monster.minHP()) {
             doNext(endHpVictory);
@@ -11550,10 +11540,10 @@ public class Combat extends BaseContent {
 		return venomCRecharge;
 	}
 
-    internal var combatRound:int = 0;
+    internal var combatRound:int = 1;
 
     public function startCombatImpl(monster_:Monster, plotFight_:Boolean = false):void {
-        combatRound = 0;
+        combatRound = 1;
         CoC.instance.plotFight = plotFight_;
         mainView.hideMenuButton(MainView.MENU_DATA);
         mainView.hideMenuButton(MainView.MENU_APPEARANCE);
@@ -12300,7 +12290,7 @@ public function OrcaJuggle():void {
             outputText("\n\nYou cannot juggle any further. ");
         }
         outputText("\n\n" + player.statusEffectv1(StatusEffects.OrcaPlayRoundLeft) + " rounds to play  left.\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
     }
 }
 
@@ -12329,7 +12319,7 @@ public function OrcaCleanup():void {
         }
     }
     outputText("\n\n" + player.statusEffectv1(StatusEffects.OrcaPlayRoundLeft) + " rounds to play left.\n\n");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function OrcaWack():void {
@@ -12476,7 +12466,7 @@ public function OrcaImpale():void {
             monster.removeStatusEffect(StatusEffects.OrcaHasWacked);
             monster.createStatusEffect(StatusEffects.OrcaHasWackedFinish, 0, 0, 0, 0);
         }
-        enemyAIAndResources();
+        enemyAIImpl();
     }
 }
 
@@ -12502,7 +12492,7 @@ public function OrcaLeggoMyEggo():void {
     }
     outputText("[monster He] heaves, trying to catch [monster his] breath before [monster he] stands back up, preparing to fight once more. ");
     outputText("\n\n");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function CancerGrab():void {
@@ -12601,7 +12591,7 @@ public function CancerGrab():void {
     monster.createStatusEffect(StatusEffects.CancerGrab, 3 + rand(3), 0, 0, 0);
     if (monster.hasStatusEffect(StatusEffects.Dig)) monster.removeStatusEffect(StatusEffects.Dig);
     outputText("\n\n");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function Tremor():void {
@@ -12637,7 +12627,7 @@ public function Tremor():void {
     monster.createStatusEffect(StatusEffects.Stunned, 3, 0, 0, 0);
     player.createStatusEffect(StatusEffects.CooldownTremor, 5, 0, 0, 0);
     outputText("\n\n");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function SingIntensify(Bee:Boolean = false):void {
@@ -12653,7 +12643,7 @@ public function SingIntensify(Bee:Boolean = false):void {
             player.addStatusValue(StatusEffects.Sing,1,+1);
         }
         outputText("\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
     }
     else {
         outputText("Try as you might you cannot intensify the strength of your song any further.");
@@ -12695,7 +12685,7 @@ public function SingArouse(Bee:Boolean = false):void {
     if (randomcrit) outputText(" Critical hit!");
     outputText("\n\n");
     combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function SingCaptivate():void {
@@ -12704,7 +12694,7 @@ public function SingCaptivate():void {
     monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
     player.createStatusEffect(StatusEffects.CooldownSingCaptivate,4,0,0,0);
     outputText("\n\n");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function SingDevastatingAria():void {
@@ -12734,14 +12724,14 @@ public function SingDevastatingAria():void {
     if (crit) outputText(" Critical hit!");
     outputText("\n\n");
     combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function SingOut():void {
     clearOutput();
     outputText("You stop singing and resume fighting normally.\n\n");
     player.removeStatusEffect(StatusEffects.Sing);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function Straddle():void {
@@ -12789,7 +12779,7 @@ public function Straddle():void {
         }
         else outputText("You take hold of your dazed opponent and gently pull [monster him] to the ground, straddling [monster him] as you get into position.");
         if (player.hasPerk(PerkLib.StraddleImproved)) player.addStatusValue(StatusEffects.StraddleRoundLeft, 1, +2);
-        enemyAIAndResources();
+        enemyAIImpl();
 }
 
 //private var straddleDamage:Number
@@ -12878,7 +12868,7 @@ public function StraddleTease():void {
             outputText("Your opponent finally manages to struggle free of your grapple!\n\n");
         }
     }
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function randomTeaseKiss(straddleDamage:Number, randomcrit:Boolean):void {
@@ -13227,14 +13217,14 @@ public function straddleLeggoMyEggo():void {
     player.removeStatusEffect(StatusEffects.StraddleRoundLeft);
     outputText("[monster He] catches [monster his] breath before [monster he] stands back up, apparently prepared to fight some more. ");
     outputText("\n\n");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function DigOut():void {
     clearOutput();
     outputText("You dig back up to the surface, gasping for air.\n\n");
     monster.removeStatusEffect(StatusEffects.Dig);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function Guillotine():void {
@@ -13269,7 +13259,7 @@ public function Guillotine():void {
         return;
     }
     outputText("\n\n");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function ScyllaSqueeze():void {
@@ -13329,7 +13319,7 @@ public function ScyllaSqueeze():void {
         return;
     }
     outputText("\n\n");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function ScyllaTease():void {
@@ -13342,12 +13332,11 @@ public function ScyllaTease():void {
     }
     if (monster.lustVuln == 0) {
         outputText("You casually caress your opponent with a free hand as you use one of your tentacle to expertly molest its bottom half, but it has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
         return;
     }
     //(Otherwise)
     else {
-        recoveryOfResources();
         var damage:Number;
         var chance:Number;
         //Tags used for bonus damage and chance later on
@@ -13440,7 +13429,7 @@ public function ScyllaLeggoMyEggo():void {
     outputText("You release [themonster] from [monster his] bonds, and [monster he] drops to the ground, catching [monster his] breath before [monster he] stands back up, apparently prepared to fight some more.");
     outputText("\n\n");
     monster.removeStatusEffect(StatusEffects.ConstrictedScylla);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function SwallowWhole():void {
@@ -13500,12 +13489,11 @@ public function SwallowTease():void {
     }
     if (monster.lustVuln == 0) {
         outputText("You casually caress your opponent with a free hand as you use some of your tentacles to expertly molest its bottom half, but it has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
         return;
     }
     //(Otherwise)
     else {
-        recoveryOfResources();
         var damage:Number;
         var chance:Number;
         //Tags used for bonus damage and chance later on
@@ -13632,7 +13620,7 @@ public function WhipStrangulate():void {
 		return;
 	}
 	outputText("\n\n");
-	enemyAIAndResources();
+	enemyAIImpl();
 }
 
 public function WhipLeggoMyEggo():void {
@@ -13640,7 +13628,7 @@ public function WhipLeggoMyEggo():void {
     outputText("You release [themonster] from your "+player.weaponName+", and [monster he] drops to the ground, catching [monster his] breath before [monster he] stands back up, apparently prepared to fight some more.");
     outputText("\n\n");
     monster.removeStatusEffect(StatusEffects.ConstrictedWhip);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function CrabLeggoMyEggo():void {
@@ -13648,7 +13636,7 @@ public function CrabLeggoMyEggo():void {
     outputText("You release [themonster] from your grip, and [monster he] drops to the ground, catching [monster his] breath before [monster he] stands back up, apparently prepared to fight some more.");
     outputText("\n\n");
     monster.removeStatusEffect(StatusEffects.CancerGrab);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function WebTease():void {
@@ -13659,12 +13647,11 @@ public function WebTease():void {
     }
     if (monster.lustVuln == 0) {
         outputText("You giggle and run your hands against your victim's flesh, naughty bits purposely left exposed for you to grope and tease, but it has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
         return;
     }
     //(Otherwise)
     else {
-        recoveryOfResources();
         var damage:Number;
         var chance:Number;
         var bimbo:Boolean = false;
@@ -13756,12 +13743,11 @@ public function GooTease():void {
     }
     if (monster.lustVuln == 0) {
         outputText("You casually caress your opponent with a free hand as you use one of your tentacle to expertly molest its bottom half, but it has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
         return;
     }
     //(Otherwise)
     else {
-        recoveryOfResources();
         var damage:Number;
         var chance:Number;
         var bimbo:Boolean = false;
@@ -13859,7 +13845,7 @@ public function GooLeggoMyEggo():void {
     clearOutput();
     outputText("You release [themonster] from your body and [monster he] drops to the ground, catching [monster his] breath before [monster he] stands back up, apparently prepared to fight some more.\n\n");
     monster.removeStatusEffect(StatusEffects.GooEngulf);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function spiderBiteAttack():void {
@@ -13868,7 +13854,7 @@ public function spiderBiteAttack():void {
     if (monster is LivingStatue)
     {
         outputText("Your fangs can't even penetrate the giant's flesh.");
-        enemyAIAndResources();
+        enemyAIImpl();
         return;
     }
     if(monster.lustVuln == 0) outputText("  Your aphrodisiac toxin has no effect!");
@@ -13906,19 +13892,18 @@ public function spiderBiteAttack():void {
     WrathGenerationPerHit2(5);
     player.tailVenom -= player.VenomWebCost() * 5;
     flags[kFLAGS.VENOM_TIMES_USED] += 1;
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function ManticoreFeed():void {
     clearOutput();
     if (monster.lustVuln == 0) {
         outputText("You attempt to suck out the cum from your victim's penis, but it has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
         return;
     }
     //(Otherwise)
     else {
-        recoveryOfResources();
         var damage:Number;
         var bimbo:Boolean = false;
         var bro:Boolean = false;
@@ -13981,12 +13966,11 @@ public function displacerFeedContinue():void {
     clearOutput();
     if (monster.lustVuln == 0) {
         outputText("You attempt to suck out the milk from your victim's breast, but it has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
         return;
     }
     //(Otherwise)
     else {
-        recoveryOfResources();
         var damage:Number;
         var bimbo:Boolean = false;
         var bro:Boolean = false;
@@ -14049,12 +14033,11 @@ public function SlimeRapeFeed():void {
     clearOutput();
     if (monster.lustVuln == 0) {
         outputText("Despite your best effort you can't seem to stimulate your opponent using your fluidic body. Your foe clearly does not experience lust in the same way as you.\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
         return;
     }
     //(Otherwise)
     else {
-        recoveryOfResources();
         var damage:Number;
         var bimbo:Boolean = false;
         var bro:Boolean = false;
@@ -14127,7 +14110,7 @@ public function VampiricBite():void {
         outputText(" Your opponent makes use of your confusion to free itself.");
         HPChange((-100 * (1 + player.newGamePlusMod())), false);
         monster.removeStatusEffect(StatusEffects.EmbraceVampire);
-        enemyAIAndResources();
+        enemyAIImpl();
         return;
     }
     outputText("You bite [themonster] drinking deep of [monster his] blood ");
@@ -14180,7 +14163,7 @@ public function VampiricBite():void {
             outputText("\n\nYour opponent finally manages to struggle free of your grapple!\n\n");
         }
     }
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function VampireLeggoMyEggo():void {
@@ -14188,7 +14171,7 @@ public function VampireLeggoMyEggo():void {
     outputText("You let your opponent free, ending your embrace.");
     outputText("\n\n");
     monster.removeStatusEffect(StatusEffects.EmbraceVampire);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 //Claws Rend
@@ -14243,7 +14226,7 @@ public function clawsRend():void {
         return;
     }
     outputText("\n\n");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function displacerCombatFeed():void {
@@ -14259,14 +14242,14 @@ public function PussyLeggoMyEggo():void {
     outputText("You let your opponent free ending your grapple.\n\n");
     if (monster.hasStatusEffect(StatusEffects.DisplacerPlug)) monster.removeStatusEffect(StatusEffects.DisplacerPlug);
     monster.removeStatusEffect(StatusEffects.Pounce);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function BreakOutWeb():void {
     clearOutput();
     outputText("You let your opponent free from your web.\n\n");
     monster.removeStatusEffect(StatusEffects.MysticWeb);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 //Naga Hypnosis
@@ -14283,7 +14266,7 @@ public function HypnosisHeal():void {
     if (!player.hasStatusEffect(StatusEffects.CastedSpell)) player.createStatusEffect(StatusEffects.CastedSpell, 0, 0, 0, 0);
     monster.removeStatusEffect(StatusEffects.HypnosisNaga);
     spellPerkUnlock();
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function HypnosisDarknessShard():void {
@@ -14300,7 +14283,7 @@ public function HypnosisDarknessShard():void {
     if (!player.hasStatusEffect(StatusEffects.CastedSpell)) player.createStatusEffect(StatusEffects.CastedSpell, 0, 0, 0, 0);
     monster.removeStatusEffect(StatusEffects.HypnosisNaga);
     spellPerkUnlock();
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function HypnosisDuskWave():void {
@@ -14317,7 +14300,7 @@ public function HypnosisDuskWave():void {
     if (!player.hasStatusEffect(StatusEffects.CastedSpell)) player.createStatusEffect(StatusEffects.CastedSpell, 0, 0, 0, 0);
     monster.removeStatusEffect(StatusEffects.HypnosisNaga);
     spellPerkUnlock();
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function HypnosisAttack():void {
@@ -14336,7 +14319,7 @@ public function HypnosisCoil():void {
         outputText("You maintain the trance, smiling as you prolong the mesmerising dance, moving your hips from side to side and displaying your assets. [Themonster] is lost in your gaze, and unable to act.");
         monster.createStatusEffect(StatusEffects.Constricted, Duuuration, 0, 0, 0);
     }
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function HypnosisMaintain():void {
@@ -14352,7 +14335,7 @@ public function HypnosisMaintain():void {
     outputText("You maintain the trance, smiling as you prolong the mesmerising dance, moving your hips from side to side and displaying your assets. [Themonster] is lost in your gaze, and unable to act. ");
     monster.teased(lustDmg);
     outputText("\n\n");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 //Bear hug
@@ -14376,21 +14359,21 @@ public function bearHug():void {
         return;
     }
     outputText("\n\n");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function BearLeggoMyEggo():void {
     clearOutput();
     outputText("You let your opponent free, ending your grab.\n\n");
     monster.removeStatusEffect(StatusEffects.GrabBear);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function taintedMindAttackAttempt():void {
     clearOutput();
     outputText("You ready an attack, but find your hands groping your own body instead. Somehow the demon’s magic has made it impossible to strike at him, crossing wires that weren’t meant to be crossed. Frowning, you look down at your more aroused form, determined not to fall for this a second time.");
     player.takeLustDamage(15, true);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 //Heal Zenji
@@ -14399,7 +14382,7 @@ public function HealZenji():void {
     outputText("Zenji readies his spear, wedging himself between you and your opponent, \"<i>I am stronger! Thank you, [name]!</i>\"\n\n");
     var recharge:Number = player.statusEffectv3(StatusEffects.CombatFollowerZenji);
     player.addStatusValue(StatusEffects.CombatFollowerZenji, 3, -recharge);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function runAway(callHook:Boolean = true):void {
@@ -14421,7 +14404,7 @@ public function runAway(callHook:Boolean = true):void {
     if (inCombat && player.hasStatusEffect(StatusEffects.Sealed) && player.statusEffectv2(StatusEffects.Sealed) == 4) {
         clearOutput();
         outputText("You try to run, but you just can't seem to escape.  <b>Your ability to run was sealed, and now you've wasted a chance to attack!</b>\n\n");
-        enemyAIAndResources();
+        enemyAIImpl();
         return;
     }
     //Rut doesnt let you run from dicks.
@@ -14550,7 +14533,7 @@ public function runAway(callHook:Boolean = true):void {
 			SceneLib.dungeons.riverdungeon.almostdefeatedByTwinBosses();
 		} else {
             outputText("You're trapped in your foe's domain - there is nowhere to run!\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
 		}
         return;
     }
@@ -14560,7 +14543,7 @@ public function runAway(callHook:Boolean = true):void {
         if (!player.canFly()) outputText("You will not be able to swim fast enough. ");
         else outputText("You grit your teeth with effort as you try to fly away but the tentacles suddenly grab your [legs] and pull you down. ");
         outputText("It looks like you cannot escape. ");
-        enemyAIAndResources();
+        enemyAIImpl();
         return;
     }
     if (monster is Ember) {
@@ -14582,7 +14565,7 @@ public function runAway(callHook:Boolean = true):void {
 	if (player.hasStatusEffect(StatusEffects.LockingCurse)) {
 		if (player.statusEffectv1(StatusEffects.LockingCurse) == 1) {
 			outputText("The anubis acursed magic prevents you from escaping as an invisible wall blocks your path!");
-			enemyAIAndResources();
+			enemyAIImpl();
 			return;
 		}
 		if (player.statusEffectv1(StatusEffects.LockingCurse) == 0 && !monster.hasStatusEffect(StatusEffects.Dig)) {
@@ -14596,7 +14579,7 @@ public function runAway(callHook:Boolean = true):void {
 			}
 			else {
 				outputText("The anubis has you surrounded by h"+(monster.hasVagina()?"er":"is")+" pet, there is no escape by land!");
-				enemyAIAndResources();
+				enemyAIImpl();
 				return;
 			}
 		}
@@ -14618,7 +14601,7 @@ public function runAway(callHook:Boolean = true):void {
             clearOutput();
             if (monster.short == "goblin") outputText("You try to flee, but get stuck in the sticky white goop surrounding you.\n\n");
             else outputText("You put all your skills at running to work, ducking and diving in an effort to escape, but are unable to get away!\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
             return;
         }
         //Nonstuck!
@@ -14727,7 +14710,7 @@ public function runAway(callHook:Boolean = true):void {
         //Fail:
         else {
             outputText("Despite some impressive jinking, " + SceneLib.emberScene.emberMF("he", "she") + " catches you, tackling you to the ground.\n\n");
-            enemyAIAndResources();
+            enemyAIImpl();
         }
         return;
     }
@@ -14844,7 +14827,7 @@ public function onlyZenjiRunnawayTrain():Boolean {
 public function struggleCreepingDoom():void {
     outputText("You shake away the pests in disgust, managing to get rid of them for a time.\n\n");
     monster.removeStatusEffect(StatusEffects.CreepingDoom);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function takeFlightWings():void {
@@ -14875,7 +14858,7 @@ public function takeFlight():void {
         player.createPerk(PerkLib.Resolute, 0, 0, 0, 0);
     }
     monster.createStatusEffect(StatusEffects.MonsterAttacksDisabled, 0, 0, 0, 0);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 public function flightDurationNatural():Number {
     var flightDurationNatural:Number = 7;
@@ -15015,7 +14998,7 @@ public function greatDive():void {
         monster.removeStatusEffect(StatusEffects.MonsterAttacksDisabled);
     }
     checkAchievementDamage(damage);
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function impaleMultiplier():Number {
@@ -15067,7 +15050,7 @@ public function assumeAsuraForm():void {
     assumeAsuraForm007();
 	if (player.hasPerk(PerkLib.JobWarrior) && player.hasPerk(PerkLib.AsuraToughness)) mspecials.warriorsrage007();
     statScreenRefresh();
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 public function assumeAsuraForm007():void {
     var temp1:Number = 0;
@@ -15108,7 +15091,7 @@ public function returnToNormalShape():void {
 	//if (perkBonusDamage po asura toughness)
     player.statStore.removeBuffs("AsuraForm");
 	if (player.buff("WarriorsRage").getRemainingTicks() > 9000) player.statStore.removeBuffs("WarriorsRage");
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function asurasHowl():void {
@@ -15212,7 +15195,7 @@ public function asurasXFingersOfDestruction(fingercount:String):void {
     heroBaneProc(damage);
     EruptingRiposte();
     statScreenRefresh();
-    enemyAIAndResources();
+    enemyAIImpl();
 }
 
 public function sendSkeletonToFight():void {
@@ -15270,7 +15253,7 @@ public function sendSkeletonToFight():void {
 				addButton(0, "Next", combatMenu, false);
 			}
 		}
-		else enemyAIAndResources();
+		else enemyAIImpl();
 	}
 }
 public function skeletonSmash():void {
@@ -15309,7 +15292,7 @@ public function skeletonSmash():void {
     //checkAchievementDamage(damage);
     outputText("\n\n");
     if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-    else enemyAIAndResources();
+    else enemyAIImpl();
 }
 
 public function noLimiterState():void {

--- a/classes/classes/Scenes/Combat/CombatMagic.as
+++ b/classes/classes/Scenes/Combat/CombatMagic.as
@@ -976,7 +976,7 @@ public class CombatMagic extends BaseCombatContent {
 				outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 				monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 	
@@ -984,7 +984,7 @@ public class CombatMagic extends BaseCombatContent {
 		clearOutput();
 		outputText("Information Noona Warning:\n\n<b>Your Green Covenant is deactivated now.</b>");
 		player.removeStatusEffect(StatusEffects.GreenCovenant);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	private function handleShell():Boolean{
@@ -993,7 +993,7 @@ public class CombatMagic extends BaseCombatContent {
             flags[kFLAGS.SPELLS_CAST]++;
             if(!player.hasStatusEffect(StatusEffects.CastedSpell)) player.createStatusEffect(StatusEffects.CastedSpell,0,0,0,0);
             spellPerkUnlock();
-            combat.enemyAIAndResources();
+            enemyAI();
             return true;
         }
 		return false;

--- a/classes/classes/Scenes/Combat/CombatSoulskills.as
+++ b/classes/classes/Scenes/Combat/CombatSoulskills.as
@@ -594,7 +594,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(flags[kFLAGS.HERO_BANE_DAMAGE_BANK]);
 		combat.heroBaneProc2();
 		combat.EruptingRiposte2();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function SextupleThrust():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
@@ -625,7 +625,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(flags[kFLAGS.HERO_BANE_DAMAGE_BANK]);
 		combat.heroBaneProc2();
 		combat.EruptingRiposte2();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function NonupleThrust():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
@@ -657,7 +657,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		combat.heroBaneProc2();
 		combat.EruptingRiposte2();
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 	private function MultiThrustDSingle():Number {
 		var damage:Number = 0;
@@ -877,7 +877,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(damage);
 		combat.heroBaneProc(damage);
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	public function Comet():void {
@@ -917,7 +917,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(damage);
 		combat.heroBaneProc(damage);
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 	
 	public function HailOfBlades1():void {
@@ -937,7 +937,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		combat.heroBaneProc2();
 		combat.EruptingRiposte2();
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 	public function HailOfBlades2():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 2;
@@ -947,7 +947,7 @@ public class CombatSoulskills extends BaseCombatContent {
 			if (monster.spe - player.spe < 8) outputText("[Themonster] narrowly avoids weapons!");
 			else if (monster.spe-player.spe < 20) outputText("[Themonster] dodges weapons with superior quickness!");
 			else outputText("[Themonster] deftly avoids weapons.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		var soulforcecost:Number = 200 * soulskillCost() * soulskillcostmulti();
@@ -963,7 +963,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		combat.heroBaneProc2();
 		combat.EruptingRiposte2();
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 	public function HailOfBlades3():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 2;
@@ -973,7 +973,7 @@ public class CombatSoulskills extends BaseCombatContent {
 			if (monster.spe - player.spe < 8) outputText("[Themonster] narrowly avoids weapons!");
 			else if (monster.spe-player.spe < 20) outputText("[Themonster] dodges weapons with superior quickness!");
 			else outputText("[Themonster] deftly avoids weapons.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		var soulforcecost:Number = 800 * soulskillCost() * soulskillcostmulti();
@@ -989,7 +989,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		combat.heroBaneProc2();
 		combat.EruptingRiposte2();
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 	private function BladesD(hits:Number = 1):void {
 		var damage:Number = player.wis * 0.5;
@@ -1104,7 +1104,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(damage);
 		combat.heroBaneProc(damage);
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	public function CleansingPalm():void {
@@ -1120,13 +1120,13 @@ public class CombatSoulskills extends BaseCombatContent {
 			// Not a completely corrupted monkmouse
 			if (JojoScene.monk < 2) {
 				outputText("You thrust your palm forward, sending a blast of pure energy towards Jojo. At the last second he sends a blast of his own against yours canceling it out\n\n");
-				combat.enemyAIAndResources();
+				enemyAI();
 				return;
 			}
 		}
 		if (monster is LivingStatue) {
 			outputText("You thrust your palm forward, causing a blast of pure energy to slam against the giant stone statue- to no effect!");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		var corruptionMulti:Number = (monster.cor - 20) / 25;
@@ -1182,7 +1182,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		combat.EruptingRiposte();
 		statScreenRefresh();
 		if(monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 	
 	public function IceFist():void {
@@ -1243,7 +1243,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		combat.EruptingRiposte();
 		outputText("\n\n");
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	public function FirePunch():void {
@@ -1313,7 +1313,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		outputText("Your movement becomes more fluid and precise, increasing your speed and evasion.\n\n");
 		player.createStatusEffect(StatusEffects.HurricaneDance, 5, 0, 0, 0);
 		player.createStatusEffect(StatusEffects.CooldownHurricaneDance, 10, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function EarthStance():void {
@@ -1325,7 +1325,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		outputText("Your body suddenly hardens like rock. You will be way harder to damage for a while.\n\n");
 		player.createStatusEffect(StatusEffects.EarthStance, 3, 0, 0, 0);
 		player.createStatusEffect(StatusEffects.CooldownEarthStance, 10, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function PunishingKick():void {
@@ -1421,33 +1421,33 @@ public class CombatSoulskills extends BaseCombatContent {
 		if (!player.hasStatusEffect(StatusEffects.BloodCultivator) && flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] == 0) anubiHeartLeeching(damage);
 		combat.heroBaneProc(damage);
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	public function activaterOverlimit():void {
 		clearOutput();
 		outputText("You let out a primal roar of pain and fury, as you push your body beyond its normal capacity, a blood red aura cloaking your form.\n\n");
 		player.createStatusEffect(StatusEffects.Overlimit, 0, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function deactivaterOverlimit():void {
 		clearOutput();
 		outputText("You let your rage fade, your red aura and manic strength vanishing along with it. You wince, feeling the strain you put your body through. You \n\n");
 		player.removeStatusEffect(StatusEffects.Overlimit);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function VioletPupilTransformation():void {
 		clearOutput();
 		outputText("Deciding you need additional regeneration during current fight you spend moment to concentrate and activate Violet Pupil Transformation.  Your eyes starting to glow with a violet hua and you can feel refreshing feeling spreading all over your body.\n");
 		player.createStatusEffect(StatusEffects.VioletPupilTransformation,0,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function DeactivateVioletPupilTransformation():void {
 		clearOutput();
 		outputText("Deciding you not need for now to constantly using Violet Pupil Transformation you concentrate and deactivating it.");
 		player.removeStatusEffect(StatusEffects.VioletPupilTransformation);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	
 	private static const ScarletSpiritChargeABC:Object = FnHelpers.FN.buildLogScaleABC(10,100,1000,10,100);
@@ -1482,13 +1482,13 @@ public class CombatSoulskills extends BaseCombatContent {
 		var tempStrTouSpe:Number = 0;
 		outputText("You focus the power of your blood and soul, allowing the scarlet energy fill your being. Your [skin] begins to glow as the power within you coalesces, whirling within you with the force of a tsunami.\n");
 		doEffect.call();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function DeactivateScarletSpiritCharge():void {
 		clearOutput();
 		outputText("You disrupt the flow of blood within you, your body slumps as the glow radiating from your [skin] dissipates back into your natural hue.");
 		player.statStore.removeBuffs("ScarletSpiritCharge");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	
 	private static const TranceABC:Object = FnHelpers.FN.buildLogScaleABC(10,100,1000,10,100);
@@ -1544,13 +1544,13 @@ public class CombatSoulskills extends BaseCombatContent {
 		var tempStrTou:Number = 0;
 		outputText("You focus the power of your mind and soul, letting the mystic energy fill you. Your [skin] begins to crystalize as the power within you takes form. The power whirls within you like a hurricane, the force of it lifting you off your feet. This power...  You will use it to reach victory!\n");
 		doEffect.call();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function DeactivateTranceTransformation():void {
 		clearOutput();
 		outputText("You disrupt the flow of power within you, softly falling to the ground as the crystal sheathing your [skin] dissipates into nothingness.");
 		player.statStore.removeBuffs("TranceTransformation");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function BeatOfWar():void {
@@ -1610,7 +1610,7 @@ public class CombatSoulskills extends BaseCombatContent {
 			}
 		}
 		outputText(".\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function SoulDrain():void {
@@ -1650,7 +1650,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		anubiHeartLeeching(damage);
 		combat.heroBaneProc(damage);
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 	public function FingerOfDeath():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 2;
@@ -1693,7 +1693,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		combat.heroBaneProc2();
 		combat.EruptingRiposte2();
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 	
 	public function bloodSwipe():void {
@@ -1967,7 +1967,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	private function endTurnByBloodSkillUse(damage:Number):void {
@@ -1982,7 +1982,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		combat.heroBaneProc(damage);
 		statScreenRefresh();
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	/*
@@ -2039,7 +2039,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		if ((monster is FrostGiant || monster is YoungFrostGiant) && player.hasStatusEffect(StatusEffects.GiantBoulder)) {
 			if (monster as FrostGiant) (monster as FrostGiant).giantBoulderHit(2);
 			if (monster as YoungFrostGiant) (monster as YoungFrostGiant).youngGiantBoulderHit(2);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("You flush, drawing on your body's desires to empower your muscles and toughen you up.\n\n");
@@ -2071,7 +2071,7 @@ public class CombatSoulskills extends BaseCombatContent {
 		if(!player.hasStatusEffect(StatusEffects.CastedSpell)) player.createStatusEffect(StatusEffects.CastedSpell,0,0,0,0);
 		spellPerkUnlock();
 		if(player.lust >= player.maxOverLust()) doNext(endLustLoss);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}*/
 	/*
 	 //Mantis Omni Slash (AoE attack) - przerobić to na soulskilla zużywającego jak inne soulforce z rosnącym kosztem im wyższy lvl postaci ^^ owinno wciąż jakoś być powiązane z posiadaniem mantis arms czy też ulepszonych mantis arms (czyt. versji 2.0 tych ramion z TF bdącego soul evolution of Mantis) ^^
@@ -2102,7 +2102,7 @@ public class CombatSoulskills extends BaseCombatContent {
 	 if (monster.spe - player.spe < 8) outputText(monster.capitalA + monster.short + " narrowly avoids your attacks!\n\n");
 	 if (monster.spe - player.spe >= 8 && monster.spe-player.spe < 20) outputText(monster.capitalA + monster.short + " dodges your attacks with superior quickness!\n\n");
 	 if (monster.spe - player.spe >= 20) outputText(monster.capitalA + monster.short + " deftly avoids your slow attacks.\n\n");
-	 combat.enemyAIAndResources();
+	 enemyAI();
 	 return;
 	 if (monster.plural) {
 	 if (player.perkv1(IMutationsLib.MantislikeAgilityIM) >= 1) {
@@ -2162,7 +2162,7 @@ public class CombatSoulskills extends BaseCombatContent {
 	 combat.WrathGenerationPerHit2(5);
 	 if (flags[kFLAGS.MULTIPLE_ATTACK_STYLE] == 0) {
 	 outputText("\n");
-	 combat.enemyAIAndResources();
+	 enemyAI();
 	 }
 	 if (flags[kFLAGS.MULTIPLE_ATTACK_STYLE] == 1) {
 	 flags[kFLAGS.MULTIPLE_ATTACK_STYLE] -= 1;
@@ -2215,7 +2215,7 @@ public class CombatSoulskills extends BaseCombatContent {
 	 if (monster.spe - player.spe < 8) outputText(monster.capitalA + monster.short + " narrowly avoids your attack!");
 	 if (monster.spe - player.spe >= 8 && monster.spe-player.spe < 20) outputText(monster.capitalA + monster.short + " dodges your attack with superior quickness!");
 	 if (monster.spe - player.spe >= 20) outputText(monster.capitalA + monster.short + " deftly avoids your slow attack.");
-	 combat.enemyAIAndResources();
+	 enemyAI();
 	 return;
 	 }
 	 var soulforcecost:Number = 10 * soulskillCost() * soulskillcostmulti();
@@ -2245,7 +2245,7 @@ public class CombatSoulskills extends BaseCombatContent {
 	 combat.heroBaneProc(damage);
 	 outputText("\n\n");
 	 if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-	 else combat.enemyAIAndResources();
+	 else enemyAI();
 	 }*/
 }
 }

--- a/classes/classes/Scenes/Combat/General/TeaseSkill.as
+++ b/classes/classes/Scenes/Combat/General/TeaseSkill.as
@@ -160,9 +160,6 @@ public class TeaseSkill extends AbstractGeneral {
 			}
         }
 		if (display) outputText("\n\n");
-		recoveryOfResources();
-    }
-
-    
+    }    
 }
 }

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -994,44 +994,44 @@ public class MagicSpecials extends BaseCombatContent {
 			clearOutput();
 			outputText("You reach for the enemy's mind, but cannot find anything.  You frantically search around, but there is no consciousness as you know it in the room.\n\n");
 			fatigue(1);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (monster is LivingStatue)
 		{
 			outputText("There is nothing inside the golem to whisper to.");
 			fatigue(1);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		fatigue(10, USEFATG_MAGIC_NOBM);
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if(monster.hasPerk(PerkLib.Focused)) {
 			if(!monster.plural) outputText("[Themonster] is too focused for your whispers to influence!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Enemy too strong or multiplesI think you
 		if(player.inte < monster.inte || monster.plural) {
 			outputText("You reach for your enemy's mind, but can't break through.\n");
 			fatigue(10);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//[Failure]
 		if(rand(10) == 0) {
 			outputText("As you reach for your enemy's mind, you are distracted and the chorus of voices screams out all at once within your mind. You're forced to hastily silence the voices to protect yourself.");
 			fatigue(10);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("You reach for your enemy's mind, watching as its sudden fear petrifies your foe.\n\n");
 		monster.createStatusEffect(StatusEffects.Fear,1,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function fenrirFreezingBreath():void {
@@ -1056,14 +1056,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The ice courses by the stone skin harmlessly. Thou it does leave the surface of the statue shimerring with a thin layer of the ice.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Special enemy avoidances
@@ -1092,12 +1092,8 @@ public class MagicSpecials extends BaseCombatContent {
 		if (monster is Lethice && (monster as Lethice).fightPhase == 3) {
 			outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 			monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
-			combat.enemyAIAndResources();
 		}
-		else {
-			recoveryOfResources();
-			combatRoundOver();
-		}
+		enemyAI();
 	}
 
 	public function yetiFreezingBreath():void {
@@ -1143,14 +1139,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The ice courses by the stone skin harmlessly. Thou it does leave the surface of the statue shimerring with a thin layer of the ice.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Special enemy avoidances
@@ -1187,7 +1183,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.EmpoweredAria)) player.createStatusEffect(StatusEffects.Sing,5,0,0,0);
 		else player.createStatusEffect(StatusEffects.Sing,1,0,0,0);
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function singCompellingAria():void {
@@ -1225,9 +1221,9 @@ public class MagicSpecials extends BaseCombatContent {
 			{
 				outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 				monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
-				combat.enemyAIAndResources();
+				enemyAI();
 			}
-			else combat.enemyAIAndResources();
+			else enemyAI();
 		}
 		else if (player.statusEffectv1(StatusEffects.ChanneledAttack) == 1) {
 			outputText("You are still singing. Your compelling aria reaches far up to your opponent");
@@ -1247,7 +1243,7 @@ public class MagicSpecials extends BaseCombatContent {
 			monster.teased(lustDmg2);
 			player.addStatusValue(StatusEffects.ChanneledAttack, 1, 1);
 			outputText("\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 		else {
 			fatigue(50, USEFATG_MAGIC_NOBM);
@@ -1268,7 +1264,7 @@ public class MagicSpecials extends BaseCombatContent {
 			player.createStatusEffect(StatusEffects.ChanneledAttack, 1, 0, 0, 0);
 			player.createStatusEffect(StatusEffects.ChanneledAttackType, 1, 0, 0, 0);
 			outputText("\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 
@@ -1307,7 +1303,7 @@ public class MagicSpecials extends BaseCombatContent {
 		combat.heroBaneProc(damage);
 		statScreenRefresh();
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	public function OrgasmicLightningStrike():void {
@@ -1360,14 +1356,14 @@ public class MagicSpecials extends BaseCombatContent {
 			if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.Stunned,5,0,0,0);
 			player.removeStatusEffect(StatusEffects.ChanneledAttack);
 			player.removeStatusEffect(StatusEffects.ChanneledAttackType);
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 		else if (player.statusEffectv1(StatusEffects.ChanneledAttack) == 1) {
 			outputText("You continue masturbating, lost in the sensation as lightning runs across your form. You are almost there!\n\n");
 			temp2 = 5 + rand(player.lib / 5 + player.cor / 10);
 			dynStats("lus", temp2, "scale", false);
 			player.addStatusValue(StatusEffects.ChanneledAttack, 1, 1);
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 		else {
 			clearOutput();
@@ -1380,7 +1376,7 @@ public class MagicSpecials extends BaseCombatContent {
 			dynStats("lus", temp2, "scale", false);
 			player.createStatusEffect(StatusEffects.ChanneledAttack, 1, 0, 0, 0);
 			player.createStatusEffect(StatusEffects.ChanneledAttackType, 3, 0, 0, 0);
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 
@@ -1446,7 +1442,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
 		if (monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
 		if (player.perkv1(IMutationsLib.HeartOfTheStormIM) >= 3 && rand(100) < 10 && !monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.Stunned,2,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function Luststorm():void {
@@ -1512,7 +1508,7 @@ public class MagicSpecials extends BaseCombatContent {
 		player.createStatusEffect(StatusEffects.lustStorm,0,0,0,0);
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
 		if (monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	public function PlasmaBlast():void {
@@ -1596,7 +1592,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (!monster.hasPerk(PerkLib.Resolute)) monster.createStatusEffect(StatusEffects.Stunned, 1, 0, 0, 0);
 		outputText("\n\n");
 		combat.heroBaneProc(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function startOniRampage():void {
@@ -1620,7 +1616,7 @@ public class MagicSpecials extends BaseCombatContent {
 			player.removeStatusEffect(StatusEffects.ChanneledAttack);
 			player.removeStatusEffect(StatusEffects.ChanneledAttackType);
 			outputText("\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 		else {
 			fatigue(50, USEFATG_MAGIC_NOBM);
@@ -1628,7 +1624,7 @@ public class MagicSpecials extends BaseCombatContent {
 			outputText("That does it! You crouch and lift a leg then another in alternance, stomping the ground as you focus your anger.\n\n");
 			player.createStatusEffect(StatusEffects.ChanneledAttack, 1, 0, 0, 0);
 			player.createStatusEffect(StatusEffects.ChanneledAttackType, 2, 0, 0, 0);
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 	public function minOniScoreReq():Number {
@@ -1687,14 +1683,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The fire courses by the stone skin harmlessly. It does leave the surface of the statue glossier in its wake.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		else if (monster is Lethice && (monster as Lethice).fightPhase == 2)
@@ -1883,7 +1879,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.armor == armors.FMDRESS && player.isWoodElf()) lustDmg *= 2;
 		if(monster.lustVuln == 0) {
 			outputText("It has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText(" [monster he] barely manages to shove you off before you turn [monster him] into a frozen husk, highly shocked yet aroused by the experience.  ");
@@ -1898,7 +1894,7 @@ public class MagicSpecials extends BaseCombatContent {
 		doNext(playerMenu);
 		if (monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
 		else if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	private function mosterTeaseText():void {
@@ -1958,14 +1954,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The acid courses by the stone skin harmlessly. It does leave the surface of the statue glossier in its wake.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("You spit a blob of neon blue acid at [themonster] your corrosive fluids burning at "+((monster.hasPerk(PerkLib.EnemyGroupType) || monster.hasPerk(PerkLib.EnemyLargeGroupType)) ? "their" : "[monster his]")+" flesh.");
@@ -2016,14 +2012,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The fire courses by the stone skin harmlessly. It does leave the surface of the statue glossier in its wake.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		else if (monster is Lethice && (monster as Lethice).fightPhase == 2)
@@ -2117,14 +2113,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The fire courses by the stone skin harmlessly. It does leave the surface of the statue glossier in its wake.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		else if (monster is Lethice && (monster as Lethice).fightPhase == 2)
@@ -2213,14 +2209,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The ice courses by the stone skin harmlessly. Thou it does leave the surface of the statue shimerring with a thin layer of the ice.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("Tapping into the power deep within you, you let loose a bellowing roar at your enemy, so forceful that even the environs crumble around [monster him].  [Themonster] does [monster his] best to avoid it, but the wave of force is too fast.");
@@ -2279,14 +2275,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The lightning courses by the stone skin harmlessly. Thou it does leave the surface of the statue sparkling with a few residual lighting discharges.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("Tapping into the power deep within you, you let loose a bellowing roar at your enemy, so forceful that even the environs crumble around [monster him].  [Themonster] does [monster his] best to avoid it, but the wave of force is too fast.");
@@ -2344,14 +2340,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The darkness courses by the stone skin harmlessly. Thou it does leave the surface of the statue with a thin layer of dark glow.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("Tapping into the power deep within you, you let loose a bellowing roar at your enemy, so forceful that even the environs crumble around [monster him].  [Themonster] does [monster his] best to avoid it, but the wave of force is too fast.");
@@ -2409,14 +2405,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The poison courses by the stone skin harmlessly. Thou it does leave the surface of the statue with a thin layer of dark glow.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("Tapping into the power deep within you, you let loose a bellowing roar at your enemy, so forceful that even the environs crumble around [monster him].  [Themonster] does [monster his] best to avoid it, but the wave of force is too fast.");
@@ -2482,14 +2478,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The water courses by the stone skin harmlessly. Thou it does leave the surface of the statue with a thin layer of dark glow.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("Tapping into the power deep within you, you let loose a bellowing roar at your enemy, so forceful that even the environs crumble around [monster him].  [Themonster] does [monster his] best to avoid it, but the wave of force is too fast.<b>Your opponent is now wet with water!</b>");
@@ -2547,14 +2543,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The water courses by the stone skin harmlessly. Thou it does leave the surface of the statue with a thin layer of dark glow.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("Tapping into the power deep within you, you let loose a bellowing roar at your enemy, so forceful that even the environs crumble around [monster him].  [Themonster] does [monster his] best to avoid it, but the wave of force is too fast.");
@@ -2723,14 +2719,14 @@ public class MagicSpecials extends BaseCombatContent {
 			//Shell
 			if(monster.hasStatusEffect(StatusEffects.Shell)) {
 				outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-				combat.enemyAIAndResources();
+				enemyAI();
 				return;
 			}
 			if (combat.checkConcentration()) return; //Amily concentration
 			if (monster is LivingStatue)
 			{
 				outputText("The elemental energies courses by the stone skin harmlessly. Thou it does leave the surface of the statue with a thin layer of multicolor glow.");
-				combat.enemyAIAndResources();
+				enemyAI();
 			return;
 			}
 			outputText("You wreel back your head, sucking in a large breath of air before letting out all the collected energy. You let loose a bellowing roar at [themonster], so forceful that even the landscape begins to warp around the blast. [Themonster] attempts to dodge but the sheer size and speed is to immense to avoid as they are slammed with Fire, Ice, Lightning and Darkness. ");
@@ -2768,7 +2764,7 @@ public class MagicSpecials extends BaseCombatContent {
 			for each (var perkDragonObj:Object in CombatMagic.magicCounterPerks) {
 				if (player.hasPerk(perkDragonObj.tier3) || player.hasPerk(perkDragonObj.tier4)) player.addStatusValue(perkDragonObj.counter, 3, 1);
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 
@@ -2779,7 +2775,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (monster is LivingStatue)
 		{
 			outputText("This thing is just seldom immune to poison like come on its a statue!");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Works similar to bee stinger, must be regenerated over time. Shares the same poison-meter
@@ -2837,7 +2833,7 @@ public class MagicSpecials extends BaseCombatContent {
 			fatigue(10);
 			player.takeFireDamage(10 + rand(20), true);
 			outputText("\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		var damage:Number = 0;
@@ -2849,14 +2845,14 @@ public class MagicSpecials extends BaseCombatContent {
 		damage = Math.round(damage);
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The fire courses by the stone skin harmlessly. It does leave the surface of the statue glossier in its wake.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (monster is Doppleganger)
@@ -2878,7 +2874,7 @@ public class MagicSpecials extends BaseCombatContent {
 			outputText("Isabella shoulders her shield into the path of the emerald flames.  They burst over the wall of steel, splitting around the impenetrable obstruction and washing out harmlessly to the sides.\n\n");
 			if (SceneLib.isabellaFollowerScene.isabellaAccent()) outputText("\"<i>Is zat all you've got?  It'll take more than a flashy magic trick to beat Izabella!</i>\" taunts the cow-girl.\n\n");
 			else outputText("\"<i>Is that all you've got?  It'll take more than a flashy magic trick to beat Isabella!</i>\" taunts the cow-girl.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		else if (valaReflect(damage, "fireball", player.takeFireDamage, true)) {}
@@ -2898,7 +2894,7 @@ public class MagicSpecials extends BaseCombatContent {
 			else if(monster.lust >= 99) {
 				doNext(endLustVictory);
 			}
-			else combat.enemyAIAndResources();
+			else enemyAI();
 			return;
 		}
 		else {
@@ -2922,7 +2918,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if(monster.HP <= monster.minHP()) {
 			doNext(endHpVictory);
 		}
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 //player gains hellfire perk.
@@ -2949,7 +2945,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue) {
 			outputText("The fire courses over the stone behemoths skin harmlessly. It does leave the surface of the statue glossier in its wake.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		else if (monster is Lethice && (monster as Lethice).fightPhase == 2) {
@@ -2969,14 +2965,14 @@ public class MagicSpecials extends BaseCombatContent {
 			else if(monster.lust >= monster.maxOverLust()) {
 				doNext(endLustVictory);
 			}
-			else combat.enemyAIAndResources();
+			else enemyAI();
 			return;
 		}
 		else if(monster.short == "Isabella" && !monster.hasStatusEffect(StatusEffects.Stunned)) {
 			outputText("  Isabella shoulders her shield into the path of the crimson flames.  They burst over the wall of steel, splitting around the impenetrable obstruction and washing out harmlessly to the sides.\n\n");
 			if (SceneLib.isabellaFollowerScene.isabellaAccent()) outputText("\"<i>Is zat all you've got?  It'll take more than a flashy magic trick to beat Izabella!</i>\" taunts the cow-girl.\n\n");
 			else outputText("\"<i>Is that all you've got?  It'll take more than a flashy magic trick to beat Isabella!</i>\" taunts the cow-girl.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		else if (valaReflect(damage, "hellfire", player.takeLustDamage, true)) {}
@@ -3050,7 +3046,7 @@ public class MagicSpecials extends BaseCombatContent {
 				outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 				monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 
@@ -3068,7 +3064,7 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		else outputText("You roar and unleash your savage fury, forgetting about defense from any physical or magical attacks in order to destroy your foe!\n\n");
 		player.createStatusEffect(StatusEffects.Berzerking,berzerkDuration,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function berzerkG2():void {
 		clearOutput();
@@ -3076,7 +3072,7 @@ public class MagicSpecials extends BaseCombatContent {
 		player.HP -= Math.round(player.maxOverHP() * 0.5);
 		if (!player.hasPerk(PerkLib.EndlessRage)) player.addStatusValue(StatusEffects.Berzerking, 1, -2);
 		player.addStatusValue(StatusEffects.Berzerking, 2, 1);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function berzerkG3():void {
 		clearOutput();
@@ -3084,7 +3080,7 @@ public class MagicSpecials extends BaseCombatContent {
 		player.HP -= Math.round(player.maxOverHP() * 0.5);
 		if (!player.hasPerk(PerkLib.EndlessRage)) player.addStatusValue(StatusEffects.Berzerking, 1, -2);
 		player.addStatusValue(StatusEffects.Berzerking, 2, 1);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function berzerkG4():void {
 		clearOutput();
@@ -3092,7 +3088,7 @@ public class MagicSpecials extends BaseCombatContent {
 		player.HP -= Math.round(player.maxOverHP() * 0.5);
 		if (!player.hasPerk(PerkLib.EndlessRage)) player.addStatusValue(StatusEffects.Berzerking, 1, -2);
 		player.addStatusValue(StatusEffects.Berzerking, 2, 1);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function bloodFrenzy():void {
@@ -3107,7 +3103,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if(player.hasVagina()) outputText(" vagina");
 		outputText(" drooling as you let go of your ability to reason and lose yourself, sinking into a blood driven frenzy!\n\n");
 		player.buff("Blood Frenzy").setStats({'spe.mult':Math.round(player.speStat.mult.value*MultiplierBonus),'int.mult':-Math.round(player.intStat.mult.value),'lib.mult':Math.round(player.libStat.mult.value*MultiplierBonus)}).combatPermanent();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function lustzerk():void {
@@ -3124,7 +3120,7 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		else outputText("You roar and unleash your lustful fury, forgetting about defense from any sexual attacks or magical attacks in order to destroy your foe!\n\n");
 		player.createStatusEffect(StatusEffects.Lustzerking,lustzerkDuration,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function lustzerkG2():void {
 		clearOutput();
@@ -3132,7 +3128,7 @@ public class MagicSpecials extends BaseCombatContent {
 		player.HP -= Math.round(player.maxOverHP() * 0.5);
 		if (!player.hasPerk(PerkLib.EndlessRage)) player.addStatusValue(StatusEffects.Lustzerking, 1, -2);
 		player.addStatusValue(StatusEffects.Lustzerking, 2, 1);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function lustzerkG3():void {
 		clearOutput();
@@ -3140,7 +3136,7 @@ public class MagicSpecials extends BaseCombatContent {
 		player.HP -= Math.round(player.maxOverHP() * 0.5);
 		if (!player.hasPerk(PerkLib.EndlessRage)) player.addStatusValue(StatusEffects.Lustzerking, 1, -2);
 		player.addStatusValue(StatusEffects.Lustzerking, 2, 1);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function lustzerkG4():void {
 		clearOutput();
@@ -3148,7 +3144,7 @@ public class MagicSpecials extends BaseCombatContent {
 		player.HP -= Math.round(player.maxOverHP() * 0.5);
 		if (!player.hasPerk(PerkLib.EndlessRage)) player.addStatusValue(StatusEffects.Lustzerking, 1, -2);
 		player.addStatusValue(StatusEffects.Lustzerking, 2, 1);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function blazingBattleSpirit():void {
@@ -3160,7 +3156,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("Your bodily flames begin to rage as you enter a passionate battle fury.\n\n");
 		player.createStatusEffect(StatusEffects.BlazingBattleSpirit,blazingBattleSpiritDuration,0,0,0);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function cauterize():void {
@@ -3169,7 +3165,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("You wince in pain but feel relief as your wounds begin to smoke and close.\n\n");
 		player.createStatusEffect(StatusEffects.Cauterize,10,0,0,0);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function WinterClaws():void {
@@ -3181,7 +3177,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("Your claws coat themselves with a thick layer of sharp ice.\n\n");
 		player.createStatusEffect(StatusEffects.WinterClaw,WinterClawsDuration,0,0,0);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function flameBlade():void {
@@ -3193,7 +3189,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("Your run "+((player.racialScore(Races.KITSHOO) >= 12 && player.tail.type == Tail.KITSHOO)?"one of your tails":"your tail")+" across your weapon igniting it with raging flames.\n\n");
 		player.createStatusEffect(StatusEffects.FlameBlade,flameBladeDuration,0,0,0);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElectrifyWeapon():void {
@@ -3205,7 +3201,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("Your lift your weapon toward the sky, drawing bolts of lightning towards it.\n\n");
 		player.createStatusEffect(StatusEffects.ElectrifyWeapon,electrifyWeaponDuration,0,0,0);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function warriorsrage():void {
@@ -3214,7 +3210,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("You roar and unleash your warrior's rage in order to destroy your foe!\n\n");
 		warriorsrage007();
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function warriorsrage007():void {
 		var temp:Number;
@@ -3288,7 +3284,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("You roar and unleash your inner beast assuming Crinos Shape in order to destroy your foe!\n\n");
 		assumeCrinosShape007();
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function assumeCrinosShape007():void {
 		var temp1:Number = 0;
@@ -3375,20 +3371,20 @@ public class MagicSpecials extends BaseCombatContent {
 		clearOutput();
 		outputText("Gathering all you willpower you forcefully subduing your inner beast and returning to your normal shape.");
 		player.statStore.removeBuffs("CrinosShape");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function activaterTyrantState():void {
 		clearOutput();
 		outputText("You stare at your foe, letting your Lust build and bubble within you. Sweet release is in front of you…But first… You feel the heat building in your loins, and you let out a roar, the heat spreading through your body. You face your opponent with an unsettling grin. Let’s Dance!\n\n");
 		player.createStatusEffect(StatusEffects.TyrantState, 0, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function deactivaterTyrantState():void {
 		clearOutput();
 		outputText("Breathing heavily, you focus your mind. The heat through your body isn’t going away yet, but at the very least, you aren’t generating more. With a lot of mental effort, you reign in your lusty thoughts.\n\n");
 		player.removeStatusEffect(StatusEffects.TyrantState);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function activaterFalseWeapon():void {
 		clearOutput();
@@ -3396,7 +3392,7 @@ public class MagicSpecials extends BaseCombatContent {
 		player.lust -= Math.round(player.maxLust() * 0.1);
 		outputText("You focus on the heat in your body, and with your mind focused, you send your heat down, into the ground. The ground cracks under your [legs], and from the crack emerges a stone, shaped nearly perfectly into the shape of your [weapon].\n\n");
 		player.createStatusEffect(StatusEffects.FalseWeapon, 0, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	
 	public function lightupFoxflamePelt():void {
@@ -3420,13 +3416,13 @@ public class MagicSpecials extends BaseCombatContent {
 		player.buff("FoxflamePelt").addStats({spe:tempSpe}).withText("Foxflame Pelt").combatPermanent();
 		player.HP = oldHPratio*player.maxHP();
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function extinguishFoxflamePelt():void {
 		clearOutput();
 		outputText("Gathering you willpower you forcefully extinguish flames coating your body.");
 		player.statStore.removeBuffs("FoxflamePelt");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function EverywhereAndNowhere():void {
@@ -3436,7 +3432,7 @@ public class MagicSpecials extends BaseCombatContent {
 		player.createStatusEffect(StatusEffects.EverywhereAndNowhere,6,0,0,0);
 		if (player.hasPerk(PerkLib.NaturalInstincts)) player.createStatusEffect(StatusEffects.EverywhereAndNowhere,9,0,0,0);
 		else player.createStatusEffect(StatusEffects.CooldownEveryAndNowhere,10,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function Displacement():void {
@@ -3446,7 +3442,7 @@ public class MagicSpecials extends BaseCombatContent {
 		player.createStatusEffect(StatusEffects.Displacement,6,0,0,0);
 		if (player.hasPerk(PerkLib.NaturalInstincts)) player.createStatusEffect(StatusEffects.CooldownDisplacement,9,0,0,0);
 		else player.createStatusEffect(StatusEffects.CooldownDisplacement,10,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function Prank():void {
@@ -3455,7 +3451,7 @@ public class MagicSpecials extends BaseCombatContent {
 		monster.createStatusEffect(StatusEffects.Stunned, 0, 0, 0, 0);
 		if (player.hasPerk(PerkLib.NaturalInstincts)) player.createStatusEffect(StatusEffects.CooldownPrank,3,0,0,0);
 		else player.createStatusEffect(StatusEffects.CooldownPrank,4,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function KnowledgeOverload():void {
@@ -3471,7 +3467,7 @@ public class MagicSpecials extends BaseCombatContent {
 		var overloadduration:Number = 0;
 		overloadduration += Math.round(camp.codex.checkUnlocked() / 10);
 		monster.createStatusEffect(StatusEffects.Stunned, overloadduration, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function Provoke():void {
@@ -3489,7 +3485,7 @@ public class MagicSpecials extends BaseCombatContent {
 		monster.armorDef -= armordebuff;
 		provokeornah += Math.round(camp.codex.checkUnlocked() / 100);
 		monster.createStatusEffect(StatusEffects.Provoke, 3, provokeornah, armordebuff, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function WeirdWords():void {
@@ -3519,7 +3515,7 @@ public class MagicSpecials extends BaseCombatContent {
 		doMagicDamage(damage, true, true);
 		if (crit) outputText(" <b>*Critical Hit!*</b>");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function MoneyStrike():void {
@@ -3564,7 +3560,7 @@ public class MagicSpecials extends BaseCombatContent {
 			outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 			monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
 		}
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function Minimise():void {
@@ -3575,7 +3571,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("You shrink to your minimum size, evading your opponent as you mock [monster his] attempt to hit you.\n\n");
 		player.createStatusEffect(StatusEffects.Minimise,50+evasionIncrease,0,0,0);
 		player.buff("Minimise").addStats({"str":-50}).withText("Minimise").combatPermanent();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function Enlarge():void {
@@ -3584,7 +3580,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("You grow back to your normal size.\n\n");
 		player.buff("Minimise").remove();
 		player.removeStatusEffect(StatusEffects.Minimise);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function Flicker():void {
@@ -3596,7 +3592,7 @@ public class MagicSpecials extends BaseCombatContent {
 		monster.createStatusEffect(StatusEffects.InvisibleOrStealth,2+DurationIncrease,0,0,0);
 		if (player.hasPerk(PerkLib.NaturalInstincts)) player.createStatusEffect(StatusEffects.CooldownFlicker, 3, 0, 0, 0);
 		else player.createStatusEffect(StatusEffects.CooldownFlicker,4,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function TacticalDistraction():void {
@@ -3611,7 +3607,7 @@ public class MagicSpecials extends BaseCombatContent {
 		monster.createStatusEffect(StatusEffects.Stunned, 0, 0, 0, 0);
 		if (player.hasPerk(PerkLib.NaturalInstincts)) player.createStatusEffect(StatusEffects.CooldownTDistraction,4,0,0,0);
 		else player.createStatusEffect(StatusEffects.CooldownTDistraction,5,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function NagaHypnosis():void {
@@ -3621,7 +3617,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.headjewelryName == "pair of Golden Naga Hairpins") hypnosisDuration += 1;
 		outputText("You give [themonster] a sexy belly dance show, moving your hip from a side to another and displaying your assets as you insidiously mesmerise it into laying down [monster his] guard, all the while maintaining eye contact. [Themonster] is completely captivated by your dancing.");
 		monster.createStatusEffect(StatusEffects.HypnosisNaga,hypnosisDuration,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function maleficium():void {
@@ -3632,7 +3628,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("You moan in delight as your body fills with profane powers, empowering your spells and making you blush with barely contained desire.\n\n");
 		if (player.cor < 60 && player.perkv1(IMutationsLib.ObsidianHeartIM) >= 1) dynStats("cor", 0.3);
 		player.createStatusEffect(StatusEffects.Maleficium,maleficiumDuration,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function infernalflare():void {
@@ -3649,13 +3645,13 @@ public class MagicSpecials extends BaseCombatContent {
 			flags[kFLAGS.SPELLS_CAST]++;
 			if(!player.hasStatusEffect(StatusEffects.CastedSpell)) player.createStatusEffect(StatusEffects.CastedSpell,0,0,0,0);
 			spellPerkUnlock();
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if ((monster is FrostGiant || monster is YoungFrostGiant) && player.hasStatusEffect(StatusEffects.GiantBoulder)) {
 			if (monster as FrostGiant) (monster as FrostGiant).giantBoulderHit(2);
 			if (monster as YoungFrostGiant) (monster as YoungFrostGiant).youngGiantBoulderHit(2);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		clearOutput();
@@ -3712,7 +3708,7 @@ public class MagicSpecials extends BaseCombatContent {
 				outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 				monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 
@@ -3721,7 +3717,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("finds the hole to your pucker plugging it perfectly as embery sap flows directly from the plants into your core. Now one with the nearby corrupted vegetation you overflow with magical might as the plants literally pump their power directly into you.\n");
 		player.createStatusEffect(StatusEffects.CooldownGreenCovenant, 12, 0, 0, 0);
 		player.createStatusEffect(StatusEffects.GreenCovenant, 0, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function perfectclarity():void {
@@ -3732,7 +3728,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("You gasp as your body fills with holy powers, empowering your spells but making you feel more fragile.\n\n");
 		//if (player.cor < 60 && player.perkv1(IMutationsLib.DiamondHeartIM) >= 1) dynStats("cor", 0.3);
 		player.createStatusEffect(StatusEffects.PerfectClarity,clarityDuration,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function judgementflare():void {
@@ -3749,13 +3745,13 @@ public class MagicSpecials extends BaseCombatContent {
 			flags[kFLAGS.SPELLS_CAST]++;
 			if(!player.hasStatusEffect(StatusEffects.CastedSpell)) player.createStatusEffect(StatusEffects.CastedSpell,0,0,0,0);
 			spellPerkUnlock();
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if ((monster is FrostGiant || monster is YoungFrostGiant) && player.hasStatusEffect(StatusEffects.GiantBoulder)) {
 			if (monster as FrostGiant) (monster as FrostGiant).giantBoulderHit(2);
 			if (monster as YoungFrostGiant) (monster as YoungFrostGiant).youngGiantBoulderHit(2);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		clearOutput();
@@ -3812,7 +3808,7 @@ public class MagicSpecials extends BaseCombatContent {
 				outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 				monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 
@@ -3829,13 +3825,13 @@ public class MagicSpecials extends BaseCombatContent {
 			flags[kFLAGS.SPELLS_CAST]++;
 			if(!player.hasStatusEffect(StatusEffects.CastedSpell)) player.createStatusEffect(StatusEffects.CastedSpell,0,0,0,0);
 			spellPerkUnlock();
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if ((monster is FrostGiant || monster is YoungFrostGiant) && player.hasStatusEffect(StatusEffects.GiantBoulder)) {
 			if (monster as FrostGiant) (monster as FrostGiant).giantBoulderHit(2);
 			if (monster as YoungFrostGiant) (monster as YoungFrostGiant).youngGiantBoulderHit(2);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		clearOutput();
@@ -3871,7 +3867,7 @@ public class MagicSpecials extends BaseCombatContent {
 				outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 				monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 
@@ -3929,7 +3925,7 @@ public class MagicSpecials extends BaseCombatContent {
 				monster.createStatusEffect(StatusEffects.RegenInhibitorPetrify, petrifyduration, 0, 0, 0);
 			}
 		}
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function manaShot():void {
@@ -3943,13 +3939,13 @@ public class MagicSpecials extends BaseCombatContent {
 			flags[kFLAGS.SPELLS_CAST]++;
 			if(!player.hasStatusEffect(StatusEffects.CastedSpell)) player.createStatusEffect(StatusEffects.CastedSpell,0,0,0,0);
 			spellPerkUnlock();
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if ((monster is FrostGiant || monster is YoungFrostGiant) && player.hasStatusEffect(StatusEffects.GiantBoulder)) {
 			if (monster as FrostGiant) (monster as FrostGiant).giantBoulderHit(2);
 			if (monster as YoungFrostGiant) (monster as YoungFrostGiant).youngGiantBoulderHit(2);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		clearOutput();
@@ -3997,7 +3993,7 @@ public class MagicSpecials extends BaseCombatContent {
 				outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 				monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 	public function manaBarrage():void {
@@ -4011,13 +4007,13 @@ public class MagicSpecials extends BaseCombatContent {
 			flags[kFLAGS.SPELLS_CAST]++;
 			if(!player.hasStatusEffect(StatusEffects.CastedSpell)) player.createStatusEffect(StatusEffects.CastedSpell,0,0,0,0);
 			spellPerkUnlock();
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if ((monster is FrostGiant || monster is YoungFrostGiant) && player.hasStatusEffect(StatusEffects.GiantBoulder)) {
 			if (monster as FrostGiant) (monster as FrostGiant).giantBoulderHit(2);
 			if (monster as YoungFrostGiant) (monster as YoungFrostGiant).youngGiantBoulderHit(2);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		clearOutput();
@@ -4070,7 +4066,7 @@ public class MagicSpecials extends BaseCombatContent {
 				outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 				monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 	public function arigeanChargedShot():void {
@@ -4109,9 +4105,9 @@ public class MagicSpecials extends BaseCombatContent {
 			{
 				outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 				monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
-				combat.enemyAIAndResources();
+				enemyAI();
 			}
-			else combat.enemyAIAndResources();
+			else enemyAI();
 		}
 		else {
 			useMana((400*arigeanMagicSpecialsCost()), Combat.USEMANA_MAGIC);
@@ -4120,7 +4116,7 @@ public class MagicSpecials extends BaseCombatContent {
 			outputText("You begin charging your extra mouth in preparation for a heavy attack.\n\n");
 			player.createStatusEffect(StatusEffects.ChanneledAttack, 1, 0, 0, 0);
 			player.createStatusEffect(StatusEffects.ChanneledAttackType, 8, 0, 0, 0);
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 	public function arigeanFinalityBarrage():void {
@@ -4137,7 +4133,7 @@ public class MagicSpecials extends BaseCombatContent {
 			HPChange(-Math.round(player.maxHP() * 0.6), true);
 			monster.HP -= Math.round(monster.maxHP() * 0.3);
 		}
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	private function arigeanAssociationCortexBoost():Number {
 		var aACB:Number = 1.2;
@@ -4162,14 +4158,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your breath touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The acid courses by the stone skin harmlessly. It does leave the surface of the statue glossier in its wake.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (player.hasPerk(PerkLib.NaturalInstincts)) player.createStatusEffect(StatusEffects.CooldownHydraAcidBreath,7,0,0,0);
@@ -4283,7 +4279,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		spellPerkUnlock();
 		combat.heroBaneProc(damage);
-		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) enemyAI();
 		else {
 			if(monster.HP <= monster.minHP()) doNext(endHpVictory);
 			if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
@@ -4304,7 +4300,7 @@ public class MagicSpecials extends BaseCombatContent {
 		combat.darkRitualCheckDamage();
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("Holding out your palm, you conjure fox flame that dances across your fingertips.  You launch it at [themonster] with a ferocious throw, and it bursts on impact, showering dazzling sparks everywhere.  ");
@@ -4383,7 +4379,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		spellPerkUnlock();
 		combat.heroBaneProc(damage);
-		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) enemyAI();
 		else {
 			if(monster.HP <= monster.minHP()) doNext(endHpVictory);
 			if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
@@ -4402,7 +4398,7 @@ public class MagicSpecials extends BaseCombatContent {
 		combat.darkRitualCheckDamage();
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Deals direct damage and lust regardless of enemy defenses.  Especially effective against non-corrupted targets.
@@ -4486,7 +4482,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		spellPerkUnlock();
 		combat.heroBaneProc(damage);
-		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) enemyAI();
 		else {
 			if(monster.HP <= monster.minHP()) doNext(endHpVictory);
 			if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
@@ -4505,7 +4501,7 @@ public class MagicSpecials extends BaseCombatContent {
 		combat.darkRitualCheckDamage();
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("Holding out your palms, you conjure an ethereal blue on one palm and corrupted purple flame on other which dances across your fingertips.  After well practised move of fusing them both into one of mixed colors ball of fire you launch it at [themonster] with a ferocious throw, and it bursts on impact, showering dazzling azure and lavender sparks everywhere.  ");
@@ -4588,7 +4584,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		spellPerkUnlock();
 		combat.heroBaneProc(damage);
-		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) enemyAI();
 		else {
 			if(monster.HP <= monster.minHP()) doNext(endHpVictory);
 			if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
@@ -4607,7 +4603,7 @@ public class MagicSpecials extends BaseCombatContent {
 		combat.darkRitualCheckDamage();
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("Holding out your palm, you conjure an ethereal blue flame that dances across your fingertips.  You launch it at [themonster] with a ferocious throw, and it bursts on impact, showering dazzling azure sparks everywhere.  ");
@@ -4691,7 +4687,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		spellPerkUnlock();
 		combat.heroBaneProc(damage);
-		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) enemyAI();
 		else {
 			if(monster.HP <= monster.minHP()) doNext(endHpVictory);
 			if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
@@ -4720,13 +4716,13 @@ public class MagicSpecials extends BaseCombatContent {
 		//Fatigue Cost: 25
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if(monster is EncapsulationPod || monster.inte == 0) {
 			outputText("You reach for the enemy's mind, but cannot find anything.  You frantically search around, but there is no consciousness as you know it in the room.\n\n");
 			fatigue(1);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		var soulforcecost:int = 20 * soulskillCost() * soulskillcostmulti();
@@ -4765,7 +4761,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.TamamoNoMaeCursedKimono)) speedDebuff *= 2;
 		monster.speStat.core.value -= speedDebuff;
 		monster.createStatusEffect(StatusEffects.Fear, 2+ItemMod, speedDebuff, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	//Illusion
@@ -4775,7 +4771,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if(monster is EncapsulationPod || monster.inte == 0) {
 			outputText("In the tight confines of this pod, there's no use making such an attack!\n\n");
 			fatigue(1);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		var soulforcecost:int = Math.floor(20 * soulskillCost() * soulskillcostmulti());
@@ -4800,7 +4796,7 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Decrease enemy speed and increase their susceptibility to lust attacks if already 110% or more
@@ -4845,7 +4841,7 @@ public class MagicSpecials extends BaseCombatContent {
 		monster.teased(lustDmg);
 		outputText("\n\n");
 		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
-		if(monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.lust < monster.maxOverLust()) enemyAI();
 		else {
 			if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
 		}
@@ -4881,7 +4877,7 @@ public class MagicSpecials extends BaseCombatContent {
 		//Failure
 		else outputText("Your target proves too fast for your technique to catch up.");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function TelekineticGrab():void {
@@ -4899,7 +4895,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("You weave your hand causing [themonster] body to levitate and fly to you as you use telekinesis to hold your opponent.\n\n");
 		monster.createStatusEffect(StatusEffects.TelekineticGrab, 4 + rand(2), 0, 0, 0);
 		player.createStatusEffect(StatusEffects.CooldownTelekineticGrab, 12, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	//Slime Bolt
@@ -4988,7 +4984,7 @@ public class MagicSpecials extends BaseCombatContent {
 		statScreenRefresh();
 		outputText("\n\n");
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	//Cursed Riddle
@@ -5057,7 +5053,7 @@ public class MagicSpecials extends BaseCombatContent {
 			outputText("\n\n");
 		}
 	if(monster.HP <= monster.minHP()) doNext(endHpVictory);
-	else combat.enemyAIAndResources();
+	else enemyAI();
 	}
 
 	//Fae Storm
@@ -5128,7 +5124,7 @@ public class MagicSpecials extends BaseCombatContent {
 			EffectList.splice(EffectList.indexOf(choice), 1)
 		}
 		outputText(".\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	
 	//Pixie Dust
@@ -5182,7 +5178,7 @@ public class MagicSpecials extends BaseCombatContent {
 			EffectList.splice(EffectList.indexOf(choice), 1)
 		}
 		outputText(".\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	private function FaeStormLightning():void{
@@ -5276,7 +5272,7 @@ public class MagicSpecials extends BaseCombatContent {
 		monster.createStatusEffect(StatusEffects.Polymorphed, 3+DurationIncrease, 0, 0, 0);
 		if (player.hasPerk(PerkLib.NaturalInstincts)) player.createStatusEffect(StatusEffects.CooldownBalefulPolymorph,15,0,0,0);
 		else player.createStatusEffect(StatusEffects.CooldownBalefulPolymorph, 16, 0, 0, 0)
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	//Transfer
@@ -5297,7 +5293,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if(monster.lustVuln == 0) {
 			outputText("It has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
 			player.lust += lusttransfered;
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		mosterTeaseText();
@@ -5305,7 +5301,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		doNext(playerMenu);
 		if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 //Fascinate
@@ -5313,13 +5309,13 @@ public class MagicSpecials extends BaseCombatContent {
 		clearOutput();
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if(monster is EncapsulationPod || monster.inte == 0) {
 			outputText("You reach for the enemy's mind, but cannot find anything.  You frantically search around, but there is no consciousness as you know it in the room.\n\n");
 			fatigue(1);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		fatigue(30, USEFATG_PHYSICAL);
@@ -5336,7 +5332,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.armor == armors.FMDRESS && player.isWoodElf()) lustDmg *= 2;
 		if(monster.lustVuln == 0) {
 			outputText("It has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if(monster.lust < (monster.maxLust() * 0.3)) outputText("[Themonster] squirms as the magic affects [monster him].  ");
@@ -5362,7 +5358,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		doNext(playerMenu);
 		if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 //Lust strike
@@ -5370,7 +5366,7 @@ public class MagicSpecials extends BaseCombatContent {
 		clearOutput();
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		fatigue(50, USEFATG_MAGIC_NOBM);
@@ -5384,7 +5380,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.EromancyExpert)) lustDmg *= 1.5;
 		if(monster.lustVuln == 0) {
 			outputText("It has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if(monster.lust < (monster.maxLust() * 0.3)) outputText("[Themonster] squirms as the magic affects [monster him].  ");
@@ -5409,7 +5405,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		doNext(playerMenu);
 		if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	public function mindThrust():void {
@@ -5436,7 +5432,7 @@ public class MagicSpecials extends BaseCombatContent {
 		doTrueDamage(damage, true, true);
 		if (crit) outputText(" <b>*Critical Hit!*</b>");
 		outputText(".\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function mindBlast():void {
@@ -5454,7 +5450,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("You assault your opponent’s mind with lewd thoughts, locking them into a blissful daze.");
 		player.createStatusEffect(StatusEffects.CooldownSpellMindBlast,14-PsionicEmpowermentBonus,0,0,0);
 		monster.createStatusEffect(StatusEffects.Stunned, duration,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function mirrorImage():void {
@@ -5478,7 +5474,7 @@ public class MagicSpecials extends BaseCombatContent {
 			outputText("You weave a powerful illusion, creating "+ numberOfImage +" replicas of yourself.\n\n");
 			player.createStatusEffect(StatusEffects.MirrorImage,numberOfImage,0,0,0);
 		}
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function possess():void {
@@ -5542,7 +5538,7 @@ public class MagicSpecials extends BaseCombatContent {
 		else {
 			outputText("With a smile and a wink, your form becomes completely intangible, and you waste no time in throwing yourself into the opponent's frame. Unfortunately, it seems they were more mentally prepared than you hoped, and you're summarily thrown out of their body before you're even able to have fun with them. Darn, you muse. Gotta get smarter.\n\n");
 		}
-		if(!combatIsOver()) combat.enemyAIAndResources();
+		if(!combatIsOver()) enemyAI();
 	}
 	public function possess2():void {
 		if (player.hasStatusEffect(StatusEffects.HarpyBind)) player.removeStatusEffect(StatusEffects.HarpyBind);
@@ -5580,7 +5576,7 @@ public class MagicSpecials extends BaseCombatContent {
 		damage = Math.round(damage);
 		doMagicDamage(damage, true, true);
 		monster.createStatusEffect(StatusEffects.Fear,1+rand(3),0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 //Feline Curse
@@ -5595,7 +5591,7 @@ public class MagicSpecials extends BaseCombatContent {
 		dynStats("lus", selflust);
 		monster.createStatusEffect(StatusEffects.Polymorphed, 3, 0, 0, 0);
 		if (player.lust >= player.maxOverLust()) doNext(endLustLoss);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 //Infernal Claw
@@ -5622,7 +5618,7 @@ public class MagicSpecials extends BaseCombatContent {
 		combat.heroBaneProc(damage * 2);
 		doNext(playerMenu);
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 //Eclipsing shadow
@@ -5634,7 +5630,7 @@ public class MagicSpecials extends BaseCombatContent {
 		else player.createStatusEffect(StatusEffects.CooldownEclipsingShadow,20,0,0,0);
 		outputText("You open your wings wide and call upon the power of your tainted blood a pair of black orbs forming at your fingertips. You shatter them on the ground plunging the area in complete darkness and extinguishing all light. While your opponent will be hard pressed to see anything your ability to echolocate allows you to navigate with perfect clarity.");
 		monster.createStatusEffect(StatusEffects.Blind, 15, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 //Sonic scream
@@ -5646,7 +5642,7 @@ public class MagicSpecials extends BaseCombatContent {
 		else player.createStatusEffect(StatusEffects.CooldownSonicScream, 15, 0, 0, 0);
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your magic touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		var damage:Number = 0;
@@ -5666,7 +5662,7 @@ public class MagicSpecials extends BaseCombatContent {
 		combat.heroBaneProc(damage);
 		doNext(playerMenu);
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 	
 //Vampire Thirst Stacks To Health/Mana
@@ -5712,14 +5708,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your winds touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The winds courses by the stone skin harmlessly. It does leave the surface of the statue glossier in its wake.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		else if (monster is Lethice && (monster as Lethice).fightPhase == 2)
@@ -5798,14 +5794,14 @@ public class MagicSpecials extends BaseCombatContent {
 		//Shell
 		if(monster.hasStatusEffect(StatusEffects.Shell)) {
 			outputText("As soon as your winds touches the multicolored shell around [themonster], it sizzles and fades to nothing.  Whatever that thing is, it completely blocks your magic!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LivingStatue)
 		{
 			outputText("The winds courses by the stone skin harmlessly. It does leave the surface of the statue glossier in its wake.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		else if (monster is Lethice && (monster as Lethice).fightPhase == 2)
@@ -5888,7 +5884,7 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		outputText("\n\n");
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 	public function ChaosBeamsRulette():void {
 		var damage:Number = scalingBonusIntelligence() * spellModWhite();
@@ -5987,7 +5983,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("You gaze deep into [themonster] eyes smashing [monster his] thoughts and resolve to nothingness along the way. [monster his] is nothing, you are everything. [Themonster] is left stunned by the experience.\n\n");
 		//player.createStatusEffect(StatusEffects.CooldownNet,8,0,0,0);
 		monster.createStatusEffect(StatusEffects.Stunned,2,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectAir():void {
@@ -6039,7 +6035,7 @@ public class MagicSpecials extends BaseCombatContent {
 		windwallduration *= 2;
 		player.createStatusEffect(StatusEffects.WindWall, 0, windwallduration, 0, 0);
 		outputText("You call on your elemental projecting a air wall between you and [themonster] to deflect incoming projectiles.\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectEarth():void {
@@ -6083,7 +6079,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.statusEffectv2(StatusEffects.SummonedElementalsEarth) >= 31) stoneskinduration += 3;
 		player.createStatusEffect(StatusEffects.StoneSkin, stoneskinbonus, stoneskinduration, 0, 0);
 		outputText("Your elemental lifts stone and dirt from the ground, encasing you in a earthen shell stronger than any armor.\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectFire():void {
@@ -6144,7 +6140,7 @@ public class MagicSpecials extends BaseCombatContent {
 		doFireDamage(damage, true, true);
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectWater():void {
@@ -6191,7 +6187,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("Your elemental encases your body within a bubble of curative spring water, slowly closing your wounds. The bubbles pop leaving you wet, but on the way to full recovery. <b>([font-heal]+" + temp + "</font>)</b>");
 		HPChange(temp,false);
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectEther():void {
@@ -6260,7 +6256,7 @@ public class MagicSpecials extends BaseCombatContent {
 		doMagicDamage(damage, true, true);
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectWood():void {
@@ -6344,7 +6340,7 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText("Your elemental temporarily covers your skin with bark, shielding you against strikes. This is the bark of medicinal plants and as such you recover from your injuries. <b>([font-heal]+" + temp + "</font>)</b>");
 		HPChange(temp,false);
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectMetal():void {
@@ -6388,7 +6384,7 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.statusEffectv2(StatusEffects.SummonedElementalsMetal) >= 31) metalskinduration += 3;
 		player.createStatusEffect(StatusEffects.MetalSkin, metalskinbonus, metalskinduration, 0, 0);
 		outputText("Your elemental encases your body into a layer of flexible yet solid steel. The metal gives strength to your frame, empowering your unarmed strikes.\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectIce():void {
@@ -6449,7 +6445,7 @@ public class MagicSpecials extends BaseCombatContent {
 		doIceDamage(damage, true, true);
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectLightning():void {
@@ -6509,7 +6505,7 @@ public class MagicSpecials extends BaseCombatContent {
 		doLightningDamage(damage, true, true);
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectDarkness():void {
@@ -6569,7 +6565,7 @@ public class MagicSpecials extends BaseCombatContent {
 		doDarknessDamage(damage, true, true);
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectPoison():void {
@@ -6637,7 +6633,7 @@ public class MagicSpecials extends BaseCombatContent {
 		monster.teased(Math.round(monster.lustVuln * lustdamage));
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectPurity():void {
@@ -6698,7 +6694,7 @@ public class MagicSpecials extends BaseCombatContent {
 		doMagicDamage(damage, true, true);
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ElementalAspectCorruption():void {
@@ -6759,7 +6755,7 @@ public class MagicSpecials extends BaseCombatContent {
 		doMagicDamage(damage, true, true);
 		outputText("\n\n");
 		//checkMinionsAchievementDamage(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	
 	public function FusionSpecialFirst(element:Number, type:Number):void {
@@ -6829,7 +6825,7 @@ public class MagicSpecials extends BaseCombatContent {
 			}
 		}
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function FusionSpecialSecond(element:Number, type:Number):void {
 		clearOutput();
@@ -6861,40 +6857,40 @@ public class MagicSpecials extends BaseCombatContent {
 		outputText(" <b>([font-heal]+" + temp + "</font>)</b>");
 		HPChange(temp,false);
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function FusionSpecialTrueEvasion():void {
 		clearOutput();
 		outputText("You disperse with the ambient air letting things run through you rather than blocking them. Good fucking luck to whoever would want to strike you right now.\n\n");
 		player.createStatusEffect(StatusEffects.CooldownTrueEvasion, 10, 0, 0, 0);
 		player.createStatusEffect(StatusEffects.TrueEvasion, 3, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function FusionSpecialAdamantineShell():void {
 		clearOutput();
 		outputText("You draw strength from the earth, your rock body turning to the metallic sheen and hardness of pure adamantium.\n\n");
 		player.createStatusEffect(StatusEffects.CooldownAdamantineShell, 10, 0, 0, 0);
 		player.createStatusEffect(StatusEffects.AdamantineShell, 7, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function FusionSpecialFieryRageActivate():void {
 		clearOutput();
 		outputText("You let the flame of anger consume you entering a fiery rage.\n\n");
 		player.createStatusEffect(StatusEffects.FieryRage, 0, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function FusionSpecialFieryRageDeactivate():void {
 		clearOutput();
 		outputText("You extinguish your flames, calming down from your fiery rage.\n\n");
 		player.removeStatusEffect(StatusEffects.FieryRage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function FusionSpecialMomentOfClarity():void {
 		clearOutput();
 		outputText("You empty your mind from needless thought turning yourself calm like the immobile water of a pond, only letting the ripple of the moment bother you. Thanks to your inner calm you manage to shrug off the desires that plagues you to concentrate on the ongoing battle with perfect clarity.\n\n");
 		player.createStatusEffect(StatusEffects.CooldownMomentOfClarity, 6, 0, 0, 0);
 		player.createStatusEffect(StatusEffects.MomentOfClarity, 3, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	//Arian's stuff
@@ -6917,7 +6913,7 @@ public class MagicSpecials extends BaseCombatContent {
 		SceneLib.arianScene.clearTalisman();
 		monster.createStatusEffect(StatusEffects.ImmolationDoT,3,0,0,0);
 		combat.heroBaneProc(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function shieldingSpell():void {
@@ -6926,7 +6922,7 @@ public class MagicSpecials extends BaseCombatContent {
 		player.createStatusEffect(StatusEffects.Shielding,0,0,0,0);
 		player.removeStatusEffect(StatusEffects.ShieldingSpell);
 		SceneLib.arianScene.clearTalisman();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function iceprisonSpell():void {
@@ -6942,7 +6938,7 @@ public class MagicSpecials extends BaseCombatContent {
 		SceneLib.arianScene.clearTalisman();
 		monster.createStatusEffect(StatusEffects.Stunned,3,0,0,0);
 		combat.heroBaneProc(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 }
 }

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -938,7 +938,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		EngineCore.WrathChange(-PAC);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function powerShoot():void {
@@ -1013,7 +1013,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.heroBaneProc(damage);
 		flags[kFLAGS.ARROWS_SHOT]++;
 		bowPerkUnlock();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function pcCleave():void {
@@ -1085,7 +1085,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			}
 			else monster.createStatusEffect(StatusEffects.IzmaBleed,3,0,0,0);
 		}
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function sneakAttack():void {
@@ -1309,7 +1309,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathWeaponsProc();
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function feint():void {
@@ -1323,7 +1323,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			monster.createStatusEffect(StatusEffects.Distracted, feintduration, 0, 0, 0);
 		}
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function sneakAttackRange():void {
@@ -1408,7 +1408,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (flags[kFLAGS.ARROWS_SHOT] >= 1) awardAchievement("Arrow to the Knee", kACHIEVEMENTS.COMBAT_ARROW_TO_THE_KNEE);
 			bowPerkUnlock();
 		}
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function warriorShout():void {
@@ -1517,7 +1517,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathWeaponsProc();
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function chargingcoooooost():Number {
 		var percent:Number = 40;
@@ -1544,7 +1544,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (monster.spe - player.spe < 8) outputText("[Themonster] narrowly avoids your attack!");
 			if (monster.spe - player.spe >= 8 && monster.spe-player.spe < 20) outputText("[Themonster] dodges your attack with superior quickness!");
 			if (monster.spe - player.spe >= 20) outputText("[Themonster] deftly avoids your slow attack.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		var damage:Number = 0;
@@ -1607,7 +1607,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function whipping():void {
@@ -1625,7 +1625,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (monster.spe - player.spe < 8) outputText("[Themonster] narrowly avoids your attack!");
 			if (monster.spe - player.spe >= 8 && monster.spe-player.spe < 20) outputText("[Themonster] dodges your attack with superior quickness!");
 			if (monster.spe - player.spe >= 20) outputText("[Themonster] deftly avoids your slow attack.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		var damage:Number = 0;
@@ -1683,7 +1683,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function whirlwindClaws():void {
@@ -1699,7 +1699,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (monster.spe - player.spe < 8) outputText("[Themonster] narrowly avoids your attack!");
 			if (monster.spe - player.spe >= 8 && monster.spe-player.spe < 20) outputText("[Themonster] dodges your attack with superior quickness!");
 			if (monster.spe - player.spe >= 20) outputText("[Themonster] deftly avoids your slow attack.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		fatigue(50, USEFATG_PHYSICAL);
@@ -1780,7 +1780,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function anemoneSting():void {
@@ -1834,7 +1834,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		//New lines and moving on!
 		outputText("\n\n");
 		doNext(combatMenu);
-		if(!combatIsOver()) combat.enemyAIAndResources();
+		if(!combatIsOver()) enemyAI();
 	}
 
 
@@ -1863,7 +1863,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		outputText("\n\n");
 		combat.WrathGenerationPerHit2(5);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function tailSlapAttack():void {
@@ -1945,7 +1945,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5*player.tailCount);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	private function tailSlapAttackKitshoo():Number {
 		var lustDmg:Number = monster.lustVuln * ((player.inte / 12 + player.wis / 8) * ((spellMod() + soulskillMagicalMod()) / 2) + rand(monster.lib + monster.cor) / 5);
@@ -1983,7 +1983,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		combat.WrathGenerationPerHit2(5);
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function inkSpray():void {
@@ -2019,7 +2019,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		statScreenRefresh();
 		if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	public function milkBlast():void {
@@ -2057,7 +2057,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function cumCannon():void {
@@ -2094,7 +2094,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
 		awardAchievement("Cum Cannon", kACHIEVEMENTS.COMBAT_CUM_CANNON);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function takeFlight():void {
@@ -2106,7 +2106,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			player.createPerk(PerkLib.Resolute, 0, 0, 0, 0);
 		}
 		monster.createStatusEffect(StatusEffects.MonsterAttacksDisabled, 0, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function takeFlightGoglinMech():void {
@@ -2118,7 +2118,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			player.createPerk(PerkLib.Resolute, 0, 0, 0, 0);
 		}
 		monster.createStatusEffect(StatusEffects.MonsterAttacksDisabled, 0, 0, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function bodySlam():void {
@@ -2153,7 +2153,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(slamDmg);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function minThicknessReq():Number {
 		var miniThicknessvalue:Number = 95;
@@ -2226,7 +2226,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		monster.statStore.addBuffObject({spe:-15}, "Poison",{text:"Poison"});
 		combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		combat.WrathGenerationPerHit2(5);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function terrifyingHowl():void {
@@ -2235,25 +2235,25 @@ public class PhysicalSpecials extends BaseCombatContent {
 			clearOutput();
 			outputText("You unleash a deafening howl, but [themonster] has no reaction to the sound\n\n");
 			fatigue(10);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		fatigue(40, USEFATG_PHYSICAL);
 		if(monster.hasPerk(PerkLib.Focused)) {
 			if(!monster.plural) outputText("[Themonster] is too focused for your howl to influence!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//[Failure]
 		if(rand(10) == 0) {
 			outputText("You unleash a deafening howl, but partway through your voice cracks and you start coughing.\n\n");
 			fatigue(10);
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		outputText("You unleash a deafening howl causing [themonster] to back off in fear momentarily dazed.\n\n");
 		monster.createStatusEffect(StatusEffects.Fear,1,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function wingSlapAttack():void {
@@ -2312,7 +2312,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	private function temporalGolemsAplification():Number {
@@ -2382,7 +2382,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (shatter) outputText(" <b>*Golem Core shattered!*</b>");
 		if (overloadedGolemCoresBag) outputText(" <b>*Golem Core wasn't picked due to lack of space to store them!*</b>");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function sendTemporalGolem3():void {
 		clearOutput();
@@ -2436,7 +2436,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (overloadedGolemCoresBag) outputText(" <b>*None of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		if (partialyoverloadedGolemCoresBag) outputText(" <b>*Some of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function sendTemporalGolem5():void {
 		clearOutput();
@@ -2490,7 +2490,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (overloadedGolemCoresBag) outputText(" <b>*None of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		if (partialyoverloadedGolemCoresBag) outputText(" <b>*Some of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function sendTemporalGolem4():void {
 		flags[kFLAGS.TEMPORAL_GOLEMS_BAG] -= 4;
@@ -2520,7 +2520,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (overloadedGolemCoresBag) outputText(" <b>*None of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		if (partialyoverloadedGolemCoresBag) outputText(" <b>*Some of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function sendTemporalGolem10():void {
 		flags[kFLAGS.TEMPORAL_GOLEMS_BAG] -= 10;
@@ -2550,7 +2550,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (overloadedGolemCoresBag) outputText(" <b>*None of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		if (partialyoverloadedGolemCoresBag) outputText(" <b>*Some of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function sendTemporalGolem20():void {
 		flags[kFLAGS.TEMPORAL_GOLEMS_BAG] -= 20;
@@ -2580,7 +2580,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (overloadedGolemCoresBag) outputText(" <b>*None of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		if (partialyoverloadedGolemCoresBag) outputText(" <b>*Some of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function sendTemporalGolemKamikazeProtocol():void {
 		clearOutput();
@@ -2614,7 +2614,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (overloadedGolemCoresBag) outputText(" <b>*None of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		if (partialyoverloadedGolemCoresBag) outputText(" <b>*Some of used Golem Cores wasn't picked due to lack of space to store them!*</b>");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function permanentgolemsendcost():Number {
@@ -2756,7 +2756,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			menu();
 			addButton(0, "Next", combatMenu, false);
 		}
-		if (doit) combat.enemyAIAndResources();
+		if (doit) enemyAI();
 	}
 
 	public function sendPermanentImprovedGolem(cnt:int = 1, doit:Boolean = false):void {
@@ -2792,7 +2792,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			menu();
 			addButton(0, "Next", combatMenu, false);
 		}
-		if (doit) combat.enemyAIAndResources();
+		if (doit) enemyAI();
 	}
 
 	public function sendPermanentSteelGolem(cnt:int = 1, doit:Boolean = false):void {
@@ -2826,7 +2826,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			menu();
 			addButton(0, "Next", combatMenu, false);
 		}
-		if (doit) combat.enemyAIAndResources();
+		if (doit) enemyAI();
 	}
 
 	public function sendPermanentImprovedSteelGolem(cnt:int = 1, doit:Boolean = false):void {
@@ -2864,7 +2864,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			menu();
 			addButton(0, "Next", combatMenu, false);
 		}
-		if (doit) combat.enemyAIAndResources();
+		if (doit) enemyAI();
 	}
 
 	public function notSendAnyGolem():void {
@@ -2886,7 +2886,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		monster.teased(pollen, false);
 		outputText("\n\n");
 		player.createStatusEffect(StatusEffects.AlraunePollen,0,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function AlrauneEntangle():void {
@@ -2905,7 +2905,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.NaturalArsenal)) EntangleNerf += 0.1;
 		player.createStatusEffect(StatusEffects.AlrauneEntangle,EntangleNerf,EntangleNerf,0,0);
 		monster.statStore.addBuffObject({"str.mult":-EntangleNerf,"spe.mult":-EntangleNerf}, "EntangleNerf",{text:"EntangleNerf"});
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function AlrauneStrangulate():void {
@@ -2925,7 +2925,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		doDamage(damage);
 		combat.WrathGenerationPerHit2(5);
 		outputText("You tighten your vines around your opponent's neck to strangle it. [Themonster] struggles against your natural noose, getting obvious marks on its neck and " + damage + " damage for their trouble.\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function blazingRocketKick():void {
@@ -2951,7 +2951,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.EruptingRiposte();
 		doNext(playerMenu);
 		if (monster.HP <= monster.minHP()) doNext(endHpVictory);
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 
 	public function EggThrowLustDamageRepeat():void {
@@ -3040,7 +3040,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		outputText("\n\n");
 		combat.WrathGenerationPerHit2(5);
-		if (!combatIsOver()) combat.enemyAIAndResources();
+		if (!combatIsOver()) enemyAI();
 	}
 
 	public function OmniEggthrowAttack():void {
@@ -3068,7 +3068,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		outputText("\n\n");
 		combat.WrathGenerationPerHit2(5);
-		if (!combatIsOver()) combat.enemyAIAndResources();
+		if (!combatIsOver()) enemyAI();
 	}
 
 
@@ -3146,7 +3146,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function StoneFistAttack():void {
@@ -3227,7 +3227,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function TailSlamAttack():void {
@@ -3304,7 +3304,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function TailCleaveAttack():void {
@@ -3381,7 +3381,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function WingBuffetAttack():void {
@@ -3448,7 +3448,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function TornadoStrike():void {
@@ -3501,7 +3501,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		combat.WrathGenerationPerHit2(5);
 		combat.heroBaneProc(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function PCWebAttack():void {
@@ -3513,7 +3513,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (combat.checkConcentration()) return; //Amily concentration
 		if (monster is LizanRogue) {
 			outputText("As your webbing flies at him the lizan flips back, slashing at the adhesive strands with the claws on his hands and feet with practiced ease.  It appears he's used to countering this tactic.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Blind
@@ -3526,7 +3526,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			outputText("You miss [themonster] completely - ");
 			if(monster.plural) outputText("they");
 			else outputText(monster.mf("he","she") + " moved out of the way!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Over-webbed
@@ -3555,7 +3555,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		awardAchievement("How Do I Shot Web?", kACHIEVEMENTS.COMBAT_SHOT_WEB);
 		outputText("\n\n");
-		if(!combatIsOver()) combat.enemyAIAndResources();
+		if(!combatIsOver()) enemyAI();
 	}
 	public function scyllaGrapple():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
@@ -3599,7 +3599,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			}
 		}
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function whipGrapple():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
@@ -3639,7 +3639,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			}
 		}
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function orcaPlay():void {
@@ -3676,7 +3676,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			else player.createStatusEffect(StatusEffects.CooldownPlay,15,0,0,0);
 			player.createStatusEffect(StatusEffects.OrcaPlayRoundLeft,3,0,0,0);
 			outputText("\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 	
@@ -3707,9 +3707,9 @@ public class PhysicalSpecials extends BaseCombatContent {
 			{
 				outputText("\n\n<i>\"Ouch. Such arcane skills for one so uncouth,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your magics?\"</i>\n\n");
 				monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
-				combat.enemyAIAndResources();
+				enemyAI();
 			}
-			else combat.enemyAIAndResources();
+			else enemyAI();
 		}
 		else if (player.statusEffectv1(StatusEffects.ChanneledAttack) == 1) {
 			outputText("You are still singing. Your compelling voice reaches far up to your opponent.");
@@ -3728,7 +3728,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			monster.teased(lustDmg2);
 			player.addStatusValue(StatusEffects.ChanneledAttack, 1, 1);
 			outputText("\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 		else {
 			fatigue(50, USEFATG_MAGIC_NOBM);
@@ -3748,7 +3748,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			player.createStatusEffect(StatusEffects.ChanneledAttack, 1, 0, 0, 0);
 			player.createStatusEffect(StatusEffects.ChanneledAttackType, 7, 0, 0, 0);
 			outputText("\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 	}
 	
@@ -3759,7 +3759,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("You mentally reach for your ring, and you feel a surge of anger, love and fear. You can all but feel Kiha’s wingbeats, the sensation making your own shoulder blades itch. You can’t relax, not with [enemy] in front of you, but you know that help is on the way!")
 		player.createStatusEffect(StatusEffects.CallOutKiha, 0, 0, 0, 0);
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function gooEngulf():void {
@@ -3800,7 +3800,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			}
 		}
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function vampireEmbrace():void {
@@ -3834,7 +3834,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		else outputText("You leap and box in [themonster] with your wings, embracing [monster he] as you prepare to feast.");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function catPounce():void {
@@ -3874,7 +3874,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			}
 		}
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function arigeanCrunch():void {
@@ -3959,7 +3959,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		else outputText("[Themonster] moves back just in time to avoid being crushed.");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	
 	public function arigeanRam():void {
@@ -4002,7 +4002,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			combat.EruptingRiposte();
 		}
 		else outputText("[Themonster] swiftly step out of the way, causing you to charge past [monster him].");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function bearGrab():void {
@@ -4043,7 +4043,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		//Failure
 		else outputText("Your opponent seeing it coming dodge to the side as you smash the ground where [monster he] used to stand.");
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function bearSlam():void {
@@ -4138,7 +4138,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.EruptingRiposte();
 		monster.createStatusEffect(StatusEffects.Stunned, 3, 0, 0, 0);
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function skyPounce():void {
@@ -4248,7 +4248,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			}
 		}
 		outputText("\n\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function hydraBiteAttack():void {
@@ -4258,7 +4258,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (monster is LivingStatue)
 		{
 			outputText("Your fangs can't even penetrate the giant's flesh.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		fatigue((10 * player.statusEffectv1(StatusEffects.HydraTailsPlayer)), USEFATG_PHYSICAL);
@@ -4293,7 +4293,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		player.tailVenom -= player.VenomWebCost() * 5;
 		flags[kFLAGS.VENOM_TIMES_USED] += 1;
-		if (!combatIsOver()) combat.enemyAIAndResources();
+		if (!combatIsOver()) enemyAI();
 	}
 	public function hydraBiteAttackpoweeeeer():void {
 		var HBD:Number = 0;
@@ -4314,7 +4314,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (monster is LivingStatue)
 		{
 			outputText("Your fangs can't even penetrate the giant's flesh.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Works similar to bee stinger, must be regenerated over time. Shares the same poison-meter
@@ -4345,7 +4345,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		player.tailVenom -= player.VenomWebCost() * 5;
 		flags[kFLAGS.VENOM_TIMES_USED] += 1;
-		if (!combatIsOver()) combat.enemyAIAndResources();
+		if (!combatIsOver()) enemyAI();
 	}
 
 	public function spiderBiteAttack():void {
@@ -4355,7 +4355,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (monster is LivingStatue)
 		{
 			outputText("Your fangs can't even penetrate the giant's flesh.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Works similar to bee stinger, must be regenerated over time. Shares the same poison-meter
@@ -4424,7 +4424,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		player.tailVenom -= player.VenomWebCost() * 5;
 		flags[kFLAGS.VENOM_TIMES_USED] += 1;
-		if (!combatIsOver()) combat.enemyAIAndResources();
+		if (!combatIsOver()) enemyAI();
 	}
 	public function antBiteAttack():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
@@ -4433,7 +4433,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (monster is LivingStatue)
 		{
 			outputText("Your "+(player.faceType == Face.ANT ? "mandibles":"fangs")+" can't even penetrate the giant's flesh.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Works similar to bee stinger, must be regenerated over time. Shares the same poison-meter
@@ -4457,7 +4457,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		player.tailVenom -= player.VenomWebCost() * 5;
 		flags[kFLAGS.VENOM_TIMES_USED] += 1;
-		if (!combatIsOver()) combat.enemyAIAndResources();
+		if (!combatIsOver()) enemyAI();
 	}
 	public function devastatingBiteAttack():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
@@ -4466,7 +4466,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (monster is LivingStatue)
 		{
 			outputText("Your razor sharp teeth cannot penetrate the stone of a statue");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Works similar to bee stinger, must be regenerated over time. Shares the same poison-meter
@@ -4488,7 +4488,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		outputText("\n\n");
 		combat.WrathGenerationPerHit2(5);
-		if (!combatIsOver()) combat.enemyAIAndResources();
+		if (!combatIsOver()) enemyAI();
 	}
 	public function fenrirFrostbite():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
@@ -4508,7 +4508,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (monster is LivingStatue)
 		{
 			outputText("Your fangs can't even penetrate the giant's flesh.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Frostbite for Fenrir
@@ -4550,7 +4550,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		checkAchievementDamage(damage);
 		combat.heroBaneProc(damage);
-		if (!combatIsOver()) combat.enemyAIAndResources();
+		if (!combatIsOver()) enemyAI();
 	}
 
 	//Mantis Omni Slash (AoE attack)
@@ -4583,7 +4583,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (monster.spe - player.spe < 8) outputText("[Themonster] narrowly avoids your attacks!\n\n");
 			if (monster.spe - player.spe >= 8 && monster.spe-player.spe < 20) outputText("[Themonster] dodges your attacks with superior quickness!\n\n");
 			if (monster.spe - player.spe >= 20) outputText("[Themonster] deftly avoids your slow attacks.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (monster.plural) {
@@ -4661,7 +4661,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			return;
 		}
 		outputText("\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 //Gore Attack - uses 25 fatigue!
 	public function goreAttack():void {
@@ -4676,7 +4676,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (player.horns.type == Horns.COW_MINOTAUR || player.horns.type == Horns.KIRIN || player.horns.type == Horns.BICORN || player.horns.type == Horns.FROSTWYRM) outputText("horns ");
 			else outputText("horn, ");
 			outputText("to stab only at air.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if ((player.hasPerk(PerkLib.PhantomStrike) && (player.fatigue + physicalCost(50) > player.maxFatigue())) || (!player.hasPerk(PerkLib.PhantomStrike) && (player.fatigue + physicalCost(25) > player.maxFatigue()))) {
@@ -4799,7 +4799,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
 		//Victory ORRRRR enemy turn.
-		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) enemyAI();
 		else {
 			if(monster.HP <= monster.minHP()) doNext(endHpVictory);
 			if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
@@ -4821,7 +4821,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (player.horns.type == Horns.COW_MINOTAUR || player.horns.type == Horns.KIRIN || player.horns.type == Horns.BICORN || player.horns.type == Horns.FROSTWYRM) outputText("horns ");
 			else outputText("horn, ");
 			outputText("to stab only at air.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if ((player.hasPerk(PerkLib.PhantomStrike) && (player.fatigue + physicalCost(50) > player.maxFatigue())) || (!player.hasPerk(PerkLib.PhantomStrike) && (player.fatigue + physicalCost(25) > player.maxFatigue()))) {
@@ -4926,7 +4926,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
 		//Victory ORRRRR enemy turn.
-		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) enemyAI();
 		else {
 			if(monster.HP <= monster.minHP()) doNext(endHpVictory);
 			if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
@@ -4938,7 +4938,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 	//This is now automatic - newRound arg defaults to true:	menuLoc = 0;
 		if (monster is WormMass) {
 			outputText("Taking advantage of your new natural weapon, you quickly charge at the freak of nature. Sensing impending danger, the creature willingly drops its cohesion, causing the mass of worms to fall to the ground with a sick, wet 'thud', leaving your horns to stab only at air.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (player.hasPerk(PerkLib.PhantomStrike)) fatigue(30, USEFATG_PHYSICAL);
@@ -5042,7 +5042,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
 		//Victory ORRRRR enemy turn.
-		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) enemyAI();
 		else {
 			if(monster.HP <= monster.minHP()) doNext(endHpVictory);
 			if(monster.lust >= monster.maxOverLust()) doNext(endLustVictory);
@@ -5056,7 +5056,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		//Worms are immune!
 		if (monster is WormMass) {
 			outputText("Taking advantage of your new natural weapons, you quickly thrust your stinger at the freak of nature. Sensing impending danger, the creature willingly drops its cohesion, causing the mass of worms to fall to the ground with a sick, wet 'thud', leaving you to stab only at air.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Determine if dodged!
@@ -5065,13 +5065,13 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if(monster.spe - player.spe < 8) outputText("[Themonster] narrowly avoids your stinger!\n\n");
 			else if(monster.spe-player.spe < 20) outputText("[Themonster] dodges your stinger with superior quickness!\n\n");
 			else outputText("[Themonster] deftly avoids your slow attempts to sting [monster him].\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//determine if avoided with armor.
 		if(monster.armorDef - player.level >= 10 && rand(4) > 0) {
 			outputText("Despite your best efforts, your sting attack can't penetrate [themonster]'s defenses.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Sting successful!
@@ -5133,7 +5133,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		player.tailVenom -= player.VenomWebCost() * 5;
 		flags[kFLAGS.VENOM_TIMES_USED] += 1;
 		//Kick back to main if no damage occured!
-		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) enemyAI();
 		else doNext(endLustVictory);
 	}
 //Player tail spike attack
@@ -5196,7 +5196,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		//Worms are immune!
 		if (monster is WormMass) {
 			outputText("Taking advantage of your new natural weapons, you quickly shoot an envenomed spike at the freak of nature. Sensing impending danger, the creature willingly drops its cohesion, causing the mass of worms to fall to the ground with a sick, wet 'thud', leaving your spike impale the ground behind.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Determine if dodged!
@@ -5205,20 +5205,20 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if(monster.spe - player.spe < 8) outputText("[Themonster] narrowly avoids your spike!\n\n");
 			if(monster.spe - player.spe >= 8 && monster.spe-player.spe < 20) outputText("[Themonster] dodges your spike with superior quickness!\n\n");
 			if(monster.spe - player.spe >= 20) outputText("[Themonster] deftly avoids your slow attempts to hit with a spike [monster him].\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//determine if avoided with armor.
 		if(monster.armorDef - player.level >= 10 && rand(4) > 0) {
 			outputText("Despite your best efforts, your spike attack can't penetrate [themonster]'s defenses.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Sting successful!
 		outputText("You drop on all fours, flinging your tail forward and shooting an envenomed spike at [themonster].");
 		tailspikedamage();
 		outputText("\n\n");
-		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) enemyAI();
 		else doNext(endLustVictory);
 	}
 
@@ -5228,7 +5228,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		clearOutput();
 		if (monster is WormMass) {
 			outputText("Taking advantage of your new natural weapons, you quickly shoot a flurry of envenomed spike at the freak of nature. Sensing impending danger, the creature willingly drops its cohesion, causing the mass of worms to fall to the ground with a sick, wet 'thud', leaving your spike impale the ground behind.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Determine if dodged!
@@ -5237,13 +5237,13 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (monster.spe - player.spe >= 20) outputText("[Themonster] deftly avoids your slow attempts to hit with a spike [monster him].\n\n");
 			else if (monster.spe - player.spe >= 8) outputText("[Themonster] dodges your spike with superior quickness!\n\n");
 			else outputText("[Themonster] narrowly avoids your spike!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//determine if avoided with armor.
 		if(monster.armorDef - player.level >= 10 && rand(4) > 0) {
 			outputText("Despite your best efforts, your spikes can't penetrate [themonster]'s defenses.\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Sting successful!
@@ -5259,7 +5259,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if (player.hasPerk(PerkLib.WeaponClawsSavageRend) && player.tailVenom >= player.VenomWebCost() * 5) tailspikedamage();
 		if ((player.hasPerk(PerkLib.HistoryFeral) || player.hasPerk(PerkLib.PastLifeFeral)) && player.tailVenom >= player.VenomWebCost() * 5) tailspikedamage();
 		outputText("\n\n");
-		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) combat.enemyAIAndResources();
+		if(monster.HP > 0 && monster.lust < monster.maxOverLust()) enemyAI();
 		else doNext(endLustVictory);
 	}
 
@@ -5313,14 +5313,14 @@ public class PhysicalSpecials extends BaseCombatContent {
 					else outputText("  Sadly, [themonster] moves aside, denying you the chance to give [monster him] a smooch.\n\n");
 					break;
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Success but no effect:
 		if(monster.lustVuln <= 0 || !monster.hasCock()) {
 			if(monster.plural) outputText("  Mouth presses against mouth, and you allow your tongue to stick out to taste the saliva of one of their number, making sure to give them a big dose.  Pulling back, you look at [themonster] and immediately regret wasting the time on the kiss.  It had no effect!\n\n");
 			else outputText("  Mouth presses against mouth, and you allow your tongue to stick to taste [monster his]'s saliva as you make sure to give them a big dose.  Pulling back, you look at [themonster] and immediately regret wasting the time on the kiss.  It had no effect!\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		attack = rand(4);
@@ -5364,7 +5364,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		outputText("\n\n");
 		//Sets up for end of combat, and if not, goes to AI.
-		if(!combatIsOver()) combat.enemyAIAndResources();
+		if(!combatIsOver()) enemyAI();
 	}
 //Mouf Attack
 // (Similar to the bow attack, high damage but it raises your fatigue).
@@ -5405,7 +5405,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if(monster.spe - player.spe >= 8 && monster.spe-player.spe < 20) outputText("[Themonster] dodges your attack with superior quickness!");
 			if(monster.spe - player.spe >= 20) outputText("[Themonster] deftly avoids your slow attack.");
 			outputText("\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		damage += combat.meleeUnarmedDamageNoLagSingle(2) * 3;
@@ -5476,7 +5476,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 				flags[kFLAGS.IN_COMBAT_PLAYER_USED_SHARK_BITE] = 1;
 				combat.combatMenu(false);
 			}
-			else combat.enemyAIAndResources();
+			else enemyAI();
 		}
 		else {
 			if(monster.HP <= monster.minHP()) doNext(endHpVictory);
@@ -5494,7 +5494,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		outputText("You dig yourself into the ground, moving out of your opponent’s reach.");
 		monster.createStatusEffect(StatusEffects.Dig,5,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function Drink():void {
@@ -5504,7 +5504,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			outputText("OOOH YESHHHH! This is just what you needed. You smile doopily as you enter the famous oni drunken daze, your muscle filling with extra alchoholic might. Now that your thirst is quenched you're totaly going to destroy the puny thing who dared to challenge you.\n\n");
 			CoC.instance.mutations.DrunkenPowerEmpower();
 		}
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function kick():void {
@@ -5538,7 +5538,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 
 		if (flags[kFLAGS.PC_FETISH] >= 3) {
 			outputText("You attempt to attack, but at the last moment your body wrenches away, preventing you from even coming close to landing a blow!  Ceraph's piercings have made normal attack impossible!  Maybe you could try something else?\n\n");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		if (combat.checkConcentration()) return; //Amily concentration
@@ -5564,7 +5564,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			else {
 				outputText("You attempt to crush the worms with your reprisal, only to have the collective move its individual members, creating a void at the point of impact, leaving you to attack only empty air.\n\n");
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Determine if dodged!
@@ -5577,7 +5577,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 				outputText(" to dodge your kick!");
 				outputText("\n\n");
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		//Determine damage
@@ -5638,7 +5638,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		checkAchievementDamage(damage);
 		combat.heroBaneProc(damage);
 		combat.EruptingRiposte();
-		if (!combatIsOver())combat.enemyAIAndResources();
+		if (!combatIsOver())enemyAI();
 	}
 
 	public function shieldBash():void {
@@ -5649,7 +5649,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (monster.spe - player.spe >= 20) outputText("[Themonster] deftly avoids your slow attack.");
 			else if (monster.spe - player.spe >= 8) outputText("[Themonster] dodges your attack with superior quickness!");
 			else outputText("[Themonster] narrowly avoids your attack!");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		var damage:int = 10 + (player.str / 1.5) + rand(player.str / 2) + (player.shieldBlock * 2);
@@ -5686,21 +5686,21 @@ public class PhysicalSpecials extends BaseCombatContent {
 			player.removeStatusEffect(StatusEffects.CounterAction);
 			doNext(playerMenu);
 		}
-		else combat.enemyAIAndResources();
+		else enemyAI();
 	}
 	public function netEntangle():void {
 		clearOutput();
 		outputText("You skillfully toss your net at [themonster] restraining [monster his] movement.");
 		player.createStatusEffect(StatusEffects.CooldownNet,5,0,0,0);
 		monster.createStatusEffect(StatusEffects.Stunned,3,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ELFarcheryElvenEye():void {
 		clearOutput()
 		outputText("You focus your vision concentrating on the target and pinpointing weak points to maximise the damage of your arrows!\n\n");
 		player.createStatusEffect(StatusEffects.ElvenEye,8,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function ELFarcheryPinDown():void {
@@ -5819,7 +5819,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 				outputText("\n\n<i>\"Ouch. Such a cowardly weapon,\"</i> Lethice growls. With a snap of her fingers, a pearlescent dome surrounds her. <i>\"How will you beat me without your pathetic " + ammoWord + "s?\"</i>\n\n");
 				monster.createStatusEffect(StatusEffects.Shell, 2, 0, 0, 0);
 			}
-			combat.enemyAIAndResources();
+			enemyAI();
 		}
 		if (monster.HP <= monster.minHP()) {
 			doNext(endHpVictory);
@@ -5831,7 +5831,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		player.createStatusEffect(StatusEffects.CooldownPinDown,8,0,0,0);
 		monster.createStatusEffect(StatusEffects.Stunned,3,0,0,0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function archerSidewinder():void {
@@ -5887,7 +5887,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		checkAchievementDamage(damage);
 		combat.heroBaneProc(damage);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function EnvenomedBoltEffects(Omnishot:Number = 1, ammoWord:String = "arrows"):void{
@@ -6089,13 +6089,13 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		checkAchievementDamage(damage);
 		combat.heroBaneProc(damage);
-		if (monster.HP <= monster.minHP() || flags[kFLAGS.MULTIPLE_ARROWS_STYLE] == 1) combat.enemyAIAndResources();
+		if (monster.HP <= monster.minHP() || flags[kFLAGS.MULTIPLE_ARROWS_STYLE] == 1) enemyAI();
 		else archerBarrage2();
 	}
 	private function archerBarrage2():void {
 		if (player.fatigue + bowCost(200) > player.maxFatigue()) {
 			outputText("You are too tired to shoot next volley of arrows.");
-			combat.enemyAIAndResources();
+			enemyAI();
 			return;
 		}
 		flags[kFLAGS.MULTIPLE_ARROWS_STYLE]--;
@@ -6128,7 +6128,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		combat.WrathGenerationPerHit2(5);
 		checkAchievementDamage(damage);
 		combat.heroBaneProc(damage);
-		if (monster.HP <= monster.minHP() || flags[kFLAGS.MULTIPLE_ARROWS_STYLE] == 1) combat.enemyAIAndResources();
+		if (monster.HP <= monster.minHP() || flags[kFLAGS.MULTIPLE_ARROWS_STYLE] == 1) enemyAI();
 		else archerBarrage2();
 	}
 	private function archerBarrage3():Number {
@@ -6147,13 +6147,13 @@ public class PhysicalSpecials extends BaseCombatContent {
 		var DurationIncrease:Number = 0;
 		if (player.keyItemvX("HB Stealth System", 1) >= 1) DurationIncrease += 1;
 		monster.createStatusEffect(StatusEffects.InvisibleOrStealth, 1, DurationIncrease, 0, 0);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 	public function StealthModeDeactivate():void {
 		clearOutput();
 		outputText("Depowering system you cause mech form to become visible.\n\n");
 		monster.removeStatusEffect(StatusEffects.InvisibleOrStealth);
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function mechScatterLaser():void {
@@ -6208,7 +6208,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		combat.heroBaneProc(damage);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 /*
 	public function mechStarcannon():void {
@@ -6236,7 +6236,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		combat.heroBaneProc(damage);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 */
 	public function mechTazer():void {
@@ -6272,7 +6272,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			monster.createStatusEffect(StatusEffects.Stunned, 2, 0, 0, 0);
 		}
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function mechOmniMissile():void {
@@ -6310,7 +6310,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		combat.heroBaneProc(damage);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function mechStimpackMedicalDispenser():void {
@@ -6341,7 +6341,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		heal = Math.round(heal);
 		player.createStatusEffect(StatusEffects.GoblinMechStimpack, 10, heal, 0, 0);
 		if (crit) outputText(" <b>*Critical Hit!*</b>");
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function mechGravityShots():void {
@@ -6374,7 +6374,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		combat.heroBaneProc(damage);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function mechRaijinBlaster():void {
@@ -6420,7 +6420,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		combat.heroBaneProc(damage);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function mechSnowballGenerator():void {
@@ -6450,7 +6450,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		combat.heroBaneProc(damage);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function mechWhitefireBeamCannon():void {
@@ -6492,7 +6492,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		combat.heroBaneProc(damage);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function mechDynapunchGlove():void {
@@ -6532,7 +6532,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		combat.heroBaneProc(damage);
 		statScreenRefresh();
-		combat.enemyAIAndResources();
+		enemyAI();
 	}
 
 	public function PhysicalSpecials() {

--- a/classes/classes/Scenes/Combat/Soulskills/CleansingPalmSkill.as
+++ b/classes/classes/Scenes/Combat/Soulskills/CleansingPalmSkill.as
@@ -83,7 +83,6 @@ public class CleansingPalmSkill extends AbstractSoulSkill {
 				if (display) {
 					outputText("You thrust your palm forward, sending a blast of pure energy towards Jojo. At the last second he sends a blast of his own against yours canceling it out\n\n");
 				}
-				combat.enemyAIAndResources();
 				return;
 			}
 		}
@@ -91,7 +90,6 @@ public class CleansingPalmSkill extends AbstractSoulSkill {
 			if (display) {
 				outputText("You thrust your palm forward, causing a blast of pure energy to slam against the giant stone statue- to no effect!");		
 			}
-			combat.enemyAIAndResources();
 			return;
 		}
 

--- a/classes/classes/Scenes/Quests/UrtaQuest.as
+++ b/classes/classes/Scenes/Quests/UrtaQuest.as
@@ -1487,7 +1487,7 @@ private function urtaVaultAttack():void {
 			return;
 		}
 		else outputText("\n");
-		combat.enemyAIAndResources();
+		enemyAI();
 		return;
 	}
 	//Basic damage stuff


### PR DESCRIPTION
Removed duplicate "combatroundover" call in "combatmenu" function
Removed unneeded "enemyai" calls in CleansingPalmSkill
Replaced all instances of "enemyaiandresources" back to the original "enemyai", with "recoveryofresources", now being called in "combatroundover()"

Deleted now unneeded "enemyaiandresources" function
Combat Round counter now properly starts from 1, not 0
Unneeded "recoveryofresources" function calls removed, due to now being in "combatroundover()"
The enemy will now act after using a turn picking up spent weapons instead of getting another turn