### PR TITLE
Exp Banking is finaly gone!

### DIFF
--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -11138,15 +11138,19 @@ public class Combat extends BaseContent {
         if (monster.XP <= 0) monster.XP = 0;
         if (!monster.hasPerk(PerkLib.NoExpGained))
         {
-            //If pc exp is lower then the cap award exp else do nothing
-            // this is to avoid lowering exp if player had higher from a tribulation or a treasure allowing player exp
-            // not to be reseted by a fight if its above so to prevent tribulation exp being lost by accident
-            if (player.XP < player.requiredXP()){
-                //Award player experience
-                player.XP += monster.XP;
-                //Set player exp to never be banked from a single battle!
-                if (player.XP > player.requiredXP()) player.XP = player.requiredXP();
-            }
+            //if (!ExpBankingisOn) player.XP += monster.XP;
+            //else {
+                // If pc exp is lower then the cap award exp else do nothing.
+                // This is to avoid lowering exp if player had higher from a tribulation or a treasure allowing player exp
+                // not to be reseted by a fight if its above so to prevent tribulation exp being lost by accident
+                if (player.XP < player.requiredXP())
+                {
+                    //Award player experience
+                    player.XP += monster.XP;
+                    //Set player exp to never be banked from a single battle!
+                    if (player.XP > player.requiredXP()) player.XP = player.requiredXP();
+                }
+            //}
         }
         mainView.statsView.showStatUp('xp');
         dynStats("lust", 0, "scale", false); //Forces up arrow.

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -11138,9 +11138,15 @@ public class Combat extends BaseContent {
         if (monster.XP <= 0) monster.XP = 0;
         if (!monster.hasPerk(PerkLib.NoExpGained))
         {
-            player.XP += monster.XP;
-            //Set player exp to never be banked from a single battle!
-            if (player.XP > player.requiredXP()) player.XP = player.requiredXP();
+            //If pc exp is lower then the cap award exp else do nothing
+            // this is to avoid lowering exp if player had higher from a tribulation or a treasure allowing player exp
+            // not to be reseted by a fight if its above so to prevent tribulation exp being lost by accident
+            if (player.XP < player.requiredXP()){
+                //Award player experience
+                player.XP += monster.XP;
+                //Set player exp to never be banked from a single battle!
+                if (player.XP > player.requiredXP()) player.XP = player.requiredXP();
+            }
         }
         mainView.statsView.showStatUp('xp');
         dynStats("lust", 0, "scale", false); //Forces up arrow.

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -11136,7 +11136,12 @@ public class Combat extends BaseContent {
         if (((player.gems + monster.gems) >= 1000000000 || (player.gems + monster.gems) < 0) && monster.gems > 0) player.gems = 1000000000;
         else player.gems += monster.gems;
         if (monster.XP <= 0) monster.XP = 0;
-        if (!monster.hasPerk(PerkLib.NoExpGained)) player.XP += monster.XP;
+        if (!monster.hasPerk(PerkLib.NoExpGained))
+        {
+            player.XP += monster.XP;
+            //Set player exp to never be banked from a single battle!
+            if (player.XP > player.requiredXP()) player.XP = player.requiredXP();
+        }
         mainView.statsView.showStatUp('xp');
         dynStats("lust", 0, "scale", false); //Forces up arrow.
     }


### PR DESCRIPTION
Exp banking from defeating foes is now history. Tribulation and exp gained from other source will still be able to be banked. see the "//Set player exp to never be banked from a single battle!" anotation for exact location (currently line 11142)

We could bring back exp banking as an option in the start menu next to hardcore (some folks like to cheat I guess)