### PR TITLE
Buffed Lust Strike and improved it's readability

### DIFF
--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -512,7 +512,7 @@ public class MagicSpecials extends BaseCombatContent {
 			var word1:String = player.perkv1(IMutationsLib.BlackHeartIM) >= 1? ", intelligence" : "";
 			var word2:String = player.perkv1(IMutationsLib.BlackHeartIM) >= 2? ", wisdom" : "";
 			var word3:String = player.perkv1(IMutationsLib.BlackHeartIM) >= 3? ", sensitivity" : "";
-			bd.hint("Use arcane gestures to flare up enemy lust. The higher your libido" + word3 + word2 + word1 + " and horny you're at the moment the higher enemy lust will rise. \n");
+			bd.hint("Use arcane gestures to flare up enemy lust. \nThe higher your libido" + word3 + word2 + word1 + " and \nthe hornier you are, the more the enemy will be aroused. \n");
 			bd.requireFatigue(50, true);
 			if(player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 				bd.disable("You cannot focus on drawing symbols while you're having so much difficult breathing.");
@@ -5821,28 +5821,32 @@ public class MagicSpecials extends BaseCombatContent {
 		}
 		fatigue(50, USEFATG_MAGIC_NOBM);
 		outputText("You start drawing symbols in the air toward [themonster].");
-		var lustRatio:Number = 10;
-		if (player.perkv1(IMutationsLib.BlackHeartIM) >= 4) lustRatio -= 5;
-		var lustDmg:Number = player.lust / lustRatio + player.lib / 10;
-		if (player.perkv1(IMutationsLib.BlackHeartIM) >= 1) lustDmg += player.inte / 10;
-		if (player.perkv1(IMutationsLib.BlackHeartIM) >= 2) lustDmg += player.wis / 10;
-		if (player.perkv1(IMutationsLib.BlackHeartIM) >= 3) lustDmg += player.sens / 10;
+		var lustRatio:Number = 4;
+		if (player.perkv1(IMutationsLib.BlackHeartIM) >= 2) lustRatio = 2;
+		if (player.perkv1(IMutationsLib.BlackHeartIM) >= 4) lustRatio = 1;
+		var lustDmg:Number = player.lust / lustRatio + player.lib / 4; // these values were 10
+		if (player.perkv1(IMutationsLib.BlackHeartIM) >= 1) lustDmg += player.inte / 4;
+		if (player.perkv1(IMutationsLib.BlackHeartIM) >= 2) lustDmg += player.wis / 4;
+		if (player.perkv1(IMutationsLib.BlackHeartIM) >= 3) lustDmg += player.sens / 4;
 		if (player.hasPerk(PerkLib.EromancyExpert)) lustDmg *= 1.5;
 		if(monster.lustVuln == 0) {
-			outputText("It has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
+			outputText("\nIt has no effect!  Your foe clearly does not experience lust in the same way as you.\n\n");
 			enemyAI();
 			return;
 		}
-		if(monster.lust < (monster.maxLust() * 0.3)) outputText("[Themonster] squirms as the magic affects [monster him].  ");
+		
+		if(monster.lust < (monster.maxLust() * 0.3)) outputText("\n[themonster] squirms as the magic affects [monster him].  ");
 		if(monster.lust >= (monster.maxLust() * 0.3) && monster.lust < (monster.maxLust() * 0.6)) {
-			if(monster.plural) outputText("[Themonster] stagger, suddenly weak and having trouble focusing on staying upright.  ");
-			else outputText("[Themonster] staggers, suddenly weak and having trouble focusing on staying upright.  ");
+			if(monster.plural) outputText("\n[themonster] stagger, suddenly weak and having trouble focusing on staying upright.  ");
+			else outputText("\n[themonster] staggers, suddenly weak and having trouble focusing on staying upright.  ");
 		}
 		if(monster.lust >= (monster.maxLust() * 0.6)) {
-			outputText("[Themonster]'");
+			outputText("\n[Themonster]'");
 			if(!monster.plural) outputText("s");
 			outputText(" eyes glaze over with desire for a moment.  ");
 		}
+		
+		
 		mosterTeaseText();
 		lustDmg *= magicAbilitiesGoBrrr();
 		if(player.armorName == "Scandalous Succubus Clothing") lustDmg *= 1.25;
@@ -5850,6 +5854,16 @@ public class MagicSpecials extends BaseCombatContent {
 		if (player.armor == armors.FMDRESS && player.isWoodElf()) lustDmg *= 2;
 		if (player.perkv1(IMutationsLib.BlackHeartIM) >= 4) lustDmg += combat.teases.teaseBaseLustDamage();
 		monster.teased(Math.round(monster.lustVuln * lustDmg));
+		
+		var LSVulnLimit:int = 0;
+		if (player.hasPerk(PerkLib.CorruptTheBody)) LSVulnLimit = -1;
+		if (player.hasPerk(PerkLib.CorruptTheHeart)) LSVulnLimit = -2;
+		if (player.hasPerk(PerkLib.CorruptTheMind)) LSVulnLimit = -3;
+		if (player.hasPerk(PerkLib.CorruptTheSoul) || monster.lustVuln > LSVulnLimit){
+			monster.lustVuln += (0.1+ (player.perkv1(IMutationsLib.BlackHeartIM)/20));
+			outputText("\n\nA bit of the magic seems to remain within [themonster].\nIt seems to be making [monster him] more lustful.");
+		}
+		
 		outputText("\n\n");
 		if (player.hasPerk(PerkLib.EromancyMaster)) combat.teaseXP(1 + combat.bonusExpAfterSuccesfullTease());
 		doNext(playerMenu);
@@ -7447,4 +7461,5 @@ public class MagicSpecials extends BaseCombatContent {
 		enemyAI();
 	}
 }
+
 }

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -5837,8 +5837,8 @@ public class MagicSpecials extends BaseCombatContent {
 		
 		if(monster.lust < (monster.maxLust() * 0.3)) outputText("\n[themonster] squirms as the magic affects [monster him].  ");
 		if(monster.lust >= (monster.maxLust() * 0.3) && monster.lust < (monster.maxLust() * 0.6)) {
-			if(monster.plural) outputText("\n[themonster] stagger, suddenly weak and having trouble focusing on staying upright.  ");
-			else outputText("\n[themonster] staggers, suddenly weak and having trouble focusing on staying upright.  ");
+			if(monster.plural) outputText("\n[Themonster] stagger, suddenly weak and having trouble focusing on staying upright.  ");
+			else outputText("\n[Themonster] staggers, suddenly weak and having trouble focusing on staying upright.  ");
 		}
 		if(monster.lust >= (monster.maxLust() * 0.6)) {
 			outputText("\n[Themonster]'");
@@ -7463,3 +7463,4 @@ public class MagicSpecials extends BaseCombatContent {
 }
 
 }
+


### PR DESCRIPTION
Made Lust Strike's combat hint easier to read, and added new lines to it's combat text.

Buffed Lust Strike's scaling from 10% libido, lust, intelligence, wisdom and sensitivity, to 25% libido, intelligence, wisdom, sensitivity and 25-100% lust (based on Black Heart tier).

Added a side effect to Lust Strike: Lowers enemy's lust resist(if not immune) by 10-30%(based on Black Heart tier), applies the lust vulnerability limits of perks [Corrupt The Body], [Corrupt The Heart], [Corrupt The Mind] and [Corrupt The Soul].