### PR TITLE
Fix poltergeist legs TF

### DIFF
--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -9763,12 +9763,12 @@ public final class Mutations extends MutationsHelper {
             changes++;
         }
         //Legs
-        if (player.lowerBody == LowerBody.GHOST && player.lowerBody != LowerBody.GHOST_2 && rand(3) == 0 && changes < changeLimit && type == 1) {
+        if (type == 1 && player.lowerBody == LowerBody.GHOST && rand(3) == 0 && changes < changeLimit) {
             outputText("[pg]");
             transformations.LowerBodyGhost2.applyEffect();
             changes++;
         }
-        if (player.hairType == 2 && player.lowerBody != LowerBody.GHOST && rand(3) == 0 && changes < changeLimit) {
+        if (player.hairType == Hair.GHOST && !InCollection(player.lowerBody, LowerBody.GHOST, LowerBody.GHOST_2) && rand(3) == 0 && changes < changeLimit) {
             if (player.lowerBody == LowerBody.HUMAN) {
                 outputText("[pg]");
                 transformations.LowerBodyGhost.applyEffect();


### PR DESCRIPTION
### Gameplay changes
Poltergeist legs TF from using Protoplasm was kinda borked, since it looped though `LowerBody.HUMAN` → `LowerBody.GHOST` → `LowerBody.GHOST_2` over and over again, wasting a lot of Protoplasms.
Fixed that by making it so that Ectoplasm and Protoplasm doesn't change the lowerbody anymore, once it reached `LowerBody.GHOST_2` (or `LowerBody.GHOST` for Ectoplasm).
I was considering about making Ectoplasm change `LowerBody.GHOST_2` back to `LowerBody.GHOST`, but then decided, that this is not really needed and for those, who want to be an eldritch poltergeist with ghost-legs, there's always soulforce to fix that.

### Internal changes
Changes to line 9766 where just a little cleanup by removing redundant code from that conditional.