### PR TITLE
Dark Slime update

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -3678,6 +3678,10 @@ import classes.Scenes.Combat.CombatAbility;
 				if (player.hasPerk(PerkLib.TechOverdrive) && player.perkv4(PerkLib.TechOverdrive) < 1) addButton(2, "TechOverdrive", permanentizePerk4, PerkLib.TechOverdrive);
 				else if (player.hasPerk(PerkLib.TechOverdrive) && player.perkv4(PerkLib.TechOverdrive) > 0) addButtonDisabled(2, "TechOverdrive", "Tech Overdrive perk is already made permanent and will carry over in all subsequent ascensions.");
 				else addButtonDisabled(2, "TechOverdrive", "Tech Overdrive");
+				if (true && player.perkv4(PerkLib.DarkSlimeEmpressCore) < 1) addButton(3, "S.D.S.Core", permanentizePerk4, PerkLib.DarkSlimeEmpressCore);
+				else if (player.hasPerk(PerkLib.DarkSlimeEmpressCore) && player.perkv4(PerkLib.TechOverdrive) > 0) addButtonDisabled(3, "S.D.S.Core", "Sovereign's Dark Slime Core perk is already made permanent and will carry over in all subsequent ascensions.");
+				else addButtonDisabled(3, "S.D.S.Core", "Sovereign's Dark Slime Core");
+				
 				//3
 				//addButton(4, "Next", ascensionPermeryMenu, page + 1);
 				//5

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -3678,9 +3678,9 @@ import classes.Scenes.Combat.CombatAbility;
 				if (player.hasPerk(PerkLib.TechOverdrive) && player.perkv4(PerkLib.TechOverdrive) < 1) addButton(2, "TechOverdrive", permanentizePerk4, PerkLib.TechOverdrive);
 				else if (player.hasPerk(PerkLib.TechOverdrive) && player.perkv4(PerkLib.TechOverdrive) > 0) addButtonDisabled(2, "TechOverdrive", "Tech Overdrive perk is already made permanent and will carry over in all subsequent ascensions.");
 				else addButtonDisabled(2, "TechOverdrive", "Tech Overdrive");
-				if (true && player.perkv4(PerkLib.DarkSlimeEmpressCore) < 1) addButton(3, "S.D.S.Core", permanentizePerk4, PerkLib.DarkSlimeEmpressCore);
-				else if (player.hasPerk(PerkLib.DarkSlimeEmpressCore) && player.perkv4(PerkLib.TechOverdrive) > 0) addButtonDisabled(3, "S.D.S.Core", "Sovereign's Dark Slime Core perk is already made permanent and will carry over in all subsequent ascensions.");
-				else addButtonDisabled(3, "S.D.S.Core", "Sovereign's Dark Slime Core");
+				if (player.hasPerk(PerkLib.DarkSlimeEmpressCore) && player.perkv4(PerkLib.DarkSlimeEmpressCore) < 1) addButton(3, "S.D.Essence", permanentizePerk4, PerkLib.DarkSlimeEmpressCore);
+				else if (player.hasPerk(PerkLib.DarkSlimeEmpressCore) && player.perkv4(PerkLib.DarkSlimeEmpressCore) > 0) addButtonDisabled(3, "S.D.Essence", "Sovereign's Dark Essence perk is already made permanent and will carry over in all subsequent ascensions.");
+				else addButtonDisabled(3, "S.D.Essence", "Sovereign's Dark Essence");
 				
 				//3
 				//addButton(4, "Next", ascensionPermeryMenu, page + 1);
@@ -4269,3 +4269,4 @@ import classes.Scenes.Combat.CombatAbility;
 		}
 	} // what the fuck are those weird comments here? ^
 }
+

--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -3678,9 +3678,9 @@ import classes.Scenes.Combat.CombatAbility;
 				if (player.hasPerk(PerkLib.TechOverdrive) && player.perkv4(PerkLib.TechOverdrive) < 1) addButton(2, "TechOverdrive", permanentizePerk4, PerkLib.TechOverdrive);
 				else if (player.hasPerk(PerkLib.TechOverdrive) && player.perkv4(PerkLib.TechOverdrive) > 0) addButtonDisabled(2, "TechOverdrive", "Tech Overdrive perk is already made permanent and will carry over in all subsequent ascensions.");
 				else addButtonDisabled(2, "TechOverdrive", "Tech Overdrive");
-				if (player.hasPerk(PerkLib.DarkSlimeEmpressCore) && player.perkv4(PerkLib.DarkSlimeEmpressCore) < 1) addButton(3, "S.D.Essence", permanentizePerk4, PerkLib.DarkSlimeEmpressCore);
-				else if (player.hasPerk(PerkLib.DarkSlimeEmpressCore) && player.perkv4(PerkLib.DarkSlimeEmpressCore) > 0) addButtonDisabled(3, "S.D.Essence", "Sovereign's Dark Essence perk is already made permanent and will carry over in all subsequent ascensions.");
-				else addButtonDisabled(3, "S.D.Essence", "Sovereign's Dark Essence");
+				if (player.hasPerk(PerkLib.DarkSlimeEmpressCore) && player.perkv4(PerkLib.DarkSlimeEmpressCore) < 1) addButton(3, "E.D.Essence", permanentizePerk4, PerkLib.DarkSlimeEmpressCore);
+				else if (player.hasPerk(PerkLib.DarkSlimeEmpressCore) && player.perkv4(PerkLib.DarkSlimeEmpressCore) > 0) addButtonDisabled(3, "E.D.Essence", "Empress's Dark Essence perk is already made permanent and will carry over in all subsequent ascensions.");
+				else addButtonDisabled(3, "E.D.Essence", "Empress's Dark Essence");
 				
 				//3
 				//addButton(4, "Next", ascensionPermeryMenu, page + 1);
@@ -4269,4 +4269,5 @@ import classes.Scenes.Combat.CombatAbility;
 		}
 	} // what the fuck are those weird comments here? ^
 }
+
 

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -1351,8 +1351,8 @@ public static const NADIA_INCUBATION:int		                                    = 
 public static const DIVA_PREGNANCY_TYPE:int                                		    = 1343;
 public static const DIVA_INCUBATION:int                                  			= 1344;
 public static const ENCOUNTERED_DARKSLIME_EMPRESS:int                               = 1345;
-public static const UNKNOWN_FLAG_NUMBER_01346:int                                   = 1346;
-public static const UNKNOWN_FLAG_NUMBER_01347:int                                   = 1347;
+public static const PLAYER_SLIMES_COUNT:int                                         = 1346;
+public static const IN_COMBAT_PLAYER_SLIMES_ATTACKED:int                            = 1347;
 public static const UNKNOWN_FLAG_NUMBER_01348:int                                   = 1348;
 public static const UNKNOWN_FLAG_NUMBER_01349:int                                   = 1349;
 public static const UNKNOWN_FLAG_NUMBER_01350:int                                   = 1350;
@@ -3019,5 +3019,4 @@ public static const GLOBAL_FLAGS_ARRAY:Array = [
 	USSDISPLAY_STYLE, IMDB_DETAILS, BUTTON_ICONS_DISABLED, STATBAR_ANIMATIONS
 ];
 	}
-
 }

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -1350,7 +1350,7 @@ public static const NADIA_PREGNANCY_TYPE:int     	                              
 public static const NADIA_INCUBATION:int		                                    = 1342;
 public static const DIVA_PREGNANCY_TYPE:int                                		    = 1343;
 public static const DIVA_INCUBATION:int                                  			= 1344;
-public static const UNKNOWN_FLAG_NUMBER_01345:int                                   = 1345;
+public static const ENCOUNTERED_DARKSLIME_EMPRESS:int                               = 1345;
 public static const UNKNOWN_FLAG_NUMBER_01346:int                                   = 1346;
 public static const UNKNOWN_FLAG_NUMBER_01347:int                                   = 1347;
 public static const UNKNOWN_FLAG_NUMBER_01348:int                                   = 1348;
@@ -3019,4 +3019,5 @@ public static const GLOBAL_FLAGS_ARRAY:Array = [
 	USSDISPLAY_STYLE, IMDB_DETAILS, BUTTON_ICONS_DISABLED, STATBAR_ANIMATIONS
 ];
 	}
+
 }

--- a/classes/classes/IMutations/SlimeMetabolismMutation.as
+++ b/classes/classes/IMutations/SlimeMetabolismMutation.as
@@ -34,7 +34,7 @@ import classes.Races;
             if (pTier >= 3){
                 descS += ". Gain temporary regeneration +" + pAccc + "% after a fluid intake for one hour";
             }
-            if (pTier >= 3){
+            if (pTier >= 4){
                 descS += ". Fluid intake heals all status damage, drains and weakening by 5% per intake";
             }
             if (descS != "")descS += ".";

--- a/classes/classes/Items/HeadJewelry.as
+++ b/classes/classes/Items/HeadJewelry.as
@@ -113,6 +113,11 @@ package classes.Items
 				outputText("You would very much like to equip this item, but your body stiffness prevents you from doing so.");
 				return false;
 			}
+			if (game.player.hasKeyItem("Slimy Crown") && game.player.isSlime() && game.player.hasHairMaterial()){
+				outputText("You would like to equip this item, but you're already wearing a gooey crown atop your head.");
+				return false;
+			}
+			
 			return super.canEquip(doOutput, slot);
 		}
 		

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -4169,7 +4169,7 @@ public class PerkLib
 				"Increase all damage dealt with darkness spells by 100% and reduce darkness damage taken by 50%.");
 		public static const DarkSlimeCore:PerkType = mk("Dark Slime Core", "Dark Slime Core",
 				"Grants more control over your slimy body, allowing you to go twice as long without fluids.");
-		public static const DarkSlimeEmpressCore:PerkType = mk("Sovereign's Dark Essence", "Sovereign's Dark Essence",
+		public static const DarkSlimeEmpressCore:PerkType = mk("Empress's Dark Essence", "Empress's Dark Essence",
 				"Increases your control over slime, allowing you to utilize external mass better.");
 		public static const RoyalSlimeJelly:PerkType = mk("Royal Jelly", "Royal Jelly",
 				"Increases your control over slime. ");//Perk from Slimy Crown
@@ -9008,5 +9008,6 @@ public class PerkLib
 }
 
 }
+
 
 

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -4169,7 +4169,7 @@ public class PerkLib
 				"Increase all damage dealt with darkness spells by 100% and reduce darkness damage taken by 50%.");
 		public static const DarkSlimeCore:PerkType = mk("Dark Slime Core", "Dark Slime Core",
 				"Grants more control over your slimy body, allowing you to go twice as long without fluids.");
-		public static const DarkSlimeEmpressCore:PerkType = mk("Sovereign's Dark Slime Core", "Sovereign's Dark Slime Core",
+		public static const DarkSlimeEmpressCore:PerkType = mk("Sovereign's Dark Essence", "Sovereign's Dark Essence",
 				"Increases your control over slime, allowing you to utilize external mass better.");
 		public static const RoyalSlimeJelly:PerkType = mk("Royal Jelly", "Royal Jelly",
 				"Increases your control over slime. ");//Perk from Slimy Crown
@@ -9008,4 +9008,5 @@ public class PerkLib
 }
 
 }
+
 

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -4170,7 +4170,9 @@ public class PerkLib
 		public static const DarkSlimeCore:PerkType = mk("Dark Slime Core", "Dark Slime Core",
 				"Grants more control over your slimy body, allowing you to go twice as long without fluids.");
 		public static const DarkSlimeEmpressCore:PerkType = mk("Sovereign's Dark Slime Core", "Sovereign's Dark Slime Core",
-				"Grants more control over slime itself, allowing you to utilize external mass better.");
+				"Increases your control over slime, allowing you to utilize external mass better.");
+		public static const RoyalSlimeJelly:PerkType = mk("Royal Jelly", "Royal Jelly",
+				"Increases your control over slime. ");//Perk from Slimy Crown
 		public static const DeadMetabolism:PerkType = mk("Dead metabolism", "Dead metabolism",
 				"Kills off hunger. (hunger meter wouldn't decay with time)");
 		public static const DeathlyPower:PerkType = mk("Deathly power", "Deathly power",
@@ -9006,3 +9008,4 @@ public class PerkLib
 }
 
 }
+

--- a/classes/classes/PerkLib.as
+++ b/classes/classes/PerkLib.as
@@ -4169,6 +4169,8 @@ public class PerkLib
 				"Increase all damage dealt with darkness spells by 100% and reduce darkness damage taken by 50%.");
 		public static const DarkSlimeCore:PerkType = mk("Dark Slime Core", "Dark Slime Core",
 				"Grants more control over your slimy body, allowing you to go twice as long without fluids.");
+		public static const DarkSlimeEmpressCore:PerkType = mk("Sovereign's Dark Slime Core", "Sovereign's Dark Slime Core",
+				"Grants more control over slime itself, allowing you to utilize external mass better.");
 		public static const DeadMetabolism:PerkType = mk("Dead metabolism", "Dead metabolism",
 				"Kills off hunger. (hunger meter wouldn't decay with time)");
 		public static const DeathlyPower:PerkType = mk("Deathly power", "Deathly power",
@@ -9002,4 +9004,5 @@ public class PerkLib
         }
 	}
 }
+
 }

--- a/classes/classes/PlayerEvents.as
+++ b/classes/classes/PlayerEvents.as
@@ -1876,6 +1876,15 @@ public class PlayerEvents extends BaseContent implements TimeAwareInterface {
 					needNext = true;
 				}
 			}
+			if (player.hasKeyItem("Slimy Crown") >= 0 && player.isSlime() && !player.hasPerk(PerkLib.RoyalSlimeJelly)) { //Gain crown perk
+				if (player.hasStatusEffect(StatusEffects.SlimeCraving) && player.isGoo() && player.rearBody.type == RearBody.METAMORPHIC_GOO && player.arms.type == Arms.GOO) {
+					outputText("\nYou feel something change, a crown forms on top of your gooey head.\n");
+					outputText("(<b>Gained New Perk: Royal Jelly - "+PerkLib.RoyalSlimeJelly.longDesc+"</b>)\n");
+					player.createPerk(PerkLib.RoyalSlimeJelly, 0, 0, 0, 0);
+					needNext = true;
+				}
+			}
+			
 			if (player.hasPerk(PerkLib.DarkSlimeCore)) { //Lose DARK slime core perk
 				if (player.rearBody.type != RearBody.METAMORPHIC_GOO || player.arms.type != Arms.GOO || !LowerBody.isGoo(player)) {
 					outputText("\nYour form ripples, as if uncertain at the changes your body is undergoing.  The goo of your flesh cools, its sensitive, responsive membrane thickening into [skin] while bones and muscles knit themselves into a cohesive torso, chest and hips gaining definition.  Translucent ooze clouds and the gushing puddle at your feet melts together, splitting into solid trunks as you regain your legs.  Before long, you can no longer see through your own body and, with an unsteady shiver, you pat yourself down, readjusting to solidity.  A lurching heat in your chest suddenly reminds you of the slime core that used to float inside you.  Gingerly touching your " + CoC.instance.player.chestDesc() + ", you can feel a small, second heartbeat under your ribs that gradually seems to be sinking, past your belly. A lurching wave of warmth sparks through you, knocking you off your fresh legs and onto your " + Appearance.buttDescription(player) + ".  A delicious pressure pulses in your abdomen and you loosen your [armor] as sweat beads down your neck.  You clench your eyes, tongue lolling in your mouth, and the pressure builds and builds until, in ecstatic release, your body arches in an orgasmic release.\n\n");
@@ -1885,6 +1894,13 @@ public class PlayerEvents extends BaseContent implements TimeAwareInterface {
 					needNext = true;
 				}
 			}
+			if (player.hasPerk(PerkLib.RoyalSlimeJelly) && !player.isSlime()) { //Lose crown perk
+				outputText("\nYou feel.. less royal.");
+				outputText("\n(<b>Lost Perk: Royal Jelly</b>)")
+				player.removePerk(PerkLib.RoyalSlimeJelly);
+				needNext = true;
+			}
+			
 			if (player.hasKeyItem("Ruby Orb") >= 0) { //Regain DARK slime core
 				if (player.hasStatusEffect(StatusEffects.SlimeCraving) && !player.hasPerk(PerkLib.DarkSlimeCore) && player.isGoo() && player.rearBody.type == RearBody.METAMORPHIC_GOO && player.arms.type == Arms.GOO && LowerBody.isGoo(player)) {
 					outputText("\nAs you adjust to your new, goo-like body, you remember the ruby heart you expelled so long ago.  As you reach to pick it up, it quivers and pulses with a warm, cheerful light.  Your fingers close on it and the nucleus slides through your palm, into your body!\n\n");

--- a/classes/classes/Races/DarkSlimeRace.as
+++ b/classes/classes/Races/DarkSlimeRace.as
@@ -52,6 +52,7 @@ public class DarkSlimeRace extends Race {
 				.hasStatusEffect(StatusEffects.SlimeCraving, "Slime Craving", +1)
 				.hasPerk(PerkLib.DarkSlimeCore, +1)
 				.hasPerk(PerkLib.DarkSlimeEmpressCore, +5)
+				.hasPerk(PerkLib.RoyalSlimeJelly, +2)
 				.hasPerk(PerkLib.GOBXChemical, -1000);
 		
 		addConditionedScores(function (body:BodyData):Boolean {
@@ -97,11 +98,11 @@ public class DarkSlimeRace extends Race {
 					"tou.mult": +1.95,
 					"spe.mult": -0.75,
 					"int.mult": +1.85,
-					"lib.mult": +1.5
+					"lib.mult": +1.7
 				})
 				.end();
 		
-		buildTier(32, "Dark Slime Empress")
+		buildTier(34, "Dark Slime Empress")
 				.namesMaleFemale("Dark Slime Emperor", "Dark Slime Empress")
 				.requirePerk(PerkLib.DarkSlimeEmpressCore)
 				.requirePerk(PerkLib.TransformationImmunity2)
@@ -109,9 +110,10 @@ public class DarkSlimeRace extends Race {
 					"tou.mult": +2.75,
 					"spe.mult": -0.95,
 					"int.mult": +3.4,
-					"lib.mult": +1.85
+					"lib.mult": +2.05
 				})
 				.end();
 	}
 }
 }
+`҃

--- a/classes/classes/Races/DarkSlimeRace.as
+++ b/classes/classes/Races/DarkSlimeRace.as
@@ -51,6 +51,7 @@ public class DarkSlimeRace extends Race {
 				}, +1)
 				.hasStatusEffect(StatusEffects.SlimeCraving, "Slime Craving", +1)
 				.hasPerk(PerkLib.DarkSlimeCore, +1)
+				.hasPerk(PerkLib.DarkSlimeEmpressCore, +5)
 				.hasPerk(PerkLib.GOBXChemical, -1000);
 		
 		addConditionedScores(function (body:BodyData):Boolean {
@@ -68,8 +69,8 @@ public class DarkSlimeRace extends Race {
 		addMutation(IMutationsLib.SlimeMetabolismIM);
 		addMutation(IMutationsLib.SlimeFluidIM);
 		
-		buildTier(12, "dark slime")
-				.namesMaleFemale("dark slime boi", "dark slime girl")
+		buildTier(12, "Dark Slime")
+				.namesMaleFemale("Dark Slime boi", "Dark Slime Girl")
 				.buffs({
 					"tou.mult": +0.90,
 					"spe.mult": -0.40,
@@ -78,12 +79,36 @@ public class DarkSlimeRace extends Race {
 				})
 				.end();
 		
-		buildTier(16, "dark slime queen")
+		buildTier(16, "Dark Slime Princess")
+				.namesMaleFemale("Dark Slime Prince", "Dark Slime Princess")
 				.buffs({
 					"tou.mult": +1.15,
 					"spe.mult": -0.50,
 					"int.mult": +0.45,
 					"lib.mult": +1.45
+				})
+				.end();
+				
+		buildTier(20, "Dark Slime Queen")
+				.namesMaleFemale("Dark Slime King", "Dark Slime Queen")
+				.require("Slimy Crown", function(body:BodyData):Boolean {
+				return body.player.hasKeyItem("Slimy Crown")!=-1 })
+				.buffs({
+					"tou.mult": +1.65,
+					"spe.mult": -0.75,
+					"int.mult": +0.55,
+					"lib.mult": +2.40
+				})
+				.end();
+		
+		buildTier(25, "Dark Slime Empress")
+				.namesMaleFemale("Dark Slime Emperor", "Dark Slime Empress")
+				.requirePerk(PerkLib.DarkSlimeEmpressCore)
+				.buffs({
+					"tou.mult": +3.0,
+					"spe.mult": -0.95,
+					"int.mult": +1.25,
+					"lib.mult": +2.80
 				})
 				.end();
 	}

--- a/classes/classes/Races/DarkSlimeRace.as
+++ b/classes/classes/Races/DarkSlimeRace.as
@@ -107,10 +107,10 @@ public class DarkSlimeRace extends Race {
 				.requirePerk(PerkLib.DarkSlimeEmpressCore)
 				.requirePerk(PerkLib.TransformationImmunity2)
 				.buffs({
-					"tou.mult": +3.1,
+					"tou.mult": +7.0,
 					"spe.mult": -0.95,
-					"int.mult": +3.4,
-					"lib.mult": +2.5
+					"int.mult": +5.5,
+					"lib.mult": +3.75
 				})
 				.end();
 	}

--- a/classes/classes/Races/DarkSlimeRace.as
+++ b/classes/classes/Races/DarkSlimeRace.as
@@ -85,7 +85,7 @@ public class DarkSlimeRace extends Race {
 				.buffs({
 					"tou.mult": +1.05,
 					"spe.mult": -0.50,
-					"int.mult": +0.90,
+					"int.mult": +0.85,
 					"lib.mult": +1.00
 				})
 				.end();
@@ -97,7 +97,7 @@ public class DarkSlimeRace extends Race {
 				.buffs({
 					"tou.mult": +1.45,
 					"spe.mult": -0.75,
-					"int.mult": +1.75,
+					"int.mult": +1.65,
 					"lib.mult": +1.25
 				})
 				.end();

--- a/classes/classes/Races/DarkSlimeRace.as
+++ b/classes/classes/Races/DarkSlimeRace.as
@@ -72,7 +72,7 @@ public class DarkSlimeRace extends Race {
 		buildTier(12, "Dark Slime")
 				.namesMaleFemale("Dark Slime boi", "Dark Slime Girl")
 				.buffs({
-					"tou.mult": +0.90,
+					"tou.mult": +0.65,
 					"spe.mult": -0.40,
 					"int.mult": +0.45,
 					"lib.mult": +1.00
@@ -84,31 +84,32 @@ public class DarkSlimeRace extends Race {
 				.buffs({
 					"tou.mult": +1.15,
 					"spe.mult": -0.50,
-					"int.mult": +0.45,
+					"int.mult": +0.90,
 					"lib.mult": +1.45
 				})
 				.end();
 				
-		buildTier(20, "Dark Slime Queen")
+		buildTier(24, "Dark Slime Queen")
 				.namesMaleFemale("Dark Slime King", "Dark Slime Queen")
-				.require("Slimy Crown", function(body:BodyData):Boolean {
-				return body.player.hasKeyItem("Slimy Crown")!=-1 })
+				.require("Slimy Crown or Sovereign's Dark Slime Core perk", function(body:BodyData):Boolean {
+				return body.player.hasKeyItem("Slimy Crown")!=-1 || body.player.hasPerk(PerkLib.DarkSlimeEmpressCore)})
 				.buffs({
-					"tou.mult": +1.65,
+					"tou.mult": +1.95,
 					"spe.mult": -0.75,
-					"int.mult": +0.55,
-					"lib.mult": +2.40
+					"int.mult": +1.85,
+					"lib.mult": +1.5
 				})
 				.end();
 		
-		buildTier(25, "Dark Slime Empress")
+		buildTier(32, "Dark Slime Empress")
 				.namesMaleFemale("Dark Slime Emperor", "Dark Slime Empress")
 				.requirePerk(PerkLib.DarkSlimeEmpressCore)
+				.requirePerk(PerkLib.TransformationImmunity2)
 				.buffs({
-					"tou.mult": +3.0,
+					"tou.mult": +2.75,
 					"spe.mult": -0.95,
-					"int.mult": +1.25,
-					"lib.mult": +2.80
+					"int.mult": +3.4,
+					"lib.mult": +1.85
 				})
 				.end();
 	}

--- a/classes/classes/Races/DarkSlimeRace.as
+++ b/classes/classes/Races/DarkSlimeRace.as
@@ -101,6 +101,17 @@ public class DarkSlimeRace extends Race {
 					"lib.mult": +1.25
 				})
 				.end();
+		buildTier(26, "Dark Slime Sovereign")
+				.require("Slimy Crown or Sovereign's Dark Slime Core perk", function(body:BodyData):Boolean {
+				return body.player.hasKeyItem("Slimy Crown")!=-1 || body.player.hasPerk(PerkLib.DarkSlimeEmpressCore)})
+				.requirePerk(PerkLib.TransformationImmunity2)
+				.buffs({
+					"tou.mult": +5.9,
+					"spe.mult": -0.85,
+					"int.mult": +4.0,
+					"lib.mult": +2.65
+				})
+				.end();
 		
 		buildTier(34, "Dark Slime Empress")
 				.namesMaleFemale("Dark Slime Emperor", "Dark Slime Empress")

--- a/classes/classes/Races/DarkSlimeRace.as
+++ b/classes/classes/Races/DarkSlimeRace.as
@@ -74,19 +74,19 @@ public class DarkSlimeRace extends Race {
 				.namesMaleFemale("Dark Slime boi", "Dark Slime Girl")
 				.buffs({
 					"tou.mult": +0.65,
-					"spe.mult": -0.40,
-					"int.mult": +0.45,
-					"lib.mult": +1.00
+					"spe.mult": -0.30,
+					"int.mult": +0.55,
+					"lib.mult": +0.90
 				})
 				.end();
 		
 		buildTier(16, "Dark Slime Princess")
 				.namesMaleFemale("Dark Slime Prince", "Dark Slime Princess")
 				.buffs({
-					"tou.mult": +1.15,
+					"tou.mult": +1.05,
 					"spe.mult": -0.50,
 					"int.mult": +0.90,
-					"lib.mult": +1.45
+					"lib.mult": +1.00
 				})
 				.end();
 				
@@ -95,10 +95,10 @@ public class DarkSlimeRace extends Race {
 				.require("Slimy Crown or Sovereign's Dark Slime Core perk", function(body:BodyData):Boolean {
 				return body.player.hasKeyItem("Slimy Crown")!=-1 || body.player.hasPerk(PerkLib.DarkSlimeEmpressCore)})
 				.buffs({
-					"tou.mult": +1.95,
+					"tou.mult": +1.45,
 					"spe.mult": -0.75,
-					"int.mult": +1.85,
-					"lib.mult": +1.7
+					"int.mult": +1.75,
+					"lib.mult": +1.25
 				})
 				.end();
 		
@@ -107,13 +107,12 @@ public class DarkSlimeRace extends Race {
 				.requirePerk(PerkLib.DarkSlimeEmpressCore)
 				.requirePerk(PerkLib.TransformationImmunity2)
 				.buffs({
-					"tou.mult": +2.75,
+					"tou.mult": +3.1,
 					"spe.mult": -0.95,
 					"int.mult": +3.4,
-					"lib.mult": +2.05
+					"lib.mult": +2.5
 				})
 				.end();
 	}
 }
 }
-`҃

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -864,6 +864,7 @@ public class Combat extends BaseContent {
 			flags[kFLAGS.IN_COMBAT_PLAYER_ANUBI_HEART_LEECH] = 0;
             flags[kFLAGS.IN_COMBAT_PLAYER_GOBLIN_MECH_AI_ATTACKED] = 0;
             flags[kFLAGS.IN_COMBAT_PLAYER_GOBLIN_GADGET_USED] = 0;
+			flags[kFLAGS.IN_COMBAT_PLAYER_SLIMES_ATTACKED] = 0;
 			if (player.hasPerk(PerkLib.FirstAttackSkeletons)) flags[kFLAGS.IN_COMBAT_PLAYER_SKELETONS_ATTACKED] = 0;
 			if (player.hasPerk(PerkLib.MyBloodForBloodPuppies)) flags[kFLAGS.IN_COMBAT_PLAYER_BLOOD_PUPPIES_ATTACKED] = 0;
 			if (player.perkv1(IMutationsLib.SharkOlfactorySystemIM) >= 4) flags[kFLAGS.IN_COMBAT_PLAYER_USED_SHARK_BITE] = 0;
@@ -1830,6 +1831,8 @@ public class Combat extends BaseContent {
             ui.doFlyingSwordTurn();
         if (ui.isMechAITurn())
             ui.doMechAITurn();
+		if (ui.isSlimeTurn())
+            ui.doSlimeTurn();
         for (var ci:int = 0; ci <= 3; ++ci)
             if (ui.isCompanionTurn(ci))
                 ui.doCompanionTurn(ci, false);
@@ -20126,3 +20129,4 @@ private function touSpeStrScale(stat:int):Number {
 }
 
 }
+

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -11834,6 +11834,12 @@ public class Combat extends BaseContent {
     }
 
     public function awardPlayer(nextFunc:Function = null):void {
+		if (monster.hasStatusEffect(StatusEffects.SlimeSurround)&&(monster.getStatusValue(StatusEffects.SlimeSurround,1)>0 || monster.getStatusValue(StatusEffects.SlimeSurround,2)>0)){
+			var slimeCount:int = monster.getStatusValue(StatusEffects.SlimeSurround, 1) + (monster.getStatusValue(StatusEffects.SlimeSurround, 2)/(player.hasPerk(PerkLib.DarkSlimeEmpressCore) ? 4:2));
+			player.HP += Math.round((player.maxHP()*0.08) * slimeCount);
+			//if (player.HP > player.maxHP()) player.HP = player.MaxHP;
+			outputText("\nYou absorb the remaining slime. <b>([font-heal]"+Math.round((player.maxHP()*0.08)*slimeCount)+"[/font])</b>\n");
+		}
         if (nextFunc == null) nextFunc = explorer.done;
         if (player.countCockSocks("gilded") > 0) {
             //trace( "awardPlayer found MidasCock. Gems bumped from: " + monster.gems );
@@ -20118,4 +20124,5 @@ private function touSpeStrScale(stat:int):Number {
         return player.hasStatusEffect(StatusEffects.UnderwaterCombatBoost) || player.hasStatusEffect(StatusEffects.NearWater) || explorer.areaTags.water;
     }
 }
+
 }

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -4937,7 +4937,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			//Failure (-10 HPs) -
 			if (monster.hasStatusEffect(StatusEffects.SlimeSurround) && monster.getStatusValue(StatusEffects.SlimeSurround, 1) > (monster.plural ? 2:0)){
 				monster.addStatusValue(StatusEffects.SlimeSurround, 1, (monster.plural ? 3:1));
-				outputText("You use a "+(monster.plural ? "large":"small")+" amount of slime on the ground to encase [The monster]"+(monster.plural ? "s":"")+".");
+				outputText("You use a "+(monster.plural ? "large":"small")+" amount of slime on the ground to encase [themonster]"+(monster.plural ? "s":"")+".");
 				monster.createStatusEffect(StatusEffects.GooEngulf, 3 + rand(3),0,0,0);
 				outputText("\n\n");
 				enemyAI();

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -2971,9 +2971,9 @@ public class PhysicalSpecials extends BaseCombatContent {
 		if(canActMore && rand(15)==1)slimeArmySingleAttack(ogDmg,dmgType,false)
 	}
 	
-	public function slimeArmyAttack():void {
+	public function slimeArmyAttack(autoAttack:Boolean=false):void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
-		clearOutput();
+		if (autoAttack==false) clearOutput();
 		
 		var slimes:Number = monster.getStatusValue(StatusEffects.SlimeSurround, 2);
 		var sAtks:Array = [0,0,0,0];
@@ -2985,13 +2985,13 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (r >75)sAtks[3]+=1
 		}
 		
-		var sDam0:Number = (combat.scalingBonusStrength()*2.5)+combat.scalingBonusToughness()*1.2;;//melee
-		var sDam1:Number = combat.scalingBonusToughness();+combat.scalingBonusStrength()+combat.scalingBonusSpeed();//ranged
-		var sDam2:Number = combat.scalingBonusLibido()*0.25;//lust
-		var sDam3:Number = combat.scalingBonusToughness()*2.5;//dark/sacrifice
+		var sDam0:Number = (combat.scalingBonusIntelligence())+combat.scalingBonusToughness()*1.2;;//melee
+		var sDam1:Number = combat.scalingBonusToughness();//ranged
+		var sDam2:Number = combat.scalingBonusLibido()*0.025;//lust
+		var sDam3:Number = combat.scalingBonusIntelligence()*2.5;//dark/sacrifice
 		
 		
-		
+		outputText("\n")
 		if (sAtks[0] > 0){
 			outputText(num2Text(sAtks[0], 100) + " of your slimes slash and stab [Themonster] with goopy spears. ");
 			while(sAtks[0]-->0){
@@ -3022,7 +3022,8 @@ public class PhysicalSpecials extends BaseCombatContent {
 		
 		
 		outputText("\n\n");
-		enemyAI();
+		combat.monsterDefeatCheck();
+		if (autoAttack==false) enemyAI();
 	}
 	
 	public function terrifyingHowl():void {

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -2935,24 +2935,43 @@ public class PhysicalSpecials extends BaseCombatContent {
 		var dmgAmp:int = 1;
 		var isDark:Boolean = (dmgType==1 && (rand(100) < (player.hasPerk(PerkLib.DarkSlimeEmpressCore) ? 66:33))) ? true:false;
 		if (dmgType == 3) isDark = true;
-		if (isDark) damage+= combat.scalingBonusLibido()*1.2;
-		if (player.hasPerk(PerkLib.HistoryTactician) || player.hasPerk(PerkLib.PastLifeTactician)) damage *= combat.historyTacticianBonus();
-		if (player.hasPerk(PerkLib.CommandingTone)) damage *= 0.1;
-		if (player.hasPerk(PerkLib.DiaphragmControl)) damage *= 0.1;
-		if (player.hasPerk(PerkLib.VocalTactician)) damage *= 0.15;
-		
-		if (flags[kFLAGS.WILL_O_THE_WISP] == 2 && dmgType!=2) {
-			dmgAmp += 0.1;
-			if (player.hasPerk(PerkLib.WispLieutenant)) dmgAmp += 0.2;
-			if (player.hasPerk(PerkLib.WispCaptain)) dmgAmp += 0.3;
-			if (player.hasPerk(PerkLib.WispMajor)) dmgAmp += 0.4;
-			if (player.hasPerk(PerkLib.WispColonel)) dmgAmp += 0.5;
+		if (isDark) damage+= combat.scalingBonusLibido() * 1.2;
+		if (dmgType == 2){
+			if (player.hasPerk(PerkLib.FlawlessBody)) damage += 10;
+			if (player.hasPerk(PerkLib.JobSeducer)) damage += player.teaseLevel * 2;
+			else damage += player.teaseLevel * 1;
 		}
-		if (player.hasPerk(PerkLib.RoyalSlimeJelly)) damage *= 0.2;
-		if (player.hasPerk(PerkLib.DarkSlimeEmpressCore)) dmgAmp += 0.2;
-		if (player.hasPerk(PerkLib.DarkSlimeEmpressCore)&& isAuto==false) dmgAmp += 0.2;
 		
-		damage *= dmgAmp;
+		if (dmgType!=2 || player.hasPerk(PerkLib.EromancyExpert)) {
+			if (player.hasPerk(PerkLib.HistoryTactician) || player.hasPerk(PerkLib.PastLifeTactician)) damage *= combat.historyTacticianBonus();
+			if (player.hasPerk(PerkLib.CommandingTone)) damage *= 0.1;
+			if (player.hasPerk(PerkLib.DiaphragmControl)) damage *= 0.1;
+			if (player.hasPerk(PerkLib.VocalTactician)) damage *= 0.15;
+			if (player.hasPerk(PerkLib.RacialParagon)) damage *= combat.RacialParagonAbilityBoost();
+			//if (player.hasPerk(PerkLib.NaturalArsenal)) damage *= 2; // Should this count for Arsenal?
+			if (player.hasPerk(PerkLib.RoyalSlimeJelly)) damage *= 0.2;
+			if (player.hasPerk(PerkLib.DarkSlimeEmpressCore)) dmgAmp += 0.2;
+			if (player.hasPerk(PerkLib.DarkSlimeEmpressCore) && isAuto==false) dmgAmp += 0.2;
+		
+			if (flags[kFLAGS.WILL_O_THE_WISP] == 2 && dmgType!=2) {
+				dmgAmp += 0.1;
+				if (player.hasPerk(PerkLib.WispLieutenant)) dmgAmp += 0.2;
+				if (player.hasPerk(PerkLib.WispCaptain)) dmgAmp += 0.3;
+				if (player.hasPerk(PerkLib.WispMajor)) dmgAmp += 0.4;
+				if (player.hasPerk(PerkLib.WispColonel)) dmgAmp += 0.5;
+			}
+			
+			if (dmgType == 2){
+				if (player.hasPerk(PerkLib.EromancyExpert)) damage *= 1.5;
+				if (player.hasPerk(PerkLib.JobCourtesan) && monster.hasPerk(PerkLib.EnemyBossType)) damage *= 1.2;
+				if (player.hasPerk(PerkLib.SluttySimplicity) && player.armor.hasTag(ItemConstants.A_REVEALING)) damage *= (1 + ((10 + rand(11)) / 100));
+				if (player.hasPerk(PerkLib.HistoryWhore) || player.hasPerk(PerkLib.PastLifeWhore)) damage *= (1 + combat.historyWhoreBonus());
+			}
+			
+			
+			damage *= dmgAmp;
+		}
+		
 		
 		outputText("\n")
 		if (dmgType == 3) {
@@ -2989,10 +3008,10 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (r >75)sAtks[3]+=1
 		}
 		
-		var sDam0:Number = (combat.scalingBonusIntelligence())+combat.scalingBonusToughness()*1.2;;//melee
-		var sDam1:Number = combat.scalingBonusToughness()*2;//ranged
-		var sDam2:Number = combat.scalingBonusLibido()*0.05;//lust
-		var sDam3:Number = combat.scalingBonusIntelligence()*4;//dark/sacrifice
+		var sDam0:Number = (combat.scalingBonusIntelligence()+combat.scalingBonusToughness())*1.8;//melee
+		var sDam1:Number = combat.scalingBonusToughness()*2.6;//ranged
+		var sDam2:Number = combat.scalingBonusLibido()*0.08;//lust
+		var sDam3:Number = combat.scalingBonusIntelligence()*5;//dark/sacrifice
 		
 		
 		

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -187,16 +187,17 @@ public class PhysicalSpecials extends BaseCombatContent {
 						bd = buttons.add("Engulf", gooEngulf).hint("Attempt to engulf a foe with your body.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 					}
-					//Slime Skills
+					//Slime-Based Skills
 					if (player.lowerBody == LowerBody.GOO && (player.isSlime() || player.hasPerk(PerkLib.DarkSlimeEmpressCore))) {
 						bd = buttons.add("Spread", spreadSlime).hint("Spread some of your slime around, covering some of the ground.\n HP cost: "+10+"% ("+Math.round(player.maxHP()/10)+")\n\nFree action");
 						if (player.isFlying()) bd.disable("You cannot spread slime while flying.");
 					}
-					if (player.lowerBody == LowerBody.GOO && player.racialTierCached(Races.DARKSLIME)>2) {
+					//DarkSlime Skills
+					if (player.lowerBody == LowerBody.GOO && player.isRaceCached(Races.DARKSLIME) && (player.hasPerk(PerkLib.RoyalSlimeJelly) || player.hasPerk(PerkLib.DarkSlimeEmpressCore)) ) {
 						bd = buttons.add("Form Slimes", formSlimeArmy).hint("Create <b>"+monster.getStatusValue(StatusEffects.SlimeSurround,1)*(player.hasPerk(PerkLib.DarkSlimeEmpressCore) ? 4:2)+"</b> Slimes from slime you've spread on the ground");
 						if (!monster.hasStatusEffect(StatusEffects.SlimeSurround) || monster.getStatusValue(StatusEffects.SlimeSurround,1)<1) bd.disable("You cannot create Slimes without slime on the ground.");
 					}
-					if (player.lowerBody == LowerBody.GOO && player.racialTierCached(Races.DARKSLIME)>2) {
+					if (player.lowerBody == LowerBody.GOO && player.isRaceCached(Races.DARKSLIME) && (player.hasPerk(PerkLib.RoyalSlimeJelly) || player.hasPerk(PerkLib.DarkSlimeEmpressCore))) {
 						bd = buttons.add("Slimes Attack", slimeArmyAttack).hint("Command your <b>"+monster.getStatusValue(StatusEffects.SlimeSurround,2)+"</b> slimes to attack with their various weapons");
 						if (!monster.hasStatusEffect(StatusEffects.SlimeSurround) || monster.getStatusValue(StatusEffects.SlimeSurround,2)<1) bd.disable("You have not formed any slimes.");
 					}
@@ -2927,8 +2928,9 @@ public class PhysicalSpecials extends BaseCombatContent {
 		enemyAI();
 	}
 	
-	public function slimeArmySingleAttack(damage:Number,dmgType:int=1,canActMore:Boolean=true):void{
+	public function slimeArmySingleAttack(damage:Number,dmgType:int=1,canActMore:Boolean=true,isAuto:Boolean=false):void{
 		//dmgType 1=phy, 2=lust, 3=merge
+		if (isAuto) damage /= 2;
 		var ogDmg:Number = damage;
 		var dmgAmp:int = 1;
 		var isDark:Boolean = (dmgType==1 && (rand(100) < (player.hasPerk(PerkLib.DarkSlimeEmpressCore) ? 66:33))) ? true:false;
@@ -2946,7 +2948,9 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if (player.hasPerk(PerkLib.WispMajor)) dmgAmp += 0.4;
 			if (player.hasPerk(PerkLib.WispColonel)) dmgAmp += 0.5;
 		}
-		if (player.hasPerk(PerkLib.DarkSlimeEmpressCore) && dmgType != 2) damage *= 0.4;
+		if (player.hasPerk(PerkLib.RoyalSlimeJelly)) damage *= 0.2;
+		if (player.hasPerk(PerkLib.DarkSlimeEmpressCore)) dmgAmp += 0.2;
+		if (player.hasPerk(PerkLib.DarkSlimeEmpressCore)&& isAuto==false) dmgAmp += 0.2;
 		
 		damage *= dmgAmp;
 		
@@ -2978,7 +2982,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 		var slimes:Number = monster.getStatusValue(StatusEffects.SlimeSurround, 2);
 		var sAtks:Array = [0,0,0,0];
 		while(slimes-->0){
-			var r:Number = rand(76+( player.hasPerk(PerkLib.DarkSlimeEmpressCore) ? 25:0 ))
+			var r:Number = rand(76+( (player.hasPerk(PerkLib.DarkSlimeEmpressCore)&& player.hasPerk(PerkLib.RoyalSlimeJelly)) ? 25:0 ))
 			if (r <= 25) sAtks[0] += 1
 			if (r>25 && r <= 50) sAtks[1] += 1
 			if (r>50 && r <= 75) sAtks[2] += 1
@@ -2986,37 +2990,38 @@ public class PhysicalSpecials extends BaseCombatContent {
 		}
 		
 		var sDam0:Number = (combat.scalingBonusIntelligence())+combat.scalingBonusToughness()*1.2;;//melee
-		var sDam1:Number = combat.scalingBonusToughness();//ranged
-		var sDam2:Number = combat.scalingBonusLibido()*0.025;//lust
-		var sDam3:Number = combat.scalingBonusIntelligence()*2.5;//dark/sacrifice
+		var sDam1:Number = combat.scalingBonusToughness()*2;//ranged
+		var sDam2:Number = combat.scalingBonusLibido()*0.05;//lust
+		var sDam3:Number = combat.scalingBonusIntelligence()*4;//dark/sacrifice
+		
 		
 		
 		outputText("\n")
 		if (sAtks[0] > 0){
 			outputText(num2Text(sAtks[0], 100) + " of your slimes slash and stab [Themonster] with goopy spears. ");
 			while(sAtks[0]-->0){
-				slimeArmySingleAttack(sDam0);
+				slimeArmySingleAttack(sDam0,1,true,autoAttack);
 			}
 		}
 		
 		if (sAtks[1] > 0){
 			outputText("\n\n" + num2Text(sAtks[1], 100) + " of your slimes lob goopy arrows at [Themonster]. ");
 			while(sAtks[1]-->0){
-				slimeArmySingleAttack(sDam1);
+				slimeArmySingleAttack(sDam1,1,true,autoAttack);
 			}
 		}
 		
 		if (sAtks[2] > 0){
 			outputText("\n\n" + num2Text(sAtks[2], 100) + " of your slimes cover [Themonster] with gooey aphrodisiacs. ");
 			while(sAtks[2]-->0){
-				slimeArmySingleAttack(sDam2, 2);
+				slimeArmySingleAttack(sDam2, 2,true,autoAttack);
 			}
 		}
 		
 		if (sAtks[3] > 0){
 			outputText("\n\n" + num2Text(sAtks[3], 100) + " of your slimes jump onto [Themonster] in a attempt to merge with it. ");
 			while(sAtks[3]-->0){
-				slimeArmySingleAttack(sDam3, 3,false);
+				slimeArmySingleAttack(sDam3, 3,false,autoAttack);
 			}
 		}
 		

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -187,6 +187,19 @@ public class PhysicalSpecials extends BaseCombatContent {
 						bd = buttons.add("Engulf", gooEngulf).hint("Attempt to engulf a foe with your body.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 					}
+					//Slime Skills
+					if (player.lowerBody == LowerBody.GOO && (player.isSlime() || player.hasPerk(PerkLib.DarkSlimeEmpressCore))) {
+						bd = buttons.add("Spread", spreadSlime).hint("Spread some of your slime around, covering some of the ground.\n HP cost: "+10+"% ("+Math.round(player.maxHP()/10)+")\n\nFree action");
+						if (player.isFlying()) bd.disable("You cannot spread slime while flying.");
+					}
+					if (player.lowerBody == LowerBody.GOO && player.racialTierCached(Races.DARKSLIME)>2) {
+						bd = buttons.add("Form Slimes", formSlimeArmy).hint("Create <b>"+monster.getStatusValue(StatusEffects.SlimeSurround,1)*(player.hasPerk(PerkLib.DarkSlimeEmpressCore) ? 4:2)+"</b> Slimes from slime you've spread on the ground");
+						if (!monster.hasStatusEffect(StatusEffects.SlimeSurround) || monster.getStatusValue(StatusEffects.SlimeSurround,1)<1) bd.disable("You cannot create Slimes without slime on the ground.");
+					}
+					if (player.lowerBody == LowerBody.GOO && player.racialTierCached(Races.DARKSLIME)>2) {
+						bd = buttons.add("Slimes Attack", slimeArmyAttack).hint("Command your <b>"+monster.getStatusValue(StatusEffects.SlimeSurround,2)+"</b> slimes to attack with their various weapons");
+						if (!monster.hasStatusEffect(StatusEffects.SlimeSurround) || monster.getStatusValue(StatusEffects.SlimeSurround,2)<1) bd.disable("You have not formed any slimes.");
+					}
 					//Embrace
 					if ((player.arms.type == Arms.BAT || player.wings.type == Wings.VAMPIRE) && !monster.hasPerk(PerkLib.EnemyGroupType) && !monster.hasPerk(PerkLib.EnemyLargeGroupType)) {
 						bd = buttons.add("Embrace", vampireEmbrace).hint("Embrace an opponent in your wings.");
@@ -2661,6 +2674,181 @@ public class PhysicalSpecials extends BaseCombatContent {
 		enemyAI();
 	}
 
+	public function spreadSlime():void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
+		clearOutput();
+		var cost:Number = 0.1;
+		var maxhp:Number = player.maxHP();
+		if(player.HP - (maxhp*cost)  < (player.minHP()+((maxhp*cost)/2))) {
+			clearOutput();
+			outputText("You just don't have the energy to spread your slime around right now...");
+			menu();
+			addButton(0, "Next", combatMenu, false);
+			return;
+		}
+		if(player.hasStatusEffect(StatusEffects.Flying)){
+			clearOutput();
+			outputText("You can't spread your slime while flying.");
+			menu();
+			addButton(0, "Next", combatMenu, false);
+			return;
+		}
+		
+		if(monster is EncapsulationPod) {
+			clearOutput();
+			outputText("You can't spread your slime while you're trapped inside something.");
+			menu();
+			addButton(0, "Next", combatMenu, false);
+			return;
+		}
+		outputText("<b>([font-damage]" + Math.round(maxhp * cost) + "[/font])</b> ");
+		
+		outputText(" You cover some of the ground with part of your slimy body.");
+		player.HP-=(maxhp*cost);
+		monster.createOrAddStatusEffect(StatusEffects.SlimeSurround, 1, 1);
+		outputText("You spread some slime from your gooey body around.\n");
+		
+		var locText:String = "the ground.";
+		
+		if (player.hasStatusEffect(StatusEffects.UnderwaterCombatBoost)){
+			locText = "the surrounding waters.";
+		}
+		
+		switch(monster.getStatusValue(StatusEffects.SlimeSurround,1)){
+			case 1:
+				outputText("Your slime now covers a small part of "+locText);
+				break;
+			case 2:
+				outputText("Your slime now covers part of "+locText);
+				break;
+			case 3:
+				outputText("Your slime now covers a large part of "+locText);
+				break;
+			case 4:
+				outputText("Your slime now covers a massive part of "+locText);
+				break;
+			default:
+				outputText("Your slime covers "+locText);
+		}
+		outputText("(<b>"+monster.getStatusValue(StatusEffects.SlimeSurround,1)+"</b>)");
+		outputText("\n\n");
+		menu();
+		addButton(0, "Next", combatMenu, false);
+	}
+	
+	public function formSlimeArmy():void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
+		clearOutput();
+		
+		var slimeNum:Number = monster.getStatusValue(StatusEffects.SlimeSurround, 1);
+		var slimePerNum:Number = player.hasPerk(PerkLib.DarkSlimeEmpressCore) ? 4:2;
+		
+		monster.addStatusValue(StatusEffects.SlimeSurround, 2, slimeNum*slimePerNum);
+		monster.addStatusValue(StatusEffects.SlimeSurround, 1, -slimeNum);
+		outputText("You form the slime spread on the ground into <b>"+slimeNum*slimePerNum+"</b> slimes; holding various weapons.");
+		
+		outputText("\n\n");
+		enemyAI();
+	}
+	
+	public function slimeArmySingleAttack(damage:Number,dmgType:int=1,canActMore:Boolean=true):void{
+		//dmgType 1=phy, 2=lust, 3=merge
+		var ogDmg:Number = damage;
+		var dmgAmp:int = 1;
+		var isDark:Boolean = (dmgType==1 && (rand(100) < (player.hasPerk(PerkLib.DarkSlimeEmpressCore) ? 66:33))) ? true:false;
+		if (dmgType == 3) isDark = true;
+		if (isDark) damage+= combat.scalingBonusLibido()*1.2;
+		if (player.hasPerk(PerkLib.HistoryTactician) || player.hasPerk(PerkLib.PastLifeTactician)) damage *= combat.historyTacticianBonus();
+		if (player.hasPerk(PerkLib.CommandingTone)) damage *= 0.1;
+		if (player.hasPerk(PerkLib.DiaphragmControl)) damage *= 0.1;
+		if (player.hasPerk(PerkLib.VocalTactician)) damage *= 0.15;
+		
+		if (flags[kFLAGS.WILL_O_THE_WISP] == 2 && dmgType!=2) {
+			dmgAmp += 0.1;
+			if (player.hasPerk(PerkLib.WispLieutenant)) dmgAmp += 0.2;
+			if (player.hasPerk(PerkLib.WispCaptain)) dmgAmp += 0.3;
+			if (player.hasPerk(PerkLib.WispMajor)) dmgAmp += 0.4;
+			if (player.hasPerk(PerkLib.WispColonel)) dmgAmp += 0.5;
+		}
+		if (player.hasPerk(PerkLib.DarkSlimeEmpressCore) && dmgType != 2) damage *= 0.4;
+		
+		damage *= dmgAmp;
+		
+		outputText("\n")
+		if (dmgType == 3) {
+			if ((rand(11) + 1) / 10 * player.tou > monster.tou){
+				var pastHPp:Number = monster.HP / monster.maxHP();
+				var pastHP:Number = monster.HP;
+				monster.statStore.addBuffObject({tou: -(player.tou + monster.tou) * 0.08}, "Merged Slime", {text:"Slime"});
+				monster.HP = monster.maxHP()*pastHPp;
+				outputText("A slime merged with [Themonster], weakening [monster him]. ")
+				combat.CommasForDigits(Math.round((monster.maxHP()*0.15)+pastHP-monster.HP))
+				monster.HP-=Math.round(monster.maxHP()*0.15)
+				monster.addStatusValue(StatusEffects.SlimeSurround, 2, -1);
+				isDark = false;
+			}
+			else outputText("A slime tried and failed to merge with [Themonster].");
+		}
+		if (isDark) combat.doDarknessDamage(damage, true, true);
+		if(!isDark && dmgType==1) combat.doPhysicalDamage(damage,true,true);
+		if(dmgType==2)	monster.teased(Math.round(monster.lustVuln * damage),false);
+		if(canActMore && rand(15)==1)slimeArmySingleAttack(ogDmg,dmgType,false)
+	}
+	
+	public function slimeArmyAttack():void {
+		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;
+		clearOutput();
+		
+		var slimes:Number = monster.getStatusValue(StatusEffects.SlimeSurround, 2);
+		var sAtks:Array = [0,0,0,0];
+		while(slimes-->0){
+			var r:Number = rand(76+( player.hasPerk(PerkLib.DarkSlimeEmpressCore) ? 25:0 ))
+			if (r <= 25) sAtks[0] += 1
+			if (r>25 && r <= 50) sAtks[1] += 1
+			if (r>50 && r <= 75) sAtks[2] += 1
+			if (r >75)sAtks[3]+=1
+		}
+		
+		var sDam0:Number = (combat.scalingBonusStrength()*2.5)+combat.scalingBonusToughness()*1.2;;//melee
+		var sDam1:Number = combat.scalingBonusToughness();+combat.scalingBonusStrength()+combat.scalingBonusSpeed();//ranged
+		var sDam2:Number = combat.scalingBonusLibido()*0.25;//lust
+		var sDam3:Number = combat.scalingBonusToughness()*2.5;//dark/sacrifice
+		
+		
+		
+		if (sAtks[0] > 0){
+			outputText(num2Text(sAtks[0], 100) + " of your slimes slash and stab [Themonster] with goopy spears. ");
+			while(sAtks[0]-->0){
+				slimeArmySingleAttack(sDam0);
+			}
+		}
+		
+		if (sAtks[1] > 0){
+			outputText("\n\n" + num2Text(sAtks[1], 100) + " of your slimes lob goopy arrows at [Themonster]. ");
+			while(sAtks[1]-->0){
+				slimeArmySingleAttack(sDam1);
+			}
+		}
+		
+		if (sAtks[2] > 0){
+			outputText("\n\n" + num2Text(sAtks[2], 100) + " of your slimes cover [Themonster] with gooey aphrodisiacs. ");
+			while(sAtks[2]-->0){
+				slimeArmySingleAttack(sDam2, 2);
+			}
+		}
+		
+		if (sAtks[3] > 0){
+			outputText("\n\n" + num2Text(sAtks[3], 100) + " of your slimes jump onto [Themonster] in a attempt to merge with it. ");
+			while(sAtks[3]-->0){
+				slimeArmySingleAttack(sDam3, 3,false);
+			}
+		}
+		
+		
+		outputText("\n\n");
+		enemyAI();
+	}
+	
 	public function terrifyingHowl():void {
 		clearOutput();
 		if(monster is EncapsulationPod || monster.inte == 0 || monster is LivingStatue) {
@@ -4538,14 +4726,24 @@ public class PhysicalSpecials extends BaseCombatContent {
 		fatigue(physicalSpecialsCost(10), USEFATG_PHYSICAL);
 		if (combat.checkConcentration()) return; //Amily concentration
 		outputText("You plunge on [themonster] and let your liquid body engulf it. ");
-		//WRAP IT UPPP
-		if(40 + rand(player.spe) > monster.spe) {
+		//WRAP IT UPPP    plural
+		if((40 + rand(player.spe) > monster.spe)) {
 			outputText("[Themonster] ends up encased in your fluid form kicking and screaming to get out.");
 			monster.createStatusEffect(StatusEffects.GooEngulf, 3 + rand(3),0,0,0);
 		}
 		//Failure
 		else {
 			//Failure (-10 HPs) -
+			if (monster.hasStatusEffect(StatusEffects.SlimeSurround) && monster.getStatusValue(StatusEffects.SlimeSurround, 1) > (monster.plural ? 2:0)){
+				monster.addStatusValue(StatusEffects.SlimeSurround, 1, (monster.plural ? 3:1));
+				outputText("You use a "+(monster.plural ? "large":"small")+" amount of slime on the ground to encase [The monster]"+(monster.plural ? "s":"")+".");
+				monster.createStatusEffect(StatusEffects.GooEngulf, 3 + rand(3),0,0,0);
+				outputText("\n\n");
+				enemyAI();
+				return;
+			}
+			
+			
 			outputText("[Themonster] dodge at the last second stepping out of your slimy embrace and using the opening to strike you.");
 			player.takePhysDamage(5, true);
 			if(Math.round(player.HP) <= Math.round(player.minHP())) {
@@ -4556,6 +4754,8 @@ public class PhysicalSpecials extends BaseCombatContent {
 		outputText("\n\n");
 		enemyAI();
 	}
+	
+	
 
 	public function vampireEmbrace():void {
 		flags[kFLAGS.LAST_ATTACK_TYPE] = 4;

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth.as
@@ -426,7 +426,6 @@ public class EbonLabyrinth extends DungeonAbstractContent {
 
     //Selects the boss. Tier (1,2) selects the boss pool. 0 - includes ALL tiers
     private function bossSelector(tier:int = 0):void {
-        if (player.isGooSkin() && flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS] < 1 && rand(10)==0){ darkSlimeEmpressScene.encounter(); return; }
 		//Make the pool of encounters
         var choices:Array = [];
         var boss:int;
@@ -555,3 +554,4 @@ public class EbonLabyrinth extends DungeonAbstractContent {
     }
 }
 }
+

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth.as
@@ -426,7 +426,8 @@ public class EbonLabyrinth extends DungeonAbstractContent {
 
     //Selects the boss. Tier (1,2) selects the boss pool. 0 - includes ALL tiers
     private function bossSelector(tier:int = 0):void {
-        //Make the pool of encounters
+        if (player.isGooSkin() && flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS] < 1 && rand(10)==0){ darkSlimeEmpressScene.encounter(); return; }
+		//Make the pool of encounters
         var choices:Array = [];
         var boss:int;
         for (boss = 0; boss < bossPool[tier].length; ++boss) //[bit_num, function]

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpress.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpress.as
@@ -116,7 +116,7 @@ use namespace CoC;
             this.bonusLust = 505 + 65*mod;
             this.level = 60 + 5*mod; //starts from 65 due to EL levelMod calculations;
             this.gems = mod > 20 ? 0 : Math.floor((2500 + rand(500)) * Math.exp(0.3*mod));
-            this.additionalXP = mod > 20 ? 0 : Math.floor(10000 * Math.exp(0.3*mod));
+            this.additionalXP = mod > 20 ? 0 : Math.floor(2500 * Math.exp(0.3*mod));
             
 			this.a = "";
 			this.short = "Dark Slime Empress";
@@ -159,3 +159,4 @@ use namespace CoC;
 		}
 	}
 }
+

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
@@ -4,38 +4,144 @@ package classes.Scenes.Dungeons.EbonLabyrinth
 import classes.BaseContent;
 import classes.EventParser;
 import classes.StatusEffects;
+import classes.GlobalFlags.kFLAGS;
+import classes.Races;
+import classes.PerkLib;
 
 public class DarkSlimeEmpressScene extends BaseContent {
     public function DarkSlimeEmpressScene() {}
 
     public function encounter():void {
         clearOutput();
-        outputText("As you enter the next room, the first thing you hear are the moans. You’re greeted to quite a sight for before you hundreds of slimy shape are making out, fucking each other in the most blatently obsene display you've ever seen. Confused, you try and figure if you stepped into some kind of orgy until you notice one slime at the back of the room who stands out. ");
-        outputText("Wearing a crown seemingly made of goop, this regal purple woman sits on a pair of stone slabs, which serves it as a makeshift throne.\n\n");
-        outputText("\"<i>Why now my loyal subjects, it seems we have a guest, welcome to my domain intruder I hope you intend on joining the feast in my honor of course. Guests… are always welcome.</i>\"\n\n");
-        outputText("All of the slime suddenly drop their activities, drooling at you with keen interest. You've got a very bad feeling. This is when you notice that all of them are linked to one another through small trails of slime on the ground. The slimes take on a makeshift formation, drawing what appears to be slimy spears and bows all pointed at you.\n\n");
-        outputText("Seeing this, you try to run for it but the purple empress waves her hand, slime sealing shut the exit behind you, the only exit out of this room. The slime giggles, the crowd imitating it shortly.\n\n");
-        outputText("\"<i>I hope you are in the mood because you and I are soon going to become very intimate.</i>\"\n\n");
+		if(flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS]==0){
+		outputText("As you enter the next room, you start hearing moans. You’re greeted to quite a sight, before you are hundreds of slimy shapes, making out and fucking each other in the most obsene display you've ever seen. Confused, you try and figure if you stepped into some kind of orgy, until you notice one slime at the back of the room who stands out. \n");
+        outputText("Wearing a crown seemingly made of goop, this regal purple woman sits on a pair of stone slabs, which serves as a makeshift throne.\n\n");
+        outputText("\"<i>Why now my loyal subjects, it seems we have a guest. Welcome to my domain, intruder.\nI hope you intend on joining the feast, in my honor of course. Guests… are always welcome.</i>\"\n\n");
+        outputText("All of the slimes suddenly drop their activities, drooling at you with keen interest. You get a very bad feeling. This is when you notice that all of them are linked to one another through small trails of slime on the ground. The slimes take on a makeshift formation, drawing what appears to be slimy spears and bows, all pointed at you.\n\n");
+        outputText("Seeing this; you try to run for it. But the purple empress waves her hand, slime seals shut the room's entrance. The dark slime sitting atop the throne giggles, the other slimes follow suit.\n\n");
+        outputText("\"<i>I hope you are in the mood, because soon you and I are going to become very.. intimate.</i>\"\n\n");
         outputText("<b>It's too late to escape now, it's a fight!</b>");
-        startCombat(new DarkSlimeEmpress(), true);
+		}
+		if (flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS]==1){
+			
+			if (player.hasKeyItem("Slimy Crown") == -1) {
+				outputText("As you enter the next room, you're greeted by a familiar sight. Before you are hundreds of slimy shapes, making out and fucking each other in the most obsene display you've ever seen.");
+				outputText("And at the back of the room, sitting on a makeshift throne, a familiar figure. A dark purple, slimy woman with a goopy crown resting atop her head.");
+				
+				outputText("\"<i>Why now my loyal subjects, it seems we have a guest.. oh, a returning guest at that. Welcome back to my domain intruder I hope you intend on joining the feast this time, in my honor of course.</i>\"\n\n");
+				outputText("All of the slimes suddenly drop their activities, drooling at you with keen interest. The slimes take on a makeshift formation, drawing what appears to be slimy spears and bows, all pointed at you.\n\n");
+				outputText("Seeing this, you try to run for it but the purple empress's slimes had already sealed the room's entrance. The dark slime sitting atop the throne giggles, the other slimes follow suit.\n\n");
+				outputText("\"<i>I hope you are in the mood, because soon you and I are going to become very.. intimate.</i>\"\n\n");
+			}
+			else{
+				outputText("As you enter the next room,  you’re greeted by a odd sight. \nThe floor is covered in purple goo. Just as you wonder what happened here, you see her. \n");
+				outputText("A familiar figure, a dark purple, slimy woman. She looks up at you, rage visible in her eyes.\n\n");
+				outputText("\"<i><b>YOU!</b></i>\" she yells as some of the purple goo seals the room's entrance.\n");
+				if (player.isRaceCached(Races.SLIME) || player.isRaceCached(Races.MAGMASLIME) || player.isRaceCached(Races.DARKSLIME))outputText("\"<i>I'm going to enjoy ripping my crown out of you.</i>\""); 
+				else outputText("\"<i>I'm going to make you regret taking my crown from me.</i>\"");
+				outputText(" She says as slimes slowly form from the purple goo covering the floor.");
+			}
+		}
+		if (flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS] == 2){
+			outputText("As you enter the next room, you're greeted to a odd, yet familiar sight." +
+			"\nThe floor is covered in purple goo, and a empty makeshift throne sits empty; reminding you of the fallen sovereign who's life you clamed as your own." +
+			"\nYou grab up some of the goo covering the floor and leave.\n\n");
+			
+			inventory.takeItem(consumables.DSLIMEJ,endEncounter)
+		}
+		
+		
+		if(flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS]==0) flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS] = 1;
+		if (flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS]<2) startCombat(new DarkSlimeEmpress(), true);
     }
     
     public function defeatedBy():void {
         clearOutput();
-        outputText("As you fall defeated the slimes all cover you, encasing you in jelly.\n\n");
-        outputText("\"<i>It is but customary that one should bow or kneel before their empress. Some punishment is in order.</i>\"\n\n");
-        outputText("The slime begins to violate you in every way possible. You want to scream in pleasure but when you do the slime takes advantage of your open mouth to pour down your throat. You feel yourself melt and dissolve as your memory and mind become increasingly confused. You are [name] but at the same time you are Clarissa, Elisabeth and Sabrina, a hundred confusing names ");
-        outputText("float into your mind until you finally understand. You are one but many, everything and nothing, just one consciousness amongst the hundreds that live within the empress’s immortal jelly. Your body is made of slime but there is only one core to rule them all, the core of your beloved empress. ");
-        outputText("The first order she gives is an easy one, to resume the feast and you’re all too happy to partake. A few months later a new human will visit this hall, it will be your greatest pleasure to give him or her a warm, gooey welcome.\n\n");
+        outputText("As you fall defeated, the slimes start to cover you. Encasing you in jelly.\n\n");
+			if (player.hasKeyItem("Slimy Crown") == -1) {
+				outputText("\"<i>It is but customary that one should kneel before their empress. Some punishment is in order.</i>\"");
+			}
+			else {
+				outputText("\"<i>I should punish you for the humiliation from last time. But first, I'll take my crown back.</i>\" ");
+				if (player.isRaceCached(Races.SLIME) || player.isRaceCached(Races.MAGMASLIME) || player.isRaceCached(Races.DARKSLIME)) outputText("She rips out a part of your gooey body; absorbing it. ");
+				else outputText("She slides a slimy tendril down your throat; pulling out a slimy crown. She then absorbs it into her body. ");
+				outputText("A crown proceeds to form on her head.\n");
+				outputText("\"<i>Now then, shall we continue?</i>\" She turns to sit on her makeshift throne. \nAs she sits down, she waves her hand.");
+			}
+        outputText("\n\nThe slimes begin to violate you in every way possible. You want to scream in pleasure but when you do a slime takes advantage of your open mouth to pour down your throat. You feel yourself melt and dissolve as your memory and mind become increasingly confused. You are [name] but at the same time you are Clarissa, Elisabeth, Sabrina, and a hundred more confusing names ");
+        outputText("float into your mind until you finally understand. You are one but many, everything but nothing. Just one consciousness amongst the hundreds that live within the empress’s immortal jelly. Your body is made of slime but there is only one core to rule them all, the core of your beloved empress. ");
+        outputText("The first order she gives is an easy one, to resume the feast, and you’re all too happy to partake. \nA few months later a new human will visit this hall, it will be your greatest pleasure to give him or her a warm, gooey welcome.\n\n");
         //[GAME OVER]
         EventParser.gameOver();
     }
     public function defeat():void {
         clearOutput();
-        outputText("The empress’s purple legion falter for an instant, the slime blocking the exit falling off. You don't wait for the sovereign to recover her composure and rush for the exit, the empress screaming orders as you leave. Thankfully slimes are not overly fast and you manage to make it back to the corridor junction you came from.\n\n");
-        if (player.hasStatusEffect(StatusEffects.TFDealer1) && player.statusEffectv1(StatusEffects.TFDealer1) < 1) player.addStatusValue(StatusEffects.TFDealer1, 1, 1);
-        else player.createStatusEffect(StatusEffects.TFDealer1, 1, 0, 0, 0);
-        cleanupAfterCombat();
+		outputText("The purple empress falls to the floor, defeated.");
+		menu();
+		addButton(14, "Leave", runLeave);
+		if (player.hasKeyItem("Slimy Crown")==-1) addButton(14, "Take Crown", crownLeave);
+		
+		addButtonIfTrue(12, "Merge", DSEMerge, "Req. Dark Slime Core and Slimy Crown", player.hasKeyItem("Slimy Crown")>-1 && player.hasPerk(PerkLib.DarkSlimeCore), "Try to absorb her into yourself.");
     }
+	
+	private function DSEMerge():void {
+		clearOutput();
+		outputText("The empress’s purple legion falter as she collapses to the floor." +
+		"\nTaking this chance you approach the uncrowned sovereign, looking down at her weakened form." +
+		"\nShe looks up at you, eyes still burning with rage, but without the energy to even speak, let alone defy you."+
+		"\n\nMuch like a starving wolf standing before a wounded deer; you're unable to stop yourself." +
+		"\nYou begin to encase her in your gooey body. \nImmediately she  tries to resist, but she is far too weak to stop you." +
+		"\n\nAs your purple bodies start to merge she begins to moan, seemingly in intense pleasure. " +
+		"\nWhile you also feel pleasure, you also feel something more.. hunger."+
+		"\nAt first you thought you were just craving pleasure just like the other residents of this world, but this is something else." +
+		"\nYou suck her body into yours more aggressively than before." +
+		"\nSensing your goal has changed, the fallen empress desperately tries to free herself, but she has no means of doing so." + 
+		"\nSlowly, you absorb her gooey mass into your own. \nShe appears to enjoy the process, despite the rage and sorrow displayed on her sill visible face." +
+		"\n\nNow all that seems to remain of her is a second, alien feeling core, within your mass." +
+		"\nUnable to fully control the second core, you try to slowly push it next to your original core." +
+		"\n\nIt brushes against the first core, a shock of pleasure runs throughout your gooey body." +
+		"\nEven brushing the cores against each other was enough to send shockwaves of pleasure through your body, so pushing them together should feel even better." +
+		"\nEnticed by the pleasure it brought, you try to push the cores together." +
+		"\n\nYou feel your mind breaking, your senses are overloaded, you can feel only intense pleasure. You can't even tell if your eyes are open or not." +
+		"\nOnce the feeling subsides, you no longer feel two cores inside your body. " +
+		"\nYou look down at yourself, and you see only one core, noticeably larger than before. " +
+		"\nAfter examining your body, you deside to leave. \n\n" );
+		outputText("You exit the room and return to the corridor you were previously in.\n\n");
+		
+		player.createPerk(PerkLib.DarkSlimeEmpressCore, 0, 0, 0, 0);
+		outputText("(<b>Gained New Perk: Sovereign's Dark Slime Core - Increased control over external slime.</b>)\n\n");
+		
+		flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS] = 2;
+		
+		beforeLeave();
+	}
+	
+	private function runLeave():void {
+		outputText("The empress’s purple legion falter, the slimes blocking the exit fall off. \n");
+		outputText("You don't wait long enough for the sovereign to recover her composure. You rush for the exit, the empress screaming orders as you leave. Thankfully slimes are not overly fast and you manage to make it back to the corridor junction you came from.\n\n");
+		beforeLeave()
+	}
+	private function crownLeave():void {
+		outputText("The empress’s purple legion falter, the slimes blocking the exit fall off. \n");
+		outputText("You take this chance to grab the slimy crown above her head. \n");
+		if (player.isRaceCached(Races.SLIME) || player.isRaceCached(Races.MAGMASLIME) || player.isRaceCached(Races.DARKSLIME)) outputText("<b>It melts into you.</b> \n");
+		else outputText("It melts in your hand, falling into a puddle on the ground. \n\n");
+		if (player.isRaceCached(Races.DARKSLIME) && !player.hasPerk(PerkLib.DarkSlimeCore)) outputText("As it melts into you, a crystal like gem seems to form within you.\n");
+		outputText("You don't wait long enough for the sovereign to recover her composure. You rush for the exit, the empress screaming orders as you leave. Thankfully slimes are not overly fast and you manage to make it back to the corridor junction you came from.\n\n");
+        if (player.hasKeyItem("Slimy Crown")==-1 &&(player.isRaceCached(Races.SLIME) || player.isRaceCached(Races.MAGMASLIME) || player.isRaceCached(Races.DARKSLIME))){
+			
+			outputText("\n\n(Key Item Gained: Slimy Crown)");
+			player.createKeyItem("Slimy Crown", 0, 0, 0, 0);
+			if (player.isRaceCached(Races.DARKSLIME) && !player.hasPerk(PerkLib.DarkSlimeCore)) player.gainPerk(PerkLib.DarkSlimeCore, true);
+		}
+		beforeLeave();
+	}
+	
+	private function beforeLeave():void {
+		if (player.hasStatusEffect(StatusEffects.TFDealer1) && player.statusEffectv1(StatusEffects.TFDealer1) < 1) player.addStatusValue(StatusEffects.TFDealer1, 1, 1);
+        else player.createStatusEffect(StatusEffects.TFDealer1, 1, 0, 0, 0);
+		menu();
+		addButton(1, "Next", cleanupAfterCombat);
+	}
 }
 }

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
@@ -7,6 +7,7 @@ import classes.StatusEffects;
 import classes.GlobalFlags.kFLAGS;
 import classes.Races;
 import classes.PerkLib;
+import classes.CoC;
 
 public class DarkSlimeEmpressScene extends BaseContent {
     public function DarkSlimeEmpressScene() {}
@@ -22,9 +23,9 @@ public class DarkSlimeEmpressScene extends BaseContent {
         outputText("\"<i>I hope you are in the mood, because soon you and I are going to become very.. intimate.</i>\"\n\n");
         outputText("<b>It's too late to escape now, it's a fight!</b>");
 		}
-		if (flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS]==1){
+		if (flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS]==1 || flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS]==2){
 			
-			if (player.hasKeyItem("Slimy Crown") == -1) {
+			if (flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS]==1) {
 				outputText("As you enter the next room, you're greeted by a familiar sight. Before you are hundreds of slimy shapes, making out and fucking each other in the most obsene display you've ever seen.");
 				outputText("And at the back of the room, sitting on a makeshift throne, a familiar figure. A dark purple, slimy woman with a goopy crown resting atop her head.");
 				
@@ -42,7 +43,7 @@ public class DarkSlimeEmpressScene extends BaseContent {
 				outputText(" She says as slimes slowly form from the purple goo covering the floor.");
 			}
 		}
-		if (flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS] == 2){
+		if (flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS] == 3){
 			outputText("As you enter the next room, you're greeted to a odd, yet familiar sight." +
 			"\nThe floor is covered in purple goo, and a empty makeshift throne sits empty; reminding you of the fallen sovereign who's life you clamed as your own." +
 			"\nYou grab up some of the goo covering the floor and leave.\n\n");
@@ -104,14 +105,33 @@ public class DarkSlimeEmpressScene extends BaseContent {
 		"\nEnticed by the pleasure it brought, you try to push the cores together." +
 		"\n\nYou feel your mind breaking, your senses are overloaded, you can feel only intense pleasure. You can't even tell if your eyes are open or not." +
 		"\nOnce the feeling subsides, you no longer feel two cores inside your body. " +
-		"\nYou look down at yourself, and you see only one core, noticeably larger than before. " +
+		"\nYou look down at yourself, and you see only one core, noticeably larger than before. Not only that, but some other things have changed, you now look more like the empress." +
 		"\nAfter examining your body, you deside to leave. \n\n" );
 		outputText("You exit the room and return to the corridor you were previously in.\n\n");
+		player.slimeFeed();
 		
+        CoC.instance.transformations.HairGoo.applyEffect(false);
+        CoC.instance.transformations.ArmsGoo.applyEffect(false);
+        CoC.instance.transformations.LowerBodyGoo.applyEffect(false);
+        CoC.instance.transformations.RearBodyMetamorphicGoo.applyEffect(false);
+        CoC.instance.transformations.EyesFiendish.applyEffect(false);
+        CoC.instance.transformations.EyesChangeColor(["red"]).applyEffect(false);
+        CoC.instance.transformations.EarsElfin.applyEffect(false);
+        CoC.instance.transformations.FaceHuman.applyEffect(false);
+        CoC.instance.transformations.TongueHuman.applyEffect(false);
+        CoC.instance.transformations.VaginaHuman().applyEffect(false);
+        CoC.instance.transformations.AntennaeNone.applyEffect(false);
+        CoC.instance.transformations.HornsNone.applyEffect(false);
+        CoC.instance.transformations.WingsNone.applyEffect(false);
+		player.createPerk(PerkLib.TransformationImmunity2, 11, 0, 0, 0);
 		player.createPerk(PerkLib.DarkSlimeEmpressCore, 0, 0, 0, 0);
-		outputText("(<b>Gained New Perk: Sovereign's Dark Slime Core - Increased control over external slime.</b>)\n\n");
+		CoC.instance.mainViewManager.updateCharviewIfNeeded();
+		player.updateRacialParagon(Races.DARKSLIME);
 		
-		flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS] = 2;
+		outputText("\n\n<b>Gained New Perk: Sovereign's Dark Slime Core - Increased control over external slime.</b>");
+		outputText("\n\n<b>Gained Perk: Transformation Immunity!</b> "+PerkLib.TransformationImmunity2.longDesc+"\n");
+		flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS] = 3;
+		outputText("\n\n");
 		
 		beforeLeave();
 	}
@@ -133,6 +153,7 @@ public class DarkSlimeEmpressScene extends BaseContent {
 			outputText("\n\n(Key Item Gained: Slimy Crown)");
 			player.createKeyItem("Slimy Crown", 0, 0, 0, 0);
 			if (player.isRaceCached(Races.DARKSLIME) && !player.hasPerk(PerkLib.DarkSlimeCore)) player.gainPerk(PerkLib.DarkSlimeCore, true);
+			flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS] = 2;
 		}
 		beforeLeave();
 	}

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
@@ -53,7 +53,7 @@ public class DarkSlimeEmpressScene extends BaseContent {
 		
 		
 		if(flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS]==0) flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS] = 1;
-		if (flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS]<2) startCombat(new DarkSlimeEmpress(), true);
+		if (flags[kFLAGS.ENCOUNTERED_DARKSLIME_EMPRESS]<3) startCombat(new DarkSlimeEmpress(), true);
     }
     
     public function defeatedBy():void {

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
@@ -105,7 +105,8 @@ public class DarkSlimeEmpressScene extends BaseContent {
 		"\nEnticed by the pleasure it brought, you try to push the cores together." +
 		"\n\nYou feel your mind breaking, your senses are overloaded, you can feel only intense pleasure. You can't even tell if your eyes are open or not." +
 		"\nOnce the feeling subsides, you no longer feel two cores inside your body. " +
-		"\nYou look down at yourself, and you see only one core, noticeably larger than before. Not only that, but some other things have changed, you now look more like the empress." +
+		"\nYou look down at yourself, seeing nothing different, but feeling that something is amiss; you look at the reflection in a nearby puddle of goo." +
+		"\nSomething changed, you now look like the empress you previously absorbed." +
 		"\nAfter examining your body, you deside to leave. \n\n" );
 		outputText("You exit the room and return to the corridor you were previously in.\n\n");
 		player.slimeFeed();

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
@@ -144,11 +144,11 @@ public class DarkSlimeEmpressScene extends BaseContent {
 	private function crownLeave():void {
 		outputText("The empress’s purple legion falter, the slimes blocking the exit fall off. \n");
 		outputText("You take this chance to grab the slimy crown above her head. \n");
-		if (player.isRaceCached(Races.SLIME) || player.isRaceCached(Races.MAGMASLIME) || player.isRaceCached(Races.DARKSLIME)) outputText("<b>It melts into you.</b> \n");
+		if (player.isGooSkin()) outputText("<b>It melts into you.</b> \n");
 		else outputText("It melts in your hand, falling into a puddle on the ground. \n\n");
-		if (player.isRaceCached(Races.DARKSLIME) && !player.hasPerk(PerkLib.DarkSlimeCore)) outputText("As it melts into you, a crystal like gem seems to form within you.\n");
+		if (player.isGooSkin()) outputText("As it melts into you, a crystal like gem seems to form within you.\n");
 		outputText("You don't wait long enough for the sovereign to recover her composure. You rush for the exit, the empress screaming orders as you leave. Thankfully slimes are not overly fast and you manage to make it back to the corridor junction you came from.\n\n");
-        if (player.hasKeyItem("Slimy Crown")==-1 &&(player.isRaceCached(Races.SLIME) || player.isRaceCached(Races.MAGMASLIME) || player.isRaceCached(Races.DARKSLIME))){
+        if (player.hasKeyItem("Slimy Crown")==-1 &&(player.isGooSkin())){
 			
 			outputText("\n\n(Key Item Gained: Slimy Crown)");
 			player.createKeyItem("Slimy Crown", 0, 0, 0, 0);

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/DarkSlimeEmpressScene.as
@@ -80,7 +80,7 @@ public class DarkSlimeEmpressScene extends BaseContent {
 		outputText("The purple empress falls to the floor, defeated.");
 		menu();
 		addButton(14, "Leave", runLeave);
-		if (player.hasKeyItem("Slimy Crown")==-1) addButton(14, "Take Crown", crownLeave);
+		if (player.hasKeyItem("Slimy Crown")==-1) addButton(13, "Take Crown", crownLeave);
 		
 		addButtonIfTrue(12, "Merge", DSEMerge, "Req. Dark Slime Core and Slimy Crown", player.hasKeyItem("Slimy Crown")>-1 && player.hasPerk(PerkLib.DarkSlimeCore), "Try to absorb her into yourself.");
     }

--- a/classes/classes/StatusEffects.as
+++ b/classes/classes/StatusEffects.as
@@ -1501,6 +1501,7 @@ import classes.StatusEffects.VampireThirstEffect;
 		public static const LockingCurse:StatusEffectType          = mkCombat("Locking Curse");
 		public static const Terrorize:StatusEffectType             = mkCombat("Terrorize");
 		public static const WerespiderAbilities:StatusEffectType   = mkCombat("WerespiderAbilities");
+		public static const SlimeSurround:StatusEffectType   = mkCombat("Surrounded by Slime");
 		
 		// enchanted item stuff
 		
@@ -1522,4 +1523,5 @@ import classes.StatusEffects.VampireThirstEffect;
 			return new StatusEffectType(id,CombatStatusEffect,1);
 		}
 	}
+
 }


### PR DESCRIPTION
Added 2 new tiers to "Dark Slime"
Added new Special for slime races "Spread"
Added new Specials for Dark Slimes(once requirements are fulfilled): "Form Slimes" and "Slimes Attack"
Changed "Engulf" so it can consume 1-3 stack of "Spread" rather than being the move dodged (amount is based on if the enemy is a group or not)
Updated Dark Slime Empress boss with conditional dialog, new conditional rewards, and 1 new scene
Lowered Exp reward from the Dark Slime Empress
Added another way to get "Dark Slime Core" perk
Added "Empress's Dark Essence" to the permanent perk menu


