### PR TITLE
Fix for exp banking setting not being stored, when turned off

### DIFF
--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -681,6 +681,7 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 				saveFile.data.flags[i] = flags[i];
 			}
 		}
+		saveFile.data.flags[kFLAGS.EXP_BANKING] = flags[kFLAGS.EXP_BANKING];
 		saveFile.data.counters = [];
 
 		//CLOTHING/ARMOR
@@ -1642,7 +1643,6 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			trace("Found internal versionID:", game.versionID);
 		}
 		unFuckSaveDataBeforeLoading(saveFile.data);
-		//PIERCINGS
 
 		// default exp banking to true for old saves. Can be toggled off in the game settings later.
 		if (saveFile.data.flags[kFLAGS.EXP_BANKING] == undefined)
@@ -1650,6 +1650,7 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 			flags[kFLAGS.EXP_BANKING] = 1;
 		}
 
+		//PIERCINGS
 		//trace("LOADING PIERCINGS");
 		player.nipplesPierced = saveFile.data.nipplesPierced;
 		player.nipplesPShort = saveFile.data.nipplesPShort;


### PR DESCRIPTION
Workaround for the silly kFLAGS-handling. Now kFLAGS.EXP_BANKING should be stored properly.