### PR TITLE
Drider fixes

### DIFF
--- a/classes/classes/Races/SpiderRace.as
+++ b/classes/classes/Races/SpiderRace.as
@@ -39,16 +39,14 @@ public class SpiderRace extends Race {
 	public override function setup():void {
 		addScores()
 				.eyeType(Eyes.SPIDER, +1)
-				.earType(Ears.INSECT, +1)
+				.earType(ANY(Ears.INSECT, Ears.ELFIN), +1)
 				.faceType(Face.SPIDER_FANGS, +1)
 				.armType(Arms.SPIDER, +1)
 				.legType(LowerBody.CHITINOUS_SPIDER_LEGS, +1)
 				.legType(LowerBody.DRIDER, +2)
 				.tailType(Tail.SPIDER_ADBOMEN, +1)
-				.earType(Ears.ELFIN,1)
 				.skinCoatType(Skin.CHITIN, +1)
 				.hasStatusEffect(StatusEffects.BlackNipples,"black nipples", +1)
-				.rearType(RearBody.ATLACH_NACHA, 0, -5)
 				.hasPerk(PerkLib.SpiderOvipositor, +1)
 		
 		addBloodline(PerkLib.SpidersDescendant, PerkLib.BloodlineSpider);

--- a/res/model.xml
+++ b/res/model.xml
@@ -4958,7 +4958,7 @@
 				<show part="tail/demon$taur"/>
 			</case>
 			<case values="Tail.SPIDER_ADBOMEN">
-				<if test="lowerBody != LowerBody.ATLACH_NACHA">
+				<if test="lowerBody != LowerBody.DRIDER && lowerBody != LowerBody.ATLACH_NACHA">
 					<show part="tail_bg/spider$taur"/>
 				</if>
 			</case>


### PR DESCRIPTION
- Spider/Drider race scoring penalized you, when you didn't have an atlach nacha rear body.
- When you had a drider lower body, the spider abdomen wasn't hidden from charview.