### PR TITLE
Slime race buff and patch + fixed elemental related bugs

### DIFF
--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -2214,6 +2214,7 @@ import classes.Scenes.Combat.CombatAbilities;
 				StatusEffects.Entangled,
 				StatusEffects.Swallowed,
 				StatusEffects.Straddle,
+				StatusEffects.SlimeInsert,
 			]
 			for each (var effect:StatusEffectType in effects) if (hasStatusEffect(effect)) return true;
 			return false;
@@ -5228,4 +5229,5 @@ import classes.Scenes.Combat.CombatAbilities;
 			}
 		}
 	}
+
 }

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -1918,7 +1918,8 @@ public class Combat extends BaseContent {
             combatMenu(false);
     }
 
-    public function baseelementalattacks(elementType:int = -1, showNext:Boolean = false):void {
+    public function basicElementalAttack():void {baseelementalattacks(-1,true,1)}
+    public function baseelementalattacks(elementType:int = -1, showNext:Boolean = false, multiCap:int=-1):void {
         if (elementType == -1) {
             clearOutput();
             elementType = flags[kFLAGS.ATTACKING_ELEMENTAL_TYPE];
@@ -2024,7 +2025,7 @@ public class Combat extends BaseContent {
 				flags[kFLAGS.ELEMENTAL_CONJUER_SUMMONS] = 1;
 				doNext(combatMenu, false);
 			} else {
-				if (!player.hasStatusEffect(StatusEffects.SimplifiedNonPCTurn)) outputText("\n\n");
+				//if (!player.hasStatusEffect(StatusEffects.SimplifiedNonPCTurn)) outputText("\n\n");
 				switch (elementType) {
 					case AIR_E      :
 						outputText("Sylph");
@@ -2054,13 +2055,14 @@ public class Combat extends BaseContent {
 					if (player.hasPerk(PerkLib.FirstAttackElementalsSu)) summonedElementalsMulti += 1;
 				}
 				outputText(" hit" + (summonedElementalsMulti > 1 ? "s":"") + " [themonster]! ");
+				if (summonedElementalsMulti > multiCap && multiCap >-1)summonedElementalsMulti=multiCap;
 				var repeats:Number = summonedElementalsMulti;
-				while (repeats-->0) elementalattacks(elementType, summonedElementals, summonedEpicElemental, showNext);
+				while (repeats-->0) elementalattacks(elementType, summonedElementals, summonedEpicElemental, showNext, repeats);
 			}
 		}
     }
 
-    public function elementalattacks(elementType:int, summonedElementals:int, summonedEpicElemental:Boolean, showNext:Boolean = false):void {
+    public function elementalattacks(elementType:int, summonedElementals:int, summonedEpicElemental:Boolean, showNext:Boolean = false, repeatTimes:Number = 0):void {
         var elementalDamage:Number = 0;
         var baseDamage:Number = summonedElementals * intwisscaling() * 0.1;
         if (summonedElementals >= 1) elementalDamage += baseDamage;
@@ -2148,18 +2150,21 @@ public class Combat extends BaseContent {
         if (crit) outputText(" <b>Critical!</b>");
         //checkMinionsAchievementDamage(elementalDamage);
 		outputText(" ");
+
         if (monster.HP > monster.minHP() && monster.lust < monster.maxOverLust()) {
 			outputText("\n\n");
 			if (flags[kFLAGS.IN_COMBAT_PLAYER_ELEMENTAL_ATTACKED] != 1 || flags[kFLAGS.IN_COMBAT_PLAYER_EPIC_ELEMENTAL_ATTACKED] != 1
 				&& (flags[kFLAGS.ELEMENTAL_CONJUER_SUMMONS] == 3 || flags[kFLAGS.ELEMENTAL_CONJUER_SUMMONS] == 4)) {
-				if (summonedEpicElemental) flags[kFLAGS.IN_COMBAT_PLAYER_EPIC_ELEMENTAL_ATTACKED] = 1;
-				else flags[kFLAGS.IN_COMBAT_PLAYER_ELEMENTAL_ATTACKED] = 1;
+				if (summonedEpicElemental) flags[kFLAGS.IN_COMBAT_PLAYER_EPIC_ELEMENTAL_ATTACKED] = 1+repeatTimes;
+				else flags[kFLAGS.IN_COMBAT_PLAYER_ELEMENTAL_ATTACKED] = 1+repeatTimes;
 				if (!player.hasStatusEffect(StatusEffects.SimplifiedNonPCTurn) || showNext) {
 					menu();
 					addButton(0, "Next", combatMenu, false);
 				}
 			}
-			else enemyAIImpl();
+			else {
+				enemyAIImpl();
+			}
         } else {
             //If monster is dead, prevent further elemental attack calls
             flags[kFLAGS.IN_COMBAT_PLAYER_ELEMENTAL_ATTACKED] = 1;
@@ -20085,3 +20090,4 @@ private function touSpeStrScale(stat:int):Number {
 }
 
 }
+

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -17661,7 +17661,10 @@ public function SlimeRapeFeed():void {
         var damagemultiplier:Number = 1;
         if (player.hasPerk(PerkLib.RacialParagon)) damagemultiplier *= RacialParagonAbilityBoost();
         damage *= damagemultiplier;
-
+		if (player.hasPerk(PerkLib.ImprovedGrapple)) {
+		if (player.hasPerk(PerkLib.GreaterGrapple)) damage *= 1.4;
+		else damage *= 1.2;
+		}
         //Determine if critical tease!
         var crit:Boolean = false;
         var critChance:int = 5;
@@ -17695,7 +17698,14 @@ public function SlimeRapeFeed():void {
     monsterDefeatCheck();
     enemyAI();
 }
-
+public function SlimeRapeStop():void {
+    clearOutput();
+    outputText("You sllide out of [Themonster], preferring to continue the fight normally.");
+	monster.removeStatusEffect(StatusEffects.SlimeInsert);
+    outputText("[monster He] catches [monster his] breath before [monster he] stands back up, apparently prepared to fight some more. \n");
+    outputText("\n\n");
+    enemyAIImpl();
+}
 //Vampiric bite
 public function VampiricBite():void {
     fatigue(20, USEFATG_PHYSICAL);
@@ -20073,4 +20083,5 @@ private function touSpeStrScale(stat:int):Number {
         return player.hasStatusEffect(StatusEffects.UnderwaterCombatBoost) || player.hasStatusEffect(StatusEffects.NearWater) || explorer.areaTags.water;
     }
 }
+
 }

--- a/classes/classes/Scenes/Combat/CombatUI.as
+++ b/classes/classes/Scenes/Combat/CombatUI.as
@@ -391,6 +391,7 @@ public class CombatUI extends BaseCombatContent {
 		} else if (monster.hasStatusEffect(StatusEffects.SlimeInsert)) {
 			menu();
 			addButton(0, "Rape", combat.SlimeRapeFeed).hint("Violate your opponent from the inside!");
+			addButton(4, "Release", combat.SlimeRapeStop).hint("Release your opponent.");
 		} else if (monster.hasStatusEffect(StatusEffects.Swallowed)) {
 			menu();
 			addButton(0, "Tease", combat.SwallowTease).hint("Use a powerful teasing attack").icon("A_Tease");
@@ -1136,3 +1137,4 @@ public class CombatUI extends BaseCombatContent {
 	}
 }
 }
+

--- a/classes/classes/Scenes/Combat/CombatUI.as
+++ b/classes/classes/Scenes/Combat/CombatUI.as
@@ -82,7 +82,7 @@ public class CombatUI extends BaseCombatContent {
 
 		//Standard menu before modifications.
 		if (flags[kFLAGS.ELEMENTAL_CONJUER_SUMMONS] == 2 || flags[kFLAGS.ELEMENTAL_CONJUER_SUMMONS] == 4) {
-			btnMelee.show("E.Attack", combat.baseelementalattacks, "Command your elemental to attack the enemy.  Damage it will deal is affected by your wisdom and intelligence.").icon("A_Melee");
+			btnMelee.show("E.Attack", combat.basicElementalAttack, "Command your elemental to attack the enemy.  Damage it will deal is affected by your wisdom and intelligence.").icon("A_Melee");
 			if (combat.isEnemyInvisible) btnMelee.disable("You cannot use command your elemental to attack an opponent you cannot see or target.");
 		}
 		else {/*
@@ -1137,4 +1137,5 @@ public class CombatUI extends BaseCombatContent {
 	}
 }
 }
+
 


### PR DESCRIPTION
Made Slime race's "Rape" attack boosted by the perks [Improved Grapple] and [Greater Grapple].

Fixed "SlimeInsert" not being counted as a constricting status effect.

Added a "Release" option after inserting your self into a enemy as a slime.

Fixed Elemental auto attacks causing the player's turn to be skipped.

Fixed Elemental basic attacks(E.Attack) not working unless click twice.