### PR TITLE
Xianxia

### DIFF
--- a/classes/classes/CoC.as
+++ b/classes/classes/CoC.as
@@ -97,7 +97,6 @@ public class CoC extends MovieClip
     public var consumables:ConsumableLib           = new ConsumableLib();
     public var useables:UseableLib                 = new UseableLib();
     public var weapons:WeaponLib                   = new WeaponLib();
-    public var weaponsOff:WeaponLib                = new WeaponLib();
     public var weaponsrange:WeaponRangeLib         = new WeaponRangeLib();
     public var weaponsflyingswords:FlyingSwordsLib = new FlyingSwordsLib();
     public var armors:ArmorLib                     = new ArmorLib();

--- a/classes/classes/ItemType.as
+++ b/classes/classes/ItemType.as
@@ -288,7 +288,9 @@ public class ItemType extends ItemConstants
 				trace("new "+_id+" / "+dynamicItemCounter);
 			} else {
 				if (ITEM_LIBRARY[_id] != null) {
-					CoC_Settings.error("Duplicate itemid " + _id + ", old item is " + (ITEM_LIBRARY[_id] as ItemType).longName);
+					var msg:String = "Duplicate itemid " + _id + ", old item is " + (ITEM_LIBRARY[_id] as ItemType).longName;
+					CoC_Settings.error(msg);
+					throw new Error(msg);
 				}
 				if (ITEM_SHORT_LIBRARY[_shortName] != null) {
 					trace("WARNING: Item with duplicate shortname: '" + _id + "' and '" + (ITEM_SHORT_LIBRARY[this._shortName] as ItemType)._id + "' share " + this._shortName);

--- a/classes/classes/Items/Armor.as
+++ b/classes/classes/Items/Armor.as
@@ -72,7 +72,7 @@ public class Armor extends Equipable
 			return list;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			if (!this.supportsUndergarment && (!game.player.upperGarment.isNothing || !game.player.lowerGarment.isNothing)) {
 				var output:String = "";
 				var wornUpper:Boolean = false;
@@ -95,17 +95,17 @@ public class Armor extends Equipable
 				if (doOutput) outputText("You would very like to equip this item but your body stiffness prevents you from doing so.");
 				return false;
 			}
-			return super.canEquip(doOutput);
+			return super.canEquip(doOutput, slot);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
-			super.afterEquip(doOutput);
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
+			super.afterEquip(doOutput, slot);
 			if (!game.isLoadingSave) {
 				game.player.addToWornClothesArray(this);
 			}
 		}
-		override public function afterUnequip(doOutput:Boolean):void {
-			super.afterUnequip(doOutput);
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
+			super.afterUnequip(doOutput, slot);
 			game.player.removePerk(PerkLib.BulgeArmor); //Exgartuan check
 			if (game.player.modArmorName.length > 0) game.player.modArmorName = "";
 		}

--- a/classes/classes/Items/Armors/BattleMaidenArmor.as
+++ b/classes/classes/Items/Armors/BattleMaidenArmor.as
@@ -28,8 +28,8 @@ import classes.Items.Armor;
 			return 10 + mod;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (!super.canEquip(doOutput)) return false;
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (!super.canEquip(doOutput, slot)) return false;
 			return LustyMaidensArmor.canUseStatic(doOutput);
 		}
 	}

--- a/classes/classes/Items/Armors/BestialBlademasterArmor.as
+++ b/classes/classes/Items/Armors/BestialBlademasterArmor.as
@@ -20,14 +20,14 @@ import classes.PerkLib;
 				withTag(A_REVEALING);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.equipBestialBlademasterItemsSet();
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.unequipBestialBlademasterItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Armors/BlizzardKimono.as
+++ b/classes/classes/Items/Armors/BlizzardKimono.as
@@ -23,17 +23,17 @@ package classes.Items.Armors
 			else outputText("You equip " + longName + ".  ");
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				game.player.removeStatusEffect(StatusEffects.YukiOnnaKimono);
 				game.player.createStatusEffect(StatusEffects.YukiOnnaKimono, 0, 0, 0, 0);
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			game.player.removeStatusEffect(StatusEffects.YukiOnnaKimono);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
 	}

--- a/classes/classes/Items/Armors/CentaurArmor.as
+++ b/classes/classes/Items/Armors/CentaurArmor.as
@@ -17,8 +17,8 @@ package classes.Items.Armors
 		{
 			super("TaurPAr","Taur P. Armor","some taur armor","a set of taur armor",23,0,1698,"A suit of armor for centaurs.","Heavy")
 		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.isTaur()) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.isTaur()) return super.canEquip(doOutput, slot);
 			if (doOutput) outputText("This armor is designed for centaurs, so it doesn't really fit you. You place the armor back in your inventory.");
 			return false;
 		}
@@ -27,7 +27,7 @@ package classes.Items.Armors
 			outputText(CelessScene.instance.Name+" helps you put on the barding and horseshoes. Wow, taking a look at yourself, you look like those knights of legend. Fighting the wicked with this armor should be quite easy.");
 		}
 		
-		override public function unequipText():void{
+		override public function unequipText(slot:int):void{
 			outputText(CelessScene.instance.Name+ "helps you remove the centaur armor. Whoa, you were starting to forget what not being weighted down by heavy armor felt like.");
 		}
 		

--- a/classes/classes/Items/Armors/CentaurBlackguardArmor.as
+++ b/classes/classes/Items/Armors/CentaurBlackguardArmor.as
@@ -14,8 +14,8 @@ package classes.Items.Armors
 			super("TaurBAr","Taur B. Armor","some taur blackguard armor","a set of taur blackguard armor",40,20,1698,"A suit of blackguard's armor for centaurs.","Heavy");
 			withTag(I_LEGENDARY);
 		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.isTaur()) return super.canEquip(doOutput)
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.isTaur()) return super.canEquip(doOutput, slot)
 			if (doOutput) outputText("The blackguard's armor is designed for centaurs, so it doesn't really fit you. You place the armor back in your inventory");
 			return false;
 		}
@@ -24,7 +24,7 @@ package classes.Items.Armors
 			outputText(CelessScene.instance.Name+" helps you put on the barding and horseshoes. Wow, taking a look at yourself, you think your intimidating appearance alone will scare the hell out of most opponents.");
 		}
 		
-		override public function unequipText():void{
+		override public function unequipText(slot:int):void{
 			outputText(CelessScene.instance.Name+ "help you remove the centaur armor. Whoa you forgot what carrying light weight was.");
 		}
 		

--- a/classes/classes/Items/Armors/CentaurPaladinArmor.as
+++ b/classes/classes/Items/Armors/CentaurPaladinArmor.as
@@ -14,8 +14,8 @@ package classes.Items.Armors
 			super("TaurHPAr","Taur HP. Armor","some taur paladin armor","a set of taur paladin armor",40,20,1698,"A suit of paladin's armor for centaurs.","Heavy");
 			withTag(I_LEGENDARY);
 		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.isTaur()) return super.canEquip(doOutput)
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.isTaur()) return super.canEquip(doOutput, slot)
 			if (doOutput) outputText("The paladin's armor is designed for centaurs, so it doesn't really fit you. You place the armor back in your inventory");
 			return false;
 		}
@@ -24,7 +24,7 @@ package classes.Items.Armors
 			outputText(CelessScene.instance.Name+" helps you put on the barding and horseshoes. Wow, taking a look at yourself, you look like those knights of legend. Fighting the wicked with this armor should be quite easy.");
 		}
 		
-		override public function unequipText():void{
+		override public function unequipText(slot:int):void{
 			outputText(CelessScene.instance.Name+ "helps you remove the centaur armor. Whoa, you were starting to forget what not being weighted down by heavy armor felt like.");
 		}
 		

--- a/classes/classes/Items/Armors/ComfortableUnderclothes.as
+++ b/classes/classes/Items/Armors/ComfortableUnderclothes.as
@@ -14,7 +14,7 @@ import classes.Player;
 			super("c.under", "c.under", "comfortable underclothes", "comfortable underclothes", 0, 0, 1, "comfortable underclothes", "Light");
 		}
 		
-		override public function beforeUnequip(doOutput:Boolean):ItemType {
+		override public function beforeUnequip(doOutput:Boolean, slot:int):ItemType {
 			return ArmorLib.NOTHING; //Player never picks up their underclothes
 		}
 	}

--- a/classes/classes/Items/Armors/DeathPrinceGoldenArmor.as
+++ b/classes/classes/Items/Armors/DeathPrinceGoldenArmor.as
@@ -15,17 +15,17 @@ package classes.Items.Armors
 			withTag(I_LEGENDARY);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				while (game.player.hasStatusEffect(StatusEffects.DeathPrinceGA)) game.player.removeStatusEffect(StatusEffects.DeathPrinceGA);
 				game.player.createStatusEffect(StatusEffects.DeathPrinceGA, 0, 0, 0, 0);
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			while (game.player.hasStatusEffect(StatusEffects.DeathPrinceGA)) game.player.removeStatusEffect(StatusEffects.DeathPrinceGA);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
 		override public function get def():Number{

--- a/classes/classes/Items/Armors/DeathPrinceOutfit.as
+++ b/classes/classes/Items/Armors/DeathPrinceOutfit.as
@@ -14,17 +14,17 @@ package classes.Items.Armors
 			super("DeathPO","DeathPrinceOutfit","Death Prince Outfit","a Death Prince Outfit",0,5,500,"The formal outfit worn by anubi slavers from the inner desert region. (+50% Magic Soulskill power, grants 2% regeneration when soulforce is above half)","Light")
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				while (game.player.hasStatusEffect(StatusEffects.DeathPrinceO)) game.player.removeStatusEffect(StatusEffects.DeathPrinceO);
 				game.player.createStatusEffect(StatusEffects.DeathPrinceO, 0, 0, 0, 0);
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			while (game.player.hasStatusEffect(StatusEffects.DeathPrinceO)) game.player.removeStatusEffect(StatusEffects.DeathPrinceO);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
 	}

--- a/classes/classes/Items/Armors/FrancescaBlackCloak.as
+++ b/classes/classes/Items/Armors/FrancescaBlackCloak.as
@@ -20,14 +20,14 @@ package classes.Items.Armors
 				withTag(A_REVEALING);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) game.player.createPerk(PerkLib.Misdirection, 0, 0, 1, 0);
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if (game.player.perkv4(PerkLib.Misdirection) == 0 && game.player.perkv3(PerkLib.Misdirection) > 0) game.player.removePerk(PerkLib.Misdirection);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Armors/GoblinTechnomancerClothes.as
+++ b/classes/classes/Items/Armors/GoblinTechnomancerClothes.as
@@ -18,8 +18,8 @@ import classes.PerkLib;
 			withTag(A_AGILE);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean{
-			if (game.player.tallness < 48) return super.canEquip(doOutput)
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean{
+			if (game.player.tallness < 48) return super.canEquip(doOutput, slot)
 			if (doOutput) outputText("There is no way this tiny set of clothing would fit your current size.");
 			return false;
 		}

--- a/classes/classes/Items/Armors/GooArmor.as
+++ b/classes/classes/Items/Armors/GooArmor.as
@@ -34,23 +34,23 @@ public final class GooArmor extends Armor {
 		EngineCore.awardAchievement("Goo Armor", kACHIEVEMENTS.GENERAL_GOO_ARMOR);
 	}
 	
-	override public function unequipText():void {
+	override public function unequipText(slot:int):void {
 		outputText("Valeria picks herself up and huffs, \"<i>Maybe we can adventure some more later on?</i>\" before undulating off towards your camp.\n\n(<b>Valeria now available in the followers tab!</b>)");
 	}
 	
-	override public function afterEquip(doOutput:Boolean):void {
+	override public function afterEquip(doOutput:Boolean, slot:int):void {
 		game.flags[kFLAGS.VALERIA_AT_CAMP] = 0;
-		super.afterEquip(doOutput);
+		super.afterEquip(doOutput, slot);
 	}
 	
-	override public function beforeUnequip(doOutput:Boolean):ItemType {
-		super.beforeUnequip(doOutput);
+	override public function beforeUnequip(doOutput:Boolean, slot:int):ItemType {
+		super.beforeUnequip(doOutput, slot);
 		return ItemType.NOTHING;
 	}
 	
-	override public function afterUnequip(doOutput:Boolean):void {
+	override public function afterUnequip(doOutput:Boolean, slot:int):void {
 		game.flags[kFLAGS.VALERIA_AT_CAMP] = 1;
-		super.afterUnequip(doOutput);
+		super.afterUnequip(doOutput, slot);
 	}
 	
 	override public function get def():Number {

--- a/classes/classes/Items/Armors/HBArmor.as
+++ b/classes/classes/Items/Armors/HBArmor.as
@@ -26,7 +26,7 @@ package classes.Items.Armors
 			else return 48;
 		}
 
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				var oldHPratio:Number = game.player.hp100/100;
 				game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] = 0;
@@ -35,20 +35,20 @@ package classes.Items.Armors
 				game.player.HP = oldHPratio*game.player.maxHP();
 				EngineCore.statScreenRefresh();
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if (game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] > 0) {
 				game.player.soulforce += game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR];
 				if (game.player.soulforce > game.player.maxOverSoulforce()) game.player.soulforce = game.player.maxOverSoulforce();
 				game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] = 0;
 			}
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.str >= 60 && game.player.spe >= 60 && game.player.tallness >= 84) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.str >= 60 && game.player.spe >= 60 && game.player.tallness >= 84) return super.canEquip(doOutput, slot);
 			if (doOutput) {
 				if (game.player.tallness < 84) outputText("You aren't tall enough to wear this armor!  ");
 				else outputText("You aren't strong and agile enough to wear this armor!  Unless you likes to move slower than snail and hit weaked than wet noddle!  ");

--- a/classes/classes/Items/Armors/HeavyAyoArmor.as
+++ b/classes/classes/Items/Armors/HeavyAyoArmor.as
@@ -26,7 +26,7 @@ package classes.Items.Armors
 			else return 12;
 		}
 
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				var oldHPratio:Number = game.player.hp100/100;
 				game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] = 0;
@@ -35,21 +35,21 @@ package classes.Items.Armors
 				game.player.HP = oldHPratio*game.player.maxHP();
 				EngineCore.statScreenRefresh();
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if (game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] > 0) {
 				game.player.soulforce += game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR];
 				if (game.player.soulforce > game.player.maxOverSoulforce()) game.player.soulforce = game.player.maxOverSoulforce();
 				game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] = 0;
 			}
 			game.player.buff("Ayo Armor").remove();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.str >= 40 && game.player.spe >= 40) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.str >= 40 && game.player.spe >= 40) return super.canEquip(doOutput, slot);
 			if(doOutput) outputText("You aren't strong and agile enough to wear this armor!  Unless you likes to move slower than snail and hit weaked than wet noddle!  ");
 			return false;
 		}

--- a/classes/classes/Items/Armors/KrakenBlackDress.as
+++ b/classes/classes/Items/Armors/KrakenBlackDress.as
@@ -23,8 +23,8 @@ import classes.Scenes.NPCs.CelessScene;
 			withTag(A_REVEALING);
 			withTag(A_AGILE);
 		}
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.isKraken() || game.player.isScylla()){return super.canEquip(doOutput)}
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.isKraken() || game.player.isScylla()){return super.canEquip(doOutput, slot)}
 			if (doOutput) outputText("You try to figure out how to wear this thing but your current body shape does not allow it. You put it back in your backpack for now.");
 			return false;
 		}

--- a/classes/classes/Items/Armors/LeatherArmorSegments.as
+++ b/classes/classes/Items/Armors/LeatherArmorSegments.as
@@ -13,12 +13,12 @@ package classes.Items.Armors
 			super("UrtaLta", "UrtaLta", "leather armor segments", "leather armor segments", 18, 2, 500, null, "Light", true);
 		}
 		
-		override public function unequipText():void {
+		override public function unequipText(slot:int):void {
 			outputText("You have your old set of " + game.armors.LEATHRA.longName + " left over.  ");
 		}
 		
-		override public function beforeUnequip(doOutput:Boolean):ItemType {
-			super.beforeUnequip(doOutput);
+		override public function beforeUnequip(doOutput:Boolean, slot:int):ItemType {
+			super.beforeUnequip(doOutput, slot);
 			return game.armors.LEATHRA;
 		}
 	}

--- a/classes/classes/Items/Armors/LightAyoArmor.as
+++ b/classes/classes/Items/Armors/LightAyoArmor.as
@@ -26,7 +26,7 @@ package classes.Items.Armors
 			else return 6;
 		}
 
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				var oldHPratio:Number = game.player.hp100/100;
 				game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] = 0;
@@ -35,21 +35,21 @@ package classes.Items.Armors
 				game.player.HP = oldHPratio*game.player.maxHP();
 				EngineCore.statScreenRefresh();
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if (game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] > 0) {
 				game.player.soulforce += game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR];
 				if (game.player.soulforce > game.player.maxOverSoulforce()) game.player.soulforce = game.player.maxOverSoulforce();
 				game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] = 0;
 			}
 			game.player.buff("Ayo Armor").remove();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.str >= 20 && game.player.spe >= 20) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.str >= 20 && game.player.spe >= 20) return super.canEquip(doOutput, slot);
 			if (doOutput) outputText("You aren't strong and agile enough to wear this armor!  Unless you likes to move slower than snail and hit weaked than wet noddle!  ");
 			return false;
 		}

--- a/classes/classes/Items/Armors/LustyMaidensArmor.as
+++ b/classes/classes/Items/Armors/LustyMaidensArmor.as
@@ -32,18 +32,18 @@ public final class LustyMaidensArmor extends Armor {
 			return 10 + game.flags[kFLAGS.BIKINI_ARMOR_BONUS];
 		}
 	
-	override public function canEquip(doOutput:Boolean):Boolean {
-			if (!super.canEquip(doOutput)) return false;
+	override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (!super.canEquip(doOutput, slot)) return false;
 			return canUseStatic(doOutput);
 		}
 	
-	override public function afterEquip(doOutput:Boolean):void {
+	override public function afterEquip(doOutput:Boolean, slot:int):void {
 		if (game.player.hasVirginVagina()) {
 			_buffs['teasedmg'] = 10 + game.flags[kFLAGS.BIKINI_ARMOR_BONUS];
 		} else {
 			_buffs['teasedmg'] = 6 + game.flags[kFLAGS.BIKINI_ARMOR_BONUS];
 		}
-		super.afterEquip(doOutput);
+		super.afterEquip(doOutput, slot);
 	}
 
 		public static function canUseStatic(doOutput:Boolean):Boolean {

--- a/classes/classes/Items/Armors/OniEnlightenedKimono.as
+++ b/classes/classes/Items/Armors/OniEnlightenedKimono.as
@@ -19,8 +19,8 @@ import classes.Player;
 			withTag(I_LEGENDARY);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.tallness >= 80) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.tallness >= 80) return super.canEquip(doOutput, slot);
 			if (doOutput) outputText("You aren't tall enough to wear this kimono!  ");
 			return false;
 		}

--- a/classes/classes/Items/Armors/OniTyrantKimono.as
+++ b/classes/classes/Items/Armors/OniTyrantKimono.as
@@ -19,8 +19,8 @@ import classes.Player;
 			withPerk(PerkLib.OniTyrantKimono, 0, 0, 0, 0);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.tallness >= 80) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.tallness >= 80) return super.canEquip(doOutput, slot);
 			if (doOutput) outputText("You aren't tall enough to wear this kimono!");
 			return false;
 		}

--- a/classes/classes/Items/Armors/SakuraPetalKimono.as
+++ b/classes/classes/Items/Armors/SakuraPetalKimono.as
@@ -15,8 +15,8 @@ package classes.Items.Armors
 			super("SP Kimo", "SakuraPetalKimono", "sakura petal kimono", "a sakura petal kimono", 0, 1, 160, "This kimono belonged to Izumi. One of the many dresses she brought from her homeland it is comfortable and fills you with a sense of contained primal strength.", "Light");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.tallness >= 80) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.tallness >= 80) return super.canEquip(doOutput, slot);
 			if (doOutput) outputText("You aren't tall enough to wear this kimono!  ");
 			return false;
 		}

--- a/classes/classes/Items/Armors/SeductiveArmor.as
+++ b/classes/classes/Items/Armors/SeductiveArmor.as
@@ -36,8 +36,8 @@ public final class SeductiveArmor extends Armor {
 			}
 		}
 	
-	override public function beforeEquip(doOutput:Boolean):Equipable {
-		super.beforeEquip(doOutput);
+	override public function beforeEquip(doOutput:Boolean, slot:int):Equipable {
+		super.beforeEquip(doOutput, slot);
 		return ArmorLib.COMFORTABLE_UNDERCLOTHES; //After seductive armor magic the player is left in their underclothes
 	}
 	}

--- a/classes/classes/Items/Armors/SpiritFlareQipao.as
+++ b/classes/classes/Items/Armors/SpiritFlareQipao.as
@@ -16,14 +16,14 @@ import classes.Player;
 			withTag(I_LEGENDARY);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) game.player.createPerk(PerkLib.Misdirection, 0, 0, 1, 0);
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if (game.player.perkv4(PerkLib.Misdirection) == 0 && game.player.perkv3(PerkLib.Misdirection) > 0) game.player.removePerk(PerkLib.Misdirection);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
 		override public function get def():Number{

--- a/classes/classes/Items/Armors/SuccubusArmor.as
+++ b/classes/classes/Items/Armors/SuccubusArmor.as
@@ -31,14 +31,14 @@ import classes.PerkLib;
 			return 10 + mod;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (!super.canEquip(doOutput)) return false;
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (!super.canEquip(doOutput, slot)) return false;
 			return LustyMaidensArmor.canUseStatic(doOutput);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			_buffs['teasedmg'] = (10 + game.flags[kFLAGS.BIKINI_ARMOR_BONUS]) * 5;
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Armors/UltraHeavyAyoArmor.as
+++ b/classes/classes/Items/Armors/UltraHeavyAyoArmor.as
@@ -26,7 +26,7 @@ package classes.Items.Armors
 			else return 18;
 		}
 
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				var oldHPratio:Number = game.player.hp100/100;
 				game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] = 0;
@@ -35,21 +35,21 @@ package classes.Items.Armors
 				game.player.HP = oldHPratio*game.player.maxHP();
 				EngineCore.statScreenRefresh();
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if (game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] > 0) {
 				game.player.soulforce += game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR];
 				if (game.player.soulforce > game.player.maxOverSoulforce()) game.player.soulforce = game.player.maxOverSoulforce();
 				game.flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] = 0;
 			}
 			game.player.buff("Ayo Armor").remove();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.str >= 100 && game.player.spe >= 100) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.str >= 100 && game.player.spe >= 100) return super.canEquip(doOutput, slot);
 			if (doOutput) outputText("You aren't strong and/or agile enough to wear this armor!  Unless you like to move slower than a snail and hit as weak as a wet noodle?  ");
 			return false;
 		}

--- a/classes/classes/Items/Dynamic/DynamicArmor.as
+++ b/classes/classes/Items/Dynamic/DynamicArmor.as
@@ -174,21 +174,21 @@ public class DynamicArmor extends Armor implements IDynamicItem {
 	override public function equipText():void {
 		DynamicItems.equipText(this);
 	}
-	override public function beforeEquip(doOutput:Boolean):Equipable {
-		super.beforeEquip(doOutput);
+	override public function beforeEquip(doOutput:Boolean, slot:int):Equipable {
+		super.beforeEquip(doOutput, slot);
 		if (!identified) {
-			return (identifiedCopy() as Equipable).beforeEquip(doOutput);
+			return (identifiedCopy() as Equipable).beforeEquip(doOutput, slot);
 		}
 		return this;
 	}
-	override public function afterEquip(doOutput:Boolean):void {
-		super.afterEquip(doOutput);
+	override public function afterEquip(doOutput:Boolean, slot:int):void {
+		super.afterEquip(doOutput, slot);
 		for each (var e:Enchantment in effects) {
 			e.onEquip(game.player, this);
 		}
 	}
-	override public function afterUnequip(doOutput:Boolean):void {
-		super.afterUnequip(doOutput);
+	override public function afterUnequip(doOutput:Boolean, slot:int):void {
+		super.afterUnequip(doOutput, slot);
 		for each (var e:Enchantment in effects) {
 			e.onUnequip(game.player, this);
 		}

--- a/classes/classes/Items/Dynamic/DynamicRing.as
+++ b/classes/classes/Items/Dynamic/DynamicRing.as
@@ -156,21 +156,21 @@ public class DynamicRing extends Jewelry implements IDynamicItem {
 		DynamicItems.equipText(this);
 	}
 	
-	override public function beforeEquip(doOutput:Boolean):Equipable {
+	override public function beforeEquip(doOutput:Boolean, slot:int):Equipable {
 		if (!identified) {
-			return (identifiedCopy() as Equipable).beforeEquip(doOutput);
+			return (identifiedCopy() as Equipable).beforeEquip(doOutput, slot);
 		}
-		return super.beforeEquip(doOutput);
+		return super.beforeEquip(doOutput, slot);
 	}
 	
-	override public function afterEquip(doOutput:Boolean):void {
-		super.afterEquip(doOutput);
+	override public function afterEquip(doOutput:Boolean, slot:int):void {
+		super.afterEquip(doOutput, slot);
 		for each (var e:Enchantment in effects) {
 			e.onEquip(game.player, this);
 		}
 	}
-	override public function afterUnequip(doOutput:Boolean):void {
-		super.afterUnequip(doOutput);
+	override public function afterUnequip(doOutput:Boolean, slot:int):void {
+		super.afterUnequip(doOutput, slot);
 		for each (var e:Enchantment in effects) {
 			e.onUnequip(game.player, this);
 		}

--- a/classes/classes/Items/Dynamic/DynamicShield.as
+++ b/classes/classes/Items/Dynamic/DynamicShield.as
@@ -168,21 +168,21 @@ public class DynamicShield extends Shield implements IDynamicItem {
 		DynamicItems.equipText(this);
 	}
 	
-	override public function beforeEquip(doOutput:Boolean):Equipable {
+	override public function beforeEquip(doOutput:Boolean, slot:int):Equipable {
 		if (!identified) {
-			return (identifiedCopy() as Equipable).beforeEquip(doOutput);
+			return (identifiedCopy() as Equipable).beforeEquip(doOutput, slot);
 		}
-		return super.beforeEquip(doOutput);
+		return super.beforeEquip(doOutput, slot);
 	}
 	
-	override public function afterEquip(doOutput:Boolean):void {
-		super.afterEquip(doOutput);
+	override public function afterEquip(doOutput:Boolean, slot:int):void {
+		super.afterEquip(doOutput, slot);
 		for each (var e:Enchantment in effects) {
 			e.onEquip(game.player, this);
 		}
 	}
-	override public function afterUnequip(doOutput:Boolean):void {
-		super.afterUnequip(doOutput);
+	override public function afterUnequip(doOutput:Boolean, slot:int):void {
+		super.afterUnequip(doOutput, slot);
 		for each (var e:Enchantment in effects) {
 			e.onUnequip(game.player, this);
 		}

--- a/classes/classes/Items/Dynamic/DynamicWeapon.as
+++ b/classes/classes/Items/Dynamic/DynamicWeapon.as
@@ -162,21 +162,21 @@ public class DynamicWeapon extends Weapon implements IDynamicItem {
 		DynamicItems.equipText(this);
 	}
 	
-	override public function beforeEquip(doOutput:Boolean):Equipable {
+	override public function beforeEquip(doOutput:Boolean, slot:int):Equipable {
 		if (!identified) {
-			return (identifiedCopy() as Equipable).beforeEquip(doOutput);
+			return (identifiedCopy() as Equipable).beforeEquip(doOutput, slot);
 		}
-		return super.beforeEquip(doOutput);
+		return super.beforeEquip(doOutput, slot);
 	}
 	
-	override public function afterEquip(doOutput:Boolean):void {
-		super.afterEquip(doOutput);
+	override public function afterEquip(doOutput:Boolean, slot:int):void {
+		super.afterEquip(doOutput, slot);
 		for each (var e:Enchantment in effects) {
 			e.onEquip(game.player, this);
 		}
 	}
-	override public function afterUnequip(doOutput:Boolean):void {
-		super.afterUnequip(doOutput);
+	override public function afterUnequip(doOutput:Boolean, slot:int):void {
+		super.afterUnequip(doOutput, slot);
 		for each (var e:Enchantment in effects) {
 			e.onUnequip(game.player, this);
 		}

--- a/classes/classes/Items/Dynamic/DynamicWeaponRange.as
+++ b/classes/classes/Items/Dynamic/DynamicWeaponRange.as
@@ -159,21 +159,21 @@ public class DynamicWeaponRange extends WeaponRange implements IDynamicItem {
 		DynamicItems.equipText(this);
 	}
 
-	override public function beforeEquip(doOutput:Boolean):Equipable {
+	override public function beforeEquip(doOutput:Boolean, slot:int):Equipable {
 		if (!identified) {
-			return (identifiedCopy() as Equipable).beforeEquip(doOutput);
+			return (identifiedCopy() as Equipable).beforeEquip(doOutput, slot);
 		}
-		return super.beforeEquip(doOutput);
+		return super.beforeEquip(doOutput, slot);
 	}
 
-	override public function afterEquip(doOutput:Boolean):void {
-		super.afterEquip(doOutput);
+	override public function afterEquip(doOutput:Boolean, slot:int):void {
+		super.afterEquip(doOutput, slot);
 		for each (var e:Enchantment in effects) {
 			e.onEquip(game.player, this);
 		}
 	}
-	override public function afterUnequip(doOutput:Boolean):void {
-		super.afterUnequip(doOutput);
+	override public function afterUnequip(doOutput:Boolean, slot:int):void {
+		super.afterUnequip(doOutput, slot);
 		for each (var e:Enchantment in effects) {
 			e.onUnequip(game.player, this);
 		}

--- a/classes/classes/Items/Equipable.as
+++ b/classes/classes/Items/Equipable.as
@@ -133,7 +133,7 @@ public class Equipable extends Useable {
 	}
 	
 	override public function canUse():Boolean {
-		return canEquip(true);
+		return canEquip(true, -1);
 	}
 	
 	/**
@@ -185,9 +185,10 @@ public class Equipable extends Useable {
 	 * Should NOT check empty target slot (but can check other slots).
 	 * (ex. equipping large weapon can check for no shield but shouldn't check for no weapon)
 	 * @param doOutput Player tries equipping the item, if fails, print why. And do any side effects related to failed equip attempt.
+	 * @param slot Slot to equip the item onto. -1 - any slot.
 	 * @return true if the player can wear the item
 	 */
-	public function canEquip(doOutput:Boolean):Boolean {
+	public function canEquip(doOutput:Boolean, slot:int):Boolean {
 		if (game.player.cor > effectPower(IELib.Require_CorBelow, 100) + game.player.corruptionTolerance) {
 			if (doOutput) outputText(getItemText("too_corrupt"))
 			return false
@@ -206,6 +207,7 @@ public class Equipable extends Useable {
 	/**
 	 * Test if player can unequip the item
 	 * @param doOutput Player tries unequiping the item, if fails, print why. And do any side effects related to failed unequip attempt.
+	 * @param slot Slot here to equip, -1 - any slot
 	 * @return true if player can unequip the item
 	 */
 	public function canUnequip(doOutput:Boolean):Boolean {
@@ -226,7 +228,7 @@ public class Equipable extends Useable {
 	 * @param doOutput
 	 * @return Actual item to be put into slot, or null
 	 */
-	public function beforeEquip(doOutput:Boolean):Equipable {
+	public function beforeEquip(doOutput:Boolean, slot:int):Equipable {
 		if (doOutput) equipText();
 		return this;
 	}
@@ -241,7 +243,7 @@ public class Equipable extends Useable {
 	 * Apply equipment effects here.
 	 * @param doOutput
 	 */
-	public function afterEquip(doOutput:Boolean):void {
+	public function afterEquip(doOutput:Boolean, slot:int):void {
 		for each (var ie:ItemEffect in effectsFlagged(IEF_ONEQUIP)) {
 			ie.onEquip(game.player, this);
 		}
@@ -269,12 +271,12 @@ public class Equipable extends Useable {
 	 * @param doOutput
 	 * @return Actual item to place into inventory (could be nothing)
 	 */
-	public function beforeUnequip(doOutput:Boolean):ItemType {
-		if (doOutput) unequipText();
+	public function beforeUnequip(doOutput:Boolean, slot:int):ItemType {
+		if (doOutput) unequipText(slot);
 		return this;
 	}
 	
-	public function unequipText():void {
+	public function unequipText(slot:int):void {
 		outputText(getItemText("onunequip"));
 	}
 	
@@ -283,7 +285,7 @@ public class Equipable extends Useable {
 	 * Undo effects here
 	 * @param doOutput
 	 */
-	public function afterUnequip(doOutput:Boolean):void {
+	public function afterUnequip(doOutput:Boolean, slot:int):void {
 		for each (var ie:ItemEffect in effectsFlagged(IEF_ONEQUIP)) {
 			ie.onEquip(game.player, this);
 		}

--- a/classes/classes/Items/FlyingSwords.as
+++ b/classes/classes/Items/FlyingSwords.as
@@ -61,7 +61,7 @@ package classes.Items
 			return list;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			if (!game.player.hasPerk(PerkLib.FlyingSwordPath)) {
 				if (doOutput) outputText("You need first to learn fine control over flying swords to equip this one.");
 				return false;

--- a/classes/classes/Items/HeadJewelries/BestialBlademasterAccoutrements.as
+++ b/classes/classes/Items/HeadJewelries/BestialBlademasterAccoutrements.as
@@ -17,14 +17,14 @@ import classes.PerkLib;
 			withPerk(PerkLib.SereneMind, 0, 0, 0, 0);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.equipBestialBlademasterItemsSet();
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.unequipBestialBlademasterItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/HeadJewelries/DeathPrinceRegalia.as
+++ b/classes/classes/Items/HeadJewelries/DeathPrinceRegalia.as
@@ -15,17 +15,17 @@ package classes.Items.HeadJewelries
 			super("DeathPR", "Death Prince Regalia", "Death Prince Regalia", "a Death Prince Regalia", 0, 0, 800, "A typical hair ornament worn by the anubi slavers from the inner desert region. Increases Soul Skill damage and grants SF regeneration when SF is above half.",HJT_HAIRPIN,"","\nSpecial: Increases Soul Skill damage by 20%. Grants 1% regeneration when SF is above half.");
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				while (game.player.hasStatusEffect(StatusEffects.DeathPrinceR)) game.player.removeStatusEffect(StatusEffects.DeathPrinceR);
 				game.player.createStatusEffect(StatusEffects.DeathPrinceR, 0, 0, 0, 0);
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			while (game.player.hasStatusEffect(StatusEffects.DeathPrinceR)) game.player.removeStatusEffect(StatusEffects.DeathPrinceR);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
 	}

--- a/classes/classes/Items/HeadJewelries/GoldenHornOrnament.as
+++ b/classes/classes/Items/HeadJewelries/GoldenHornOrnament.as
@@ -15,7 +15,7 @@ import classes.Items.HeadJewelry;
 			super("GHOrnam", "GoldenHornOrnament", "Golden horn ornament", "a Golden horn ornament", 0, 0, 400, "This set of lovely gold ornaments is meant to be worn on demon horns. While mostly intended to be used as ordinary jewelry they act as focus for black magic and increase the user's lasciviousness.",HJT_HAIRPIN,"","\nSpecial: +25% to tease / black magic damage while worn.");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			if (game.player.horns.type == Horns.DEMON) return true;
 			if (doOutput) {
 				outputText(" Just where do you even plan to put this thing on? You do not have a demon horns");

--- a/classes/classes/Items/HeadJewelries/HBHelmet.as
+++ b/classes/classes/Items/HeadJewelries/HBHelmet.as
@@ -14,8 +14,8 @@ package classes.Items.HeadJewelries
 			super("HBHelm ", "HBHelmet", "HB helmet", "a HB helmet", 0, 0, 1440, "A white helmet that seems to be part of set with HBA Armor. It cover mostly your face and sides of your head giving a bit of more protection to the user.",HJT_HELMET);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.basetallness >= 84) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.basetallness >= 84) return super.canEquip(doOutput, slot);
 			if(doOutput) outputText("You try to put helmet on but it clearly wasn't designed for someone your size (less than 7 feet are we?). Frustrated, you put it back in the bag.  ");
 			return false;
 		}

--- a/classes/classes/Items/HeadJewelries/MachinistGoggles.as
+++ b/classes/classes/Items/HeadJewelries/MachinistGoggles.as
@@ -16,8 +16,8 @@ package classes.Items.HeadJewelries
 			withPerk(PerkLib.BlindImmunity, 0, 0, 0, 0)
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (!super.canEquip(doOutput)) {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (!super.canEquip(doOutput, slot)) {
 				return false;
 			}
 			if (game.player.basetallness > 48) { //Taller than 4 ft

--- a/classes/classes/Items/HeadJewelries/SATechGoggle.as
+++ b/classes/classes/Items/HeadJewelries/SATechGoggle.as
@@ -16,8 +16,8 @@ public class SATechGoggle extends HeadJewelry
 			withPerk(PerkLib.BlindImmunity, 0, 0, 0, 0);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (!super.canEquip(doOutput)) {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (!super.canEquip(doOutput, slot)) {
 				return false;
 			}
 			if (game.player.basetallness > 48) { //Taller than 4 ft

--- a/classes/classes/Items/HeadJewelries/ScannerGoggle.as
+++ b/classes/classes/Items/HeadJewelries/ScannerGoggle.as
@@ -16,8 +16,8 @@ public class ScannerGoggle extends HeadJewelry
 			withPerk(PerkLib.BlindImmunity, 0, 0, 0, 0);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (!super.canEquip(doOutput)) {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (!super.canEquip(doOutput, slot)) {
 				return false;
 			}
 			if (game.player.basetallness > 48) { //Taller than 4 ft

--- a/classes/classes/Items/HeadJewelries/SkullCrown.as
+++ b/classes/classes/Items/HeadJewelries/SkullCrown.as
@@ -16,14 +16,14 @@ package classes.Items.HeadJewelries
 			super("SkullsCr", "SkullsCrown", "Skulls Crown", "a Skull Crown", 0, 0, 8000, "A crown made of skulls with strong aura of death surrounding it. Rumored to be blessed by the god of death have amazing effect for any undead being that would wear it. \nBase value: 8,000 \nSpecial: +2%(+4%)/-2%(-4%) HP regeneration (below 0 HP)(undead / others), +5% diehard for undead", HJT_CROWN);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.equippedSkullSetItems();
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.unequipSkullItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/HeadJewelries/SnowflakeHairpin.as
+++ b/classes/classes/Items/HeadJewelries/SnowflakeHairpin.as
@@ -15,17 +15,17 @@ package classes.Items.HeadJewelries
 			super("SnowfH", "Snowflake hairpin", "Snowflake hairpin", "a Snowflake hairpin", 0, 0, 400, "This hair ornament favored by Yuki Onna empowers ice abilities and magic but weaken fire magic as well. (+30% ice spell dmg, -30% fire spell dmg)",HJT_HAIRPIN);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				while (game.player.hasStatusEffect(StatusEffects.YukiOnnaHairpin)) game.player.removeStatusEffect(StatusEffects.YukiOnnaHairpin);
 				game.player.createStatusEffect(StatusEffects.YukiOnnaHairpin, 0, 0, 0, 0);
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			while (game.player.hasStatusEffect(StatusEffects.YukiOnnaHairpin)) game.player.removeStatusEffect(StatusEffects.YukiOnnaHairpin);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
 	}

--- a/classes/classes/Items/HeadJewelries/SphinxAccessorySet.as
+++ b/classes/classes/Items/HeadJewelries/SphinxAccessorySet.as
@@ -15,17 +15,17 @@ package classes.Items.HeadJewelries
 			super("SphinxAS", "Sphinx accessory set", "Sphinx accessory set", "a Sphinx accessory set", 0, 0, 400, "This set of enchanted accessories is favored by sphinxes. It consists of a golden tiara depicting a rising cobra, a set of arm braces and a cloth collar with blue and yellow patterns that does not cover the shoulders. It assists its wielder in making better riddles and general spellcasting.",HJT_HAIRPIN,"","\nSpecial: Increase of Cursed Riddle damage and Spellpower by 50%.");
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				while (game.player.hasStatusEffect(StatusEffects.SphinxAS)) game.player.removeStatusEffect(StatusEffects.SphinxAS);
 				game.player.createStatusEffect(StatusEffects.SphinxAS, 0, 0, 0, 0);
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			while (game.player.hasStatusEffect(StatusEffects.SphinxAS)) game.player.removeStatusEffect(StatusEffects.SphinxAS);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
 	}

--- a/classes/classes/Items/HeadJewelries/TreeOfLifeCrown.as
+++ b/classes/classes/Items/HeadJewelries/TreeOfLifeCrown.as
@@ -16,14 +16,14 @@ package classes.Items.HeadJewelries
 			super("TreeLCr", "TreeLifeCrown", "Tree of Life Crown", "a Tree of Life Crown", 0, 0, 8000, "A crown made of branches that symbolize tree of life with strong aura of life surrounding it. Rumored to be blessed by the god of life have amazing effect for any living being that would wear it. \nBase value: 8,000 \nSpecial: +2%(+4%)/-2%(-4%) HP regeneration (below 0 HP)(others / undead), +5% diehard for living beings", HJT_CROWN);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.equipTreeOfLifeItemsSet();
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.unequipTreeOfLifeItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/HeadJewelry.as
+++ b/classes/classes/Items/HeadJewelry.as
@@ -108,12 +108,12 @@ package classes.Items
 			return list;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			if (game.player.hasPerk(PerkLib.Rigidity)) {
 				outputText("You would very like to equip this item but your body stiffness prevents you from doing so.");
 				return false;
 			}
-			return super.canEquip(doOutput);
+			return super.canEquip(doOutput, slot);
 		}
 		
 	}

--- a/classes/classes/Items/Jewelries/StarfireBand.as
+++ b/classes/classes/Items/Jewelries/StarfireBand.as
@@ -12,7 +12,7 @@ package classes.Items.Jewelries
 			withBuffs({'res_fire':40,'res_physical':10,'res_magic':10}, true);
 		}
 
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				outputText("This Ring is clearly the work of a master jeweller and enchanter. Just wearing this band fills your body with comfortable warmth. ");
 				if (KihaFollower.ProposalStatus == 3) {
@@ -23,12 +23,12 @@ package classes.Items.Jewelries
 				while (game.player.hasStatusEffect(StatusEffects.FieryBand)) game.player.removeStatusEffect(StatusEffects.FieryBand);
 				game.player.createStatusEffect(StatusEffects.FieryBand, 0, 0, 0, 0);
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			while (game.player.hasStatusEffect(StatusEffects.FieryBand)) game.player.removeStatusEffect(StatusEffects.FieryBand);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/MiscJewelries/DemonicMageTailOrnament.as
+++ b/classes/classes/Items/MiscJewelries/DemonicMageTailOrnament.as
@@ -16,7 +16,7 @@ import classes.Items.MiscJewelry;
 			withBuffs({'int':5});
 		}
 
-		override public function canEquip(doOutput:Boolean):Boolean{
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean{
 			if (game.player.tailType == Tail.DEMONIC) return true;
 			if (doOutput) {
 				outputText(" Just where do you even plan to put this thing on? You do not have a demon tail");

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -27,7 +27,6 @@ public final class Mutations extends MutationsHelper {
     //const BIKINI_ARMOR_BONUS:int = 769;
 
     public var emberTFchanges:EmberTF = new EmberTF();
-    public var sagittariusBowTFchanges:Centaurinum = new Centaurinum();
 	public var saveUpdater:SaveUpdater = new SaveUpdater();
 
     public function DrunkenPowerEmpower():void {
@@ -3161,7 +3160,7 @@ public final class Mutations extends MutationsHelper {
 				player.MutagenBonus("lib", 1);
 			}
 		}
-		if (changes < changeLimit) sagittariusBowTFchanges.centaurTFEffects(true);
+		if (changes < changeLimit) consumables.CENTARI.centaurTFEffects(true);
 		if (!player.inRut) player.goIntoRut(true);
 	}
 

--- a/classes/classes/Items/Necklaces/NecroNecklace.as
+++ b/classes/classes/Items/Necklaces/NecroNecklace.as
@@ -19,12 +19,12 @@ package classes.Items.Necklaces
 			super("NecroNe", "necronecklace", "necro necklace", "a necro necklace", 0, 0, 1200, "A simple necklace made from bones. Increase user mastery over animated bone constructs. \n\nType: Jewelry (Necklace) \nBase value: 4,500 \nSpecial: Increases by 1 control over skeletons of any type.", "Necklace");
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.equipNecroItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if ((CoC.instance.player.perkv2(PerkLib.PrestigeJobNecromancer) - 1) > SceneLib.campMakeWinions.maxSkeletonWarriors() || (CoC.instance.player.perkv1(PerkLib.GreaterHarvest) - 1) > SceneLib.campMakeWinions.maxSkeletonArchers() || (CoC.instance.player.perkv2(PerkLib.GreaterHarvest) - 1) > SceneLib.campMakeWinions.maxSkeletonMages()) {
 				outputText("\n\nAfter you unequip necro necklace some of your skeletons falls apart due to not enough control to sustain them. You gather leftover bones for future use.  ");
 				if ((CoC.instance.player.perkv2(PerkLib.PrestigeJobNecromancer) - 1) > SceneLib.campMakeWinions.maxSkeletonWarriors()) {
@@ -41,7 +41,7 @@ package classes.Items.Necklaces
 				}
 			}
 			SceneLib.setItemsChecks.unequipNecroItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Necklaces/SilverCrossNecklace.as
+++ b/classes/classes/Items/Necklaces/SilverCrossNecklace.as
@@ -35,12 +35,12 @@ package classes.Items.Necklaces
 			outputText("A small chain with a silver cross or X attached. At first glance, it seems to be a very ordinary accessory."+((CoC.instance.player.hasPerk(PerkLib.Soulless) && CoC.instance.player.hasVagina())?" While originally this collar served to bind you to Xuviel’s will, something you no longer need, it now actually assists you instead of hindering you, granting your corrupted body amazing powers.":"")+"");
 		}
 		*/
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave && !game.player.hasStatusEffect(StatusEffects.MeetXuviel)) game.player.createStatusEffect(StatusEffects.MeetXuviel, 0, 0, 0, 0);
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function unequipText():void{
+		override public function unequipText(slot:int):void{
 			outputText("You "+(CoC.instance.player.hasStatusEffect(StatusEffects.MeetXuviel)?"untie master Xuviel’s necklace with nostalgic fondness":"untie necklace")+". You could keep it on but right now you want to try a different accessory. It comes off with no difficulty obviously, putting it back should also be child’s play.");
 		}
 		

--- a/classes/classes/Items/Necklaces/SkullNecklace.as
+++ b/classes/classes/Items/Necklaces/SkullNecklace.as
@@ -16,14 +16,14 @@ package classes.Items.Necklaces
 			super("SkullNe", "SkullNecklace", "Skull Necklace", "a Skull Necklace", 0, 0, 4000, "A necklace made of skulls with strong aura of death surrounding it. Rumored to be blessed by the god of death have amazing effect for any undead being that would wear it. \n\nType: Jewelry (Necklace) \nBase value: 4,000 \nSpecial: +2%(+4%)/-2%(-4%) HP regeneration (below 0 HP)(undead / others), +5% diehard for undead","Necklace");
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.equippedSkullSetItems();
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.unequipSkullItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Necklaces/TreeOfLifeNecklace.as
+++ b/classes/classes/Items/Necklaces/TreeOfLifeNecklace.as
@@ -16,14 +16,14 @@ package classes.Items.Necklaces
 			super("TreeLNe", "TreeLifeNecklace", "Tree of Life Necklace", "a Tree of Life Necklace", 0, 0, 4000, "A necklace made of branches that symbolize tree of life with strong aura of life surrounding it. Rumored to be blessed by the god of life have amazing effect for any living being that would wear it. \n\nType: Jewelry (Necklace) \nBase value: 4,000 \nSpecial: +2%(+4%)/-2%(-4%) HP regeneration (below 0 HP)(others / undead), +5% diehard for living beings","Necklace");
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.equipTreeOfLifeItemsSet();
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.unequipTreeOfLifeItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Shield.as
+++ b/classes/classes/Items/Shield.as
@@ -47,7 +47,7 @@ public class Shield extends Equipable
 			return list;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			if (game.player.weaponRangePerk == "Dual Firearms" || game.player.weaponRangePerk == "Dual 2H Firearms") {
 				if (doOutput) outputText("Your current range weapons requires two hands. Unequip your current range weapons or switch to one-handed before equipping this shield. ");
 				return false;
@@ -69,10 +69,10 @@ public class Shield extends Equipable
 				if (doOutput) outputText("This shield requires use of both hands. Unequip your current melee weapon before equipping it. ");
 				return false;
 			}
-			return super.canEquip(doOutput);
+			return super.canEquip(doOutput, slot);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				if ((perk == "Massive" && game.player.weapon != WeaponLib.FISTS && !game.player.hasPerk(PerkLib.GigantGrip))
 						|| (game.player.weapon.isSingleLarge() && !game.player.hasPerk(PerkLib.GigantGrip))
@@ -82,7 +82,7 @@ public class Shield extends Equipable
 				}
 				if (game.player.weaponRangePerk == "Dual Firearms" || game.player.weaponRangePerk == "2H Firearm" || game.player.weaponRangePerk == "Dual 2H Firearms") SceneLib.inventory.unequipWeaponRange();
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
 		override public function getItemText(textid:String):String {

--- a/classes/classes/Items/Shields/AetherS.as
+++ b/classes/classes/Items/Shields/AetherS.as
@@ -43,23 +43,23 @@ import classes.Scenes.NPCs.AetherTwinsFollowers;
 			outputText("\n\n\"<i>Well alright then, [name]!</i>\" Aether (Sin) says excitedly, \"<i>Let's go!</i>\"\n\n");
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				game.flags[kFLAGS.AETHER_SINISTER_TWIN_AT_CAMP] = 2;
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function unequipText():void {
+		override public function unequipText(slot:int):void {
 			outputText("Aether (Sin) lays on the ground for a moment, \"<i>I will be waiting in the camp</i>\" she says before teleporting back to your camp.\n\n(<b>Aether (Sin) is now available in the followers tab!</b>)");
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			game.flags[kFLAGS.AETHER_SINISTER_TWIN_AT_CAMP] = 1;
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
-		override public function beforeUnequip(doOutput:Boolean):ItemType {
+		override public function beforeUnequip(doOutput:Boolean, slot:int):ItemType {
 			return ShieldLib.NOTHING;
 		}
 	}

--- a/classes/classes/Items/Shields/AncientConduit.as
+++ b/classes/classes/Items/Shields/AncientConduit.as
@@ -2,14 +2,14 @@
  * ...
  * @author Liadri
  */
-package classes.Items.Shields 
+package classes.Items.Shields
 {
 	import classes.Items.Shield;
 
 	public class AncientConduit extends Shield
 	{
 		
-		public function AncientConduit() 
+		public function AncientConduit()
 		{
 			super("AConduit", "A.Conduit", "Ancient Conduit", "a gold, wing-shaped device", 1, 100, "This golden, wing-shaped Conduit was given to you by the ancient Pharaoh of the Sands. Worn on your off-hand, you can feel the power coursing through the world beneath you as long as you wear it. Your stone slabs, shrunken to the size of playing cards, sit next to your wrist, just waiting for you to draw");
 		}
@@ -20,8 +20,8 @@ package classes.Items.Shields
 			return temp;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.cor < (33 + game.player.corruptionTolerance)) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.cor < (33 + game.player.corruptionTolerance)) return super.canEquip(doOutput,slot);
 			if(doOutput) outputText("You grab hold of the handle of the shield only to have it grow burning hot.  You're forced to let it go lest you burn yourself.  Something within the shield must be displeased.  ");
 			return false;
 		}

--- a/classes/classes/Items/Shields/BeautifulShield.as
+++ b/classes/classes/Items/Shields/BeautifulShield.as
@@ -18,8 +18,8 @@ package classes.Items.Shields
 			return temp;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.cor < (33 + game.player.corruptionTolerance)) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.cor < (33 + game.player.corruptionTolerance)) return super.canEquip(doOutput, slot);
 			if(doOutput) outputText("You grab hold of the handle of the shield only to have it grow burning hot.  You're forced to let it go lest you burn yourself.  Something within the shield must be displeased.  ");
 			return false;
 		}

--- a/classes/classes/Items/Shields/NecroShield.as
+++ b/classes/classes/Items/Shields/NecroShield.as
@@ -19,12 +19,12 @@ package classes.Items.Shields
 			super("NecroSh", "necroshield", "necro shield", "a necro shield", 5, 1000, "A simple shield made from bones. Increase user mastery over animated bone constructs.");
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.equipNecroItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if ((CoC.instance.player.perkv2(PerkLib.PrestigeJobNecromancer) - 1) > SceneLib.campMakeWinions.maxSkeletonWarriors() || (CoC.instance.player.perkv1(PerkLib.GreaterHarvest) - 1) > SceneLib.campMakeWinions.maxSkeletonArchers() || (CoC.instance.player.perkv2(PerkLib.GreaterHarvest) - 1) > SceneLib.campMakeWinions.maxSkeletonMages()) {
 				outputText("\n\nAfter you unequip necro shield some of your skeletons falls apart due to not enough control to sustain them. You gather leftover bones for future use.  ");
 				if ((CoC.instance.player.perkv2(PerkLib.PrestigeJobNecromancer) - 1) > SceneLib.campMakeWinions.maxSkeletonWarriors()) {
@@ -41,7 +41,7 @@ package classes.Items.Shields
 				}
 			}
 			SceneLib.setItemsChecks.unequipNecroItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Undergarment.as
+++ b/classes/classes/Items/Undergarment.as
@@ -68,7 +68,7 @@ import classes.PerkLib;
 			return _sexiness;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			if (!game.player.armor.supportsUndergarment) {
 				outputText("It would be awkward to put on undergarments when you're currently wearing your type of clothing. You should consider switching to different clothes. You put it back into your inventory.");
 				return false;
@@ -85,7 +85,7 @@ import classes.PerkLib;
 				outputText("You would very like to equip this item but your body stiffness prevents you from doing so.");
 				return false;
 			}
-			return super.canEquip(doOutput);
+			return super.canEquip(doOutput, slot);
 		}
 	}
 

--- a/classes/classes/Items/Undergarments/TechnomancerBra.as
+++ b/classes/classes/Items/Undergarments/TechnomancerBra.as
@@ -13,8 +13,8 @@ package classes.Items.Undergarments
 			super("TechBra", "TechnomancerBra", "Technomancer bra", "a Technomancer bra", UT_TOP, 600, 0, 0, 0, "A black latex bra to match with the technomancer clothes, it is decorated with a gears motif and is oil, shock and stainproof. This item also improve your aptitude at using technology. \n\nType: Undergarment (Upper)");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean{
-			if (game.player.basetallness < 48){return super.canEquip(doOutput)}
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean{
+			if (game.player.basetallness < 48){return super.canEquip(doOutput, slot)}
 			if (doOutput) outputText("There is no way this tiny set of clothing would fit your current size.");
 			return false;
 		}

--- a/classes/classes/Items/Undergarments/TechnomancerPanties.as
+++ b/classes/classes/Items/Undergarments/TechnomancerPanties.as
@@ -14,8 +14,8 @@ package classes.Items.Undergarments
 			super("T.Panty", "T.Panties", "Technomancer panties", "a pair of Technomancer panties", UT_BOTTOM, 600, 0, 0, 0, "A black latex panty to match with the technomancer clothes, it is decorated with a gears motif and is oil, shock and stainproof. This item also improve your aptitude at using technology. \n\nType: Undergarment (Lower)");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean{
-			if (game.player.basetallness < 48){return super.canEquip(doOutput)}
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean{
+			if (game.player.basetallness < 48){return super.canEquip(doOutput, slot)}
 			if (doOutput) outputText("There is no way this tiny set of clothing would fit your current size.");
 			return false;
 		}

--- a/classes/classes/Items/Vehicles.as
+++ b/classes/classes/Items/Vehicles.as
@@ -42,12 +42,12 @@ package classes.Items
 			return desc;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			if (game.player.hasPerk(PerkLib.Rigidity)) {
 				if (doOutput) outputText("You would very like to enter " + longName + " cockpit but your body stiffness prevents you from doing so.");
 				return false;
 			}
-			return super.canEquip(doOutput);
+			return super.canEquip(doOutput, slot);
 		}
 		
 		override public function equipText():void {

--- a/classes/classes/Items/Vehicles/GiantSlayerMech.as
+++ b/classes/classes/Items/Vehicles/GiantSlayerMech.as
@@ -19,8 +19,8 @@ public class GiantSlayerMech extends Vehicles
 			super("GS Mech", "GiantSlayerMech", "Giant Slayer Mech", "a Giant Slayer Mech", 0, 0, 2000, "A customisable goblin invention, this bipedal, large mech is equipped with a comfortable seat, fit for a goblin or a small person. Within it you feel like you could kill gods or well gigants... \n\nType: Goblin Mech \nBase value: 2000","Mech");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (!super.canEquip(doOutput)) {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (!super.canEquip(doOutput, slot)) {
 				return false;
 			}
 			if (game.player.isRace(Races.ELF) || game.player.isRace(Races.WOODELF)) { //Elf
@@ -34,7 +34,7 @@ public class GiantSlayerMech extends Vehicles
 			return true;
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				//status effect to later track when mech enter enrage/stage 2 mode
 				if (game.player.hasKeyItem("Upgraded Armor plating 1.0") >= 0 || game.player.hasKeyItem("Upgraded Leather Insulation 1.0") >= 0) {
@@ -52,10 +52,10 @@ public class GiantSlayerMech extends Vehicles
 				}
 				outputText("As you turn the mech on the welcoming voice of your AI booms in. \"<i>Welcome back aboard operator [name]. All functions are nominal.</i>\"");
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if (game.player.hasKeyItem("Upgraded Armor plating 1.0") >= 0 || game.player.hasKeyItem("Upgraded Leather Insulation 1.0") >= 0) {
 				var RHP:Number = 1;
 				if (game.player.hasKeyItem("Upgraded Armor plating 1.0") >= 0) RHP += 0.25;
@@ -70,7 +70,7 @@ public class GiantSlayerMech extends Vehicles
 				game.player.HP /= RHP;
 			}
 			game.player.HP = Math.round(game.player.HP);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Vehicles/GoblinMechAlpha.as
+++ b/classes/classes/Items/Vehicles/GoblinMechAlpha.as
@@ -19,8 +19,8 @@ public class GoblinMechAlpha extends Vehicles
 			super("GobMAlp", "GoblinMechAlpha", "Goblin Mech Alpha", "a Goblin Mech Alpha", 0, 0, 500, "A customisable goblin invention, this six-legged, large mech is equipped with a comfortable seat, fit for a goblin or a rather small person. \n\nType: Goblin Mech \nBase value: 500","Mech");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (!super.canEquip(doOutput)) {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (!super.canEquip(doOutput, slot)) {
 				return false;
 			}
 			if (game.player.isRace(Races.ELF) || game.player.isRace(Races.WOODELF)) { //Elf
@@ -34,7 +34,7 @@ public class GoblinMechAlpha extends Vehicles
 			return true;
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				if (game.player.hasKeyItem("Upgraded Armor plating 1.0") >= 0) game.player.HP = 1.2 * game.player.maxHP();
 				if (game.player.hasKeyItem("Upgraded Armor plating 2.0") >= 0) game.player.HP = 1.4 * game.player.maxHP();
@@ -44,10 +44,10 @@ public class GoblinMechAlpha extends Vehicles
 				if (game.player.hasKeyItem("Upgraded Armor plating 6.0") >= 0) game.player.HP = 2.2 * game.player.maxHP();
 				outputText("As you turn the mech on the welcoming voice of your AI booms in. \"<i>Welcome back aboard operator [name]. All functions are nominal.</i>\"");
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if (game.player.hasKeyItem("Upgraded Armor plating 1.0") >= 0) game.player.HP /= 1.2;
 			if (game.player.hasKeyItem("Upgraded Armor plating 2.0") >= 0) game.player.HP /= 1.4;
 			if (game.player.hasKeyItem("Upgraded Armor plating 3.0") >= 0) game.player.HP /= 1.6;
@@ -55,7 +55,7 @@ public class GoblinMechAlpha extends Vehicles
 			if (game.player.hasKeyItem("Upgraded Armor plating 5.0") >= 0) game.player.HP /= 2;
 			if (game.player.hasKeyItem("Upgraded Armor plating 6.0") >= 0) game.player.HP /= 2.2;
 			game.player.HP = Math.round(game.player.HP);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Vehicles/GoblinMechPrime.as
+++ b/classes/classes/Items/Vehicles/GoblinMechPrime.as
@@ -19,8 +19,8 @@ public class GoblinMechPrime extends Vehicles
 			super("GobMPri", "GoblinMechPrime", "Goblin Mech Prime", "a Goblin Mech Prime", 0, 0, 2000, "A customisable goblin invention, this six-legged, large mech is equipped with a comfortable seat, fit for a goblin or a rather small person. The prime design, unlike the more common model, sports a better armature and energy management, which improves both the defensive and offensive capacity of the mech. \n\nType: Goblin Mech \nBase value: 2000","Mech");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (!super.canEquip(doOutput)) {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (!super.canEquip(doOutput, slot)) {
 				return false;
 			}
 			if (game.player.isRace(Races.ELF) || game.player.isRace(Races.WOODELF)) { //Elf
@@ -34,7 +34,7 @@ public class GoblinMechPrime extends Vehicles
 			return true;
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				if (game.player.hasKeyItem("Upgraded Armor plating 1.0") >= 0) game.player.HP = 1.4 * game.player.maxHP();
 				if (game.player.hasKeyItem("Upgraded Armor plating 2.0") >= 0) game.player.HP = 1.8 * game.player.maxHP();
@@ -44,10 +44,10 @@ public class GoblinMechPrime extends Vehicles
 				if (game.player.hasKeyItem("Upgraded Armor plating 6.0") >= 0) game.player.HP = 3.4 * game.player.maxHP();
 				outputText("As you turn the mech on the welcoming voice of your AI booms in. \"<i>Welcome back aboard operator [name]. All functions are nominal.</i>\"");
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if (game.player.hasKeyItem("Upgraded Armor plating 1.0") >= 0) game.player.HP /= 1.4;
 			if (game.player.hasKeyItem("Upgraded Armor plating 2.0") >= 0) game.player.HP /= 1.8;
 			if (game.player.hasKeyItem("Upgraded Armor plating 3.0") >= 0) game.player.HP /= 2.2;
@@ -55,7 +55,7 @@ public class GoblinMechPrime extends Vehicles
 			if (game.player.hasKeyItem("Upgraded Armor plating 5.0") >= 0) game.player.HP /= 3;
 			if (game.player.hasKeyItem("Upgraded Armor plating 6.0") >= 0) game.player.HP /= 3.4;
 			game.player.HP = Math.round(game.player.HP);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Vehicles/HowlingBansheeMech.as
+++ b/classes/classes/Items/Vehicles/HowlingBansheeMech.as
@@ -17,8 +17,8 @@ package classes.Items.Vehicles
 			withBuffs({"str.mult": 0.15, "tou.mult": 0.10, "spe.mult": 0.25});
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (!super.canEquip(doOutput)) {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (!super.canEquip(doOutput, slot)) {
 				return false;
 			}
 			if (game.player.basetallness < 84) { //Shorter than 7 ft
@@ -53,18 +53,18 @@ package classes.Items.Vehicles
 			return boost;
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			if (!game.isLoadingSave) {
 				game.player.HP = boost * game.player.maxHP();
 				game.player.HP = Math.round(game.player.HP);
 			}
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			game.player.HP /= boost;
 			game.player.HP = Math.round(game.player.HP);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Weapon.as
+++ b/classes/classes/Items/Weapon.as
@@ -247,7 +247,7 @@ public class Weapon extends Equipable
 			return list;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			//========================//
 			// Size/Dual/Shield check //
 			//========================//
@@ -314,10 +314,10 @@ public class Weapon extends Equipable
 				return false;
 			}
 			// All checks passed, check superclass //
-			return super.canEquip(doOutput);
+			return super.canEquip(doOutput, slot);
 		}
 		
-		override public function beforeEquip(doOutput:Boolean):Equipable {
+		override public function beforeEquip(doOutput:Boolean, slot:int):Equipable {
 			if (!game.player.shield.isNothing) {
 				if (isLarge() && !game.player.hasPerk(PerkLib.GigantGrip)
 					|| isMassive() && !game.player.hasPerk(PerkLib.TitanGrip)){
@@ -326,7 +326,7 @@ public class Weapon extends Equipable
 			}
 			if (game.flags[kFLAGS.FERAL_COMBAT_MODE] == 1 && isSingleOrDualSmallToMassive()) game.flags[kFLAGS.FERAL_COMBAT_MODE] = 0;
 			
-			return super.beforeEquip(doOutput);
+			return super.beforeEquip(doOutput, slot);
 		}
 		
 		/**

--- a/classes/classes/Items/WeaponRange.as
+++ b/classes/classes/Items/WeaponRange.as
@@ -91,15 +91,15 @@ public class WeaponRange extends Equipable
 			return list;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			if (game.player.hasPerk(PerkLib.Rigidity)) {
 				if (doOutput) outputText("You would very like to equip this item but your body stiffness prevents you from doing so.");
 				return false;
 			}
-			return super.canEquip(doOutput);
+			return super.canEquip(doOutput, slot);
 		}
 		
-		override public function beforeEquip(doOutput:Boolean):Equipable {
+		override public function beforeEquip(doOutput:Boolean, slot:int):Equipable {
 			if (perk == "2H Firearm") {
 				if (doOutput) outputText("Because this weapon requires the use of two hands, you have unequipped your shield. ");
 				SceneLib.inventory.unequipShield();
@@ -108,7 +108,7 @@ public class WeaponRange extends Equipable
 				if (doOutput) outputText("Because those weapons requires the use of two hands, you have unequipped your shield. ");
 				SceneLib.inventory.unequipShield();
 			}
-			return super.beforeEquip(doOutput);
+			return super.beforeEquip(doOutput, slot);
 		}
 		override public function getItemText(textid:String):String {
 			if (textid == "legendary_fail") {

--- a/classes/classes/Items/Weapons/AetherD.as
+++ b/classes/classes/Items/Weapons/AetherD.as
@@ -58,22 +58,22 @@ import classes.Scenes.NPCs.AetherTwinsFollowers;
 			outputText("\n\n\"<i>Well alright then, [name]!</i>\" Aether (Dex) says excitedly, \"<i>Let's go!</i>\"\n\n");
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			game.flags[kFLAGS.AETHER_DEXTER_TWIN_AT_CAMP] = 2;
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function unequipText():void {
+		override public function unequipText(slot:int):void {
 			outputText("Aether (Dex) lays on the ground for a moment, \"<i>I will be waiting in the camp</i>\" she says before teleporting back to your camp.\n\n(<b>Aether (Dex) is now available in the followers tab!</b>)");
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			game.flags[kFLAGS.AETHER_DEXTER_TWIN_AT_CAMP] = 1;
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
-		override public function beforeUnequip(doOutput:Boolean):ItemType {
-			super.beforeUnequip(doOutput);
+		override public function beforeUnequip(doOutput:Boolean, slot:int):ItemType {
+			super.beforeUnequip(doOutput, slot);
 			return WeaponLib.FISTS;
 		}
 	}

--- a/classes/classes/Items/Weapons/BeautifulFlyWhisk.as
+++ b/classes/classes/Items/Weapons/BeautifulFlyWhisk.as
@@ -66,9 +66,10 @@ import classes.PerkLib;
 				_buffs['psoulskillpower'] = newMult;
 				_buffs['msoulskillpower'] = newMult;
                 if (game.player.weapon == this) {
+	                var slot:int = game.player.slotOfEquippedItem(this);
                     //re-requip to update player's perk
-					afterUnequip(false);
-					afterEquip(false);
+					afterUnequip(false, slot);
+					afterEquip(false, slot);
                 }
                 lastCor = game.player.cor;
             }

--- a/classes/classes/Items/Weapons/BeautifulStaff.as
+++ b/classes/classes/Items/Weapons/BeautifulStaff.as
@@ -48,8 +48,9 @@ import classes.TimeAwareInterface;
 				_buffs['spellpower'] = calcWizardsMult();
                 if (game.player.weapon == this) {
                     //re-requip to update player's perk
-					afterUnequip(false);
-					afterEquip(false);
+	                var slot:int = game.player.slotOfEquippedItem(this);
+					afterUnequip(false, slot);
+					afterEquip(false, slot);
                 }
                 lastCor = game.player.cor;
             }

--- a/classes/classes/Items/Weapons/Eclipse.as
+++ b/classes/classes/Items/Weapons/Eclipse.as
@@ -44,8 +44,9 @@ public class Eclipse extends Weapon implements TimeAwareInterface
 				_buffs['spellpower'] = calcWizardsMult();
                 if (game.player.weapon == this) {
                     //re-requip to update player's perk
-                    afterUnequip(false);
-                    afterEquip(false);
+	                var slot:int = game.player.slotOfEquippedItem(this);
+                    afterUnequip(false, slot);
+                    afterEquip(false, slot);
                 }
             }
             lastCor = game.player.cor;

--- a/classes/classes/Items/Weapons/Fists.as
+++ b/classes/classes/Items/Weapons/Fists.as
@@ -13,7 +13,7 @@ package classes.Items.Weapons
 		
 		override public function useText():void {} //No text for equipping fists
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			return true;
 		}
 		

--- a/classes/classes/Items/Weapons/NecroWand.as
+++ b/classes/classes/Items/Weapons/NecroWand.as
@@ -23,12 +23,12 @@ package classes.Items.Weapons
 			withBuff('spellpower', +0.1);
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			SceneLib.setItemsChecks.equipNecroItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			if ((CoC.instance.player.perkv2(PerkLib.PrestigeJobNecromancer) - 1) > SceneLib.campMakeWinions.maxSkeletonWarriors() || (CoC.instance.player.perkv1(PerkLib.GreaterHarvest) - 1) > SceneLib.campMakeWinions.maxSkeletonArchers() || (CoC.instance.player.perkv2(PerkLib.GreaterHarvest) - 1) > SceneLib.campMakeWinions.maxSkeletonMages()) {
 				outputText("\n\nAfter you unequip necro wand some of your skeletons falls apart due to not enough control to sustain them. You gather leftover bones for future use.  ");
 				if ((CoC.instance.player.perkv2(PerkLib.PrestigeJobNecromancer) - 1) > SceneLib.campMakeWinions.maxSkeletonWarriors()) {
@@ -45,7 +45,7 @@ package classes.Items.Weapons
 				}
 			}
 			SceneLib.setItemsChecks.unequipNecroItemsSet();
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Weapons/Nexus.as
+++ b/classes/classes/Items/Weapons/Nexus.as
@@ -48,8 +48,9 @@ public class Nexus extends Weapon implements TimeAwareInterface
 				_buffs['spellpower'] = calcWizardsMult();
                 if (game.player.weapon == game.weapons.OCCULUS) {
                     //re-requip to update player's perk
-                    afterUnequip(false);
-                    afterEquip(false);
+	                var slot:int = game.player.slotOfEquippedItem(this);
+                    afterUnequip(false, slot);
+                    afterEquip(false, slot);
                 }
             }
             lastCor = game.player.cor;

--- a/classes/classes/Items/Weapons/NocturnusStaff.as
+++ b/classes/classes/Items/Weapons/NocturnusStaff.as
@@ -47,8 +47,9 @@ public class NocturnusStaff extends Weapon implements TimeAwareInterface
 				_buffs['spellpower'] = calcWizardsMult();
                 if (game.player.weapon == this) {
                     //re-requip to update player's perk
-                    afterUnequip(false);
-                    afterEquip(false);
+	                var slot:int = game.player.slotOfEquippedItem(this);
+                    afterUnequip(false, slot);
+                    afterEquip(false, slot);
                 }
             }
             lastCor = game.player.cor;

--- a/classes/classes/Items/Weapons/Occulus.as
+++ b/classes/classes/Items/Weapons/Occulus.as
@@ -45,8 +45,9 @@ public class Occulus extends Weapon implements TimeAwareInterface
 				_buffs['spellpower'] = calcWizardsMult();
                 if (game.player.weapon == game.weapons.OCCULUS) {
                     //re-requip to update player's perk
-                    afterUnequip(false);
-                    afterEquip(false);
+	                var slot:int = game.player.slotOfEquippedItem(this);
+                    afterUnequip(false, slot);
+                    afterEquip(false, slot);
                 }
             }
             lastCor = game.player.cor;

--- a/classes/classes/Items/Weapons/Paracelsus.as
+++ b/classes/classes/Items/Weapons/Paracelsus.as
@@ -21,7 +21,7 @@ import classes.TimeAwareInterface;
 		}
 		
         //Normal weapon stuff
-		public function Paracelsus() 
+		public function Paracelsus()
 		{
 			super("Paracel", "Paracelsus", "Paracelsus", "a Paracelsus", "bonk", 22, 600, "A legendary staff said to have been made by Marae for her champion. This weapon radiates divine power, purifying its wielder and protecting them from impurity.", WT_STAFF, WSZ_LARGE);
 			withBuff('spellpower', +1.0);
@@ -45,8 +45,9 @@ import classes.TimeAwareInterface;
 				_buffs['spellpower'] = calcWizardsMult();
                 if (game.player.weapon == this) {
                     //re-requip to update player's perk
-					afterUnequip(false);
-					afterEquip(false);
+	                var slot:int = game.player.slotOfEquippedItem(this);
+					afterUnequip(false, slot);
+					afterEquip(false, slot);
                 }
                 lastCor = game.player.cor;
             }

--- a/classes/classes/Items/Weapons/ScarredBlade.as
+++ b/classes/classes/Items/Weapons/ScarredBlade.as
@@ -14,8 +14,8 @@ public class ScarredBlade extends Weapon
 			withEffect(IELib.AttackBonus_Cor, 1/3);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.cor >= (66 - game.player.corruptionTolerance)) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.cor >= (66 - game.player.corruptionTolerance)) return super.canEquip(doOutput, slot);
 			if (doOutput) SceneLib.sheilaScene.rebellingScarredBlade(true);
 			return false;
 		}

--- a/classes/classes/Items/Weapons/SoulDrill.as
+++ b/classes/classes/Items/Weapons/SoulDrill.as
@@ -30,18 +30,18 @@ package classes.Items.Weapons
 			return game.player.statusEffectv1(StatusEffects.SoulDrill1) >= 1 ? "drill" : "pierce";
 		}
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			game.player.createStatusEffect(StatusEffects.SoulDrill1,0,0,0,0);
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			while (game.player.hasStatusEffect(StatusEffects.SoulDrill1)) game.player.removeStatusEffect(StatusEffects.SoulDrill1);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.hasPerk(PerkLib.GigantGrip)) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.hasPerk(PerkLib.GigantGrip)) return super.canEquip(doOutput, slot);
 			if (doOutput) outputText("You aren't skilled in handling large weapons with one hand yet to effectively use this drill. Unless you want to hurt yourself instead enemies when trying to use it...  ");
 			return false;
 		}

--- a/classes/classes/Items/Weapons/ThePhalluspear.as
+++ b/classes/classes/Items/Weapons/ThePhalluspear.as
@@ -23,14 +23,14 @@ import classes.Items.Weapon;
 		}
 		
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			game.player.createStatusEffect(StatusEffects.ThePhalluspear1,0,0,0,0);
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			while (game.player.hasStatusEffect(StatusEffects.ThePhalluspear1)) game.player.removeStatusEffect(StatusEffects.ThePhalluspear1);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 	}
 }

--- a/classes/classes/Items/Weapons/ThePhalluspears.as
+++ b/classes/classes/Items/Weapons/ThePhalluspears.as
@@ -23,14 +23,14 @@ import classes.Items.Weapon;
 		}
 		
 		
-		override public function afterEquip(doOutput:Boolean):void {
+		override public function afterEquip(doOutput:Boolean, slot:int):void {
 			game.player.createStatusEffect(StatusEffects.ThePhalluspear1,0,0,0,0);
-			super.afterEquip(doOutput);
+			super.afterEquip(doOutput, slot);
 		}
 		
-		override public function afterUnequip(doOutput:Boolean):void {
+		override public function afterUnequip(doOutput:Boolean, slot:int):void {
 			while (game.player.hasStatusEffect(StatusEffects.ThePhalluspear1)) game.player.removeStatusEffect(StatusEffects.ThePhalluspear1);
-			super.afterUnequip(doOutput);
+			super.afterUnequip(doOutput, slot);
 		}
 		
 	}

--- a/classes/classes/Items/Weapons/Tidarion.as
+++ b/classes/classes/Items/Weapons/Tidarion.as
@@ -48,8 +48,9 @@ public class Tidarion extends Weapon implements TimeAwareInterface {
             _buffs['spellpower'] = calcWizardsMult();
             if (game.player.weapon == game.weapons.TIDAR) {
                 //re-requip to update player's perk
-                afterUnequip(false);
-                afterEquip(false);
+                var slot:int = game.player.slotOfEquippedItem(this);
+                afterUnequip(false, slot);
+                afterEquip(false, slot);
             }
             lastCor = game.player.cor;
         }

--- a/classes/classes/Items/Weapons/UnicornStaff.as
+++ b/classes/classes/Items/Weapons/UnicornStaff.as
@@ -48,8 +48,9 @@ public class UnicornStaff extends Weapon implements TimeAwareInterface
 				_buffs['spellpower'] = calcWizardsMult();
                 if (game.player.weapon == game.weapons.U_STAFF) {
                     //re-requip to update player's perk
-                    afterUnequip(false);
-                    afterEquip(false);
+	                var slot:int = game.player.slotOfEquippedItem(this);
+                    afterUnequip(false, slot);
+                    afterEquip(false, slot);
                 }
             }
             lastCor = game.player.cor;

--- a/classes/classes/Items/WeaponsRange/BeautifulBow.as
+++ b/classes/classes/Items/WeaponsRange/BeautifulBow.as
@@ -21,8 +21,8 @@ package classes.Items.WeaponsRange
 			return temp;
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.cor < (33 + game.player.corruptionTolerance)) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.cor < (33 + game.player.corruptionTolerance)) return super.canEquip(doOutput, slot);
 			if(doOutput) outputText("You grab hold of the handle of the bow only to have it grow burning hot.  You're forced to let it go lest you burn yourself.  Something within the bow must be displeased.  ");
 			return false;
 		}

--- a/classes/classes/Items/WeaponsRange/DuAlakablam.as
+++ b/classes/classes/Items/WeaponsRange/DuAlakablam.as
@@ -16,9 +16,9 @@ package classes.Items.WeaponsRange
 			withBuffs({'rangedaccuracy':-40});
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			if ((game.player.hasPerk(PerkLib.DualWield) && (game.player.hasPerk(PerkLib.GigantGrip) || game.player.hasPerk(PerkLib.AntyDexterity))) || (game.player.hasPerk(PerkLib.GigantGrip) && game.player.hasPerk(PerkLib.AntyDexterity))) {
-				return super.canEquip(doOutput);
+				return super.canEquip(doOutput, slot);
 			}
 			if (!game.player.hasPerk(PerkLib.GigantGrip) && !game.player.hasPerk(PerkLib.AntyDexterity)) {
 				if (doOutput) outputText("You aren't skilled enough to handle this pair of firearms!  ");

--- a/classes/classes/Items/WeaponsRange/HarkonnenII.as
+++ b/classes/classes/Items/WeaponsRange/HarkonnenII.as
@@ -16,9 +16,9 @@ package classes.Items.WeaponsRange
 			withBuffs({'rangedaccuracy':-100});
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			if ((game.player.hasPerk(PerkLib.DualWield) && (game.player.hasPerk(PerkLib.GigantGrip) || game.player.hasPerk(PerkLib.AntyDexterity))) || (game.player.hasPerk(PerkLib.GigantGrip) && game.player.hasPerk(PerkLib.AntyDexterity))) {
-				return super.canEquip(doOutput);
+				return super.canEquip(doOutput, slot);
 			}
 			if (!game.player.hasPerk(PerkLib.GigantGrip) && !game.player.hasPerk(PerkLib.AntyDexterity)) {
 				if (doOutput) outputText("You aren't skilled enough to handle this pair of firearms!  ");

--- a/classes/classes/Items/WeaponsRange/LactoBlasters.as
+++ b/classes/classes/Items/WeaponsRange/LactoBlasters.as
@@ -17,8 +17,8 @@ package classes.Items.WeaponsRange
 			super("LactoBlaster", "LactoBlaster", "Lactoblaster", "a LactoBlaster", "shot", 1, 1000, "Both a sex toy and a weapon the Lactoblaster uses one most unconventionnal ammunition, breast milks. Invented to take advantage of lacta bovine near endless supply of milk, this setup consists of two machine guns linked to a massive tank to be strapped on the users back and a harness with two milkers. The gun is only as strong as the user's milk production and since the weapon seldom constantly milk the lacta bovine it will never need to satisfy its milking needs. As expected this setup is quite heavy and only a very strong individual or a lacta bovine could use it.", "Dual Firearms");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.hasPerk(PerkLib.DualWield) && game.player.str >= 100 && game.player.biggestTitSize() > 4) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.hasPerk(PerkLib.DualWield) && game.player.str >= 100 && game.player.biggestTitSize() > 4) return super.canEquip(doOutput, slot);
 			if (doOutput) {
 				if (!game.player.hasPerk(PerkLib.DualWield)) outputText("You have yet to master the art of dual wielding! ");
 				if (game.player.str < 100) outputText("This setup is to heavy for you to wield! ");

--- a/classes/classes/Items/WeaponsRange/TwinDartPistol.as
+++ b/classes/classes/Items/WeaponsRange/TwinDartPistol.as
@@ -15,8 +15,8 @@ package classes.Items.WeaponsRange
 			super("TDPisto", "TwinDartPistol", "Twin Dart pistol", "a Twin Dart pistol", "shot", 1, 240, "A pair of dart pistol. This weapon is not designed to wound but to deliver loads of chemical into the victim bloodstream.\n\nGoblin Mech Compatibile", "Dual Firearms");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.hasPerk(PerkLib.DualWield) || game.player.hasPerk(PerkLib.AntyDexterity)) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.hasPerk(PerkLib.DualWield) || game.player.hasPerk(PerkLib.AntyDexterity)) return super.canEquip(doOutput, slot);
 			if (doOutput) outputText("You aren't skilled enough to handle this pair of firearms! (req. Dual Wield/Anty-Dexternity)  ");
 			return false;
 		}

--- a/classes/classes/Items/WeaponsRange/TwinDesertEagles.as
+++ b/classes/classes/Items/WeaponsRange/TwinDesertEagles.as
@@ -15,8 +15,8 @@ package classes.Items.WeaponsRange
 			super("TDeEagl", "TDesertEagles", "Twin Desert Eagles", "a Twin Desert Eagles", "shot", 25, 1240, "A twin hand firearms, the desert eagles has the largest bullets out of the pistol family. Their shots are deadly and precises through the guns has one hell of a recoil.\n\nGoblin Mech Compatibile", "Dual Firearms");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.hasPerk(PerkLib.DualWield) || game.player.hasPerk(PerkLib.AntyDexterity)) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.hasPerk(PerkLib.DualWield) || game.player.hasPerk(PerkLib.AntyDexterity)) return super.canEquip(doOutput, slot);
 			if (doOutput) outputText("You aren't skilled enough to handle this pair of firearms! (req. Dual Wield/Anty-Dexternity)  ");
 			return false;
 		}

--- a/classes/classes/Items/WeaponsRange/TwinGrakaturd.as
+++ b/classes/classes/Items/WeaponsRange/TwinGrakaturd.as
@@ -15,8 +15,8 @@ package classes.Items.WeaponsRange
 			super("TwinGra", "TwinGrakaturd", "Twin Grakaturd", "a Twin Grakaturd", "shot", 25, 860, "A pair of weapon favored by gunners who like to charge in gun blazing and think after.\n\nGoblin Mech Compatibile", "Dual Firearms");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.hasPerk(PerkLib.DualWield) || game.player.hasPerk(PerkLib.AntyDexterity)) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.hasPerk(PerkLib.DualWield) || game.player.hasPerk(PerkLib.AntyDexterity)) return super.canEquip(doOutput, slot);
 			if (doOutput) outputText("You aren't skilled enough to handle this pair of firearms! (req. Dual Wield/Anty-Dexternity)  ");
 			return false;
 		}

--- a/classes/classes/Items/WeaponsRange/TwinM1Cerberuses.as
+++ b/classes/classes/Items/WeaponsRange/TwinM1Cerberuses.as
@@ -15,9 +15,9 @@ package classes.Items.WeaponsRange
 			super("TM1Cerb", "TwinM1Cerberuses", "Twin M1 Cerberuses", "a Twin M1 Cerberuses", "shot", 45, 1860, "A twin rifles prized for their precision and versatility, the Cerberuses shoots multiple bullet in salvo ensuring that if one shot land all the others do with minimal recoil.\n\nGoblin Mech Compatibile", "Dual 2H Firearms");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
 			if ((game.player.hasPerk(PerkLib.DualWield) && (game.player.hasPerk(PerkLib.GigantGrip) || game.player.hasPerk(PerkLib.AntyDexterity))) || (game.player.hasPerk(PerkLib.GigantGrip) && game.player.hasPerk(PerkLib.AntyDexterity))) {
-				return super.canEquip(doOutput);
+				return super.canEquip(doOutput, slot);
 			}
 			if (!game.player.hasPerk(PerkLib.GigantGrip) && !game.player.hasPerk(PerkLib.AntyDexterity)) {
 				if (doOutput) outputText("You aren't skilled enough to handle this pair of firearms! (req. Gigant's Grip/Anty-Dexternity)  ");

--- a/classes/classes/Items/WeaponsRange/TwinSixShooter.as
+++ b/classes/classes/Items/WeaponsRange/TwinSixShooter.as
@@ -15,8 +15,8 @@ package classes.Items.WeaponsRange
 			super("TwinSixS", "TwinSixShooter", "Twin Six shooter", "a Twin Six shooter", "shot", 20, 1160, "A two revolvers with six chambers. Their shots are deadly and precise.", "Dual Firearms");
 		}
 		
-		override public function canEquip(doOutput:Boolean):Boolean {
-			if (game.player.hasPerk(PerkLib.DualWield) || game.player.hasPerk(PerkLib.AntyDexterity)) return super.canEquip(doOutput);
+		override public function canEquip(doOutput:Boolean, slot:int):Boolean {
+			if (game.player.hasPerk(PerkLib.DualWield) || game.player.hasPerk(PerkLib.AntyDexterity)) return super.canEquip(doOutput, slot);
 			if (doOutput) outputText("You aren't skilled enough to handle this pair of firearms! (req. Dual Wield/Anty-Dexternity)  ");
 			return false;
 		}

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -2172,7 +2172,7 @@ use namespace CoC;
 				return internalUnequipItem(slot, doOutput, force);
 			}
 			if (!force) {
-				if (!newItem.canEquip(doOutput)) return null;
+				if (!newItem.canEquip(doOutput, slot)) return null;
 			}
 			var oldItem:Equipable = _equipment[slot];
 			var returnItem:ItemType;
@@ -2185,10 +2185,10 @@ use namespace CoC;
 			saveHPRatio();
 			var actualItem:Equipable;
 			if (game.isLoadingSave) actualItem = newItem;
-			else actualItem = newItem.beforeEquip(doOutput);
+			else actualItem = newItem.beforeEquip(doOutput, slot);
 			if (actualItem && !actualItem.isNothing) {
 				_equipment[slot] = actualItem;
-				actualItem.afterEquip(doOutput);
+				actualItem.afterEquip(doOutput, slot);
 			}
 			restoreHPRatio();
 			return returnItem;
@@ -2214,13 +2214,13 @@ use namespace CoC;
 			if (!force) {
 				if (!oldItem.canUnequip(doOutput)) return null;
 			}
-			var returnItem:ItemType = oldItem.beforeUnequip(doOutput);
+			var returnItem:ItemType = oldItem.beforeUnequip(doOutput, slot);
 			if (returnItem == null) {
 				trace("[WARNING] beforeUnequip returned null from "+oldItem.id+", should return 'nothing' instead");
 				returnItem = ItemConstants.EquipmentSlots[slot].nothing();
 			}
 			_equipment[slot] = ItemConstants.EquipmentSlots[slot].nothing();
-			oldItem.afterUnequip(doOutput);
+			oldItem.afterUnequip(doOutput, slot);
 			restoreHPRatio();
 			return returnItem;
 		}


### PR DESCRIPTION
* `can/before/after Equip/Unequip` and `unequipText` functions have `slot:int` argument.
* Items with duplicate ids crash the game now, because they shouldn't exist and can lead to obscure bugs.
* fixed duplicate item libraries