### PR TITLE
More EXP banking fixes

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -2005,14 +2005,14 @@ import classes.Scenes.Combat.CombatAbility;
 		private function toggleXPBankingOn():void {
 			clearOutput();
 			outputText("You have chosen to have Exp Banking enabled.");
-			flags[kFLAGS.EXP_BANKING] = 1;
+			flags[kFLAGS.EXP_BANKING] = 0;
 			setTheFuckingDifficultyForFuckingGood();
 			doNext(chooseGameModes);
 		}
 		private function toggleXPBankingOff():void {
 			clearOutput();
 			outputText("You have chosen to have Exp Banking disabled.");
-			flags[kFLAGS.EXP_BANKING] = 0;
+			flags[kFLAGS.EXP_BANKING] = 1;
 			setTheFuckingDifficultyForFuckingGood();
 			doNext(chooseGameModes);
 		}
@@ -2075,7 +2075,7 @@ import classes.Scenes.Combat.CombatAbility;
 			outputText("\n<b>Hardcore Modifier:</b> "+(flags[kFLAGS.HARDCORE_MODE] == 1?"Enabled (No level limits for unlocking new areas)":"Disabled")+"\n");
 			outputText("<b>Hunger Modifier:</b> "+(flags[kFLAGS.HUNGER_ENABLED] > 0?"Enabled (PC must manage his own hunger lest you want see his death from starvation)":"Disabled")+"\n");
 			outputText("<b>Realistic Mode Modifier:</b> "+(flags[kFLAGS.HUNGER_ENABLED] > 0.5?"Enabled (PC must manage his own hunger lest you want see his death from starvation + your cum production is capped and having oversized parts will weigh you down)":"Disabled")+"\n");
-			outputText("<b>Exp Banking:</b> "+(flags[kFLAGS.EXP_BANKING] > 0?"Enabled":"Disabled (PC can stack experience indefinitily from defeated opponents)")+"\n");
+			outputText("<b>Exp Banking:</b> "+(flags[kFLAGS.EXP_BANKING] > 0?"Disabled":"Enabled (PC can stack experience indefinitely from defeated opponents)")+"\n");
 
 			outputText("\n");
 			player.displayFinalGameDifficulty();
@@ -2094,8 +2094,8 @@ import classes.Scenes.Combat.CombatAbility;
 			if (flags[kFLAGS.HUNGER_ENABLED] != 0) addButton(5, "Hunger (Off)", toggleForHungerOff);
 			if (flags[kFLAGS.HUNGER_ENABLED] != 0.5) addButton(6, "Hunger (On)", toggleForHungerOn);
 			if (flags[kFLAGS.HUNGER_ENABLED] != 1) addButton(7, "Realistic (On)", toggleForRealisticOn);
-			if (flags[kFLAGS.EXP_BANKING] != 1) addButton(8, "Exp Banking (On)", toggleXPBankingOn);
-			if (flags[kFLAGS.EXP_BANKING] != 0) addButton(9, "Exp Banking (Off)", toggleXPBankingOff);
+			if (flags[kFLAGS.EXP_BANKING] != 0) addButton(8, "Exp Banking (On)", toggleXPBankingOn);
+			if (flags[kFLAGS.EXP_BANKING] != 1) addButton(9, "Exp Banking (Off)", toggleXPBankingOff);
 			//10+
 			//11-
 			addButton(14, "Start", startTheGame);

--- a/classes/classes/GameSettings.as
+++ b/classes/classes/GameSettings.as
@@ -125,8 +125,8 @@ public class GameSettings extends BaseContent {
 				outputText("Realistic Mode Modifier: <b>[font-red]Enabled[/font]</b> (PC must manage his own hunger lest you want see his death from starvation + your cum production is capped and having oversized parts will weigh you down)");
 			}
 			outputText("\n\n");
-			outputText("Exp Banking: " + (flags[kFLAGS.EXP_BANKING] == 1
-				? "<b>[font-olive]Enabled[/font]</b> (PC can stack experience indefinitily from defeated opponents)"
+			outputText("Exp Banking: " + (flags[kFLAGS.EXP_BANKING] == 0
+				? "<b>[font-olive]Enabled[/font]</b> (PC can stack experience indefinitely from defeated opponents)"
 				: "<b>[font-red]Disabled[/font]</b>"
 			));
 			outputText("\n\n");
@@ -199,8 +199,8 @@ public class GameSettings extends BaseContent {
 			if (flags[kFLAGS.HUNGER_ENABLED] != 0) addButton(6, "Hunger (Off)", disableHungerModifierForReal);
 			if (flags[kFLAGS.HUNGER_ENABLED] != 0.5) addButton(7, "Hunger (On)", enableHungerModifierForReal);
 			if (flags[kFLAGS.HUNGER_ENABLED] != 1) addButton(8, "Realistic (On)", enableRealisticModifierForReal);
-			addButton(9, "EXP Banking (" + (flags[kFLAGS.EXP_BANKING] == 0 ? "On" : "Off") + ")",
-				flags[kFLAGS.EXP_BANKING] == 0 ? toggleXPBankingOn : toggleXPBankingOff);
+			addButton(9, "EXP Banking (" + (flags[kFLAGS.EXP_BANKING] > 0 ? "On" : "Off") + ")",
+				flags[kFLAGS.EXP_BANKING] > 0 ? toggleXPBankingOn : toggleXPBankingOff);
 			if (flags[kFLAGS.GAME_DIFFICULTY] <= 0) addButton(10, "Easier Mode", toggleFlag, kFLAGS.EASY_MODE_ENABLE_FLAG, settingsScreenGameSettings).hint("Toggles easier than easy mode. Enemy damage is 10% of normal and bad-ends can be ignored.");
 			else addButtonDisabled(10, "Easier Mode", "Diffulty setting is too high to allow toggle easy mode.");
 			addButton(11, "Fetishes", fetishSubMenu).hint("Toggle some of the weird fetishes such as watersports and worms.");
@@ -868,14 +868,14 @@ public class GameSettings extends BaseContent {
 	public function toggleXPBankingOn():void {
 		clearOutput();
 		outputText("You have chosen to have Exp Banking enabled.");
-		flags[kFLAGS.EXP_BANKING] = 1;
+		flags[kFLAGS.EXP_BANKING] = 0;
 		setTheFuckingDifficultyForFuckingGood();
 		doNext(settingsScreenGameSettings);
 	}
 	public function toggleXPBankingOff():void {
 		clearOutput();
 		outputText("You have chosen to have Exp Banking disabled.");
-		flags[kFLAGS.EXP_BANKING] = 0;
+		flags[kFLAGS.EXP_BANKING] = 1;
 		setTheFuckingDifficultyForFuckingGood();
 		doNext(settingsScreenGameSettings);
 	}
@@ -970,7 +970,7 @@ public class GameSettings extends BaseContent {
 		if (flags[kFLAGS.BOSS_CHAMPION_ELITE_SCALING] > 0) sTFDFFG += 1;
 		if (flags[kFLAGS.HUNGER_ENABLED] > 0) sTFDFFG += 1;
 		if (flags[kFLAGS.HARDCORE_MODE] > 0) sTFDFFG += 1;
-		if (flags[kFLAGS.EXP_BANKING] == 0) sTFDFFG += 1;
+		if (flags[kFLAGS.EXP_BANKING] > 0) sTFDFFG += 1;
 		flags[kFLAGS.GAME_DIFFICULTY] = sTFDFFG;
 	}
 


### PR DESCRIPTION
The stored value for exp banking has been changed to 0 for exp banking on and 1 for exp banking off. There were some changes missing. Fixed that, along with a typo: 'indefinitily' -> 'indefinitely'