### PR TITLE
Fix swapped colors in scales color set

### DIFF
--- a/res/model.xml
+++ b/res/model.xml
@@ -294,8 +294,8 @@
 		<key src="#8888FF" base="scales" transform="lighten(25)"/>
 		<key src="#5c5cfe" base="scales" transform="lighten(10)"/>
 		<key src="#4444FF" base="scales"/>
-		<key src="#0000CC" base="scales" transform="darken(25)"/>
-		<key src="#2f2fe7" base="scales" transform="darken(35)"/>
+		<key src="#2f2fe7" base="scales" transform="darken(25)"/>
+		<key src="#0000CC" base="scales" transform="darken(35)"/>
 		<key src="#000033" base="scales" transform="darken(50)"/>
 		<key src="#AAFFAA" base="scales2" transform="lighten(25)"/>
 		<key src="#55ab55" base="scales2" transform="lighten(10)"/>

--- a/res/model2.xml
+++ b/res/model2.xml
@@ -193,8 +193,8 @@
 		<key src="#8888FF" base="scales" transform="lighten(25)"/>
 		<key src="#5c5cfe" base="scales" transform="lighten(10)"/>
 		<key src="#4444FF" base="scales"/>
-		<key src="#0000CC" base="scales" transform="darken(25)"/>
-		<key src="#2f2fe7" base="scales" transform="darken(35)"/>
+		<key src="#2f2fe7" base="scales" transform="darken(25)"/>
+		<key src="#0000CC" base="scales" transform="darken(35)"/>
 		<key src="#000033" base="scales" transform="darken(50)"/>
 		<key src="#AAFFAA" base="scales2" transform="lighten(25)"/>
 		<key src="#55ab55" base="scales2" transform="lighten(10)"/>


### PR DESCRIPTION
From the scales set, color `#2f2fe7` had `darken(35)` in it, while `#0000CC` had `darken(25)` although it should be the other way around because `#0000CC` is obviously darker, than `#2f2fe7`.

Fixed that