### PR TITLE
Fix for Fairy Queen TF not removing balls and fix breast rows

### DIFF
--- a/classes/classes/Scenes/Dungeons/DeepCave/ValaScene.as
+++ b/classes/classes/Scenes/Dungeons/DeepCave/ValaScene.as
@@ -840,13 +840,19 @@ public class ValaScene extends BaseContent implements SaveableState
 			player.skinType = Skin.PLAIN;
 			player.skinAdj = "flawless";
 			if (player.hasCock()) player.removeCock(0, player.cockTotal());
+			player.balls = 0;
+			player.ballSize = 1;
 			player.skin.coverage = Skin.COVERAGE_NONE;
-			var growth:int = 1 + rand(3);
-			if (player.breastRows.length > 0) {
-				if (player.breastRows[0].breastRating < 2) growth++;
-				if (player.breastRows[0].breastRating < 3 && rand(2) == 0) growth++;
-				if (player.breastRows[0].breastRating < 4 && rand(3) == 0) growth++;
+			while (player.breastRows.length > 1)
+			{
+				player.removeBreastRow(1, 1);
 			}
+			if (player.breastRows.length == 0) player.createBreastRow();
+			var growth:int = 1 + rand(3);
+			if (player.breastRows[0].breastRating < 2) growth++;
+			if (player.breastRows[0].breastRating < 3 && rand(2) == 0) growth++;
+			if (player.breastRows[0].breastRating < 4 && rand(3) == 0) growth++;
+			player.breastRows[0].breastRating += growth;
 			player.createPerk(PerkLib.TransformationImmunity2, 4, 0, 0, 0);
 			player.updateRacialParagon(Races.FAIRY);
 			IMutationsLib.FeyArcaneBloodstreamIM.trueMutation = true;


### PR DESCRIPTION
- Fairy Queen TF didn't remove balls. Fixed that.
- Made sure, that the player ends up with exactly 1 breast row, not more and not less and then apply breast growth.