### PR TITLE
Fix NPCs leaving soulless PC

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -7902,6 +7902,7 @@ use namespace CoC;
 			if (flags[kFLAGS.AMILY_FOLLOWER] == 1) {
 				flags[kFLAGS.AMILY_FOLLOWER] = 0;
 				flags[kFLAGS.AMILY_CORRUPT_FLIPOUT] = 1;
+				flags[kFLAGS.AMILY_WARNING] = 1;
 				flags[kFLAGS.AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 0;
 				if (hasStatusEffect(StatusEffects.CombatFollowerAmily)) removeStatusEffect(StatusEffects.CombatFollowerAmily);
 				if (flags[kFLAGS.PLAYER_COMPANION_1] == "Amily") flags[kFLAGS.PLAYER_COMPANION_1] = "";
@@ -7909,8 +7910,8 @@ use namespace CoC;
 				if (flags[kFLAGS.PLAYER_COMPANION_3] == "Amily") flags[kFLAGS.PLAYER_COMPANION_3] = "";
 			}
 			if (flags[kFLAGS.KIHA_FOLLOWER] > 0) {
-				flags[kFLAGS.KIHA_CORRUPTION_BITCH] == 1;
-				if (hasStatusEffect(StatusEffects.CombatFollowerAmily)) removeStatusEffect(StatusEffects.CombatFollowerAmily);
+				flags[kFLAGS.KIHA_CORRUPTION_BITCH] = 1;
+				if (hasStatusEffect(StatusEffects.CombatFollowerKiha)) removeStatusEffect(StatusEffects.CombatFollowerKiha);
 				if (flags[kFLAGS.PLAYER_COMPANION_1] == "Kiha") flags[kFLAGS.PLAYER_COMPANION_1] = "";
 				if (flags[kFLAGS.PLAYER_COMPANION_2] == "Kiha") flags[kFLAGS.PLAYER_COMPANION_2] = "";
 				if (flags[kFLAGS.PLAYER_COMPANION_3] == "Kiha") flags[kFLAGS.PLAYER_COMPANION_3] = "";

--- a/classes/classes/SaveUpdater.as
+++ b/classes/classes/SaveUpdater.as
@@ -2718,6 +2718,7 @@ public class SaveUpdater extends NPCAwareContent {
 					if (flags[kFLAGS.AMILY_FOLLOWER] == 1) {
 						flags[kFLAGS.AMILY_FOLLOWER] = 0;
 						flags[kFLAGS.AMILY_CORRUPT_FLIPOUT] = 1;
+						flags[kFLAGS.AMILY_WARNING] = 1;
 						flags[kFLAGS.AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 0;
 						if (player.hasStatusEffect(StatusEffects.CombatFollowerAmily)) player.removeStatusEffect(StatusEffects.CombatFollowerAmily);
 						if (flags[kFLAGS.PLAYER_COMPANION_1] == "Amily") flags[kFLAGS.PLAYER_COMPANION_1] = "";
@@ -2725,8 +2726,8 @@ public class SaveUpdater extends NPCAwareContent {
 						if (flags[kFLAGS.PLAYER_COMPANION_3] == "Amily") flags[kFLAGS.PLAYER_COMPANION_3] = "";
 					}
 					if (flags[kFLAGS.KIHA_FOLLOWER] > 0) {
-						flags[kFLAGS.KIHA_CORRUPTION_BITCH] == 1;
-						if (player.hasStatusEffect(StatusEffects.CombatFollowerAmily)) player.removeStatusEffect(StatusEffects.CombatFollowerAmily);
+						flags[kFLAGS.KIHA_CORRUPTION_BITCH] = 1;
+						if (player.hasStatusEffect(StatusEffects.CombatFollowerKiha)) player.removeStatusEffect(StatusEffects.CombatFollowerKiha);
 						if (flags[kFLAGS.PLAYER_COMPANION_1] == "Kiha") flags[kFLAGS.PLAYER_COMPANION_1] = "";
 						if (flags[kFLAGS.PLAYER_COMPANION_2] == "Kiha") flags[kFLAGS.PLAYER_COMPANION_2] = "";
 						if (flags[kFLAGS.PLAYER_COMPANION_3] == "Kiha") flags[kFLAGS.PLAYER_COMPANION_3] = "";


### PR DESCRIPTION
### Gameplay changes
Fixed issues with NPCs leaving the soulless PC upon becoming soulless.

Actually Kiha didn't leave the camp and you couldn't get Amily to return.

### Internal changes
Fixed Amily not being able to return by adding
```as3
flags[kFLAGS.AMILY_WARNING] = 1;
```
And Kiha didn't leave because the code read 
```as3
flags[kFLAGS.KIHA_CORRUPTION_BITCH] == 1;
```
And if Kiha was a combat follower she wasn't removed as such, because the code to remove Amily was duped.