### PR TITLE
Various fixes for issues with the gargoyle-form

### DIFF
--- a/classes/classes/Character.as
+++ b/classes/classes/Character.as
@@ -573,7 +573,7 @@ import classes.Scenes.NPCs.Forgefather;
 				if (Forgefather.refinement == 0) multimax += (.15);
 				if (Forgefather.refinement == 1) multimax += (.25);
 				if (Forgefather.refinement == 2 || Forgefather.refinement == 3) multimax += (.35);
-				if (Forgefather.refinement == 4) multimax += (.5);
+				if (Forgefather.refinement >= 4) multimax += (.5);
 			}
 			if (hasPerk(PerkLib.HclassHeavenTribulationSurvivor)) max += (100 * (1 + flags[kFLAGS.NEW_GAME_PLUS_LEVEL]));
 			if (hasPerk(PerkLib.GclassHeavenTribulationSurvivor)) max += (150 * (1 + flags[kFLAGS.NEW_GAME_PLUS_LEVEL]));
@@ -676,7 +676,7 @@ import classes.Scenes.NPCs.Forgefather;
 				if (Forgefather.refinement == 0) multimax += (.15);
 				if (Forgefather.refinement == 1) multimax += (.25);
 				if (Forgefather.refinement == 2 || Forgefather.refinement == 3) multimax += (.35);
-				if (Forgefather.refinement == 4) multimax += (.5);
+				if (Forgefather.refinement >= 4) multimax += (.5);
 			}
 			if (hasPerk(PerkLib.HistoryCultivator) || hasPerk(PerkLib.PastLifeCultivator)) multimax += 0.1;
 			if (hasPerk(PerkLib.JobSoulCultivator)) {//8005-9005 soulforce na razie przed liczeniem mnożnika jest
@@ -762,7 +762,7 @@ import classes.Scenes.NPCs.Forgefather;
 				if (Forgefather.refinement == 0) multimax += (.15);
 				if (Forgefather.refinement == 1) multimax += (.25);
 				if (Forgefather.refinement == 2 || Forgefather.refinement == 3) multimax += (.35);
-				if (Forgefather.refinement == 4) multimax += (.5);
+				if (Forgefather.refinement >= 4) multimax += (.5);
 			}
 			max *= multimax;//~245%
 			max = Math.round(max);//476 414,75
@@ -874,7 +874,7 @@ import classes.Scenes.NPCs.Forgefather;
 				if (Forgefather.refinement == 0) multimax += (.15);
 				if (Forgefather.refinement == 1) multimax += (.25);
 				if (Forgefather.refinement == 2 || Forgefather.refinement == 3) multimax += (.35);
-				if (Forgefather.refinement == 4) multimax += (.5);
+				if (Forgefather.refinement >= 4) multimax += (.5);
 			}
 			if (hasPerk(PerkLib.AscensionInnerPower)) max += perkv1(PerkLib.AscensionInnerPower) * 120;
 			if (jewelryEffectId == JewelryLib.MODIFIER_MP) max += jewelryEffectMagnitude;

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -745,7 +745,7 @@ use namespace CoC;
 				if (Forgefather.refinement == 0) armorDef *= (1.15);
 				if (Forgefather.refinement == 1) armorDef *= (1.25);
 				if (Forgefather.refinement == 2 || Forgefather.refinement == 3) armorDef *= (1.5);
-				if (Forgefather.refinement == 4) armorDef *= (2);
+				if (Forgefather.refinement >= 4) armorDef *= (2);
 			}
 			//if (flags[kFLAGS.GARGOYLE_BODY_MATERIAL] == 1) {
 				//if (arms.type == Arms.GARGOYLE || arms.type == Arms.GARGOYLE_2) armorDef += (30 * newGamePlusMod);
@@ -983,7 +983,7 @@ use namespace CoC;
 				if (Forgefather.refinement == 0) armorMDef *= (1.15);
 				if (Forgefather.refinement == 1) armorMDef *= (1.25);
 				if (Forgefather.refinement == 2 || Forgefather.refinement == 3) armorMDef *= (1.5);
-				if (Forgefather.refinement == 4) armorMDef *= (2);
+				if (Forgefather.refinement >= 4) armorMDef *= (2);
 			}
 			//if (flags[kFLAGS.GARGOYLE_BODY_MATERIAL] == 1) armorMDef += (25 * newGamePlusMod);
 			//if (flags[kFLAGS.GARGOYLE_BODY_MATERIAL] == 2) {
@@ -1690,7 +1690,7 @@ use namespace CoC;
 				if (Forgefather.refinement == 0) attack *= (1.15);
 				if (Forgefather.refinement == 1) attack *= (1.25);
 				if (Forgefather.refinement == 2 || Forgefather.refinement == 3) attack *= (1.5);
-				if (Forgefather.refinement == 4) attack *= (2);
+				if (Forgefather.refinement >= 4) attack *= (2);
 			}
 			if (hasStatusEffect(StatusEffects.ChargeWeapon)) {
 				if (weaponName == "fists" && !hasPerk(PerkLib.ImprovingNaturesBlueprintsNaturalWeapons)) attack += 0;
@@ -1792,7 +1792,7 @@ use namespace CoC;
 				if (Forgefather.refinement == 0) rangeattack *= (1.15);
 				if (Forgefather.refinement == 1) rangeattack *= (1.25);
 				if (Forgefather.refinement == 2 || Forgefather.refinement == 3) rangeattack *= (1.5);
-				if (Forgefather.refinement == 4) rangeattack *= (2);
+				if (Forgefather.refinement >= 4) rangeattack *= (2);
 			}
 		/*	if(hasPerk(PerkLib.LightningStrikes) && spe >= 60 && weaponRangePerk != "Large") {
 				rangeattack += Math.round((spe - 50) / 3);
@@ -7552,7 +7552,7 @@ use namespace CoC;
 				if (Forgefather.refinement == 0) max *= (1.15);
 				if (Forgefather.refinement == 1) max *= (1.25);
 				if (Forgefather.refinement == 2 || Forgefather.refinement == 3) max *= (1.35);
-				if (Forgefather.refinement == 4) max *= (1.5);
+				if (Forgefather.refinement >= 4) max *= (1.5);
 			}
 			if (hasPerk(PerkLib.ElementalBondFlesh) && statusEffectv1(StatusEffects.SummonedElementals) >= 2) max += maxHP_ElementalBondFleshMulti() * statusEffectv1(StatusEffects.SummonedElementals);
 			if (hasPerk(PerkLib.Soulless)) max = Math.round(max*0.5);

--- a/classes/classes/Races/GargoyleRace.as
+++ b/classes/classes/Races/GargoyleRace.as
@@ -138,6 +138,7 @@ public class GargoyleRace extends Race {
 						touBuff -= 20;
 						break;
 					case 4:
+					case 5:
 						intBuff += 500;
 						wisBuff += 250;
 						strBuff -= 30;
@@ -168,6 +169,7 @@ public class GargoyleRace extends Race {
 						intBuff -= 20;
 						break;
 					case 4:
+					case 5:
 						wisBuff += 500;
 						strBuff += 200;
 						intBuff -= 30;
@@ -201,6 +203,7 @@ public class GargoyleRace extends Race {
 						wisBuff -= 20;
 						break;
 					case 4:
+					case 5:
 						touBuff += 500;
 						strBuff += 250;
 						intBuff -= 30;
@@ -235,6 +238,7 @@ public class GargoyleRace extends Race {
 						wisBuff -= 20;
 						break;
 					case 4:
+					case 5:
 						strBuff += 500;
 						speBuff += 250;
 						intBuff -= 30;
@@ -269,6 +273,7 @@ public class GargoyleRace extends Race {
 						wisBuff -= 20;
 						break;
 					case 4:
+					case 5:
 						speBuff += 500;
 						strBuff += 125;
 						intBuff += 125;
@@ -289,13 +294,13 @@ public class GargoyleRace extends Race {
 		}
 		switch (Forgefather.channelInlay){
 			case "emerald":
-				if (Forgefather.refinement == 4) speBuff += 100;
+				if (Forgefather.refinement >= 4) speBuff += 100;
 				else if (Forgefather.refinement == 3) speBuff += 50;
 				break;
 		}
 		switch (Forgefather.gem){
 			case "emerald":
-				if (Forgefather.refinement == 4) speBuff += 50;
+				if (Forgefather.refinement >= 4) speBuff += 50;
 				else if (Forgefather.refinement == 3) speBuff += 25;
 				break;
 		}

--- a/classes/classes/Scenes/Combat/AbstractSpell.as
+++ b/classes/classes/Scenes/Combat/AbstractSpell.as
@@ -277,9 +277,9 @@ public class AbstractSpell extends CombatAbility {
 				}
 				if (player.statStore.hasBuff("AjidAji")) damage *= 1.3;
 				if (Forgefather.channelInlay == "ruby" && Forgefather.refinement == 3) damage *= 1.25
-				if (Forgefather.channelInlay == "ruby" && Forgefather.refinement == 4) damage *= 1.5
+				if (Forgefather.channelInlay == "ruby" && Forgefather.refinement >= 4) damage *= 1.5
 				if (Forgefather.gem == "ruby" && Forgefather.refinement == 3) damage *= 1.12
-				if (Forgefather.gem == "ruby" && Forgefather.refinement == 4) damage *= 1.25
+				if (Forgefather.gem == "ruby" && Forgefather.refinement >= 4) damage *= 1.25
 				damage *= combat.fireDamageBoostedByDao();
 				break;
 			}
@@ -287,9 +287,9 @@ public class AbstractSpell extends CombatAbility {
 				damage = calcVoltageMod(damage, casting);
 				if (player.hasPerk(PerkLib.ElectrifiedDesire)) damage *= (1 + (player.lust100 * 0.01));
 				if (Forgefather.channelInlay == "topaz" && Forgefather.refinement == 3) damage *= 1.25
-				if (Forgefather.channelInlay == "topaz" && Forgefather.refinement == 4) damage *= 1.5
+				if (Forgefather.channelInlay == "topaz" && Forgefather.refinement >= 4) damage *= 1.5
 				if (Forgefather.gem == "topaz" && Forgefather.refinement == 3) damage *= 1.12
-				if (Forgefather.gem == "topaz" && Forgefather.refinement == 4) damage *= 1.25
+				if (Forgefather.gem == "topaz" && Forgefather.refinement >= 4) damage *= 1.25
 				damage *= combat.lightningDamageBoostedByDao();
 				break;
 			}
@@ -299,18 +299,18 @@ public class AbstractSpell extends CombatAbility {
 				if (player.armor == armors.BLIZZ_K) damage *= 1.5;
 				if (player.headJewelry == headjewelries.SNOWFH) damage *= 1.3;
 				if (Forgefather.channelInlay == "sapphire" && Forgefather.refinement == 3) damage *= 1.25
-				if (Forgefather.channelInlay == "sapphire" && Forgefather.refinement == 4) damage *= 1.5
+				if (Forgefather.channelInlay == "sapphire" && Forgefather.refinement >= 4) damage *= 1.5
 				if (Forgefather.gem == "sapphire" && Forgefather.refinement == 3) damage *= 1.12
-				if (Forgefather.gem == "sapphire" && Forgefather.refinement == 4) damage *= 1.25
+				if (Forgefather.gem == "sapphire" && Forgefather.refinement >= 4) damage *= 1.25
 				damage *= combat.iceDamageBoostedByDao();
 				break;
 			}
 			case DamageType.DARKNESS: {
 				damage = calcEclypseMod(damage, casting);
 				if (Forgefather.channelInlay == "amethyst" && Forgefather.refinement == 3) damage *= 1.25
-				if (Forgefather.channelInlay == "amethyst" && Forgefather.refinement == 4) damage *= 1.5
+				if (Forgefather.channelInlay == "amethyst" && Forgefather.refinement >= 4) damage *= 1.5
 				if (Forgefather.gem == "amethyst" && Forgefather.refinement == 3) damage *= 1.12
-				if (Forgefather.gem == "amethyst" && Forgefather.refinement == 4) damage *= 1.25
+				if (Forgefather.gem == "amethyst" && Forgefather.refinement >= 4) damage *= 1.25
 				damage *= combat.darknessDamageBoostedByDao();
 				break;
 			}

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -8156,7 +8156,7 @@ public class Combat extends BaseContent {
             if (Forgefather.refinement == 0) unarmedMulti += (.15);
             if (Forgefather.refinement == 1) unarmedMulti += (.25);
             if (Forgefather.refinement == 2 || Forgefather.refinement == 3) unarmedMulti += (.5);
-            if (Forgefather.refinement == 4) unarmedMulti += (1);
+            if (Forgefather.refinement >= 4) unarmedMulti += (1);
         }
         if (player.statStore.hasBuff("CrinosShape") && player.hasPerk(PerkLib.ImprovingNaturesBlueprintsNaturalWeapons)) {
 			if (player.perkv1(IMutationsLib.FerasBirthrightIM) >= 2) unarmed *= 1.2;
@@ -17633,9 +17633,9 @@ public function greatDive():void {
     if (player.perkv1(IMutationsLib.HarpyHollowBonesIM) >= 2) damage *= 1.5;
     if (player.perkv1(IMutationsLib.HarpyHollowBonesIM) >= 3) damage *= 2;
     if (Forgefather.channelInlay == "emerald" && Forgefather.refinement == 3) damage *= 1.25;
-    if (Forgefather.channelInlay == "emerald" && Forgefather.refinement == 4) damage *= 1.5;
+    if (Forgefather.channelInlay == "emerald" && Forgefather.refinement >= 4) damage *= 1.5;
     if (Forgefather.gem == "emerald" && Forgefather.refinement == 3) damage *= 1.12;
-    if (Forgefather.gem == "emerald" && Forgefather.refinement == 4) damage *= 1.25;
+    if (Forgefather.gem == "emerald" && Forgefather.refinement >= 4) damage *= 1.25;
     outputText("You focus on [Themonster], ");
     if (player.statusEffectv2(StatusEffects.Flying) == 0) outputText("fold your wings and dive");
     if (player.statusEffectv2(StatusEffects.Flying) == 1) outputText("direct your "+player.weaponFlyingSwordsName+" downward");

--- a/classes/classes/Scenes/Combat/CombatMagic.as
+++ b/classes/classes/Scenes/Combat/CombatMagic.as
@@ -336,7 +336,7 @@ public class CombatMagic extends BaseCombatContent {
 			if (Forgefather.refinement == 0) mod += (.15);
 			if (Forgefather.refinement == 1) mod += (.25);
 			if (Forgefather.refinement == 2 || Forgefather.refinement == 3) mod += (.5);
-			if (Forgefather.refinement == 4) mod += (1);
+			if (Forgefather.refinement >= 4) mod += (1);
 		}
 		if (player.hasPerk(PerkLib.AscensionMysticality)) mod *= 1 + (player.perkv1(PerkLib.AscensionMysticality) * 0.1);
 		if (player.weapon == weapons.ASCENSU) mod *= 6.5;

--- a/classes/classes/Scenes/NPCs/Forgefather.as
+++ b/classes/classes/Scenes/NPCs/Forgefather.as
@@ -774,7 +774,7 @@ public class Forgefather extends NPCAwareContent implements SaveableState	{
 				player.destroyItems(consumables.SHEEPMK, 2);
 				player.destroyItems(consumables.ECTOPLS, 1);
 				player.destroyItems(consumables.GODMEAD, 1);
-				refinement++;
+				refinement = 3;
 				explorer.stopExploring();
 				camp.returnToCampUseTwelveHours();
 				return;
@@ -784,7 +784,7 @@ public class Forgefather extends NPCAwareContent implements SaveableState	{
 				player.destroyItems(consumables.COAL___, 2);
 				player.destroyItems(consumables.IRONWEED, 1);
 				player.destroyItems(consumables.LIGHTOL, 1);
-				refinement++
+				refinement = 4;
 				explorer.stopExploring();
 				camp.returnToCampUseTwelveHours();
 			}
@@ -1087,7 +1087,7 @@ public class Forgefather extends NPCAwareContent implements SaveableState	{
 				}
 			}
 
-			refinement++;
+			refinement = 5;
 			explorer.stopExploring();
 			addButton(0,"Return to camp", camp.returnToCampUseSixHours);
 		}

--- a/classes/classes/Scenes/NPCs/Forgefather.as
+++ b/classes/classes/Scenes/NPCs/Forgefather.as
@@ -197,8 +197,8 @@ public class Forgefather extends NPCAwareContent implements SaveableState	{
 		
 		public function introduceSelf():void {
 			flags[kFLAGS.FORGEFATHER_MOVED_TO_TEMPLE] = 1;
-			outputText("You introduce yourself to the being. /n/n");
-			outputText("Eyeing your quite solid form, he chuckles./n");
+			outputText("You introduce yourself to the being. \n\n");
+			outputText("Eyeing your quite solid form, he chuckles.\n");
 			outputText("\"<i>That's quite the stout form you have. I thought the demons destroyed all of your kind.</i>\"\n\n");
 			outputText("You respond, telling him of the Temple, and the 2 gargoyles now there. You describe you were a champion of your village, and how you willingly gave up your original form to inhabit the stony body.\n\n");
 			outputText("Surprised, the being exclaims.\n\n");
@@ -273,7 +273,6 @@ public class Forgefather extends NPCAwareContent implements SaveableState	{
 			material = "stone";
 			player.hairType = Hair.NORMAL;
 			player.faceType = Face.DEVIL_FANGS;
-			CoC.instance.transformations.TongueDemonic.applyEffect(false);
 			player.horns.type = Horns.GARGOYLE;
 			player.horns.count = 12 + rand(4);
 			player.beardLength = 0;
@@ -342,7 +341,7 @@ public class Forgefather extends NPCAwareContent implements SaveableState	{
 			player.legCount = 2;
 			player.eyes.type = Eyes.GEMSTONES;
 			player.antennae.type = Antennae.NONE;
-			player.tongue.type = Tongue.HUMAN;
+			player.tongue.type = Tongue.DEMONIC;
 			player.ears.type = Ears.ELFIN;
 			player.gills.type = Gills.NONE;
 			player.rearBody.type = RearBody.NONE;
@@ -426,13 +425,21 @@ public class Forgefather extends NPCAwareContent implements SaveableState	{
 			else if (refinement >= 5) addButtonDisabled(6, "Change Mat's", "You've crossed the rubicon, there is no" +
 					" turning back.");
 			else addButtonDisabled(6, "Change Mat's", "Maybe you should learn what the materials do first?");
-			if (refinementExplained) addButton(7, "Refine Body", refineBody).hint("Refine your form.");
+			if (refinementExplained) {
+				if (refinement < 4) {
+					addButton(7, "Refine Body", refineBody).hint("Refine your form.");
+				} else if (refinement == 4) {
+					addButtonDisabled(7, "Refine Body", "Your form can't be refined any further, unless you change materials.");
+				} else /*if (refinement >= 5)*/ {
+					addButtonDisabled(7, "Refine Body", "You've reached your final form, there is no turning back.");
+				}
+			}
 			else addButtonDisabled(7, "Refine Body", "Maybe you should learn about refining your form first?");
 			if (gemstonesExplained) addButton(8, "Change Inlays", inlayBody).hint("Set/Change your Inlays.");
 			else addButtonDisabled(8, "Change Inlays", "Maybe you should learn about inlays first?");
 			if (gemstonesExplained) addButton(9, "Change Gems", blingBody).hint("Set/Change your Gems.");
 			else addButtonDisabled(9, "Change Gems", "Maybe you should learn about Gemstones first?");
-			if (refinement == 4 && channelInlay != "" && gem != "") addButton(10, "What's Next", learnAboutAvatars).hint("You've come this far, what more can you do?")
+			if (refinement == 4 && !avatarsExplained && channelInlay != "" && gem != "") addButton(10, "What's Next", learnAboutAvatars).hint("You've come this far, what more can you do?")
 			else if (refinement == 4 && avatarsExplained && !celessScene.isAdult) addButtonDisabled(10, "Become" +
 					" Avatar", "You need to find a being of divine purity or corruption.")
 			else if (refinement == 4 && avatarsExplained && celessScene.isAdult) addButton(10, "Become the Avatar", gargoyleFinalForm).hint("Take the final step.")
@@ -760,6 +767,7 @@ public class Forgefather extends NPCAwareContent implements SaveableState	{
 				refinement++;
 				explorer.stopExploring();
 				camp.returnToCampUseSixHours();
+				return;
 			}
 			if (refinement == 2){
 				player.destroyItems(consumables.S_WATER, 2);
@@ -769,6 +777,7 @@ public class Forgefather extends NPCAwareContent implements SaveableState	{
 				refinement++;
 				explorer.stopExploring();
 				camp.returnToCampUseTwelveHours();
+				return;
 			}
 			if (refinement == 3){
 				player.destroyItems(consumables.ROUGHLN, 3);
@@ -1059,7 +1068,7 @@ public class Forgefather extends NPCAwareContent implements SaveableState	{
 			else{
 				outputText("Once you arrive at the Font of Power at the Oasis, you are floored by the sheer purity" +
 						" of the place. The water is clear and radiant, with not a ripple upon it's surface.\n\nThe" +
-						" Forgefather instructs you to lay in the font, with only your head remaining above the surface.\n\n);");
+						" Forgefather instructs you to lay in the font, with only your head remaining above the surface.\n\n");
 				outputText(celessScene.Name + " walks forward, with a look of holy serentity upon her face, her horn" +
 						" beginning to emit a cleansing light. Once at the Font's edge, she kneels down, touching" +
 						" the surface with her horn, resulting in a blinding eruption of light. As you lie blinded" +


### PR DESCRIPTION
### Gameplay changes
- Gargoyle final form could not be reached, because the dialogue with the Forgefather never went past "What's Next" because of a missing check for `!avatarsExplained` in the conditional.
- Upon reaching gargoyle final form, the stat boosts, damage buffs and so on weren't applied anymore, because the checks went only as far as checking for `Forgefather.refinement == 4`.
- Gargoyle race includes a demonic tongue (See `GargoyleRace.as`), but when becoming a gargoyle the tongue was first changed to a demonic tongue and then to a human one.
- If you refined your body with `refinement` at at least 1, all refinements till level 4 were applied at once, even if you lacked the mats due to missing `return`-statements in the function.
- The "Refine Body"-button is now disabled, when you can't be refined any further.
- Fixed a handful typos in two Forgefather scenes.

### Internal changes
  - Removed the pointless call to `CoC.instance.transformations.TongueDemonic.applyEffect(false);` as becoming a gargoyle is not a transformation.
    Using a simple `player.tongue.type = Tongue.DEMONIC;` instead.