### PR TITLE
Grave weapon tweaks

### DIFF
--- a/classes/classes/Items/WeaponLib.as
+++ b/classes/classes/Items/WeaponLib.as
@@ -452,7 +452,7 @@ public final class WeaponLib extends ItemConstants
 				WT_EXOTIC, WSZ_MASSIVE)
 				.withTags(W_THROWN)
 				.withEffect(IELib.ScaleAttack_StrXL, 250) as Weapon;
-		public const GGRAVEA:Weapon = new Weapon("GGravea", "GlacialGraveaxe", "Glacial Graveaxe", "a Glacial Graveaxe", "cleave", 160, 160, "The titanic greataxe you found in the glacial rift, most of the weapon seems to have been carved from bedrock, with the head being made of solid, dense, ice from the heart of a glacier. The ice is light, razor sharp, and appears to never melt. The stone’s slightly discolored, as if carvings had once adorned its surface…However, such decoration seems to have been lost to time.", WT_AXE, WSZ_MASSIVE)
+		public const GGRAVEA:Weapon = new Weapon("GGravea", "GlacialGraveaxe", "Glacial Graveaxe", "a Glacial Graveaxe", "cleave", 160, 160, "The titanic greataxe you found in the tundra, most of the weapon seems to have been carved from bedrock, with the head being made of solid, dense, ice from the heart of a glacier. The ice is light, razor sharp, and appears to never melt. The stone’s slightly discolored, as if carvings had once adorned its surface…However, such decoration seems to have been lost to time.", WT_AXE, WSZ_MASSIVE)
 				.withTag(W_LGWRATH)
 				.withEffect(IELib.ScaleAttack_StrXL, 800) as Weapon;
 		public const GUANDAO:Weapon = new Weapon(
@@ -946,7 +946,7 @@ public final class WeaponLib extends ItemConstants
 				"This set of catclaw gloves was tempered using Etna's own venom and reinforced using some of her tail bone spikes, a proof of her eternal love to you. Its also enchanted to reinforce natural attacks.",
 				WT_GAUNTLET, WSZ_MEDIUM)
 				.withEffect(IELib.Bleed, 10) as Weapon;
-		public const VGRAVEH:Weapon = new Weapon("VGraveh", "VolcanicGravehammer", "Volcanic Gravehammer", "a Volcanic Gravehammer", "smash", 160, 160, "The titanic greathammer you found in the volcanic crag. This weapon seems to have been hewn from perpetually molten bedrock from deep within a volcano. How it remains this way is unknown to you, but you wonder if it was enchanted to be as such, or if it's just a natural property of the materials it's been crafted from.", WT_MACE_HAMMER, WSZ_MASSIVE)
+		public const VGRAVEH:Weapon = new Weapon("VGraveh", "VolcanicGravehammer", "Volcanic Gravehammer", "a Volcanic Gravehammer", "smash", 160, 160, "The titanic greathammer you found in the ashlands. This weapon seems to have been hewn from perpetually molten bedrock from deep within a volcano. How it remains this way is unknown to you, but you wonder if it was enchanted to be as such, or if it's just a natural property of the materials it's been crafted from.", WT_MACE_HAMMER, WSZ_MASSIVE)
 				.withTag(W_LGWRATH)
 				.withEffect(IELib.ScaleAttack_StrXL, 800) as Weapon;
 		public const W_STAFF:Weapon = new Weapon(

--- a/classes/coc/view/charview/CharViewContext.as
+++ b/classes/coc/view/charview/CharViewContext.as
@@ -111,12 +111,12 @@ public class CharViewContext extends ExecContext {
 					PlayerHasAMassiveSwordUnholy: player.weapon == game.weapons.CHAOSEA,
 
 					PlayerHasAnAxe: player.isAxeTypeWeapon(),
-					PlayerHasAnAxeHoly:player.weapon == game.weapons.WG_GAXE,
+					PlayerHasAnAxeHoly:player.weapon == game.weapons.WG_GAXE || player.weapon == game.weapons.GGRAVEA,
 					PlayerHasAnAxeUnholy:player.weapon == game.weapons.DE_GAXE || player.weapon == game.weapons.ASTERIUS,
 
 					PlayerHasAHammer: player.isMaceHammerTypeWeapon() && !player.isTetsubo() && player.weapon != game.weapons.SFLUTTE && player.weapon != game.weapons.PFLUTTE && player.weapon != game.weapons.HELLCAL && player.weapon != game.weapons.ELYSIUM,
 					//PlayerHasAHammerHoly:player.weapon == game.weapons.POCDEST,
-					//PlayerHasAHammerUnholy:player.weapon == game.weapons.DOCDEST,
+					PlayerHasAHammerUnholy:player.weapon == game.weapons.VGRAVEH,
 					PlayerHasATetsu: player.weapon == game.weapons.OTETSU || player.weapon == game.weapons.POCDEST || player.weapon == game.weapons.DOCDEST,
 					PlayerHasATetsuHoly:player.weapon == game.weapons.POCDEST,
 					PlayerHasATetsuUnholy:player.weapon == game.weapons.DOCDEST,


### PR DESCRIPTION
-Adjusted grave weapons' description to mention tundra/ashlands instead of g.rift/v.crag.
-Volcanic Gravehammer now uses the corrupt hammer sprite as a placeholder until I make a custom sprite for it.
-Glacial Graveaxe now uses the pure axe sprite as a placeholder until I make a custom sprite for it.