### PR TITLE
Cap for Kirin and Minotaur horns length

### DIFF
--- a/classes/classes/Items/Consumables/AsumaKirin.as
+++ b/classes/classes/Items/Consumables/AsumaKirin.as
@@ -284,7 +284,7 @@ public class AsumaKirin extends Consumable {
 		if (player.horns.type == Horns.KIRIN || player.horns.type == Horns.NONE) {
 			//Get bigger if player has horns
 			if (player.horns.type == Horns.KIRIN) {
-				{
+				if (player.horns.count < 40) {
 					temp = 1 + rand(3);
 					player.horns.count += temp;
 					if (temp == 0) changes--;
@@ -296,6 +296,8 @@ public class AsumaKirin extends Consumable {
 					if (player.horns.count >= 6 && player.horns.count < 12) outputText("It look like the horn on a grown kirin, big enough and dangerous enough to do some damage.");
 					if (player.horns.count >= 12 && player.horns.count < 20) outputText("It is large and wicked looking.");
 					if (player.horns.count >= 20) outputText("It is a large, pointed and spiraling horn.");
+					// cap the horns length at 40
+					if (player.horns.count > 40) player.horns.count = 40;
 					changes++;
 				}
 			}

--- a/classes/classes/Items/Consumables/MinotaurBlood.as
+++ b/classes/classes/Items/Consumables/MinotaurBlood.as
@@ -293,7 +293,7 @@ public class MinotaurBlood extends Consumable {
 						changes++;
 					}
 					//Males horns get 'uge.
-					else {
+					else if (player.horns.count < 40) {
 						temp = 1 + rand(3);
 						player.horns.count += temp;
 						if (temp == 0) changes--;
@@ -311,6 +311,7 @@ public class MinotaurBlood extends Consumable {
 							player.hoursSinceCum += 200;
 							dynStats("lus", 20, "scale", false);
 						}
+						if (player.horns.count > 40) player.horns.count = 40;
 						changes++;
 					}
 				}


### PR DESCRIPTION
By using Minotaur Blood or Asuma Kirin your horn length had no limit, but when using the gore attack it is capped at 40. So at 40+ horn length you'd waste transformatives. Therefore I've added, that the transformative doesn't grow those horns beyond a length of 40.

There ought to be more TFs, that can grow horns longer, than 40, but so far I've only checked kirin and minotaur TF.