### PR TITLE
Fix for Zenji post-halloween + color fix

### DIFF
--- a/classes/classes/Parser/ParserTags.as
+++ b/classes/classes/Parser/ParserTags.as
@@ -68,7 +68,7 @@ public class ParserTags {
         //Non-Combat Colors
         "font-lred"             : function ():* { return '<font color="'+"#d00000"+'">'; },
         "font-red"              : function ():* { return '<font color="'+"#b00000"+'">'; },
-        "font-dkred"            : function ():* { return '<font color="'+"#900000"+'">'; },
+        "font-dred"             : function ():* { return '<font color="'+"#900000"+'">'; },
         "font-green"            : function ():* { return '<font color="'+"#00a000"+'">'; },
         "font-olive"            : function ():* { return '<font color="'+"#808000"+'">'; },
         "font-blue"             : function ():* { return '<font color="'+"#0000ff"+'">'; },

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -1488,9 +1488,6 @@ public class PlayerEvents extends BaseContent implements TimeAwareInterface {
 				}
 				else player.addStatusValue(StatusEffects.TribulationCountdown, 1, -1);
 			}
-			if (!Holidays.isHalloween() && ZenjiScenes.isLover() && player.statusEffectv4(StatusEffects.ZenjiZList) == 2 && rand(5) < 2) {
-				SceneLib.zenjiScene.loverZenjiHalloweenEventEnding();//needNext = true;
-			}
 			if (SceneLib.mountain.minotaurScene.minoCumUpdate()) {
 				needNext = true;
 			}

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -384,6 +384,11 @@ public class Camp extends NPCAwareContent{
 			SceneLib.zenjiScene.loverZenjiHalloweenEvent();
 			return;
 		}
+		if (!Holidays.isHalloween() && ZenjiScenes.isLover() && player.statusEffectv4(StatusEffects.ZenjiZList) == 2 && rand(5) < 2) {
+			hideMenus();
+			SceneLib.zenjiScene.loverZenjiHalloweenEventEnding();
+			return;
+		}
 		if (SceneLib.helScene.followerHel() && !player.hasStatusEffect(StatusEffects.HeliaOff)) {
 			if (Holidays.isHeliaBirthday() && flags[kFLAGS.HEL_FOLLOWER_LEVEL] >= 2 && date.fullYear > flags[kFLAGS.HELIA_BIRTHDAY_LAST_YEAR]) {
 				hideMenus();

--- a/classes/classes/Stats/StatUtils.as
+++ b/classes/classes/Stats/StatUtils.as
@@ -2,6 +2,7 @@
  * Coded by aimozg on 01.06.2018.
  */
 package classes.Stats {
+import classes.Parser.Parser;
 import classes.internals.Utils;
 
 public class StatUtils {
@@ -108,12 +109,12 @@ public class StatUtils {
 					continue;
 				}
 				if (isPositiveStat) {
-					if (value > 0) text += '[font-green]';
-					else text += '[font-dred]';
+					if (value > 0) text += "[font-green]";
+					else text += "[font-dred]";
 				}
 				if (!isPositiveStat) {
-					if (value > 0) text += '[font-dred]';
-					else text += '[font-green]';
+					if (value > 0) text += "[font-dred]";
+					else text += "[font-green]";
 				}
 				text += '<b>' + buff.text + ':</b> ';
 				if (asPercent) {
@@ -137,12 +138,12 @@ public class StatUtils {
 		if (PerkBuff != 0)
 		{
 			if (isPositiveStat) {
-				if (PerkBuff > 0) text += '[font-green]';
-				else text += '[font-dred]';
+				if (PerkBuff > 0) text += "[font-green]";
+				else text += "[font-dred]";
 			}
 			if (!isPositiveStat) {
-				if (PerkBuff > 0) text += '[font-dred]';
-				else text += '[font-green]';
+				if (PerkBuff > 0) text += "[font-dred]";
+				else text += "[font-green]";
 			}
 			text += "<b>Perk:</b> ";
 			if (asPercent) {
@@ -153,6 +154,7 @@ public class StatUtils {
 			text += "[/font]";
 		}
 		if (hasHidden) text += '<b>Unknown Sources:</b> ±??';
+		text = Parser.recursiveParser(text);
 		return text;
 	}
 

--- a/classes/classes/display/PerkMenu.as
+++ b/classes/classes/display/PerkMenu.as
@@ -1164,6 +1164,7 @@ public class PerkMenu extends BaseContent {
 		
 		var desc:String = Parser.recursiveParser(pc.perkDesc);
 		var reqs:String = player.hasPerk(perk) ? "" : formatPerkRequirements(perk, true);
+		reqs = Parser.recursiveParser(reqs);
 		if (reqs) reqs = "\n" + reqs;
 		if (player.hasPerk(perk)) {
 			btn.disable();


### PR DESCRIPTION
It seems function calls in hourly checks are not allowing menu options, therefore you'd never clear the flag for this event through follow-up choices.

Moved code to camp.as, similar to the start of the Zenji Halloween event