### PR TITLE
fix demonChanges

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -12891,6 +12891,12 @@ public final class Mutations extends MutationsHelper {
             transformations.FaceDemon.applyEffect();
             flags[kFLAGS.TIMES_TRANSFORMED]++;
         }
+		//Elfin ears
+		if (player.faceType == Face.DEMON && player.ears.type != Ears.ELFIN && rand(3) == 0) {
+			outputText("[pg]");
+			transformations.EarsElfin.applyEffect();
+			flags[kFLAGS.TIMES_TRANSFORMED]++;
+		}
         //Demon tongue
         if (player.tongue.type != Tongue.DEMONIC && rand(2) == 0) {
             outputText("[pg]");
@@ -12898,7 +12904,7 @@ public final class Mutations extends MutationsHelper {
             flags[kFLAGS.TIMES_TRANSFORMED]++;
         }
 		//Demon/Devil eyes
-		if (player.faceType == Face.DEMON && (transformations.EyesDemon.isPossible() || transformations.EyesDevil.isPossible() || transformations.EyesDemonColors.isPossible()) && changes < changeLimit && rand(3) == 0) {
+		if (player.faceType == Face.DEMON && (transformations.EyesDemon.isPossible() || transformations.EyesDevil.isPossible() || transformations.EyesDemonColors.isPossible()) && rand(3) == 0) {
 			if (transformations.EyesDemonColors.isPossible()) {
 				transformations.EyesDemonColors.applyEffect();
 			}
@@ -12906,19 +12912,19 @@ public final class Mutations extends MutationsHelper {
 				if (rand(2) == 0) transformations.EyesDemon.applyEffect();
 				else transformations.EyesDevil.applyEffect();
 			}
-			changes++;
+			flags[kFLAGS.TIMES_TRANSFORMED]++;
 		}
         //-Remove feather-arms (copy this for goblin ale, mino blood, equinum, centaurinum, canine pepps, demon items)
-        if (changes < changeLimit && !InCollection(player.arms.type, Arms.HUMAN) && rand(4) == 0) {
+        if (!InCollection(player.arms.type, Arms.HUMAN, Arms.DEMON) && rand(4) == 0) {
             outputText("[pg]");
             transformations.ArmsHuman.applyEffect();
-            changes++;
+            flags[kFLAGS.TIMES_TRANSFORMED]++;
         }
 		//arms changes - requires furless
 		if (player.hasPlainSkinOnly() && player.arms.type == Arms.HUMAN && player.arms.type != Arms.DEMON && rand(3) == 0) {
 			outputText("[pg]");
             transformations.ArmsDemon.applyEffect();
-            changes++;
+            flags[kFLAGS.TIMES_TRANSFORMED]++;
 		}
         //foot changes - requires furless
         if (player.hasPlainSkinOnly() && rand(3) == 0) {

--- a/classes/classes/Scenes/Dungeons/Factory.as
+++ b/classes/classes/Scenes/Dungeons/Factory.as
@@ -1642,39 +1642,7 @@ use namespace CoC;
 
 		private function goDemonSharedEnd():void {
 			clearOutput();
-			player.skin.setBaseOnly({type:Skin.PLAIN, color1:"blue", pattern: Skin.PATTERN_DEMONIC_PLEASURE_RUNE});
-			if (!InCollection(player.skinColor1, DemonRace.DemonSkinColors) && !InCollection(player.skinColor2, DemonRace.DemonSkin2Colors)) {
-				var choice1:String = randomChoice(DemonRace.DemonSkinColors);
-                var choice2:String = randomChoice(DemonRace.DemonSkin2Colors);
-                player.skinColor1 = choice1;
-                player.skinColor2 = choice2;
-			}
-			if (player.hasCock()) player.lowerBody = LowerBody.DEMONIC_CLAWS;
-			else {
-				if (rand(2) == 0) player.lowerBody = LowerBody.DEMONIC_CLAWS;
-				else {
-					if (rand(2) == 0) player.lowerBody = LowerBody.DEMONIC_HIGH_HEELS;
-					else player.lowerBody = LowerBody.DEMONIC_GRACEFUL_FEET;
-				}
-			}
-			player.legCount = 2;
-			transformations.TailDemonic.applyEffect(false);
-			transformations.HairHuman.applyEffect(false);
-			transformations.FaceDemon.applyEffect(false);
-			transformations.EyesDemon.applyEffect(false);
-			transformations.ArmsDemon.applyEffect(false);
-			transformations.TongueDemonic.applyEffect(false);
-			transformations.EarsElfin.applyEffect(false);
-			transformations.HornsDemonic.applyEffect(false);
-			transformations.AntennaeNone.applyEffect(false);
-			transformations.GillsNone.applyEffect(false);
-			transformations.WingsDemonicLarge.applyEffect(false);
-			transformations.RearBodyNone.applyEffect(false);
-			if (player.hasCock()) transformations.CockDemon().applyEffect(false);
-			if (player.hasVagina()) transformations.VaginaDemonic().applyEffect(false);
-			outputText("\n<b>Gained Perk: Soulless!</b> "+PerkLib.Soulless.desc());
-			player.createPerk(PerkLib.Soulless, 0, 0, 0, 0);
-			player.npcsThatLeaveSoullessPC();
+			consumables.DEMONME.demonizePlayer();
 			if (player.level < 25) inventory.takeItem(consumables.LETHITE, playerMenu);
 			else if (player.level < 50) inventory.takeItem(consumables.LETH1TE, playerMenu);
 			else if (player.level < 75) inventory.takeItem(consumables.LETH2TE, playerMenu);


### PR DESCRIPTION
Somehow I couldn't get the demon eyes TF, no matter how many Incubi Drafts and Succubi Milks I guzzled. Got that fixed by removing the check for `changes < changeLimit`, along with a few more checks for `changes < changeLimit`.

After fixing this, the TF alternated between human and demon arms, so I fixed that.

Additionally there was a mishmash of `flags[kFLAGS.TIMES_TRANSFORMED]++;` vs. `changes++;` and because the latter wasn't applied at the end, I've replaced them with the former.

**Update:** Turning the player into a demon with the help of the secretary succubus in the factory was still hardcoded. I've changed that to call the shared demonizePlayer-method in the DemonizeMe-class. This is mostly and internal change and should only affect gameplay minimally, if any.