### PR TITLE
Fix not counting basilisk womb births towards times given birth

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -7640,6 +7640,18 @@ use namespace CoC;
 			else if (isAlraune()) knockUp(PregnancyStore.PREGNANCY_ALRAUNE, PregnancyStore.INCUBATION_ALRAUNE);
 		}
 
+		public function updateBirthedCount():void {
+			if (!hasStatusEffect(StatusEffects.Birthed)) {
+				createStatusEffect(StatusEffects.Birthed,1,0,0,0);
+			} else {
+				addStatusValue(StatusEffects.Birthed,1,1);
+				if(!hasPerk(PerkLib.BroodMother) && statusEffectv1(StatusEffects.Birthed) >= 10) {
+					EngineCore.outputText("\n<b>You have gained the Brood Mother perk</b> (Pregnancies progress twice as fast as a normal woman's).\n");
+					createPerk(PerkLib.BroodMother,0,0,0,0);
+				}
+			}
+		}
+
 		protected override function maxHP_base():Number {
 			var max:Number = super.maxHP_base();
 			if (isGargoyle() && Forgefather.material == "granite")

--- a/classes/classes/Scenes/Places/Bazaar/Benoit.as
+++ b/classes/classes/Scenes/Places/Bazaar/Benoit.as
@@ -1278,6 +1278,7 @@ private function suggestSexAfterBasiWombed(later:Boolean = true):void {
 //happens only at night, after all other night events
 //PC lays 2 eggs per 10 points of Fertility they have
 public function popOutBenoitEggs():void {
+	player.updateBirthedCount();
 	if(player.vaginas.length == 0) {
 		outputText("\nYou feel a terrible pressure in your groin... then an incredible pain accompanied by the rending of flesh.  <b>You look down and behold a new vagina</b>.\n");
 		player.createVagina();

--- a/classes/classes/Scenes/Pregnancy.as
+++ b/classes/classes/Scenes/Pregnancy.as
@@ -1506,14 +1506,7 @@ public class Pregnancy extends NPCAwareContent {
             if(player.fertility < 15) player.fertility++;
             if(player.fertility < 25) player.fertility++;
             if(player.fertility < 40) player.fertility++;
-            if(!player.hasStatusEffect(StatusEffects.Birthed)) player.createStatusEffect(StatusEffects.Birthed,1,0,0,0);
-            else {
-                player.addStatusValue(StatusEffects.Birthed,1,1);
-                if(!player.hasPerk(PerkLib.BroodMother) && player.statusEffectv1(StatusEffects.Birthed) >= 10) {
-                    EngineCore.outputText("\n<b>You have gained the Brood Mother perk</b> (Pregnancies progress twice as fast as a normal woman's).\n");
-                    player.createPerk(PerkLib.BroodMother,0,0,0,0);
-                }
-            }
+			player.updateBirthedCount();
             if(!player.hasVagina()) {
                 outputText("You feel a terrible pressure in your groin... then an incredible pain accompanied by the rending of flesh.  You look down and behold: a vagina");
                 player.createVagina();
@@ -2170,14 +2163,7 @@ public class Pregnancy extends NPCAwareContent {
             if(player.fertility < 15) player.fertility++;
             if(player.fertility < 25) player.fertility++;
             if(player.fertility < 40) player.fertility++;
-            if(!player.hasStatusEffect(StatusEffects.Birthed)) player.createStatusEffect(StatusEffects.Birthed,1,0,0,0);
-            else {
-                player.addStatusValue(StatusEffects.Birthed,1,1);
-                if(!player.hasPerk(PerkLib.BroodMother) && player.statusEffectv1(StatusEffects.Birthed) >= 10) {
-                    EngineCore.outputText("\n<b>You have gained the Brood Mother perk</b> (Pregnancies progress twice as fast as a normal woman's).\n");
-                    player.createPerk(PerkLib.BroodMother,0,0,0,0);
-                }
-            }
+            player.updateBirthedCount();
             if(player.vaginas.length < 2) {
                 outputText("You feel a terrible pressure in your groin... then an incredible pain accompanied by the rending of flesh.  You look down and behold: a vagina");
                 player.createVagina();


### PR DESCRIPTION
### Gameplay changes
When giving birth to basilisks for Benoit(e) with the Basilisk Womb, it didn't count towards 'Times given birth'. Fixed that.

### Internal changes
For the sake of DRY-coding I've moved the code to update the 'Birthed'-counter into a separate function called by `player.updateBirthedCount();` and replaced the snippets with a call to it.