### PR TITLE
Stat bar display toggle

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -472,7 +472,10 @@ import classes.Scenes.Combat.CombatAbility;
                     kFLAGS.CHARVIEW_STYLE,
                     kFLAGS.CHARVIEW_ARMOR_HIDDEN,
 					kFLAGS.EXPLORE_MENU_STYLE,
-                    kFLAGS.SPIRIT_STONES]) {
+                    kFLAGS.SPIRIT_STONES,
+					kFLAGS.HP_STATBAR_PERCENTAGE,
+					kFLAGS.LUST_STATBAR_PERCENTAGE,
+					kFLAGS.WRATH_STATBAR_PERCENTAGE]) {
 					    newFlags[flag] = flags[flag];
 				}
 			}

--- a/classes/classes/GameSettings.as
+++ b/classes/classes/GameSettings.as
@@ -10,6 +10,7 @@ import classes.Stats.RawStat;
 import classes.Stats.StatUtils;
 import classes.StatusEffects.CombatStatusEffect;
 
+import coc.view.ButtonDataList;
 import coc.view.CoCLoader;
 import coc.view.MainView;
 
@@ -934,23 +935,42 @@ public class GameSettings extends BaseContent {
 			outputText("Stat bar animations: <b>ON</b>");
 		outputText("\n\n");
 
+		if (flags[kFLAGS.HP_STATBAR_PERCENTAGE] == 0)
+			outputText("HP bars show percentages: <b>OFF</b>");
+		else
+			outputText("HP bars show percentages: <b>ON</b>");
+		outputText("\n\n");
+
+		if (flags[kFLAGS.LUST_STATBAR_PERCENTAGE] == 0)
+			outputText("Lust bars show percentages: <b>OFF</b>");
+		else
+			outputText("Lust bars show percentages: <b>ON</b>");
+		outputText("\n\n");
+
+		if (flags[kFLAGS.WRATH_STATBAR_PERCENTAGE] == 0)
+			outputText("Wrath bars show percentages: <b>OFF</b>");
+		else
+			outputText("Wrath bars show percentages: <b>ON</b>");
+		outputText("\n\n");
+
+		var buttons:ButtonDataList = new ButtonDataList();
 		menu();
-		// [ Font   ] [ Main BG] [ Text BG] [ Sprites] [CV Style]
-		// [ Images ] [ Time   ] [Measurem] [ CV Off ] [CV Armor]
-		// [BtnIcons] [ BarAnim] [        ] [        ] [ Back   ]
-		addButton(0, "Side Bar Font", toggleFlag, kFLAGS.USE_OLD_FONT, settingsScreenInterfaceSettings).hint("Toggle between old and new font for side bar.");
-		addButton(1, "Main BG", menuMainBackground).hint("Choose a background for main game interface.");
-		addButton(2, "Text BG", menuTextBackground).hint("Choose a background for text.");
-		addButton(3, "Sprites", menuSpriteSelect).hint("Turn sprites on/off and change sprite style preference.");
-		addButton(4, "Charview Style",toggleCharViewerStyle).hint("Change between in text and sidebar display");
-		addButton(5, "Toggle Images", toggleImages).hint("Enable or disable image pack.");
-		addButton(6, "Time Format", toggleTimeFormat).hint("Toggles between 12-hour and 24-hour format.");
-		addButton(7, "Measurements", toggleMeasurements).hint("Switch between imperial and metric measurements.  \n\nNOTE: Only applies to your appearance screen.");
-		addButton(8, "Toggle CharView", toggleCharViewer).hint("Turn PC visualizer on/off.");
-		addButton(9, "Charview Armor",toggleFlag, kFLAGS.CHARVIEW_ARMOR_HIDDEN, settingsScreenInterfaceSettings).hint("Turn PC armor and underwear display on/off");
-		addButton(10, "Button Icons", toggleFlag, kFLAGS.BUTTON_ICONS_DISABLED, settingsScreenInterfaceSettings);
-		addButton(11, "Statbar Anim.", toggleFlag, kFLAGS.STATBAR_ANIMATIONS, settingsScreenInterfaceSettings).hint("Toggle stat bar animations when value changes");
-		addButton(14, "Back", settingsScreenMain);
+		buttons.add("Side Bar Font", curry(toggleFlag, kFLAGS.USE_OLD_FONT, settingsScreenInterfaceSettings), "Toggle between old and new font for side bar.");
+		buttons.add("Main BG", menuMainBackground, "Choose a background for main game interface.");
+		buttons.add("Text BG", menuTextBackground, "Choose a background for text.");
+		buttons.add("Sprites", menuSpriteSelect, "Turn sprites on/off and change sprite style preference.");
+		buttons.add("Charview Style",toggleCharViewerStyle, "Change between in text and sidebar display");
+		buttons.add("Toggle Images", toggleImages, "Enable or disable image pack.");
+		buttons.add("Time Format", toggleTimeFormat, "Toggles between 12-hour and 24-hour format.");
+		buttons.add("Measurements", toggleMeasurements, "Switch between imperial and metric measurements.  \n\nNOTE: Only applies to your appearance screen.");
+		buttons.add("Toggle CharView", toggleCharViewer, "Turn PC visualizer on/off.");
+		buttons.add("Charview Armor", curry(toggleFlag, kFLAGS.CHARVIEW_ARMOR_HIDDEN, settingsScreenInterfaceSettings), "Turn PC armor and underwear display on/off");
+		buttons.add("Button Icons", curry(toggleFlag, kFLAGS.BUTTON_ICONS_DISABLED, settingsScreenInterfaceSettings));
+		buttons.add("Statbar Anim.", curry(toggleFlag, kFLAGS.STATBAR_ANIMATIONS, settingsScreenInterfaceSettings), "Toggle stat bar animations when value changes");
+		buttons.add("HP Percent", curry(toggleFlag, kFLAGS.HP_STATBAR_PERCENTAGE, settingsScreenInterfaceSettings), "Toggle between showing the HP stat as a percentage");
+		buttons.add("Lust Percent", curry(toggleFlag, kFLAGS.LUST_STATBAR_PERCENTAGE, settingsScreenInterfaceSettings), "Toggle between showing the Lust stat as a percentage");
+		buttons.add("Wrath Percent", curry(toggleFlag, kFLAGS.WRATH_STATBAR_PERCENTAGE, settingsScreenInterfaceSettings), "Toggle between showing the Wrath stat as a percentage");
+		submenu(buttons, settingsScreenMain, 0, false);
 	}
 	public function menuMainBackground():void {
 		menu();

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -3004,7 +3004,9 @@ public static const CORRUPTION_TOLERANCE_MODE:int                               
 public static const ITS_EVERY_DAY:int                                               = 2996; // all special calender events occur every day!
 public static const LOW_STANDARDS_FOR_ALL:int                                       = 2997;
 public static const HYPER_HAPPY:int                                                 = 2998;
-public static const UNKNOWN_FLAG_NUMBER_02999:int                                   = 2999;
+public static const HP_STATBAR_PERCENTAGE:int                                   	= 2999; //HP bars show a percentage rather than the core number
+public static const LUST_STATBAR_PERCENTAGE:int                                   	= 3000; //Lust bars show a percentage rather than the core number
+public static const WRATH_STATBAR_PERCENTAGE:int                                   	= 3001; //Wrath bars show a percentage rather than the core number
 
 public static const GLOBAL_FLAGS_ARRAY:Array = [
 	NEW_GAME_PLUS_BONUS_UNLOCKED_HERM, SHOW_SPRITES_FLAG, SILLY_MODE_ENABLE_FLAG, SCENEHUNTER_PRINT_CHECKS,

--- a/classes/coc/view/MonsterStatsView.as
+++ b/classes/coc/view/MonsterStatsView.as
@@ -9,6 +9,7 @@ import classes.PerkLib;
 import classes.Player;
 import classes.internals.Utils;
 
+import flash.events.MouseEvent;
 import flash.text.TextField;
 import flash.text.TextFormat;
 
@@ -71,6 +72,8 @@ public class MonsterStatsView extends Block {
 			bgColor : '#ff0000',
 			showMax : true
 		}));
+		hpBar.addEventListener("rollOver",Utils.curry(hoverStat,'hp'));
+		hpBar.addEventListener("rollOut",Utils.curry(hoverStat,'hp'));
 		addElement(lustBar = new StatBar({
 			statName   : "Lust:",
 			//	barColor   : '#ff1493',
@@ -78,6 +81,8 @@ public class MonsterStatsView extends Block {
 			hasMinBar  : true,
 			showMax    : true
 		}));
+		lustBar.addEventListener("rollOver",Utils.curry(hoverStat,'lust'));
+		lustBar.addEventListener("rollOut",Utils.curry(hoverStat,'lust'));
 		addElement(fatigueBar = new StatBar({
 			statName: "Fatigue:",
 			showMax : true
@@ -96,6 +101,8 @@ public class MonsterStatsView extends Block {
 			statName: "Wrath:",
 			showMax : true
 		}));
+		wrathBar.addEventListener("rollOver",Utils.curry(hoverStat,'wrath'));
+		wrathBar.addEventListener("rollOut",Utils.curry(hoverStat,'wrath'));
 		addElement(corBar = new StatBar({
 			statName: "Corruption:",
 			showMax : false,
@@ -142,11 +149,15 @@ public class MonsterStatsView extends Block {
 		nameText.text         = Utils.capitalizeFirstLetter(monster.short);
 		nameText.height       = nameText.textHeight+5;
 		levelBar.value        = monster.level;
+		var hpPercent:Boolean = game.flags[kFLAGS.HP_STATBAR_PERCENTAGE] == 1;
 		hpBar.maxValue        = monster.maxHP();
 		hpBar.value           = monster.HP;
+		hpBar.percentage	  = hpPercent;
+		var lustPercent:Boolean = game.flags[kFLAGS.LUST_STATBAR_PERCENTAGE] == 1;
 		lustBar.maxValue      = monster.maxLust();
 		lustBar.minValue      = monster.minLust();
 		lustBar.value         = monster.lust;
+		lustBar.percentage	  = lustPercent;
 		fatigueBar.value      = monster.fatigue;
 		fatigueBar.maxValue   = monster.maxFatigue();
 		soulforceBar.value    = monster.soulforce;
@@ -155,8 +166,10 @@ public class MonsterStatsView extends Block {
 		manaBar.value         = monster.mana;
 		manaBar.maxValue      = monster.maxMana();
 		manaBar.visible       = player.hasPerk(PerkLib.JobSorcerer);
+		var wrathPercent:Boolean = game.flags[kFLAGS.WRATH_STATBAR_PERCENTAGE] == 1;
 		wrathBar.value        = monster.wrath;
 		wrathBar.maxValue     = monster.maxWrath();
+		wrathBar.percentage	  = wrathPercent;
 		wrathBar.visible      = player.hasPerk(PerkLib.SenseWrath);
 		corBar.value          = monster.cor;
 		corBar.visible        = player.hasPerk(PerkLib.SenseCorruption);
@@ -197,6 +210,31 @@ public class MonsterStatsView extends Block {
 			dtf.color = style.statTextColor;
 			tf.defaultTextFormat = dtf;
 			tf.setTextFormat(dtf);
+		}
+	}
+	private function hoverStat(statname:String, event:MouseEvent):void {
+		var monster:Monster = CoC.instance.monster;
+		switch (event.type) {
+			case MouseEvent.ROLL_OVER:
+				var bar:StatBar = event.target as StatBar;
+				if (!bar) return;
+				if (statname == "hp") {
+					if (!CoC.instance.flags[kFLAGS.HP_STATBAR_PERCENTAGE]) return;
+					var hpText:String = "HP: " + Utils.formatNumber(Math.floor(monster.HP)) + (bar.showMax ? '/' + Utils.formatNumber(monster.maxHP()) : '');
+					CoC.instance.mainView.toolTipView.showForElement(bar,bar.statName,hpText);
+				} else if (statname == "lust") {
+					if (!CoC.instance.flags[kFLAGS.LUST_STATBAR_PERCENTAGE]) return;
+					var lustValue:String = "Lust: " + Utils.formatNumber(Math.floor(monster.lust)) + (bar.showMax ? '/' + Utils.formatNumber(monster.maxLust()) : '');
+					CoC.instance.mainView.toolTipView.showForElement(bar,bar.statName,lustValue);
+				} else if (statname == "wrath") {
+					if (!CoC.instance.flags[kFLAGS.WRATH_STATBAR_PERCENTAGE]) return;
+					var wrathText:String = "Wrath: " + Utils.formatNumber(Math.floor(monster.wrath)) + (bar.showMax ? '/' + Utils.formatNumber(monster.maxWrath()) : '');
+					CoC.instance.mainView.toolTipView.showForElement(bar,bar.statName,wrathText);
+				}
+				break;
+			case MouseEvent.ROLL_OUT: 
+				CoC.instance.mainView.toolTipView.hide();
+				break;
 		}
 	}
 }

--- a/classes/coc/view/StatBar.as
+++ b/classes/coc/view/StatBar.as
@@ -36,7 +36,8 @@ public class StatBar extends Block {
 			barHeight  : 1.0, // relative to height
 			barColor   : '#0000ff',
 			minBarColor: '#8080ff',
-			bgColor    : null
+			bgColor    : null,
+			percentage : false
 		};
 	}
 	private static var DEFAULT_OPTIONS:Object     = factoryReset();
@@ -60,6 +61,8 @@ public class StatBar extends Block {
 	private var _showMax:Boolean;
 	private var _tween:SimpleTween;
 	private var _animate:Boolean;
+	private var _percentage:Boolean;
+
 	private function get arrowSz():Number {
 		return this.height-2;
 	}
@@ -171,11 +174,17 @@ public class StatBar extends Block {
 		update();
 	}
 	private function renderValue():void {
-		var bValue:String = Math.floor(value).toString();
-		var mValue:String = Math.floor(maxValue).toString();
-		if (value > 1000000) bValue = value.toPrecision(3);
-		if (maxValue > 1000000) mValue = maxValue.toPrecision(3);
-		valueText = '' + bValue + (showMax ? '/' + mValue : '');
+		if (percentage) {
+			var pValue:Number = (value / maxValue) * 100;
+			var valueStr:String = pValue.toFixed(1);
+			valueText = '' + valueStr + '%';
+		} else {
+			var bValue:String = Math.floor(value).toString();
+			var mValue:String = Math.floor(maxValue).toString();
+			if (value > 1000000) bValue = value.toPrecision(3);
+			if (maxValue > 1000000) mValue = maxValue.toPrecision(3);
+			valueText = '' + bValue + (showMax ? '/' + mValue : '');
+		}
 	}
 	public function get rawValue():Number {
 		return _value;
@@ -278,6 +287,17 @@ public class StatBar extends Block {
 	}
 	public function get arrowDown():BitmapDataSprite {
 		return _arrowDown;
+	}
+
+	public function get percentage():Boolean
+	{
+		return _percentage;
+	}
+
+	public function set percentage(value:Boolean):void
+	{
+		_percentage = value;
+		renderValue();
 	}
 }
 }

--- a/classes/coc/view/StatsView.as
+++ b/classes/coc/view/StatsView.as
@@ -149,6 +149,8 @@ public class StatsView extends Block {
 			bgColor : '#ff0000',
 			showMax : true
 		}));
+		hpBar.addEventListener("rollOver",Utils.curry(hoverStat,'hp'));
+		hpBar.addEventListener("rollOut",Utils.curry(hoverStat,'hp'));
 		col2.addElement(lustBar = new StatBar({
 			statName   : "Lust:",
 		//	barColor   : '#ff1493',
@@ -162,6 +164,8 @@ public class StatsView extends Block {
 			statName: "Wrath:",
 			showMax : true
 		}));
+		wrathBar.addEventListener("rollOver",Utils.curry(hoverStat,'wrath'));
+		wrathBar.addEventListener("rollOut",Utils.curry(hoverStat,'wrath'));
 		col2.addElement(fatigueBar = new StatBar({
 			statName: "Fatigue:",
 			showMax : true
@@ -318,12 +322,18 @@ public class StatsView extends Block {
 		senBar.maxValue       = player.sens;
 		senBar.value          = player.effectiveSensitivity();
 		corBar.value          = player.cor;
+		var hpPercent:Boolean = game.flags[kFLAGS.HP_STATBAR_PERCENTAGE] == 1;
 		hpBar.maxValue        = player.maxHP();
 		hpBar.value           = player.HP;
+		hpBar.percentage	  = hpPercent;
+		var wrathPercent:Boolean = game.flags[kFLAGS.WRATH_STATBAR_PERCENTAGE] == 1;
 		wrathBar.maxValue 	  = player.maxWrath();
 		wrathBar.value    	  = player.wrath;
+		wrathBar.percentage	  = wrathPercent;
+		var lustPercent:Boolean = game.flags[kFLAGS.LUST_STATBAR_PERCENTAGE] == 1;
 		lustBar.maxValue      = player.maxLust();
 		lustBar.minValue      = player.minLust();
+		lustBar.percentage	  = lustPercent;
 		lustBar.value         = player.lust;
 		fatigueBar.maxValue   = player.maxFatigue();
 		fatigueBar.value      = player.fatigue;
@@ -417,7 +427,9 @@ public class StatsView extends Block {
 					if (!bar) return;
 					if (statname == "sens" || statname == "cor" || statname == "minlust") isPositiveStat = false;
 					if (statname == "minlust") {
-						var text:String = StatUtils.describeBuffs(stat, false, isPositiveStat);
+						var lustValue:String = (CoC.instance.flags[kFLAGS.LUST_STATBAR_PERCENTAGE])? "Lust: " +
+							 Utils.formatNumber(Math.floor(player.lust)) + (bar.showMax ? '/' + Utils.formatNumber(player.maxLust()) : '') + "\n": "";
+						var text:String = lustValue + StatUtils.describeBuffs(stat, false, isPositiveStat);
 						player.listMinLustMultiBuffs();
 						text += StatUtils.describeBuffs(player.minLustXStat, true, isPositiveStat);
 						CoC.instance.mainView.toolTipView.showForElement(
@@ -445,6 +457,16 @@ public class StatsView extends Block {
 								"" + StatUtils.describeBuffs(primStat.mult, true, isPositiveStat) + "";
 					}
 					CoC.instance.mainView.toolTipView.showForElement(bar,bar.statName,s);
+				} else if (statname == "hp") {
+					if (!bar) return;
+					if (!CoC.instance.flags[kFLAGS.HP_STATBAR_PERCENTAGE]) return;
+					var hpText:String = "HP: " + Utils.formatNumber(Math.floor(player.HP)) + (bar.showMax ? '/' + Utils.formatNumber(player.maxHP()) : '');
+					CoC.instance.mainView.toolTipView.showForElement(bar,bar.statName,hpText);
+				} else if (statname == "wrath") {
+					if (!bar) return;
+					if (!CoC.instance.flags[kFLAGS.WRATH_STATBAR_PERCENTAGE]) return;
+					var wrathText:String = "Wrath: " + Utils.formatNumber(Math.floor(player.wrath)) + (bar.showMax ? '/' + Utils.formatNumber(player.maxWrath()) : '');
+					CoC.instance.mainView.toolTipView.showForElement(bar,bar.statName,wrathText);
 				}
 				break;
 			case MouseEvent.ROLL_OUT:


### PR DESCRIPTION
Added 3 toggles in Interface Game Settings to control whether the HP Lust and Wrath of the player and Enemy should be displayed as a percentage or numbers