### PR TITLE
Exp banking fixes

### DIFF
--- a/classes/classes/GameSettings.as
+++ b/classes/classes/GameSettings.as
@@ -125,6 +125,11 @@ public class GameSettings extends BaseContent {
 				outputText("Realistic Mode Modifier: <b>[font-red]Enabled[/font]</b> (PC must manage his own hunger lest you want see his death from starvation + your cum production is capped and having oversized parts will weigh you down)");
 			}
 			outputText("\n\n");
+			outputText("Exp Banking: " + (flags[kFLAGS.EXP_BANKING] == 1
+				? "<b>[font-olive]Enabled[/font]</b> (PC can stack experience indefinitily from defeated opponents)"
+				: "<b>[font-red]Disabled[/font]</b>"
+			));
+			outputText("\n\n");
 			if (flags[kFLAGS.HARDCORE_MODE] == 0) {
 				outputText("Hardcore Modifier: <b>[font-olive]Disabled[/font]</b>");
 			}
@@ -194,6 +199,8 @@ public class GameSettings extends BaseContent {
 			if (flags[kFLAGS.HUNGER_ENABLED] != 0) addButton(6, "Hunger (Off)", disableHungerModifierForReal);
 			if (flags[kFLAGS.HUNGER_ENABLED] != 0.5) addButton(7, "Hunger (On)", enableHungerModifierForReal);
 			if (flags[kFLAGS.HUNGER_ENABLED] != 1) addButton(8, "Realistic (On)", enableRealisticModifierForReal);
+			addButton(9, "EXP Banking (" + (flags[kFLAGS.EXP_BANKING] == 0 ? "On" : "Off") + ")",
+				flags[kFLAGS.EXP_BANKING] == 0 ? toggleXPBankingOn : toggleXPBankingOff);
 			if (flags[kFLAGS.GAME_DIFFICULTY] <= 0) addButton(10, "Easier Mode", toggleFlag, kFLAGS.EASY_MODE_ENABLE_FLAG, settingsScreenGameSettings).hint("Toggles easier than easy mode. Enemy damage is 10% of normal and bad-ends can be ignored.");
 			else addButtonDisabled(10, "Easier Mode", "Diffulty setting is too high to allow toggle easy mode.");
 			addButton(11, "Fetishes", fetishSubMenu).hint("Toggle some of the weird fetishes such as watersports and worms.");
@@ -858,7 +865,21 @@ public class GameSettings extends BaseContent {
 		setTheFuckingDifficultyForFuckingGood();
 		doNext(settingsScreenGameSettings);
 	}
-	public function difficultySelectionMenu1():void {
+	private function toggleXPBankingOn():void {
+		clearOutput();
+		outputText("You have chosen to have Exp Banking enabled.");
+		flags[kFLAGS.EXP_BANKING] = 1;
+		setTheFuckingDifficultyForFuckingGood();
+		doNext(settingsScreenGameSettings);
+	}
+	private function toggleXPBankingOff():void {
+		clearOutput();
+		outputText("You have chosen to have Exp Banking disabled.");
+		flags[kFLAGS.EXP_BANKING] = 0;
+		setTheFuckingDifficultyForFuckingGood();
+		doNext(settingsScreenGameSettings);
+	}
+		public function difficultySelectionMenu1():void {
 		clearOutput();
 		outputText("You can choose a prime difficulty to set how hard battles will be.\n");
 		if (flags[kFLAGS.PRIMARY_DIFFICULTY] <= 0) outputText("\n No opponent(s) stats modifiers. You can resume from bad-ends with penalties. No penalties for too high wrath. Negative effects from internal mutations will be triggered after accumulating 11 points in your internal mutation score.");

--- a/classes/classes/GameSettings.as
+++ b/classes/classes/GameSettings.as
@@ -865,21 +865,21 @@ public class GameSettings extends BaseContent {
 		setTheFuckingDifficultyForFuckingGood();
 		doNext(settingsScreenGameSettings);
 	}
-	private function toggleXPBankingOn():void {
+	public function toggleXPBankingOn():void {
 		clearOutput();
 		outputText("You have chosen to have Exp Banking enabled.");
 		flags[kFLAGS.EXP_BANKING] = 1;
 		setTheFuckingDifficultyForFuckingGood();
 		doNext(settingsScreenGameSettings);
 	}
-	private function toggleXPBankingOff():void {
+	public function toggleXPBankingOff():void {
 		clearOutput();
 		outputText("You have chosen to have Exp Banking disabled.");
 		flags[kFLAGS.EXP_BANKING] = 0;
 		setTheFuckingDifficultyForFuckingGood();
 		doNext(settingsScreenGameSettings);
 	}
-		public function difficultySelectionMenu1():void {
+	public function difficultySelectionMenu1():void {
 		clearOutput();
 		outputText("You can choose a prime difficulty to set how hard battles will be.\n");
 		if (flags[kFLAGS.PRIMARY_DIFFICULTY] <= 0) outputText("\n No opponent(s) stats modifiers. You can resume from bad-ends with penalties. No penalties for too high wrath. Negative effects from internal mutations will be triggered after accumulating 11 points in your internal mutation score.");

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1644,6 +1644,12 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 		unFuckSaveDataBeforeLoading(saveFile.data);
 		//PIERCINGS
 
+		// default exp banking to true for old saves. Can be toggled off in the game settings later.
+		if (saveFile.data.flags[kFLAGS.EXP_BANKING] == undefined)
+		{
+			flags[kFLAGS.EXP_BANKING] = 1;
+		}
+
 		//trace("LOADING PIERCINGS");
 		player.nipplesPierced = saveFile.data.nipplesPierced;
 		player.nipplesPShort = saveFile.data.nipplesPShort;

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -11194,7 +11194,7 @@ public class Combat extends BaseContent {
         if (monster.XP <= 0) monster.XP = 0;
         if (!monster.hasPerk(PerkLib.NoExpGained))
         {
-            if (kFLAGS.EXP_BANKING == 1) player.XP += monster.XP;
+            if (flags[kFLAGS.EXP_BANKING] == 1) player.XP += monster.XP;
             else {
                 // If pc exp is lower then the cap award exp else do nothing.
                 // This is to avoid lowering exp if player had higher from a tribulation or a treasure allowing player exp
@@ -11203,9 +11203,9 @@ public class Combat extends BaseContent {
                 {
                     //Award player experience
                     player.XP += monster.XP;
-                    //Set player exp to never be banked from a single battle!
-                    if (player.XP > (player.requiredXP()*3)) player.XP = (player.requiredXP()*3);
                 }
+                //Set player exp to never be banked from a single battle!
+                if (player.XP > (player.requiredXP()*3)) player.XP = (player.requiredXP()*3);
             }
         }
         mainView.statsView.showStatUp('xp');


### PR DESCRIPTION
- Default Exp Banking to enabled for old saves, so no surprises
- Added a toggle for Exp Banking to the Gameplay Settings
- Exp Banking is now handled properly when gaining XP from a monster.