### PR TITLE
Dynamically display the name of a racial requirement

### DIFF
--- a/classes/classes/Race.as
+++ b/classes/classes/Race.as
@@ -272,7 +272,7 @@ public class Race {
 				s += "[font-default]";
 			}
 			score += rscore;
-			s += rr.name;
+			s += rr.getName();
 			if (rr.varyingScore() && !pass) {
 				// do not display (+X) for requirements that have varying values and
 				// didn't pass, because value could be incorrect

--- a/classes/classes/Races/README.md
+++ b/classes/classes/Races/README.md
@@ -4,7 +4,7 @@
 
 Each **Race** consists of:
 * **RacialRequirement**'s. Requirements are single checks that add/deduct racial score points. They have: 
-  * name (ex. "fox ears"), displayed in race DB page
+  * name (ex. "fox ears") or name function (to compute the name when the requirement is shown), displayed in race DB page
   * check function (`player.ears.type == Ears.FOX`)
   * pass score (ex. +1), granted if check function passes
   * fail score (ex. -1, default 0), applied if check function fails

--- a/classes/classes/internals/race/RaceScoreBuilder.as
+++ b/classes/classes/internals/race/RaceScoreBuilder.as
@@ -333,7 +333,9 @@ public class RaceScoreBuilder {
 		var oo:Object = RaceUtils.parseOperatorObject(adj, null);
 		return customRequirement(
 				"skin",
-				oo.name+" plain skin",
+				function (): String {
+					return oo.nameFn()+" plain skin";
+				},
 				function(body:BodyData):Boolean {
 					return body.player.hasPlainSkinOnly() && oo.operatorFn(body.skinBaseAdj);
 				},
@@ -345,7 +347,7 @@ public class RaceScoreBuilder {
 		var oo:Object = RaceUtils.parseOperatorObject(color, BodyData.defaultPhraseFn(" plain skin",null));
 		return customRequirement(
 				"skin",
-				oo.name,
+				oo.nameFn,
 				function(body:BodyData):Boolean {
 					return body.player.hasPlainSkinOnly() && oo.operatorFn(body.skinColor1);
 				},
@@ -367,13 +369,17 @@ public class RaceScoreBuilder {
 				slotRequirement(BodyData.SLOT_TAIL_COUNT, count, score, failScore, false),
 				slotRequirement(BodyData.SLOT_TAIL_TYPE, type, score, failScore, false)
 		);
-		if (count is Number) {
-			if (count > 1) req.name += " tails";
-			else req.name += " tail";
-		} else {
-			req.name += " tail(s)"
-		}
-		addRequirement(req, customName);
+		const nameFn:Function = function():String {
+			var suffix:String = "";
+			if (count is Number) {
+				if (count > 1) suffix = " tails";
+				else suffix = " tail";
+			} else {
+				suffix = " tail(s)"
+			}
+			return req.getName() + suffix;
+		};
+		addRequirement(req.withNameFn(nameFn), customName);
 		return this;
 	}
 	public function tongueType(type:*, score:int, failScore:int=0, customName:String = ""):RaceScoreBuilder {
@@ -610,7 +616,7 @@ public class RaceScoreBuilder {
 	 */
 	public function customRequirement(
 			group:String,
-			name:String,
+			name:*/*String|Function*/,
 			checkFn:Function,
 			score: int,
 			failScore:int=0
@@ -654,7 +660,7 @@ public class RaceScoreBuilder {
 	
 	protected function addRequirement(requirement:RacialRequirement,
 									  customName:String=""):void {
-		if (customName != "") requirement.name = customName;
+		if (customName != "") requirement.setNameStr(customName);
 		race.requirements.push(requirement);
 	}
 	
@@ -672,7 +678,7 @@ public class RaceScoreBuilder {
 				type, "["+race.name+" "+ slotName+"] ");
 		addRequirement(new RacialRequirement(
 				slotName,
-				customName || req.name,
+				customName || req.nameFn,
 				req.check,
 				score,
 				failScore,
@@ -711,7 +717,9 @@ public class RaceScoreBuilder {
 		var oo:Object = RaceUtils.parseOperatorObject(value,BodyData.defaultPhraseFn("",nameFn),"["+race.name+" "+pattern+"]");
 		addRequirement(new RacialRequirement(
 				group,
-				customName || pattern.replace(/\$value/g,oo.name),
+				customName || function (): String {
+					return pattern.replace(/\$value/g,oo.nameFn())
+				},
 				RaceUtils.composeOpArg(argumentFn, oo.operatorFn),
 				score,
 				failScore,
@@ -734,7 +742,7 @@ public class RaceScoreBuilder {
 		);
 		return new RacialRequirement(
 				slotName,
-				operatorObject.name,
+				operatorObject.nameFn,
 				RaceUtils.composeOpArg(argumentFn, operatorObject.operatorFn),
 				score,
 				failScore,
@@ -755,7 +763,7 @@ public class RaceScoreBuilder {
 				errorContext
 		);
 		return {
-			name: operatorObject.name,
+			nameFn: operatorObject.nameFn,
 			check: RaceUtils.composeOpArg(argumentFn, operatorObject.operatorFn)
 		}
 	}

--- a/classes/classes/internals/race/RaceTierBuilder.as
+++ b/classes/classes/internals/race/RaceTierBuilder.as
@@ -275,7 +275,7 @@ public class RaceTierBuilder {
 				operatorObject.operatorFn
 		);
 		requirements.push(new RaceTierRequirement(
-				operatorObject.name,
+				operatorObject.nameFn(),
 				checkFn
 		));
 	}


### PR DESCRIPTION
Racial requirement can be given a function for the name. The name can then be computed when the requirement is displayed.

For instance, the dragon's requirement `taller than 10 foot (+1)` will display `taller than 3.05 metres (+1)` when the flags `USE_METRICS` is set to true.
Previously the name was stored in a string and computed when the requirement was created; it would not change no matter the state of `USE_METRICS`.