### PR TITLE
Fix for active true mutations not being saved

### DIFF
--- a/classes/classes/IMutationPerkType.as
+++ b/classes/classes/IMutationPerkType.as
@@ -84,12 +84,11 @@ public class IMutationPerkType extends PerkType
 		private var _maxLvl:int;
 		private var _slot:String;
 		private var _pBuffs:Object = {};
-		private var _trueVariant:Boolean;
 		private static var _IMvalid:Object = {};
 		private static var _IMNotvalid:Object = {};
 
 
-		public function IMutationPerkType(id:String, name:String, slot:String, maxLvl:int, trueVariant:Boolean = false) {
+		public function IMutationPerkType(id:String, name:String, slot:String, maxLvl:int) {
 			//GDI probably pre-initialization issue again
 			if (_IMvalid.hasOwnProperty(id)) {
 				name += "_errorIM"
@@ -100,7 +99,6 @@ public class IMutationPerkType extends PerkType
 			super(id, name, name, name, false);
 			this._maxLvl = maxLvl;
 			this._slot = slot;
-			this._trueVariant = trueVariant;
 			(MutationsBySlot[slot] ||= []).push(this);
 		}
 
@@ -120,10 +118,19 @@ public class IMutationPerkType extends PerkType
 		}
 
 		public function get trueMutation():Boolean{
-			return _trueVariant;
+			return player.trueMutations.indexOf(this.id) != -1;
 		}
 		public function set trueMutation(isTrue:Boolean):void{
-			_trueVariant = isTrue;
+			var tmIndex:int = player.trueMutations.indexOf(this.id);
+			if (isTrue) { // Add it to the true mutations array
+				if (tmIndex == -1) { // ... but only, if it's not already added to avoid dupes.
+					player.trueMutations.push(this.id);
+				}
+			} else {      // Remove it from the true mutations array
+				if (tmIndex != -1) { // ... but only, if it's listed.
+					player.trueMutations.splice(tmIndex, 1);
+				}
+			}
 		}
 		public function evolveText():String {
 			var descS:String = "";

--- a/classes/classes/IMutations/AlphaHowlMutation.as
+++ b/classes/classes/IMutations/AlphaHowlMutation.as
@@ -79,7 +79,7 @@ public class AlphaHowlMutation extends IMutationPerkType
         }
 
         public function AlphaHowlMutation() {
-            super(mName + " IM", mName, SLOT_LUNGS, 4, false);
+            super(mName + " IM", mName, SLOT_LUNGS, 4);
         }
     }
 }

--- a/classes/classes/IMutations/MutationTemplate.as
+++ b/classes/classes/IMutations/MutationTemplate.as
@@ -68,7 +68,7 @@ import classes.PerkClass;
 
         public function MutationTemplate() {
             // replace SLOT_NONE with other SLOT_XXXX constant
-            super(mName + " IM", mName, SLOT_NONE, 3, true);
+            super(mName + " IM", mName, SLOT_NONE, 3);
         }
 
     }

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -235,6 +235,9 @@ use namespace CoC;
 		//Only used in survival and realistic mode
 		public var hunger:Number = 0;
 
+		//Store all active/true IMutations
+		public var trueMutations:Array = [];
+
 		//Perks used to store 'queued' perk buys
 		public var perkPoints:Number = 0;
 		public var statPoints:Number = 0;

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -957,6 +957,9 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 			saveFile.data.breastRows[i].fullness = player.breastRows[i].fullness;
 		}
 
+		//Set true IMutations Array
+		saveFile.data.trueMutations = player.trueMutations;
+
 		//Set Perk Array
 		//Populate Perk Array
 		player.perks.forEach(function (perk:PerkClass, ...args):void {
@@ -2138,6 +2141,9 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		mutationsShift.push(IMutationsLib.MutationsTemplateIM.id);
 		//Possibly ID updating.
 
+		//Set true IMutations Array
+		player.trueMutations = saveFile.data.trueMutations || [];
+		
 		//Populate Perk Array
 		for (i = 0; i < saveFile.data.perks.length; i++)
 		{


### PR DESCRIPTION
### Description
When the player gets permanently TFed he or she gets some true mutations, but the setting wasn't stored for the player and therefore not stored in the save game. Instead the property was set to true in the IMutation-class itself. This led to two issues:
First off, when you get a true mutation, like for example Twin Heart from the sand worm permTF and then load a save where you are not permanently TFed, you'll still have the true mutation active, so I still got that mutation without Evangeline when switching back to my dragon-taur.
Then, when you close the game client and load it again later, the setting is reverted to false.

### Gameplay changes
True mutations are now set at player level instead of in the IMutation-class so it can be stored in the saves now. Additionally it's not persistent anymore until you close and reopen the game client, which caused potentially unwanted behavior.

### Internal changes
I've updated the setter and the getter for `trueMutation` in `classes/classes/IMutationPerkType.as` to save the value at player-level instead, see the snippet for the getter and setter:
```as3
public function get trueMutation():Boolean{
	return player.trueMutations.indexOf(this.id) != -1;
}
public function set trueMutation(isTrue:Boolean):void{
	var tmIndex:int = player.trueMutations.indexOf(this.id);
	if (isTrue) { // Add it to the true mutations array
		if (tmIndex == -1) { // ... but only, if it's not already added to avoid dupes.
			player.trueMutations.push(this.id);
		}
	} else {      // Remove it from the true mutations array
		if (tmIndex != -1) { // ... but only, if it's listed.
			player.trueMutations.splice(tmIndex, 1);
		}
	}
}
```
