### PR TITLE
Fixed swapped Dark Ascension Perk descriptions

### DIFF
--- a/classes/classes/Perks/DarkAscensionBottomlessHungerPerk.as
+++ b/classes/classes/Perks/DarkAscensionBottomlessHungerPerk.as
@@ -14,12 +14,12 @@ package classes.Perks
 		override public function desc(params:PerkClass = null):String
 		{
 			if (!player || !params) return _desc;
-			return "(Rank: " + params.value1 + "/" + CoC.instance.charCreation.MAX_BOTTOMLESS_HUNGER_LEVEL + ") Decrease the cost of upgrading yourself through demonic energy by " + params.value1 * 5 + "%.";
+			return "(Rank: " + params.value1 + "/" + CoC.instance.charCreation.MAX_BOTTOMLESS_HUNGER_LEVEL + ") Raise max demonic energy capacity by " + params.value1 * 5 + "%.";
 		}
 		
 		public function DarkAscensionBottomlessHungerPerk() 
 		{
-			super("Dark Ascension: Bottomless hunger", "Dark Ascension: Bottomless hunger", "", "Decrease the cost of upgrading yourself through demonic energy by 5%.");
+			super("Dark Ascension: Bottomless hunger", "Dark Ascension: Bottomless hunger", "", "Raise max demonic energy capacity by 5% per level.");
 		}
 		
 		override public function keepOnAscension(respec:Boolean = false):Boolean

--- a/classes/classes/Perks/DarkAscensionEfficientSoulConsumptionPerk.as
+++ b/classes/classes/Perks/DarkAscensionEfficientSoulConsumptionPerk.as
@@ -14,12 +14,12 @@ package classes.Perks
 		override public function desc(params:PerkClass = null):String
 		{
 			if (!player || !params) return _desc;
-			return "(Rank: " + params.value1 + "/" + CoC.instance.charCreation.MAX_EFFICIENT_SOUL_CONSUMPTION_LEVEL + ") Raise max demonic energy capacity by " + params.value1 * 5 + "%.";
+			return "(Rank: " + params.value1 + "/" + CoC.instance.charCreation.MAX_EFFICIENT_SOUL_CONSUMPTION_LEVEL + ") Decrease the cost of upgrading yourself through demonic energy by " + params.value1 * 5 + "%.";
 		}
 		
 		public function DarkAscensionEfficientSoulConsumptionPerk() 
 		{
-			super("Dark Ascension: Efficient Soul Consumption", "Dark Ascension: Efficient Soul Consumption", "", "Raise max demonic energy capacity by 5% per level.");
+			super("Dark Ascension: Efficient Soul Consumption", "Dark Ascension: Efficient Soul Consumption", "", "Decrease the cost of upgrading yourself through demonic energy by 5%.");
 		}
 		
 		override public function keepOnAscension(respec:Boolean = false):Boolean


### PR DESCRIPTION
Perk descriptions for 'Dark Ascension: Efficient Soul Consumption' and 'Dark Ascension: Bottomless hunger' were swapped. Corrected that.