### PR TITLE
Fix swapped values for gargoyle wings

### DIFF
--- a/classes/classes/Scenes/Places/TempleOfTheDivine/PlayerGargoyleBuilder.as
+++ b/classes/classes/Scenes/Places/TempleOfTheDivine/PlayerGargoyleBuilder.as
@@ -173,8 +173,8 @@ use namespace CoC;
 
 		public function SculptWings():void {
 			menu();
-			addButton(0, "Bat", SculptWings_chosen, 2).hint("Sculpt bat wings.");
-			addButton(1, "Feathered", SculptWings_chosen, 1).hint("Sculpt feathered wings.");
+			addButton(0, "Bat", SculptWings_chosen, 1).hint("Sculpt bat wings.");
+			addButton(1, "Feathered", SculptWings_chosen, 2).hint("Sculpt feathered wings.");
 			addButton(14, "Back", currentStateOfStatue);
 		}
 		public function SculptWings_chosen(wings:int):void {


### PR DESCRIPTION
Values for sculpting gargoyle wings were swapped. Corrected that. Currently it only has an effect for the progress text, while the outcome as of now is always the bat like wings.