### PR TITLE
Fix permanent transformations not updating racial paragon correctly

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -2593,7 +2593,7 @@ public final class Mutations extends MutationsHelper {
         outputText("\n<b>Upgraded Ability: Hellfire -> tripple effect</b>");
         outputText("\n<b>Gained Ability: Terrifying Howl</b>");
         if (player.hasPerk(PerkLib.RacialParagon))
-            flags[kFLAGS.APEX_SELECTED_RACE] = Races.CERBERUS;
+            flags[kFLAGS.APEX_SELECTED_RACE] = Races.CERBERUS.id;
         IMutationsLib.HellhoundFireBallsIM.trueMutation = true;
         IMutationsLib.AlphaHowlIM.trueMutation = true;
 
@@ -2959,7 +2959,7 @@ public final class Mutations extends MutationsHelper {
         player.createPerk(PerkLib.Soulless, 0, 0, 0, 0);
         outputText("\n<b>Gained Perk: Transformation Immunity!</b> "+ PerkLib.TransformationImmunity2.desc());
         player.createPerk(PerkLib.TransformationImmunity2, 6, 0, 0, 0);
-        if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.IMP;
+        if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.IMP.id;
         IMutationsLib.BlackHeartIM.trueMutation = true;
         IMutationsLib.FiendishMetabolismIM.trueMutation = true;
         IMutationsLib.FiendishBallsIM.trueMutation = true;
@@ -15775,7 +15775,7 @@ public final class Mutations extends MutationsHelper {
         outputText("\n<b>Obtained perk: Conviction Of Purpose</b>  "+PerkLib.ConvictionOfPurpose.desc());
         outputText("\n<b>Gained Perk: Transformation Immunity!</b> "+ PerkLib.TransformationImmunity2.desc());
         player.createPerk(PerkLib.TransformationImmunity2, 5, 0, 0, 0);
-        if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.AZAZEL;
+        if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.AZAZEL.id;
         player.removeAllRacialMutation();
         player.refillHunger(10);
         flags[kFLAGS.TIMES_TRANSFORMED] += changes;

--- a/classes/classes/Scenes/Areas/Desert/AnubisScene.as
+++ b/classes/classes/Scenes/Areas/Desert/AnubisScene.as
@@ -98,7 +98,7 @@ public function anubisWonAndMummifyPC(genderA:Number = 0):void {
 	player.createPerk(PerkLib.LifeLeech, 0, 0, 0, 0);
 	player.createPerk(PerkLib.Undeath, 0, 0, 0, 0);
 	if (player.hasPerk(PerkLib.RacialParagon))
-		flags[kFLAGS.APEX_SELECTED_RACE] = Races.MUMMY;
+		flags[kFLAGS.APEX_SELECTED_RACE] = Races.MUMMY.id;
 	player.createPerk(PerkLib.EnergyDependent, 0, 0, 0, 0);
 	if (flags[kFLAGS.HAIR_GROWTH_STOPPED_BECAUSE_LIZARD] == 0) flags[kFLAGS.HAIR_GROWTH_STOPPED_BECAUSE_LIZARD]++;
 	var item:ItemType;

--- a/classes/classes/Scenes/Areas/Desert/SandWormScene.as
+++ b/classes/classes/Scenes/Areas/Desert/SandWormScene.as
@@ -92,7 +92,7 @@ public class SandWormScene extends BaseContent
 		player.tallness = 11 * 12;
 		transformations.LowerBodyWorm.applyEffect(false);
 		player.skin.setBaseOnly({ type: Skin.PLAIN, color1:"light pink", adj: "slippery" });
-		if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.SANDWORM;
+		if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.SANDWORM.id;
 		IMutationsLib.TrachealSystemIM.trueMutation = true;
 		IMutationsLib.TwinHeartIM.trueMutation = true;
 		player.removeAllRacialMutation();

--- a/classes/classes/Scenes/Areas/GlacialRift/WendigoScene.as
+++ b/classes/classes/Scenes/Areas/GlacialRift/WendigoScene.as
@@ -140,7 +140,7 @@ package classes.Scenes.Areas.GlacialRift
 			player.createPerk(PerkLib.EndlessHunger, 0, 0, 0, 0);
 			player.createPerk(PerkLib.WendigoCurse, 0, 0, 0, 0);
 			if (player.hasPerk(PerkLib.RacialParagon))
-				flags[kFLAGS.APEX_SELECTED_RACE] = Races.WENDIGO;
+				flags[kFLAGS.APEX_SELECTED_RACE] = Races.WENDIGO.id;
 			player.hunger = 80;
 			endEncounter();
 		}

--- a/classes/classes/Scenes/Dungeons/DeepCave/ValaScene.as
+++ b/classes/classes/Scenes/Dungeons/DeepCave/ValaScene.as
@@ -848,7 +848,7 @@ public class ValaScene extends BaseContent implements SaveableState
 				if (player.breastRows[0].breastRating < 4 && rand(3) == 0) growth++;
 			}
 			player.createPerk(PerkLib.TransformationImmunity2, 4, 0, 0, 0);
-			if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.FAIRY;
+			if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.FAIRY.id;
 			IMutationsLib.FeyArcaneBloodstreamIM.trueMutation = true;
 			player.removeAllRacialMutation();
 			player.createPerk(PerkLib.QueenOfTheFairies, 0, 0, 0, 0);

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/AtlachNachaScene.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/AtlachNachaScene.as
@@ -85,7 +85,7 @@ public class AtlachNachaScene extends BaseContent {
         if (player.tailRecharge < 15) player.tailRecharge = 15;
         player.createPerk(PerkLib.SpiderOvipositor,0,0,0,0);
         player.createPerk(PerkLib.TransformationImmunity2,1,0,0,0);
-        if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.ATLACH_NACHA;
+        if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.ATLACH_NACHA.id;
         player.createPerk(PerkLib.Venomancy, 0, 0, 0, 0);
 		outputText("\n\nEverything makes so much sense now. You were blind to the truth but thanks to the voice of the master in your head your eyes are now open. You have access to knowledge you thought you didn't possess about your reality and the reality between the reality. ");
 		outputText("Such knowledge is not for your mind alone though you want to share it with the world. Their blindness and mind untouched by him is a disease and you just happen to have the cure.  (<b>Gained Perk: Insanity!</b>)");

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/DraculinaScene.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/DraculinaScene.as
@@ -196,7 +196,7 @@ public class DraculinaScene extends BaseContent {
 		IMutationsLib.BlackHeartIM.trueMutation = true;
         IMutationsLib.VampiricBloodstreamIM.trueMutation = true;
         IMutationsLib.HollowFangsIM.trueMutation = true;
-        if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.DRACULA;
+        if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.DRACULA.id;
         player.removeAllRacialMutation();
         outputText("\n<b>Gained Perk: Soulless!</b> "+PerkLib.Soulless.desc());
         player.createPerk(PerkLib.Soulless, 0, 0, 0, 0);

--- a/classes/classes/Scenes/Places/HeXinDao/JourneyToTheEast.as
+++ b/classes/classes/Scenes/Places/HeXinDao/JourneyToTheEast.as
@@ -583,7 +583,7 @@ public class JourneyToTheEast extends HeXinDaoAbstractContent implements Saveabl
 			player.createPerk(PerkLib.LifeLeech, 0, 0, 0, 0);
 			player.createPerk(PerkLib.Undeath, 0, 0, 0, 0);
 			if (player.hasPerk(PerkLib.RacialParagon))
-				flags[kFLAGS.APEX_SELECTED_RACE] = Races.JIANGSHI;
+				flags[kFLAGS.APEX_SELECTED_RACE] = Races.JIANGSHI.id;
 			player.createPerk(PerkLib.EnergyDependent, 0, 0, 0, 0);
 			if (flags[kFLAGS.HAIR_GROWTH_STOPPED_BECAUSE_LIZARD] == 0) flags[kFLAGS.HAIR_GROWTH_STOPPED_BECAUSE_LIZARD]++;
 			var item:ItemType;

--- a/classes/classes/Scenes/Places/TempleOfTheDivine/PlayerGargoyleBuilder.as
+++ b/classes/classes/Scenes/Places/TempleOfTheDivine/PlayerGargoyleBuilder.as
@@ -382,7 +382,7 @@ use namespace CoC;
 			if (player.hasPerk(PerkLib.FutaFaculties)) player.removePerk(PerkLib.FutaFaculties);
 			player.createPerk(PerkLib.TransformationImmunity, 0, 0, 0, 0);
 			if (player.hasPerk(PerkLib.RacialParagon))
-				flags[kFLAGS.APEX_SELECTED_RACE] = Races.GARGOYLE;
+				flags[kFLAGS.APEX_SELECTED_RACE] = Races.GARGOYLE.id;
 			player.updateRacialAndPerkBuffs();
 			player.destroyItems(useables.SOULGEM, 1);
 			outputText("After the weird feelings subside, you pick up what is your actual pedestal and move it to your camp.\n\n");

--- a/classes/classes/Scenes/Places/TheTrench.as
+++ b/classes/classes/Scenes/Places/TheTrench.as
@@ -689,7 +689,7 @@ private function theTrenchGraydaQuestNPCMissionsCoronationFinalPart1():void {
 	outputText("\"<i>Eh? Did I play with my toy too hard? Dammit! I didn’t even get to wrap her into the fold.</i>\" She tosses your limp, cold body to the side.\n\n");
 	outputText("It hurts… so much…\n\n");
 	outputText("Your consciousness slowly comes to halt as your body feels like it’s overloading with foul otherworldly magic. However, before you slip into the dark, you're able to see a light blue glow emanating from where your heart used to beat, spreading an icy cold sensation to every part it touches.\n\n");
-	if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.ARIGEAN;
+	if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.ARIGEAN.id;
 	IMutationsLib.ArigeanAssociationCortexIM.trueMutation = true;
 	player.removeAllRacialMutation();
 	player.tailType = Tail.ARIGEAN_PRINCESS;

--- a/classes/classes/Scenes/Places/WoodElves.as
+++ b/classes/classes/Scenes/Places/WoodElves.as
@@ -648,7 +648,7 @@ public class WoodElves extends BaseContent implements SaveableState {
 			player.createPerk(PerkLib.BlessingOfTheAncestorTree,0,0,0,0);
 			player.createPerk(PerkLib.CovenantOfTheSpirits,0,0,0,0);
 			if (player.hasPerk(PerkLib.RacialParagon))
-				flags[kFLAGS.APEX_SELECTED_RACE] = Races.WOODELF;
+				flags[kFLAGS.APEX_SELECTED_RACE] = Races.WOODELF.id;
 			IMutationsLib.ElvishPeripheralNervSysIM.trueMutation = true;
 			player.removeAllRacialMutation();
 			explorer.stopExploring();


### PR DESCRIPTION
### Gameplay changes
When you have the Racial Paragon perk, permanent TFs, like fairy queen for example didn't update the racial paragon race correctly, so you had to manually set it afterwards.
This should be fixed now for the ones I've found with a quick regex search and replace.

### Notes
For example Fairy Queen TF used:
```as3
if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.FAIRY;
```
instead of:
```as3
if (player.hasPerk(PerkLib.RacialParagon)) flags[kFLAGS.APEX_SELECTED_RACE] = Races.FAIRY.id;
```

Fixed that with a quick regex replace `(flags\[kFLAGS.APEX_SELECTED_RACE\] *= *Races\.\w+);` with `$1.id;`