### PR TITLE
Fixing minor errors in arch imp TF and the old charviewer

### DIFF
--- a/classes/classes/Scenes/Camp/UniqueCampScenes.as
+++ b/classes/classes/Scenes/Camp/UniqueCampScenes.as
@@ -221,7 +221,7 @@ private function impTomeGiveIn():void {
 	if (player.hasVagina())outputText(" fucking your fertile imp cunt to birth the new legion of servants obediant to your royal will");
 	outputText(" comes to your mind and makes you smirk wickedly.[pg]");
 	outputText("Yea the idea of taking over the world by storm as the strongest imp gives you chills of pleasure,");
-	outputText("[if (hasock) your cock hardening][if (hascock && hasvagina) and][if (hasvagina) your snatch drooling] at the prospect, the thought nearly bringing you to a spontaneous orgasm.[pg]");
+	outputText("[if (hascock) your cock hardening][if (hascock == true && hasvagina == true) and][if (hasvagina) your snatch drooling] at the prospect, the thought nearly bringing you to a spontaneous orgasm.[pg]");
 	outputText("Done examining your new personal abode, you exit by the way you came parting the vaginal gate and leaving the book more or less the same way you got in.[pg]");
 	outputText("Back in your camp you prepare your battle plans for world domination. First, you will need more imps.[pg]");
 	CoC.instance.mutations.archImpTFforce(player);

--- a/res/model.xml
+++ b/res/model.xml
@@ -1474,7 +1474,7 @@
 		<cell rect="161,380,49,29" name="balls/Bscalessillyhuge" dx="79" dy="106"/>
 		<cell rect="balls/Bscalessillyhuge" name="balls_taur/Bscalessillyhugehuge_taur" dx="121" dy="131"/>
 		<cell rect="161,560,49,36" name="balls/Bscalesgigahuge" dx="82" dy="114"/>
-		<cell rect="balls/Bscalesmall" name="balls/Bdscalesmall" dx="79" dy="104"/>
+		<cell rect="balls/Bscalesmall" name="balls/Bdscalessmall" dx="79" dy="104"/>
 		<cell rect="balls/Bscaleslarge" name="balls/Bdscaleslarge" dx="79" dy="104"/>
 		<cell rect="balls/Bscaleshuge" name="balls/Bdscaleshuge" dx="79" dy="105"/>
 		<cell rect="balls/Bscalessillyhuge" name="balls/Bdscalessillyhuge" dx="79" dy="106"/>
@@ -1706,7 +1706,7 @@
 		<cell rect="111,599,49,29" name="pussy/chitin" dx="80" dy="99"/>
 		<cell rect="pussy/chitin" name="pussy/bee" dx="80" dy="99"/>
 		<cell rect="161,599,49,29" name="pussy/scales" dx="80" dy="99"/>
-		<cell rect="pussy/scales" name="pussy/dscale" dx="80" dy="99"/>
+		<cell rect="pussy/scales" name="pussy/dscales" dx="80" dy="99"/>
 		<cell rect="pussy/scales" name="pussy/shark" dx="80" dy="99"/>
 		<cell rect="211,599,49,29" name="pussy/orca" dx="80" dy="99"/>
 		<cell rect="261,599,49,29" name="overpussy/neonblue" dx="80" dy="99"/>


### PR DESCRIPTION
### Gameplay changes
- Due to typos in the parser code the text 'your cock hardening and your snatch drooling' (variant for herms) in the arch imp TF wasn't showing up properly.
- Typos in the model.xml (old charviewer) caused smol dragon balls and dragon pussy not to show up.

### Internal changes
Typos in the parser code for the arch imp TF caused the text for male and herm PC not to show up correctly.

Fixed that by replacing:
```as3
outputText("[if (hasock) your cock hardening][if (hascock && hasvagina) and][if (hasvagina) your snatch drooling] at the prospect, the thought nearly bringing you to a spontaneous orgasm.[pg]"); 
```
with:
```as3
outputText("[if (hascock) your cock hardening][if (hascock == true && hasvagina == true) and][if (hasvagina) your snatch drooling] at the prospect, the thought nearly bringing you to a spontaneous orgasm.[pg]"); 
```
---
Fixed two typos in the `res/model.xml`:
```xml
<cell rect="pussy/scales" name="pussy/dscale" dx="80" dy="99"/>
<cell rect="balls/Bscalesmall" name="balls/Bdscalesmall" dx="79" dy="104"/>
```
pussy/dscale → pussy/dscales
balls/Bdscalesmall → balls/Bdscalessmall

This had caused the following errors while debugging:
```
[ERROR] No such part 'pussy/dscales'
[ERROR] No such part 'balls/Bdscalessmall'
```

And as a result smol dragon balls and dragon pussy weren't loading in the charviewer.