### PR TITLE
New Combat UI

### DIFF
--- a/classes/classes/BaseContent.as
+++ b/classes/classes/BaseContent.as
@@ -299,9 +299,14 @@ import coc.xxc.StoryContext;
 			EngineCore.doNext.apply(null, [func].concat(args));
 		}
 
-		protected static function menu():void
+		protected static function menu(menuName:String=""):void
 		{
-			EngineCore.menu();
+			EngineCore.menu(menuName);
+		}
+
+		protected static function inMenu(expectedMenuName:String):Boolean
+		{
+			return EngineCore.inMenu(expectedMenuName);
 		}
 
 		protected function hideMenus():void

--- a/classes/classes/EngineCore.as
+++ b/classes/classes/EngineCore.as
@@ -399,15 +399,20 @@ public class EngineCore {
         CoC.instance.mainView.hideBottomButton(buttonToRemove);
     }
 
+    public static var menuName:String = "";
     /**
      * Hides all bottom buttons.
      */
-    public static function menu():void { //The newer, simpler menu - blanks all buttons so addButton can be used
+    public static function menu(menuName:String=""):void { //The newer, simpler menu - blanks all buttons so addButton can be used
+        EngineCore.menuName = menuName;
         for (var i:int = 0; i <= 14; i++) {
             CoC.instance.mainView.hideBottomButton(i);
         }
         CoC.instance.flushOutputTextToGUI();
         statScreenRefresh();
+    }
+    public static function inMenu(expectedMenuName:String):Boolean {
+        return menuName == expectedMenuName;
     }
 
     /**

--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -20,7 +20,6 @@ import classes.Items.ConsumableLib;
 import classes.Items.DynamicItems;
 import classes.Items.HeadJewelryLib;
 import classes.Items.IELib;
-import classes.Items.ItemConstants;
 import classes.Items.JewelryLib;
 import classes.Items.NecklaceLib;
 import classes.Items.ShieldLib;
@@ -37,11 +36,10 @@ import classes.Scenes.Areas.Ocean.UnderwaterSharkGirl;
 import classes.Scenes.Areas.Ocean.UnderwaterSharkGirlsPack;
 import classes.Scenes.Areas.Ocean.UnderwaterTigersharkGirl;
 import classes.Scenes.Camp.TrainingDummy;
+import classes.Scenes.Combat.CombatAbilities;
 import classes.Scenes.Combat.CombatAbility;
-import classes.Scenes.Combat.CombatUI;
 import classes.Scenes.Dungeons.DenOfDesire.HeroslayerOmnibus;
 import classes.Scenes.Dungeons.DungeonAbstractContent;
-import classes.Scenes.Dungeons.EbonLabyrinth.Hydra;
 import classes.Scenes.Dungeons.Factory.OmnibusOverseer;
 import classes.Scenes.Dungeons.Factory.SecretarialSuccubus;
 import classes.Scenes.Dungeons.TwilightGrove.LadyRafflesia;
@@ -55,10 +53,9 @@ import classes.internals.RandomDrop;
 import classes.internals.Utils;
 import classes.internals.WeightedDrop;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 import flash.utils.getQualifiedClassName;
-import classes.Scenes.Combat.CombatAbilities;
 
 /**
 	 * ...
@@ -2969,7 +2966,7 @@ import classes.Scenes.Combat.CombatAbilities;
 		 *     <li>Used to modify button in the bottom left corner</li>
 		 * </ul>
 		 */
-		public function postPlayerBusyBtnSpecial(btnSpecial1:CoCButton,btnSpecial2:CoCButton):void{
+		public function postPlayerBusyBtnSpecial(btnSpecial1:ButtonData,btnSpecial2:ButtonData):void{
 
 		}
 
@@ -2982,7 +2979,7 @@ import classes.Scenes.Combat.CombatAbilities;
 		 *     <li>It is used for monster that possess player binding ability, used it if you want to alter buttons callback through .call(function)</li>
 		 * </ul>
 		 */
-		public function changeBtnWhenBound(btnStruggle:CoCButton,btnBoundWait:CoCButton):void{
+		public function changeBtnWhenBound(btnStruggle:ButtonData,btnBoundWait:ButtonData):void{
 		}
 
 		/**

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -1646,7 +1646,7 @@ use namespace CoC;
 		public function carriedKnownCursedItems():/*ItemSlotClass*/Array {
 			var result:/*ItemSlotClass*/Array = [];
 			for each (var slot:ItemSlotClass in itemSlots) {
-				if (slot.unlocked && (slot.itype is IDynamicItem) && (slot.itype as IDynamicItem).curseStatus == ItemConstants.CS_KNOWN_CURSED) result.push(slot);
+				if (slot.unlocked && slot.itype is IDynamicItem && (slot.itype as IDynamicItem).curseStatus == ItemConstants.CS_KNOWN_CURSED) result.push(slot);
 			}
 			return result;
 		}

--- a/classes/classes/PlayerAppearance.as
+++ b/classes/classes/PlayerAppearance.as
@@ -294,11 +294,13 @@ public class PlayerAppearance extends BaseContent {
 			//Height and race.
 			outputText("You are a ");
 			outputText(Measurements.footInchOrMetres(player.basetallness));
-			outputText(" (out of combat: ");
-			outputText(Measurements.footInchOrMetres(player.tallness));
-			outputText(", effective: ");
-			outputText(Measurements.footInchOrMetres(player.effectiveTallness));
-			outputText(")");
+			if (player.basetallness != player.tallness || player.basetallness != player.effectiveTallness) {
+				outputText(" (out of combat: ");
+				outputText(Measurements.footInchOrMetres(player.tallness));
+				outputText(", effective: ");
+				outputText(Measurements.footInchOrMetres(player.effectiveTallness));
+				outputText(")");
+			}
 			var pcrace:String = player.race();
 			var genderlessRace:Array = ["half cow-morph", "half cow-girl", "cow-girl", "cow-girl", "cow-morph", "minotaur", "half-minotaur", "alraune", "liliraune", "half unicorn", "unicorn", "unicornkin", "half alicorn", "alicorn", "alicornkin", "true alicorn", "half bicorn", "bicorn", "bicornkin", "half nightmare","nightmare", "nightmarekin", "true nightmare"];
 			if (!(genderlessRace.indexOf(pcrace) >= 0))

--- a/classes/classes/Scenes/API/ExplorationEngine.as
+++ b/classes/classes/Scenes/API/ExplorationEngine.as
@@ -553,7 +553,7 @@ public class ExplorationEngine extends BaseContent {
 			}
 			if (n == 0) {
 				// End of the road
-				onEnd.applyTo(button(0));
+				onEnd.applyToSlot(0);
 				button(0).call(function ():void {
 					stopExploring();
 					onEnd.callback.call();
@@ -592,7 +592,7 @@ public class ExplorationEngine extends BaseContent {
 		if (debug) {
 			button(14).show("Menu", cheatMenu);
 		} else {
-			if (leave && !finished && !isAtEnd) leave.applyTo(button(14));
+			if (leave && !finished && !isAtEnd) leave.applyToSlot(14);
 		}
 		if (onMenu != null) onMenu();
 		mainViewManager.updateCharviewIfNeeded();
@@ -629,7 +629,7 @@ public class ExplorationEngine extends BaseContent {
 		button(4).show("Camp", camp.returnToCampUseOneHour)
 				 .hint("Return to camp");
 
-		if (leave && !finished && !isAtEnd) leave.applyTo(button(13));
+		if (leave && !finished && !isAtEnd) leave.applyToSlot(13);
 		button(14).show("Back", showUI).icon("Back");
 	}
 	public function generateAt(roadNo:int, roadPos:int):void {

--- a/classes/classes/Scenes/Areas/Beach/ArigeanOmnibusAbomination.as
+++ b/classes/classes/Scenes/Areas/Beach/ArigeanOmnibusAbomination.as
@@ -4,10 +4,9 @@ import classes.*;
 import classes.BodyParts.Butt;
 import classes.BodyParts.Hips;
 import classes.Scenes.SceneLib;
-import classes.GlobalFlags.kFLAGS;
 import classes.internals.*;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class ArigeanOmnibusAbomination extends Monster
 	{
@@ -108,7 +107,7 @@ public class ArigeanOmnibusAbomination extends Monster
 			player.removeStatusEffect(StatusEffects.Terrorize);
 			SceneLib.combat.enemyAIImpl();
 		}
-		override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+		override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.PlayerBoundPhysical)) {
 				btnStruggle.call(arigeanOmnibusAbominationEnsnareStruggle);
 				btnBoundWait.call(arigeanOmnibusAbominationEnsnareWait);

--- a/classes/classes/Scenes/Areas/Beach/CancerAttack.as
+++ b/classes/classes/Scenes/Areas/Beach/CancerAttack.as
@@ -7,19 +7,16 @@ package classes.Scenes.Areas.Beach
 import classes.*;
 import classes.BodyParts.Butt;
 import classes.BodyParts.Hips;
-import classes.BodyParts.Horns;
 import classes.BodyParts.Tail;
-import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.Combat.Combat;
-import classes.Scenes.Combat.CombatUI;
 import classes.Scenes.SceneLib;
 import classes.internals.WeightedDrop;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class CancerAttack extends Monster
 	{
-		override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+		override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.CancerMonsterGrab)) {
 				btnStruggle.call(cancerGrabStruggle);
 				btnBoundWait.call(cancerGrabWait);

--- a/classes/classes/Scenes/Areas/Desert/SandTrap.as
+++ b/classes/classes/Scenes/Areas/Desert/SandTrap.as
@@ -5,10 +5,10 @@ import classes.BodyParts.Butt;
 import classes.BodyParts.Hips;
 import classes.BodyParts.Tail;
 import classes.Scenes.SceneLib;
-import classes.internals.*;
 import classes.display.SpriteDb;
+import classes.internals.*;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class SandTrap extends Monster
 	{
@@ -79,7 +79,7 @@ public class SandTrap extends Monster
 			}
 		}
 
-		override public function postPlayerBusyBtnSpecial(btnSpecial1:CoCButton, btnSpecial2:CoCButton):void{
+		override public function postPlayerBusyBtnSpecial(btnSpecial1:ButtonData, btnSpecial2:ButtonData):void{
 			btnSpecial1.show("Climb", SceneLib.combat.wait2, "Climb the sand to move away from the sand trap.");
 		}
 

--- a/classes/classes/Scenes/Areas/Desert/SandWorm.as
+++ b/classes/classes/Scenes/Areas/Desert/SandWorm.as
@@ -8,7 +8,7 @@ import classes.Scenes.Combat.Combat;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class SandWorm extends Monster
 	{
@@ -136,7 +136,7 @@ public class SandWorm extends Monster
 			player.addStatusValue(StatusEffects.MonsterDig, 1, -1);
 		}
 
-		override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+		override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.Devoured)) {
 				btnStruggle.call(sandWormDevourStruggle);
 				btnBoundWait.call(sandWormDevourWait);

--- a/classes/classes/Scenes/Areas/Forest/Alraune.as
+++ b/classes/classes/Scenes/Areas/Forest/Alraune.as
@@ -13,7 +13,7 @@ import classes.Scenes.SceneLib;
 import classes.display.SpriteDb;
 import classes.internals.WeightedDrop;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class Alraune extends Monster
 	{
@@ -107,7 +107,7 @@ public class Alraune extends Monster
 			}
 		}
 
-		override public function postPlayerBusyBtnSpecial(btnSpecial1:CoCButton, btnSpecial2:CoCButton):void{
+		override public function postPlayerBusyBtnSpecial(btnSpecial1:ButtonData, btnSpecial2:ButtonData):void{
 			if (player.fatigueLeft() < 50) btnSpecial1.disable("You're too tired to struggle.");
 			else btnSpecial1.show("Struggle", SceneLib.combat.wait2, "Struggle to forcefully pull yourself a good distance away from plant woman.");
 		}

--- a/classes/classes/Scenes/Areas/Forest/Barometz.as
+++ b/classes/classes/Scenes/Areas/Forest/Barometz.as
@@ -11,7 +11,7 @@ import classes.BodyParts.LowerBody;
 import classes.Scenes.SceneLib;
 import classes.internals.WeightedDrop;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class Barometz extends Monster
 	{
@@ -80,7 +80,7 @@ public class Barometz extends Monster
 			outputText("\n");
 		}
 		
-		override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+		override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.Tentagrappled)) {
 				btnStruggle.call(baroGrappleStruggle);
 				btnBoundWait.call(baroGrappleWait);

--- a/classes/classes/Scenes/Areas/Forest/WoodElvesHuntingParty.as
+++ b/classes/classes/Scenes/Areas/Forest/WoodElvesHuntingParty.as
@@ -10,13 +10,11 @@ import classes.BodyParts.Hips;
 import classes.BodyParts.LowerBody;
 import classes.GlobalFlags.kFLAGS;
 import classes.Items.Weapon;
-import classes.Items.WeaponLib;
 import classes.Items.WeaponRange;
-import classes.Items.WeaponRangeLib;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class WoodElvesHuntingParty extends Monster
 	{
@@ -132,7 +130,7 @@ public class WoodElvesHuntingParty extends Monster
             SceneLib.combat.enemyAIImpl();
         }
 
-		override public function postPlayerBusyBtnSpecial(btnSpecial1:CoCButton, btnSpecial2:CoCButton):void{
+		override public function postPlayerBusyBtnSpecial(btnSpecial1:ButtonData, btnSpecial2:ButtonData):void{
 				if (flags[kFLAGS.PLAYER_DISARMED_WEAPON_ID] != 0) btnSpecial1.show("Pick (M)", pickUpMelee, "Pick up your melee weapon.");
 				if (flags[kFLAGS.PLAYER_DISARMED_WEAPON_R_ID] != 0) btnSpecial2.show("Pick (R)", pickUpRange, "Pick up your range weapon.");
 		}

--- a/classes/classes/Scenes/Areas/HighMountains/Izumi.as
+++ b/classes/classes/Scenes/Areas/HighMountains/Izumi.as
@@ -8,7 +8,7 @@ import classes.IMutations.*;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class Izumi extends Monster
 	{
@@ -119,7 +119,7 @@ public class Izumi extends Monster
 			checkMonster();
 		}
 
-		override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+		override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.Titsmother)) {
 				btnStruggle.call(titSmotherStruggle);
 				btnBoundWait.call(titSmotherWait);

--- a/classes/classes/Scenes/Changelog.as
+++ b/classes/classes/Scenes/Changelog.as
@@ -191,7 +191,7 @@ public class Changelog extends BaseContent
 			outputText("-Fasting Pill no longer req. to have hunger turned on.\n");
 			outputText("-Titanic Strength and Condensed Power perks would be checking effective tallness / base tallness multiplied by any bonuses from effective tallness. Base tallness is now displayed on appearance screen as out of combat tallness. Effective tallness (after adding all size increase effects and effects that boost str but not give more height) is displayed right after out of combat tallness.");
 			outputText("Giant Size / Titanic Size perks would be only applied to tallness when in combat (any scene that want to have pc account for this increased tallness would be now as new variants of scenes pc could choose).\n");
-			outputText("-After eons of been forgotten cow hair count as +1 to cow score \o/\n");
+			outputText("-After eons of been forgotten cow hair count as +1 to cow score \\o/\n");
 			outputText("-New armor (by Liadri): Arch-Necromancer cloak - buyable at Kaiba shop in Tel'Adre. Cost 800 gems, 1 magic resistance, (robe) light type armor. An outfit once worn by a powerful necromancer. It is old and tattered yet still charged with magic. This cloak and set of jewelry doubles cold and dark damage at the expense of fire and lightning. ");
 			outputText("While worn, increase spell power by 1% for every minion under your command and increase minion damage by 25%. Tease 10 bonus, Misdirection.\n");
 			outputText("-New upper underwear (by Liadri): Arch-Necromancer bra - buyable at Kaiba shop in Tel'Adre. Cost 200 gems. A bra made of silk and ornamental bones plated in silver. Increase minion damage by 20%.\n");

--- a/classes/classes/Scenes/Combat/BaseCombatContent.as
+++ b/classes/classes/Scenes/Combat/BaseCombatContent.as
@@ -4,6 +4,9 @@
 package classes.Scenes.Combat {
 import classes.BaseContent;
 
+import coc.view.ButtonData;
+import coc.view.CoCButton;
+
 public class BaseCombatContent extends BaseContent {
 	public function BaseCombatContent() {
 	}
@@ -398,5 +401,29 @@ public class BaseCombatContent extends BaseContent {
 	protected function maintainCorrosionMod():void {
         combat.magic.maintainCorrosionModImpl();
     }
+	// ====
+	//  UI
+	// ====
+
+	/**
+	 * Mark this button data as a "skill" that could be favourited.
+	 * This should be called ONLY AFTER callback is initialized, because it
+	 * will be wrapped.
+	 *
+	 * skillId is a unique button identifier
+	 */
+	protected function favbd(bd:ButtonData, skillId:String):void {
+		combat.ui.favBdImpl(bd, skillId);
+	}
+	/**
+	 * Mark this button as a "skill" that could be favourited.
+	 * This should be called ONLY AFTER callback is initialized, because it
+	 * will be wrapped.
+	 *
+	 * skillId is a unique button identifier
+	 */
+	protected function favbtn(bd:CoCButton, skillId:String):void {
+		combat.ui.favImpl(bd, skillId);
+	}
 }
 }

--- a/classes/classes/Scenes/Combat/Combat.as
+++ b/classes/classes/Scenes/Combat/Combat.as
@@ -59,6 +59,7 @@ import classes.StatusEffects.VampireThirstEffect;
 
 import coc.view.ButtonData;
 import coc.view.ButtonDataList;
+import coc.view.CoCButton;
 import coc.view.MainView;
 
 //import flash.utils.getTimer;
@@ -962,7 +963,7 @@ public class Combat extends BaseContent {
             addButton(0, "Attack", basemeleeattacks).hint("Attempt to attack the enemy with your [weapon].  Damage done is determined by your strength and weapon.");
             addButton(1, "P. Specials", SceneLib.urtaQuest.urtaSpecials).hint("Physical special attack menu.", "Physical Specials");
             addButton(2, "M. Specials", SceneLib.urtaQuest.urtaMSpecials).hint("Mental and supernatural special attack menu.", "Magical Specials");
-            CombatAbilities.Tease.createButton(monster).applyTo(button(3));
+            CombatAbilities.Tease.createButton(monster).applyToSlot(3);
             addButton(5, "Fantasize", fantasize).hint("Fantasize about your opponent in a sexual way.  Its probably a pretty bad idea to do this unless you want to end up getting raped.");
             addButton(6, "Wait", wait).hint("Take no action for this round.  Why would you do this?  This is a terrible idea.");
         }
@@ -1024,8 +1025,10 @@ public class Combat extends BaseContent {
 
     internal function buildOtherActions(buttons:ButtonDataList, backFunc:Function, aspectButtons:ButtonDataList = null):void {
         var bd:ButtonData;
-		buttons.add("Surrender(H)", surrenderByHP, "Stop defending yourself. You'll take a hell of a beating. Why would you do this?");
-        buttons.add("Surrender(L)", surrenderByLust, "Fantasize about your opponent in a sexual way so much it would fill up your lust. You'll end up getting raped...But is it rape if you get what you want?");
+		bd = buttons.add("Surrender(H)", surrenderByHP, "Stop defending yourself. You'll take a hell of a beating. Why would you do this?");
+	    favbd(bd, "Surrender(H)");
+        bd = buttons.add("Surrender(L)", surrenderByLust, "Fantasize about your opponent in a sexual way so much it would fill up your lust. You'll end up getting raped...But is it rape if you get what you want?");
+	    favbd(bd, "Surrender(L)");
         buttons.add("Minions", CoC.instance.perkMenu.minionOptions, "You can adjust the behavior of your minions during combat.");
         buttons.add("F.S. Opt", CoC.instance.perkMenu.flyingSwordBehaviourOptions, "You can adjust the behavior of your flying sword during combat.");
         if ((player.calculateMultiAttacks() > 1) || (player.hasPerk(PerkLib.JobBeastWarrior) && (player.hasNaturalWeapons() || player.haveNaturalClawsTypeWeapon())) ||
@@ -1043,13 +1046,16 @@ public class Combat extends BaseContent {
             buttons.add("CheatStats", debugCheatStats).hint("Adjust your or enemy stats. May break things!");
         }
         if (player.hasPerk(PerkLib.AbsoluteBash) && monster.hasStatusEffect(StatusEffects.TimesBashed) && monster.statusEffectv1(StatusEffects.TimesBashed) > 0 && (player.fatigue + Math.round(player.maxFatigue() * 0.1) < player.maxOverFatigue())) {
-            buttons.add("Refresh Bash", refreshbash).hint("By spending 10% of your fatigue you may reset Shield bash to full efficiency.");
+            bd = buttons.add("Refresh Bash", refreshbash).hint("By spending 10% of your fatigue you may reset Shield bash to full efficiency.");
+	        favbd(bd, "Refresh Bash");
         }
         if (player.hasPerk(PerkLib.JobDefender)) {
-            buttons.add("Defend", defendpose).hint("Take no offensive action for this round.  Are you that confident in your defensive stance?");
+            bd = buttons.add("Defend", defendpose).hint("Take no offensive action for this round.  Are you that confident in your defensive stance?");
+	        favbd(bd, "Defend");
         }
         if (player.hasPerk(PerkLib.SecondWind) && !player.hasStatusEffect(StatusEffects.CooldownSecondWind)) {
-            buttons.add("Second Wind", seconwindGo).hint("Enter your second wind, recovering from your wounds and fatigue once per battle.");
+            bd = buttons.add("Second Wind", seconwindGo).hint("Enter your second wind, recovering from your wounds and fatigue once per battle.");
+	        favbd(bd, "Second Wind");
         }
         if (player.hasStatusEffect(StatusEffects.SoulDrill1)) {
             buttons.add("Soul Drill", soul1Drill).hint("Menu to adjust your Soul Drill spinning speed.");
@@ -1061,69 +1067,107 @@ public class Combat extends BaseContent {
             buttons.append(CombatAbilities.FlyingSwordAttack.createButton(monster));
         }
         if (!player.isFlying()) {
-            if (player.canFly()) buttons.add("Take Flight", takeFlightWings)
-                .hint("Make use of your wings or other options avilable to take flight into the air for up to 7 turns. \n\nFatigue cost per turn: "+flyingWithWingsCost()+"  \n\nGives bonus to evasion, speed but also giving penalties to accuracy of range attacks or spells. Not to mention for non-spear users to attack in melee range.")
-                .disableIf(player.hasStatusEffect(StatusEffects.FlyingDisabled), "You're being prevented from taking flight!");
-			if (player.isInGoblinMech() && player.jetpackChecks()) buttons.add("Jetpack", takeFlightGoblinMech)
-				.hint("Make use of your mech jetpack to take flight into the air for up to 5 turns. \n\nWould go into cooldown after use for: 3 rounds")
-				.disableIf(player.hasStatusEffect(StatusEffects.CooldownJetpack), "You need more time before you can use jetpack again.")
-				.disableIf(player.hasStatusEffect(StatusEffects.FlyingDisabled), "You're being prevented from taking flight!");
-			if (player.weaponFlyingSwordsName != "nothing" && player.canFlyOnFlyingSwords()) buttons.add("Take Flight", takeFlightByFlyingSword)
-                .hint("Make use of your flying sword to take flight into the air. \n\nSoulforce cost per turn: "+flyingSwordUseCost()+" \n\nGives bonus to evasion, speed but also giving penalties to accuracy of range attacks or spells. Not to mention for non-spear users to attack in melee range.")
-                .disableIf(player.hasStatusEffect(StatusEffects.FlyingDisabled), "You're being prevented from taking flight!");
-			if (player.hasPerk(PerkLib.GclassHeavenTribulationSurvivor)) buttons.add("Take Flight", takeFlightNoWings)
-                .hint("Use your own soulforce to take flight into the air. \n\nSoulforce cost per turn: "+flyingWithSoulforceCost()+" \n\nGives bonus to evasion, speed but also giving penalties to accuracy of range attacks or spells. Not to mention for non-spear users to attack in melee range.")
-                .disableIf(player.hasStatusEffect(StatusEffects.FlyingDisabled), "You're being prevented from taking flight!");
-			if (player.statStore.hasBuff("FoxflamePelt") && player.tailCount >= 9) buttons.add("Take Flight", takeFlightFoxflamePelt)
-                .hint("Use your own foxflame pelt to take flight into the air. \n\nSoulforce cost per turn: "+Math.round(25 * soulskillCost() * soulskillcostmulti())+"\nMana cost per turn: "+spellCost(50 * combat.mspecials.kitsuneskill2Cost())+" \n\nGives bonus to evasion, speed but also giving penalties to accuracy of range attacks or spells. Not to mention for non-spear users to attack in melee range.")
-                .disableIf(player.hasStatusEffect(StatusEffects.FlyingDisabled), "You're being prevented from taking flight!");
+            if (player.canFly()) {
+	            bd = buttons.add("Take Flight", takeFlightWings)
+			            .hint("Make use of your wings or other options avilable to take flight into the air for up to 7 turns. \n\nFatigue cost per turn: " + flyingWithWingsCost() + "  \n\nGives bonus to evasion, speed but also giving penalties to accuracy of range attacks or spells. Not to mention for non-spear users to attack in melee range.")
+			            .disableIf(player.hasStatusEffect(StatusEffects.FlyingDisabled), "You're being prevented from taking flight!");
+	            favbd(bd, "Take Flight");
+            }
+			if (player.isInGoblinMech() && player.jetpackChecks()) {
+				bd = buttons.add("Jetpack", takeFlightGoblinMech)
+						.hint("Make use of your mech jetpack to take flight into the air for up to 5 turns. \n\nWould go into cooldown after use for: 3 rounds")
+						.disableIf(player.hasStatusEffect(StatusEffects.CooldownJetpack), "You need more time before you can use jetpack again.")
+						.disableIf(player.hasStatusEffect(StatusEffects.FlyingDisabled), "You're being prevented from taking flight!");
+				favbd(bd, "Jetpack");
+			}
+			if (player.weaponFlyingSwordsName != "nothing" && player.canFlyOnFlyingSwords()) {
+				bd = buttons.add("Take Flight", takeFlightByFlyingSword)
+						.hint("Make use of your flying sword to take flight into the air. \n\nSoulforce cost per turn: " + flyingSwordUseCost() + " \n\nGives bonus to evasion, speed but also giving penalties to accuracy of range attacks or spells. Not to mention for non-spear users to attack in melee range.")
+						.disableIf(player.hasStatusEffect(StatusEffects.FlyingDisabled), "You're being prevented from taking flight!");
+				favbd(bd, "Take Flight (Flying Sword)");
+			}
+	        if (player.hasPerk(PerkLib.GclassHeavenTribulationSurvivor)) {
+		        bd = buttons.add("Take Flight", takeFlightNoWings)
+				        .hint("Use your own soulforce to take flight into the air. \n\nSoulforce cost per turn: " + flyingWithSoulforceCost() + " \n\nGives bonus to evasion, speed but also giving penalties to accuracy of range attacks or spells. Not to mention for non-spear users to attack in melee range.")
+				        .disableIf(player.hasStatusEffect(StatusEffects.FlyingDisabled), "You're being prevented from taking flight!");
+		        favbd(bd, "Take Flight (No Wings)")
+	        }
+			if (player.statStore.hasBuff("FoxflamePelt") && player.tailCount >= 9) {
+				bd = buttons.add("Take Flight", takeFlightFoxflamePelt)
+						.hint("Use your own foxflame pelt to take flight into the air. \n\nSoulforce cost per turn: " + Math.round(25 * soulskillCost() * soulskillcostmulti()) + "\nMana cost per turn: " + spellCost(50 * combat.mspecials.kitsuneskill2Cost()) + " \n\nGives bonus to evasion, speed but also giving penalties to accuracy of range attacks or spells. Not to mention for non-spear users to attack in melee range.")
+						.disableIf(player.hasStatusEffect(StatusEffects.FlyingDisabled), "You're being prevented from taking flight!");
+				favbd(bd, "Take Flight (Foxflame Pelt)")
+			}
         }
 		if (player.isFlying()) {
-			if (player.statusEffectv2(StatusEffects.Flying) == 1) buttons.add("Land", landAfterUsingFlyingSword);
-			if (player.statusEffectv2(StatusEffects.Flying) == 2 || player.statusEffectv2(StatusEffects.Flying) == 3) buttons.add("Land", landAfterUsingSoulforce);
-            buttons.add("Great Dive", greatDive)
+			if (player.statusEffectv2(StatusEffects.Flying) == 1) {
+				buttons.add("Land", landAfterUsingFlyingSword);
+				favbd(bd, "Land");
+			}
+			if (player.statusEffectv2(StatusEffects.Flying) == 2 || player.statusEffectv2(StatusEffects.Flying) == 3) {
+				buttons.add("Land", landAfterUsingSoulforce);
+				favbd(bd, "Land");
+			}
+            bd = buttons.add("Great Dive", greatDive)
             .hint("Make a Great Dive to deal TONS of damage!")
             .disableIf(isEnemyInvisible, "You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Great Dive");
         }
         if (CombatAbilities.FlamesOfLove.isKnown) {
-            buttons.append(CombatAbilities.FlamesOfLove.createButton(monster));
+            bd = CombatAbilities.FlamesOfLove.createButton(monster);
+	        buttons.append(bd);
+	        favbd(bd, "Flames Of Love");
         }
         if (CombatAbilities.IciclesOfLove.isKnown) {
-            buttons.append(CombatAbilities.IciclesOfLove.createButton(monster));
+            bd = CombatAbilities.IciclesOfLove.createButton(monster);
+	        buttons.append(bd);
+	        favbd(bd, "Icicles Of Love");
         }
 		if (CombatAbilities.StormOfSisterhood.isKnown) {
-            buttons.append(CombatAbilities.StormOfSisterhood.createButton(monster));
+			bd = CombatAbilities.StormOfSisterhood.createButton(monster);
+            buttons.append(bd);
+			favbd(bd, "Storm Of Sisterhood");
 		}
 		if (CombatAbilities.NightOfBrotherhood.isKnown) {
-            buttons.append(CombatAbilities.NightOfBrotherhood.createButton(monster));
+			bd = CombatAbilities.NightOfBrotherhood.createButton(monster);
+            buttons.append(bd);
+			favbd(bd, "Night Of Brotherhood");
 		}
         if (CombatAbilities.Devourer.isKnown) {
-            buttons.append(CombatAbilities.Devourer.createButton(monster));
+	        bd = CombatAbilities.Devourer.createButton(monster);
+            buttons.append(bd);
+	        favbd(bd, "Devourer");
         }
 		if ((monster.hasStatusEffect(StatusEffects.Stunned) || monster.hasStatusEffect(StatusEffects.StunnedTornado) || monster.hasStatusEffect(StatusEffects.Polymorphed) || monster.hasStatusEffect(StatusEffects.Sleep) || monster.hasStatusEffect(StatusEffects.Fascinated)) && (player.fatigueLeft() >= combat.physicalCost(20)) && player.perkv1(IMutationsLib.HollowFangsIM) >= 2) {
 			bd = buttons.add("Bite", VampiricBite).hint("Suck on the blood of an opponent. \n\nFatigue Cost: " + physicalCost(20) + "");
+			favbd(bd, "Vampiric Bite");
 		}// || monster.hasStatusEffect(StatusEffects.InvisibleOrStealth)
 		if (player.hasPerk(PerkLib.SwordIntentAura)) {
 			if (player.statStore.hasBuff("SwordIntentAura")) {
-				buttons.add("SwordIntentAD", deactivateSwordIntentAura).hint("Disperse sword intent aura.");
+				bd = buttons.add("SwordIntentAD", deactivateSwordIntentAura).hint("Disperse sword intent aura.");
+				favbd(bd, "Sword Intent Aura");
 			} else {
 				bd = buttons.add("SwordIntentAA", activateSwordIntentAura, "Coat your weapons with sword intent aura. (It would drain soulforce and fatigue until dispersed)\n");
 				bd.requireSoulforce(10 * soulskillCost() * soulskillcostmulti());
 				bd.requireFatigue(10);
+				favbd(bd, "Sword Intent Aura");
 			}
 		}
 		//Esper cool beans (start)
 		if (player.hasPerk(PerkLib.PsychicBarrier)) {
 			if (player.statStore.hasBuff("PsychoBarrier")) {
-				buttons.add("Psycho-Barrier/Off", deactivatePsychoBarrier).hint("Disperse Psycho-Barrier.");
+				bd = buttons.add("Psycho-Barrier/Off", deactivatePsychoBarrier).hint("Disperse Psycho-Barrier.");
+				favbd(bd, "Psycho Barrier");
 			} else {
 				bd = buttons.add("Psycho-Barrier/On", activatePsychoBarrier, "Cover yourself with Psycho-Barrier. (It would drain fatigue until dispersed)\n");
 				bd.requireFatigue(20);
+				favbd(bd, "Psycho Barrier");
 			}
 		}
 		if (player.hasPerk(PerkLib.PsychicBolt)) {
 			bd = buttons.add("Psychic Bolt", castPsychicBolt, "Attempt to attack the enemy with psychic bolt.  Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(10);
+			favbd(bd, "Psychic Bolt");
 		}
 		if (player.hasPerk(PerkLib.TelekineticGrapple) && !monster.hasStatusEffect(StatusEffects.TelekineticGrab)) {
 			bd = buttons.add("Telekinetic Grab", mspecials.TelekineticGrab, "Use telekinesis to hold your opponent. \n\nWould go into cooldown after use for: 6 rounds");
@@ -1131,46 +1175,57 @@ public class Combat extends BaseContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownTelekineticGrab)) {
 				bd.disable("You need more time before you can use Telekinetic Grab again.\n\n");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Telekinetic Grapple");
 		}
 		if (player.hasPerk(PerkLib.Pyrokinesis)) {
 			bd = buttons.add("Pyrokinesis", usePyrokinesis, "Attempt to attack the enemy with fire ball. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Pyrokinesis");
 		}
 		if (player.hasPerk(PerkLib.Hydrokinesis)) {
 			bd = buttons.add("Hydrokinesis", useHydrokinesis, "Attempt to attack the enemy with water sphere. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Hydrokinesis");
 		}
 		if (player.hasPerk(PerkLib.Cryokinesis)) {
 			bd = buttons.add("Cryokinesis", useCryokinesis, "Attempt to attack the enemy with icicle. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Cryokinesis");
 		}
 		if (player.hasPerk(PerkLib.Geokinesis)) {
 			bd = buttons.add("Geokinesis", useGeokinesis, "Attempt to attack the enemy with rock. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Geokinesis");
 		}
 		if (player.hasPerk(PerkLib.Electrokinesis)) {
 			bd = buttons.add("Electrokinesis", useElectrokinesis, "Attempt to attack the enemy with bolt of lightning. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Electrokinesis");
 		}
 		if (player.hasPerk(PerkLib.Aerokinesis)) {
 			bd = buttons.add("Aerokinesis", useAerokinesis, "Attempt to attack the enemy with wind sphere. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd,"Aerokinesis");
 		}
 		if (player.hasPerk(PerkLib.Umbrakinesis)) {
 			bd = buttons.add("Umbrakinesis", useUmbrakinesis, "Attempt to attack the enemy with darkness sphere. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd,"Umbrakinesis");
 		}
 		if (player.hasPerk(PerkLib.Acidokinesis)) {
 			bd = buttons.add("Acidokinesis", useAcidokinesis, "Attempt to attack the enemy with acid ball. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd,"Acidokinesis");
 		}
 		if (player.hasPerk(PerkLib.Ionikinesis)) {
 			bd = buttons.add("Ionikinesis", useIonikinesis, "Attempt to attack the enemy with plasma ball. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd,"Ionikinesis");
 		}
 		if (player.hasPerk(PerkLib.Cocytokinesis)) {
 			bd = buttons.add("Cocytokinesis", useCocytokinesis, "Attempt to attack the enemy with black icicle. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd,"Cocytokinesis");
 		}
 		//Esper cool beans (end)
 		if (player.hasStatusEffect(StatusEffects.CombatFollowerZenji) && (player.statusEffectv3(StatusEffects.CombatFollowerZenji) == 1 || player.statusEffectv3(StatusEffects.CombatFollowerZenji) == 3)) {
@@ -1186,6 +1241,7 @@ public class Combat extends BaseContent {
                 buttonFunc = ElementalAspectsMenu
             }
             bd = buttons.add("Elem.Asp", buttonFunc, "Use the once-per-battle elemental aspects of your basic elementals.", "Elemental Aspects");
+			favbd(bd,"Elemental Aspects");
         }
 		if (player.shieldName == "Ancient Conduit") bd = buttons.add("A.Conduit", AncientConduitMenu);
 		if (player.hasPerk(PerkLib.JobTamer)) bd = buttons.add("Tamed Monster(s)", comtamed.tamedMonstersMenu);
@@ -1194,20 +1250,24 @@ public class Combat extends BaseContent {
 			if (monster.isFlying() && (!player.hasPerk(PerkLib.BoneyBow) && player.perkv1(PerkLib.BoneyBow) == 0) && (!player.hasPerk(PerkLib.BoneyWand) && player.perkv1(PerkLib.BoneyWand) == 0)) {
 				bd.disable("None of your skeletons can attack airborn enemies.");
 			}
+			favbd(bd,"Send Skeletons");
 			if (player.perkv2(PerkLib.JobHaruspex) > 5) {
 				bd = buttons.add("S.S.", skeletonSmash).hint("Skeleton Smash - Order your Skeletons to go all out on your foe.");
 				if (monster.isFlying()) {
 					bd.disable("None of your skeletons can attack airborn enemies.");
 				}
+				favbd(bd,"Skeleton Smash");
 			}
 		}
 		if (player.hasPerk(PerkLib.HiddenJobAsura)) {
 			if (player.statStore.hasBuff("AsuraForm")) {
 				bd = buttons.add("Return", returnToNormalShape).hint("Return to normal from Asura form.");
+				favbd(bd,"Asura Form");
 				bd = buttons.add("Asura's Howl", asurasHowl).hint("Unleash a howl before giving enemy good punching. \n\nWrath Cost: 100");
 				if (player.wrath < 100) {
 					bd.disable("Your wrath is too low to unleash your howl!");
 				}
+				favbd(bd,"Asura's Howl");
 				if (player.hasPerk(PerkLib.AbsoluteStrength)) {
 					if (player.hasPerk(PerkLib.ItsZerkingTime)) bd = buttons.add("TwFoD", asuras12FingersOfDestruction).hint("Twelve Fingers of Destruction - Poke your enemies Asura Style. \n\nWrath Cost: 50% of max Wrath");
 					else if (player.hasPerk(PerkLib.LikeAnAsuraBoss)) bd = buttons.add("TFoD", asuras10FingersOfDestruction).hint("Ten Fingers of Destruction - Poke your enemies Asura Style. \n\nWrath Cost: 50% of max Wrath");
@@ -1216,6 +1276,7 @@ public class Combat extends BaseContent {
 					if (player.wrath < (player.maxWrath() * 0.5)) {
 						bd.disable("Your wrath is too low to poke your enemies Asura Style!");
 					}
+					favbd(bd,"Fingers of Destruction");
 				}
 				if (player.hasPerk(PerkLib.AsuraStrength)) {
 				
@@ -1231,6 +1292,7 @@ public class Combat extends BaseContent {
 				if (player.statStore.hasBuff("CrinosShape")) {// && !player.hasPerk(PerkLib.HiddenJobAsura)
 					bd.disable("You are under transformantion effect incompatibile with Asura Form!");
 				}
+				favbd(bd,"Asura Form");
 			}
 		}
 		if (player.hasPerk(PerkLib.JobWarrior)) {
@@ -1239,6 +1301,7 @@ public class Combat extends BaseContent {
 			if(player.statStore.hasBuff("WarriorsRage")) {
 				bd.disable("You're already raging!");
 			}
+			favbd(bd,"Warrior's Rage");
 		}
 		if (player.hasPerk(PerkLib.Berzerker)) {
 			bd = buttons.add("Berserk", mspecials.berzerk);
@@ -1253,23 +1316,27 @@ public class Combat extends BaseContent {
 			if (player.hasStatusEffect(StatusEffects.Berzerking)) {
 				bd.disable("You're already pretty goddamn mad!");
 			}
+			favbd(bd,"Berserk");
 		}
 		if (player.hasPerk(PerkLib.Anger) && player.hasStatusEffect(StatusEffects.Berzerking)) {
 			bd = buttons.add("Berserk G2", mspecials.berzerkG2);
 			if (player.statusEffectv2(StatusEffects.Berzerking) >= 1) {
 				bd.disable("You're already reached 2nd grade of Berserk!");
 			}
+			favbd(bd,"Berserk G2");
 			if (player.statusEffectv2(StatusEffects.Berzerking) >= 1) {
 				bd = buttons.add("Berserk G3", mspecials.berzerkG3);
 				if (player.statusEffectv2(StatusEffects.Berzerking) >= 2) {
 					bd.disable("You're already reached 3rd grade of Berserk!");
 				}
+				favbd(bd,"Berserk G3");
 			}
 			if (player.hasPerk(PerkLib.EndlessRage) && player.statusEffectv2(StatusEffects.Berzerking) >= 2) {
 				bd = buttons.add("Berserk G4", mspecials.berzerkG4);
 				if (player.statusEffectv2(StatusEffects.Berzerking) >= 3) {
 					bd.disable("You're already reached 4th grade of Berserk!");
 				}
+				favbd(bd,"Berserk G4");
 			}
 		}
 		if (player.hasPerk(PerkLib.Lustzerker) || player.countRings(jewelries.FLLIRNG)) {
@@ -1285,28 +1352,33 @@ public class Combat extends BaseContent {
 			if (player.hasStatusEffect(StatusEffects.Lustzerking)) {
 				bd.disable("You're already raging, anger and lust combined!");
 			}
+			favbd(bd,"Lustserk");
 		}
 		if (player.hasPerk(PerkLib.Anger) && player.hasStatusEffect(StatusEffects.Lustzerking)) {
 			bd = buttons.add("Lustserk G2", mspecials.lustzerkG2);
 			if (player.statusEffectv2(StatusEffects.Lustzerking) >= 1) {
 				bd.disable("You're already reached 2nd grade of Lustserk!");
 			}
+			favbd(bd,"Lustserk G2");
 			if (player.statusEffectv2(StatusEffects.Lustzerking) >= 1) {
 				bd = buttons.add("Lustserk G3", mspecials.lustzerkG3);
 				if (player.statusEffectv2(StatusEffects.Lustzerking) >= 2) {
 					bd.disable("You're already reached 3rd grade of Lustserk!");
 				}
+				favbd(bd,"Lustserk G3");
 			}
 			if (player.hasPerk(PerkLib.EndlessRage) && player.statusEffectv2(StatusEffects.Lustzerking) >= 2) {
 				bd = buttons.add("Lustserk G4", mspecials.lustzerkG4);
 				if (player.statusEffectv2(StatusEffects.Lustzerking) >= 3) {
 					bd.disable("You're already reached 4th grade of Lustserk!");
 				}
+				favbd(bd,"Lustserk G4");
 			}
 		}
 		if (player.hasPerk(PerkLib.JobBeastWarrior) || player.necklaceName == "Crinos Shape necklace") {
 			if (player.statStore.hasBuff("CrinosShape")) {
-				buttons.add("Return", mspecials.returnToNormalShape).hint("Return to normal from Crinos Shape.");
+				bd = buttons.add("Return", mspecials.returnToNormalShape).hint("Return to normal from Crinos Shape.");
+				favbd(bd,"Crinos Shape");
 			} else {
 				bd = buttons.add("CrinosShape", mspecials.assumeCrinosShape).hint("Let your wrath flow through you, transforming you into a bestial shape!  Greatly increases your strength, speed and fortitude! \n\nWrath Cost: " + mspecials.crinosshapeCost() + " per turn");
 				if (player.wrath < mspecials.crinosshapeCost()) {
@@ -1315,13 +1387,16 @@ public class Combat extends BaseContent {
 				if (player.statStore.hasBuff("AsuraForm")) {// && !player.hasPerk(PerkLib.HiddenJobAsura)
 					bd.disable("You are under transformantion effect incompatibile with Crinos Shape!");
 				}
+				favbd(bd,"Crinos Shape");
 			}
 		}
 		if (player.hasPerk(PerkLib.Atavism)) {
 			if (player.statStore.hasBuff("Atavism")) {
-				buttons.add("Return", mspecials.returnToNormalStateA).hint("Return to normal from Atavism State.");
+				bd = buttons.add("Return", mspecials.returnToNormalStateA).hint("Return to normal from Atavism State.");
+				favbd(bd,"Atavism");
 			} else {
 				bd = buttons.add("Atavism", mspecials.assumeAtavismState).hint("Turn feral for a while, abandoning yourself to your animalistic instincts. Unlock the full potential in your body by boosting your physical might and sharpening your senses but silence your ability to process intelligent logical thoughts. \n");
+				favbd(bd,"Atavism");
 			}
 		}
 		if (player.racialScore(Races.ONI, false) >= mspecials.minOniScoreReq()) {
@@ -1330,15 +1405,23 @@ public class Combat extends BaseContent {
 			if(player.hasStatusEffect(StatusEffects.OniRampage)) {
 				bd.disable("You're already rampaging!");
 			}
+			favbd(bd,"Oni Rampage");
 		}
 		if (player.hasStatusEffect(StatusEffects.AlterBindScroll1)) {
-			if (player.statStore.hasBuff("NoLimiterState")) buttons.add("No Limiter", returnToNormalState).hint("Toggle off No Limiter.");
-			else buttons.add("No Limiter", noLimiterState).hint("Toggle on No Limiter. (STR+++, ?Lib-?)");
+			if (player.statStore.hasBuff("NoLimiterState")) {
+				bd = buttons.add("No Limiter", returnToNormalState).hint("Toggle off No Limiter.");
+				favbd(bd,"No Limiter");
+			} else {
+				bd = buttons.add("No Limiter", noLimiterState).hint("Toggle on No Limiter. (STR+++, ?Lib-?)");
+				favbd(bd,"No Limiter");
+			}
 		}
 		if (player.hasPerk(PerkLib.ElementalBody)) {
             for each (var fusionAbility:CombatAbility in CombatAbilities.ALL_ELEMENTAL_FUSION_ATTACKS) {
                 if (fusionAbility.isKnown) {
-                    buttons.append(fusionAbility.createButton(monster));
+	                bd = fusionAbility.createButton(monster);
+	                buttons.append(bd);
+	                favbd(bd, fusionAbility.name);
                 }
             }
 		}
@@ -20600,6 +20683,12 @@ private function touSpeStrScale(stat:int):Number {
     public function isNearWater():Boolean {
         return player.hasStatusEffect(StatusEffects.UnderwaterCombatBoost) || player.hasStatusEffect(StatusEffects.NearWater) || explorer.areaTags.water;
     }
+	protected function favbd(bd:ButtonData, skillId:String):void {
+		ui.favBdImpl(bd, skillId);
+	}
+	protected function favbtn(bd:CoCButton, skillId:String):void {
+		ui.favImpl(bd, skillId);
+	}
 }
 
 }

--- a/classes/classes/Scenes/Combat/CombatUI.as
+++ b/classes/classes/Scenes/Combat/CombatUI.as
@@ -8,6 +8,7 @@ import classes.BodyParts.LowerBody;
 import classes.BodyParts.RearBody;
 import classes.BodyParts.Tail;
 import classes.BodyParts.Wings;
+import classes.CoC;
 import classes.CoC_Settings;
 import classes.GlobalFlags.kFLAGS;
 import classes.IMutations.IMutationsLib;
@@ -737,6 +738,7 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 			// Do not create default menu if it was overwritten
 			return;
 		}
+		menu("CombatUI.mainMenu");
 		/* OLD MENU
 		 0 [ Melee ] [ Range ] [ Tease ] [  Wait   ] [ Items ]
 		 5 ability groups
@@ -769,7 +771,7 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 		Skills:
 		 0 [ Melee  ] [ Ranged ] [ Tease  ] [        ] [        ]
 		 5 [ PhySpc ] [ MagSpc ] [Soulskil] [ Magic  ] [        ]
-		10 [        ] [        ] [        ] [        ] [        ]
+		10 [        ] [        ] [        ] [        ] [  Back  ]
 
 		Other:
 		 0 [ Items  ] [  Wait  ] [Fantasiz] [  Run   ] ...old "Other"
@@ -777,9 +779,14 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 		favbd(btnMelee, "Melee Attack");
 		favbd(btnRanged, "Ranged Attack");
 		favbd(btnTease, "Tease");
+		favbd(btnPSpecials, "Physical Specials");
+		favbd(btnMSpecials, "Magical Specials");
+		favbd(btnSoulskills, "Soulskills");
+		favbd(btnMagic, "Magic");
 		favbd(btnItems, "Items");
 		favbd(btnFantasize, "Fantasize");
 		favbd(btnWait, "Wait");
+		favbd(btnRun, "Run");
 		var btnSkillsNew:ButtonData = new ButtonData();
 		btnSkillsNew.show("Skills",curry(skillsSubmenuNew, btnMelee, btnRanged, btnTease, btnPSpecials, btnMSpecials, btnSoulskills, btnMagic));
 		var btnOtherNew:ButtonData = new ButtonData();
@@ -787,7 +794,12 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 		otherButtons.prepend(btnFantasize);
 		otherButtons.prepend(btnWait);
 		otherButtons.prepend(btnItems);
-		bd = new ButtonData("Btn Config", curry(modFavCountMenu, mainMenu), "Configure number of favourite skills");
+		var text:String = CoC.instance.currentText;
+		bd = new ButtonData("Btn Config", curry(modFavCountMenu, function():void {
+			clearOutput();
+			rawOutputText(text);
+			mainMenu();
+		}), "Configure number of favourite skills");
 		otherButtons.prepend(bd);
 		btnOtherNew.show("Other", submenuOther, "Combat options and uncategorized actions");
 		/**/
@@ -799,10 +811,10 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 				if (bd) {
 					bd.applyTo(button(i));
 				} else {
-					button(i).show("-", curry(unfavSlot, i), "The favourited ability '"+favSkills[i]+"' is not available. Shift-click to unfavourite it.").disable();
+					button(i).show("N/A", curry(unfavSlot, i), "The favourited ability '"+favSkills[i]+"' is not available. Shift-click to unfavourite it.").disable().clickOnDisabled = true;
 				}
 			} else {
-				button(i).showDisabled("", "Shift+click an ability to favourite it", "Favourite slot "+(i+1))
+				button(i).showDisabled("", "Shift+click a button with '*' to favourite it", "Favourite slot "+(i+1))
 			}
 		}
 		for (i = favCount; i < 10; i++) {
@@ -1217,6 +1229,7 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 			} else if (player.hasStatusEffect(StatusEffects.MonsterDig)) {
 				bd.disable("You cannot use offensive spell against an opponent you cannot see or target.");
 			}
+			favbd(bd, "Magic Bolt");
 			if (player.hasPerk(PerkLib.MagesWrath)) {
 				bd = buttons.add("M.Bolt(Ex)", combat.magic.spellEdgyMagicBolt);
 				if (player.hasPerk(PerkLib.StaffChanneling) && (player.weapon.isWandType() || player.weaponOff.isWandType() || player.weapon.isStaffType() || player.weaponOff.isStaffType())) bd.hint("Attempt to attack the enemy with wrath-empowered magic bolt from your [weapon].  Damage done is determined by your intelligence, wisdom and weapon.", "Wrath-Empowered Magic Bolt");
@@ -1230,6 +1243,7 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 				} else if (player.hasStatusEffect(StatusEffects.MonsterDig)) {
 					bd.disable("You cannot use offensive spell against an opponent you cannot see or target.");
 				}
+				favbd(bd, "Magic Bolt Ex");
 			}
 		}
 		if (player.hasPerk(PerkLib.ElementalBolt)) {
@@ -1243,6 +1257,7 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 			} else if (player.hasStatusEffect(StatusEffects.MonsterDig)) {
 				bd.disable("You cannot use offensive spell against an opponent you cannot see or target.");
 			}
+			favbd(bd, "Elemental Bolt");
 			if (player.hasPerk(PerkLib.MagesWrath)) {
 				bd = buttons.add("E.Bolt(Ex)", combat.magic.spellEdgyElementalBolt);
 				if (player.hasPerk(PerkLib.StaffChanneling) && (player.weapon.isWandType() || player.weaponOff.isWandType() || player.weapon.isStaffType() || player.weaponOff.isStaffType())) bd.hint("Attempt to attack the enemy with wrath-empowered elemental bolt from your [weapon].  Damage done is determined by your intelligence, wisdom and weapon.", "Wrath-Empowered Elemental Bolt");
@@ -1256,9 +1271,13 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 				} else if (player.hasStatusEffect(StatusEffects.MonsterDig)) {
 					bd.disable("You cannot use offensive spell against an opponent you cannot see or target.");
 				}
+				favbd(bd, "Elemental Bolt Ex");
 			}
 		}
-		if (player.hasStatusEffect(StatusEffects.GreenCovenant)) bd = buttons.add("G.Coven(off)", combat.magic.spellGreenCovenantOff).hint("Ends Green Covenant effect.");
+		if (player.hasStatusEffect(StatusEffects.GreenCovenant)) {
+			bd = buttons.add("G.Coven(off)", combat.magic.spellGreenCovenantOff).hint("Ends Green Covenant effect.");
+			favbd(bd, "Green Covenant");
+		}
 		buildAbilityMenu(CombatAbilities.ALL_WHITE_SPELLS, whiteSpellButtons);
 		buildAbilityMenu(CombatAbilities.ALL_BLACK_SPELLS, blackSpellButtons);
 		buildAbilityMenu(CombatAbilities.ALL_GREY_SPELLS, greySpellButtons);
@@ -1267,14 +1286,38 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 		buildAbilityMenu(CombatAbilities.ALL_NECRO_SPELLS, necroSpellButtons);
 		buildAbilityMenu(CombatAbilities.ALL_BLOOD_SPELLS, bloodSpellButtons);
 		buildAbilityMenu(CombatAbilities.ALL_GREEN_SPELLS, greenSpellButtons);
-		if (whiteSpellButtons.length > 0) buttons.add("White Spells", curry(submenu,whiteSpellButtons, submenuSpells, 0, false)).hint("Open your White magic book");
-		if (blackSpellButtons.length > 0) buttons.add("Black Spells", curry(submenu,blackSpellButtons, submenuSpells, 0, false)).hint("Open your Black magic book");
-		if ((player.hasPerk(PerkLib.GreyMagic) || player.hasPerk(PerkLib.PrestigeJobGreySage)) && greySpellButtons.length > 0) buttons.add("Grey Spells", curry(submenu,greySpellButtons, submenuSpells, 0, false)).hint("Open your Grey magic book");
-		if ((player.hasPerk(PerkLib.HexKnowledge) || player.hasPerk(PerkLib.PrestigeJobGreySage)) && hexSpellButtons.length > 0) buttons.add("Hexes", curry(submenu,hexSpellButtons, submenuSpells, 0, false)).hint("Open your Hex grimoire");
-		if ((player.hasPerk(PerkLib.DivineKnowledge) || player.hasPerk(PerkLib.PrestigeJobGreySage)) && divineSpellButtons.length > 0) buttons.add("Divine", curry(submenu,divineSpellButtons, submenuSpells, 0, false)).hint("Open your Divine tome");
-		if ((player.hasPerk(PerkLib.PrestigeJobNecromancer) || player.hasPerk(PerkLib.PrestigeJobGreySage)) && necroSpellButtons.length > 0) buttons.add("Necro Spells", curry(submenu,necroSpellButtons, submenuSpells, 0, false)).hint("Open your Necromicon");
-		if ((player.hasPerk(PerkLib.HiddenJobBloodDemon) || player.hasPerk(PerkLib.PrestigeJobGreySage)) && bloodSpellButtons.length > 0) buttons.add("Blood Spells", curry(submenu,bloodSpellButtons, submenuSpells, 0, false)).hint("Open your Blood grimoire");
-		if (greenSpellButtons.length > 0) buttons.add("Green Spells", curry(submenu,greenSpellButtons, submenuSpells, 0, false)).hint("Open your Green magic book");
+		if (whiteSpellButtons.length > 0) {
+			bd = buttons.add("White Spells", curry(submenu, whiteSpellButtons, submenuSpells, 0, false)).hint("Open your White magic book");
+			favbd(bd, "White Spells");
+		}
+		if (blackSpellButtons.length > 0) {
+			bd = buttons.add("Black Spells", curry(submenu, blackSpellButtons, submenuSpells, 0, false)).hint("Open your Black magic book");
+			favbd(bd, "Black Spells");
+		}
+		if ((player.hasPerk(PerkLib.GreyMagic) || player.hasPerk(PerkLib.PrestigeJobGreySage)) && greySpellButtons.length > 0) {
+			bd = buttons.add("Grey Spells", curry(submenu, greySpellButtons, submenuSpells, 0, false)).hint("Open your Grey magic book");
+			favbd(bd, "Grey Spells");
+		}
+		if ((player.hasPerk(PerkLib.HexKnowledge) || player.hasPerk(PerkLib.PrestigeJobGreySage)) && hexSpellButtons.length > 0) {
+			bd = buttons.add("Hexes", curry(submenu, hexSpellButtons, submenuSpells, 0, false)).hint("Open your Hex grimoire");
+			favbd(bd, "Hex Spells");
+		}
+		if ((player.hasPerk(PerkLib.DivineKnowledge) || player.hasPerk(PerkLib.PrestigeJobGreySage)) && divineSpellButtons.length > 0) {
+			bd = buttons.add("Divine", curry(submenu, divineSpellButtons, submenuSpells, 0, false)).hint("Open your Divine tome");
+			favbd(bd, "Divine Spells");
+		}
+		if ((player.hasPerk(PerkLib.PrestigeJobNecromancer) || player.hasPerk(PerkLib.PrestigeJobGreySage)) && necroSpellButtons.length > 0) {
+			bd = buttons.add("Necro Spells", curry(submenu, necroSpellButtons, submenuSpells, 0, false)).hint("Open your Necromicon");
+			favbd(bd, "Necro Spells");
+		}
+		if ((player.hasPerk(PerkLib.HiddenJobBloodDemon) || player.hasPerk(PerkLib.PrestigeJobGreySage)) && bloodSpellButtons.length > 0) {
+			bd = buttons.add("Blood Spells", curry(submenu, bloodSpellButtons, submenuSpells, 0, false)).hint("Open your Blood grimoire");
+			favbd(bd, "Blood Spells");
+		}
+		if (greenSpellButtons.length > 0) {
+			bd = buttons.add("Green Spells", curry(submenu, greenSpellButtons, submenuSpells, 0, false)).hint("Open your Green magic book");
+			favbd(bd, "Green Spells");
+		}
 	}
 	
 	private function BuildSoulskillMenu(buttons:ButtonDataList):void {
@@ -1294,7 +1337,9 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 	private function buildAbilityMenu(abilities:/*CombatAbility*/Array, buttons:ButtonDataList):void {
 		for each(var ability:CombatAbility in abilities) {
 			if (ability.isKnown) {
-				buttons.append(ability.createButton(monster));
+				var bd:ButtonData = ability.createButton(monster);
+				buttons.append(bd);
+				favbd(bd, ability.name);
 			}
 		}
 	}

--- a/classes/classes/Scenes/Combat/CombatUI.as
+++ b/classes/classes/Scenes/Combat/CombatUI.as
@@ -54,7 +54,7 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 	public var favCount:int = 5;
 	public var favSkills:/*String*/Array = [null,null,null,null,null];
 	public var favLastSkills:/*String*/Array = [null,null,null,null,null];
-
+	private var manualMode:Boolean = false;
 
 	public function stateObjectName():String {
 		return "CombatUI";
@@ -80,7 +80,11 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 			favSkills = o.favSkills as Array;
 			favLastSkills = o.favLastSkills as Array;
 			favCount = intOr(o.favCount, 5);
-			if (!favSkills || favSkills.length != favCount || !favLastSkills || favLastSkills.length != (10-favCount)) {
+			if (favSkills && favSkills.length == favCount && favLastSkills && favLastSkills.length == (10 - favCount)) {
+				// Copy the arrays to not keep references to SharedObject
+				favSkills = favSkills.slice();
+				favLastSkills = favLastSkills.slice();
+			} else {
 				resetState();
 			}
 		} else {
@@ -102,6 +106,10 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 		for (var i:int = 0; i <= 10; i++) {
 			button(i).show(String(i), curry(modFavCount, i, back), ""+i+" favourite(s) / "+(10-i)+" last used");
 		}
+		button(13).show("Manual Mode", function():void {
+			manualMode = !manualMode;
+			back();
+		}, "(Useful for mobile mode) Toggle Manual Menu Edit mode to add abilities to favourites (or remove) when you click the button.");
 		button(14).show("Back", back).icon("Back");
 	}
 	private function modFavCount(i:int, back:Function):void {
@@ -136,39 +144,34 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 		favBdImpl(bd, skillId);
 		bd.applyTo(btn);
 	}
-	private function favClick(skillId:String, callback:Function):void {
-		var i:int;
-		if (shiftKeyDown) {
-			i = favSkills.indexOf(skillId);
-			if (i < 0){
-				// add to favs if possible
-				i = favSkills.indexOf(null);
-				if (i >= 0) {
-					CoCButton.lastClicked.cornerLabelText = "*" + (i + 1);
-					favSkills[i] = skillId;
-				}
-				i = favLastSkills.indexOf(skillId);
-				if (i >= 0) {
-					favLastSkills.splice(i, 1);
-					favLastSkills.push(null);
-				}
-				if (inMenu("CombatUI.mainMenu")) {
-					mainMenu();
-				}
-			} else {
-				// remove from favs
-				CoCButton.lastClicked.cornerLabelText = "*";
-				if (inMenu("CombatUI.mainMenu")) {
-					CoCButton.lastClicked.showDisabled("", "Shift+click an ability to favourite it", "Favourite slot "+(i+1));
-				}
-				favSkills[i] = null;
-			}
-			return;
+	private function addToFavs(skillId:String):void {
+		// add to favs if possible
+		var i:int = favSkills.indexOf(null);
+		if (i >= 0) {
+			CoCButton.lastClicked.cornerLabelText = "*" + (i + 1);
+			favSkills[i] = skillId;
 		}
-		if (!CoCButton.lastClicked.enabled) {
-			return;
+		i = favLastSkills.indexOf(skillId);
+		if (i >= 0) {
+			favLastSkills.splice(i, 1);
+			favLastSkills.push(null);
 		}
-		i = favSkills.indexOf(skillId);
+		if (inMenu("CombatUI.mainMenu")) {
+			mainMenu();
+		}
+	}
+	private function removeFromFavs(skillId:String):void {
+		// remove from favs
+		var i:int = favSkills.indexOf(skillId);
+		if (i < 0) return;
+		CoCButton.lastClicked.cornerLabelText = "*";
+		if (inMenu("CombatUI.mainMenu")) {
+			CoCButton.lastClicked.showDisabled("", "Shift+click an ability to favourite it", "Favourite slot "+(i+1));
+		}
+		favSkills[i] = null;
+	}
+	private function addToLastFav(skillId:String):void {
+		var i:int = favSkills.indexOf(skillId);
 		if (i < 0) {
 			// move skill to first position in favLastSkills
 			i = favLastSkills.indexOf(skillId);
@@ -182,7 +185,67 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 				favLastSkills.unshift(skillId);
 			} // else already at first position
 		}
+	}
+	private function favClick(skillId:String, callback:Function):void {
+		if (manualMode) {
+			favManualMenu(skillId, callback);
+			return;
+		}
+		if (shiftKeyDown) {
+			if (favSkills.indexOf(skillId) < 0) {
+				addToFavs(skillId);
+			} else {
+				removeFromFavs(skillId);
+			}
+			return;
+		}
+		if (!CoCButton.lastClicked.enabled) {
+			return;
+		}
+		addToLastFav(skillId);
 		callback();
+	}
+	private function favManualMenu(skillId:String, callback:Function):void {
+		var i:int = favSkills.indexOf(skillId);
+		clearOutput();
+		outputText("You're in <b>Manual Menu Edit</b> mode. You've clicked button '"+skillId+"'.\n");
+		outputText("\n<b>Invoke Cont</b> - invoke the '" + skillId + "' ability/submenu, stay in edit mode.")
+		outputText("\n<b>Invoke End</b> - invoke the '" + skillId + "' ability/submenu, leave edit mode.")
+		outputText("\n<b>Fav Cont</b> - add '" + skillId + "' to favourites, stay in edit mode.");
+		outputText("\n<b>Fav End</b> - add '" +skillId+"' to favourites, leave edit mode.");
+		outputText("\n<b>Unfav Cont</b> - remove '" + skillId + "' from favourites, stay in edit mode.");
+		outputText("\n<b>Unfav End</b> - remove '" +skillId+"' from favourites, leave edit mode.");
+		menu();
+		button(0).show("Invoke Cont", function():void {
+			addToLastFav(skillId);
+			clearOutput();
+			callback();
+		});
+		button(5).show("Invoke End", function():void {
+			manualMode = false;
+			addToLastFav(skillId);
+			clearOutput();
+			callback();
+		});
+		button(1).show("Fav Cont", function():void {
+			addToFavs(skillId);
+			mainMenu();
+		}).disableIf(i >= 0).disableIf(favSkills.indexOf(null)<0,"All favoutire slots busy!");
+		button(6).show("Fav End", function():void {
+			manualMode = false;
+			addToFavs(skillId);
+			mainMenu();
+		}).disableIf(i >= 0).disableIf(favSkills.indexOf(null)<0,"All favoutire slots busy!");
+		button(2).show("Unfav Cont", function():void {
+			removeFromFavs(skillId);
+			mainMenu();
+		}).disableIf(i < 0);
+		button(7).show("Unfav End", function():void {
+			manualMode = false;
+			removeFromFavs(skillId);
+			mainMenu();
+		}).disableIf(i < 0);
+		button(14).show("Back", mainMenu);
 	}
 
 	public function mainMenu():void {
@@ -799,7 +862,7 @@ public class CombatUI extends BaseCombatContent implements SaveableState {
 			clearOutput();
 			rawOutputText(text);
 			mainMenu();
-		}), "Configure number of favourite skills");
+		}), "Configure favourite skills button count");
 		otherButtons.prepend(bd);
 		btnOtherNew.show("Other", submenuOther, "Combat options and uncategorized actions");
 		/**/

--- a/classes/classes/Scenes/Combat/CombatUI.as
+++ b/classes/classes/Scenes/Combat/CombatUI.as
@@ -14,20 +14,22 @@ import classes.IMutations.IMutationsLib;
 import classes.Items.Weapons.Tidarion;
 import classes.PerkLib;
 import classes.Races;
+import classes.Saves;
 import classes.Scenes.Areas.VolcanicCrag.HellcatKasha;
-import classes.Scenes.Camp.CampMakeWinions;
 import classes.Scenes.Dungeons.D3.*;
 import classes.Scenes.SceneLib;
 import classes.StatusEffectClass;
 import classes.StatusEffects;
+import classes.internals.SaveableState;
 
 import coc.view.ButtonData;
 import coc.view.ButtonDataList;
 import coc.view.CoCButton;
 
-public class CombatUI extends BaseCombatContent {
+public class CombatUI extends BaseCombatContent implements SaveableState {
 
 	public function CombatUI() {
+		Saves.registerSaveableState(this);
 	}
 
 	private var magspButtons:ButtonDataList = new ButtonDataList();
@@ -44,8 +46,147 @@ public class CombatUI extends BaseCombatContent {
 	private var soulforceButtons:ButtonDataList = new ButtonDataList();
 	private var eAspectButtons:ButtonDataList = new ButtonDataList();
 	private var otherButtons:ButtonDataList = new ButtonDataList();
-	public function mainMenu():void {
+
+	public static var useNewMenu:Boolean = true;
+	// skillId:String -> ButtonData
+	public var favMap:Object = {};
+	public var favCount:int = 5;
+	public var favSkills:/*String*/Array = [null,null,null,null,null];
+	public var favLastSkills:/*String*/Array = [null,null,null,null,null];
+
+
+	public function stateObjectName():String {
+		return "CombatUI";
+	}
+
+	public function resetState():void {
+		favMap = {};
+		favCount = 5;
+		favSkills = ["Melee Attack","Ranged Attack","Tease","Items","Wait"];
+		favLastSkills = [null,null,null,null,null];
+	}
+
+	public function saveToObject():Object {
+		return {
+			favSkills: favSkills,
+			favLastSkills: favLastSkills,
+			favCount: favCount
+		}
+	}
+
+	public function loadFromObject(o:Object, ignoreErrors:Boolean):void {
+		if (o) {
+			favSkills = o.favSkills as Array;
+			favLastSkills = o.favLastSkills as Array;
+			favCount = intOr(o.favCount, 5);
+			if (!favSkills || favSkills.length != favCount || !favLastSkills || favLastSkills.length != (10-favCount)) {
+				resetState();
+			}
+		} else {
+			resetState();
+		}
+	}
+
+	public function setFavCount(newCount:int):void {
+		favCount = boundInt(0, newCount, 10);
+		favSkills = favSkills.concat(favLastSkills);
+		favLastSkills = favSkills.slice(favCount);
+		favSkills = favSkills.slice(0, favCount);
+	}
+
+	public function modFavCountMenu(back:Function):void {
+		clearOutput();
+		outputText("Current settings: \n"+favCount+" slot(s) for favourite skills\n"+(10-favCount)+" slot(s) for last used skills.\n\nSet favourite slot count to:");
 		menu();
+		for (var i:int = 0; i <= 10; i++) {
+			button(i).show(String(i), curry(modFavCount, i, back), ""+i+" favourite(s) / "+(10-i)+" last used");
+		}
+		button(14).show("Back", back).icon("Back");
+	}
+	private function modFavCount(i:int, back:Function):void {
+		setFavCount(i);
+		back();
+	}
+
+	public function favBdImpl(bd:ButtonData, skillId:String):void {
+		if (!useNewMenu) return;
+		if (skillId in favMap) {
+			trace("[WARN] Duplicate favBd call for skill "+skillId);
+			return;
+		}
+		favMap[skillId] = bd;
+		var cb:Function = bd.callback;
+		bd.callback = function():void {
+			favClick(skillId, cb);
+		}
+		var i:int = favSkills.indexOf(skillId);
+		if (i >= 0) {
+			bd.cornerLabelText = "*"+(i+1);
+			bd.toolTipText += "\n\nShift+click to remove from favourites";
+		} else {
+			bd.cornerLabelText = "*";
+			bd.toolTipText += "\n\nShift+click to add to favourites";
+		}
+		bd.clickOnDisabled = true;
+	}
+	public function favImpl(btn:CoCButton, skillId:String):void {
+		if (!useNewMenu) return;
+		var bd:ButtonData = new ButtonData().fromButton(btn);
+		favBdImpl(bd, skillId);
+		bd.applyTo(btn);
+	}
+	private function favClick(skillId:String, callback:Function):void {
+		var i:int;
+		if (shiftKeyDown) {
+			i = favSkills.indexOf(skillId);
+			if (i < 0){
+				// add to favs if possible
+				i = favSkills.indexOf(null);
+				if (i >= 0) {
+					CoCButton.lastClicked.cornerLabelText = "*" + (i + 1);
+					favSkills[i] = skillId;
+				}
+				i = favLastSkills.indexOf(skillId);
+				if (i >= 0) {
+					favLastSkills.splice(i, 1);
+					favLastSkills.push(null);
+				}
+				if (inMenu("CombatUI.mainMenu")) {
+					mainMenu();
+				}
+			} else {
+				// remove from favs
+				CoCButton.lastClicked.cornerLabelText = "*";
+				if (inMenu("CombatUI.mainMenu")) {
+					CoCButton.lastClicked.showDisabled("", "Shift+click an ability to favourite it", "Favourite slot "+(i+1));
+				}
+				favSkills[i] = null;
+			}
+			return;
+		}
+		if (!CoCButton.lastClicked.enabled) {
+			return;
+		}
+		i = favSkills.indexOf(skillId);
+		if (i < 0) {
+			// move skill to first position in favLastSkills
+			i = favLastSkills.indexOf(skillId);
+			if (i < 0) {
+				// [f1 f2 f3 f4 f5] -> [*new* f1 f2 f3 f4 f5]
+				favLastSkills.pop();
+				favLastSkills.unshift(skillId);
+			} else if (i > 0) {
+				// [f1 *f2* f3 f4 f5] -> [*f2* f1 f3 f4 f5]
+				favLastSkills.splice(i, 1);
+				favLastSkills.unshift(skillId);
+			} // else already at first position
+		}
+		callback();
+	}
+
+	public function mainMenu():void {
+		favMap = {};
+		menu("CombatUI.mainMenu");
 		magspButtons.clear();
 		physpButtons.clear();
 		spellBookButtons.clear();
@@ -66,14 +207,14 @@ public class CombatUI extends BaseCombatContent {
 		var btnTease:ButtonData      = new ButtonData().icon("A_Tease");
 		var btnWait:ButtonData       = new ButtonData();
 		var btnItems:ButtonData      = new ButtonData().icon("A_Items")
-		var btnPSpecials:ButtonData  = new ButtonData();
-		var btnMSpecials:ButtonData  = new ButtonData();
-		var btnMagic:ButtonData      = new ButtonData().icon("A_Magic")
-		var btnSoulskills:ButtonData = new ButtonData();
-		var btnOther:ButtonData      = new ButtonData();
-		var btnSpecial1:ButtonData   = new ButtonData();
-		var btnSpecial2:ButtonData   = new ButtonData();
-		var btnSpecial3:ButtonData   = new ButtonData();
+		var btnPSpecials:ButtonData  = new ButtonData().hide();
+		var btnMSpecials:ButtonData  = new ButtonData().hide();
+		var btnMagic:ButtonData      = new ButtonData().hide().icon("A_Magic")
+		var btnSoulskills:ButtonData = new ButtonData().hide();
+		var btnOther:ButtonData      = new ButtonData().hide();
+		var btnSpecial1:ButtonData   = new ButtonData().hide();
+		var btnSpecial2:ButtonData   = new ButtonData().hide();
+		var btnSpecial3:ButtonData   = new ButtonData().hide();
 		var btnFantasize:ButtonData  = new ButtonData();
 		var btnRun:ButtonData        = new ButtonData();
 
@@ -269,6 +410,7 @@ public class CombatUI extends BaseCombatContent {
 		//==============================================================================================================
 		//ALLIES - 'smart' ones (wisps & mummies & henchmen). Do not depend on PC to do anything. Call them first!
 		var playerBusy:Boolean = true; //changed to true if 'stupid' allies can help.
+		var customMenu:Boolean = false;
 		//no elses - Simpturn works without 'Next'!
 		if (player.hasStatusEffect(StatusEffects.SimplifiedNonPCTurn))
 			combat.simplifiedPrePCTurn_smart();
@@ -302,12 +444,14 @@ public class CombatUI extends BaseCombatContent {
 		else if (isPlayerBound()) {
 			mainMenuWhenBound();
 		} else if (isPlayerStunned() || isPlayerPowerStunned() || isPlayerFeared()) {
+			customMenu = true;
 			menu();
 			addButton(0, "Recover", combat.wait);
-			if (CombatAbilities.ClearMind.isKnown) CombatAbilities.ClearMind.createButton(monster).applyTo(button(1));
+			if (CombatAbilities.ClearMind.isKnown) CombatAbilities.ClearMind.createButton(monster).applyToSlot(1);
 			addButton(13, "Surrender(H)", combat.surrenderByHP).hint("Stop defending up to the point enemy would beat you down to minimal HP.");
 			addButton(14, "Surrender(L)", combat.surrenderByLust).hint("Fantasize about your opponent in a sexual way so much it would fill up your lust you'll end up getting raped.");
 		} else if (player.hasStatusEffect(StatusEffects.ChanneledAttack)) {
+			customMenu = true;
 			mainMenuWhenChanneling();
 		} else if (player.hasStatusEffect(StatusEffects.KnockedBack)) {
 			if (player.ammo <= 0 && (player.weaponRangeName == "flintlock pistol" || player.weaponRangeName == "blunderbuss rifle")){
@@ -320,6 +464,7 @@ public class CombatUI extends BaseCombatContent {
 		}
 		//HYPNOSIS
 		else if (monster.hasStatusEffect(StatusEffects.HypnosisNaga) && !monster.hasStatusEffect(StatusEffects.Constricted)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Heal", combat.HypnosisHeal);
 			addButton(1, "Attack", combat.HypnosisAttack);
@@ -331,6 +476,7 @@ public class CombatUI extends BaseCombatContent {
 				addButton(6, "D.Wave", combat.HypnosisDuskWave);
 			}
 		} else if (monster.hasStatusEffect(StatusEffects.HypnosisNaga) && monster.hasStatusEffect(StatusEffects.Constricted)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Squeeze", SceneLib.desert.nagaScene.nagaSqueeze).hint("Squeeze some HP out of your opponent! Break hypnosis! \n\nFatigue Cost: " + physicalCost(20) + "");
 			addButton(1, "Tease", SceneLib.desert.nagaScene.nagaTease).hint("Deals lesser lust damage. Does not break hypnosis.");
@@ -339,12 +485,14 @@ public class CombatUI extends BaseCombatContent {
 		}
 		//Naga grapple
 		else if (monster.hasStatusEffect(StatusEffects.Constricted) && !monster.hasStatusEffect(StatusEffects.HypnosisNaga)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Squeeze", SceneLib.desert.nagaScene.nagaSqueeze).hint("Squeeze some HP out of your opponent! \n\nFatigue Cost: " + physicalCost(20) + "");
 			addButton(1, "Tease", SceneLib.desert.nagaScene.nagaTease);
 			vampireBiteDuringGrapple(3);
 			addButton(4, "Release", SceneLib.desert.nagaScene.nagaLeggoMyEggo);
 		} else if (monster.hasStatusEffect(StatusEffects.CancerGrab)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Guillotine", combat.Guillotine).hint("Crush your foe with your pincer and attempt to break it apart! \n\nFatigue Cost: " + physicalCost(20) + "");
 			vampireBiteDuringGrapple(3);
@@ -352,6 +500,7 @@ public class CombatUI extends BaseCombatContent {
 		}
 		//Grappling scylla
 		else if (monster.hasStatusEffect(StatusEffects.ConstrictedScylla)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Squeeze", combat.ScyllaSqueeze);
 			if (monster.plural) {
@@ -363,6 +512,7 @@ public class CombatUI extends BaseCombatContent {
 			vampireBiteDuringGrapple(3);
 			addButton(4, "Release", combat.ScyllaLeggoMyEggo);
 		} else if (monster.hasStatusEffect(StatusEffects.ConstrictedWhip)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Strangulate", combat.WhipStrangulate);
 			vampireBiteDuringGrapple(3);
@@ -370,6 +520,7 @@ public class CombatUI extends BaseCombatContent {
 		}
 		//Orca be playing rought
 		else if (monster.hasStatusEffect(StatusEffects.OrcaPlay)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Juggle", combat.OrcaJuggle).hint("Deal bite damage and send your foe back in the air at the cost of a fairly decent amount of fatigue. Extend the duration of play by 2 rounds up to twice. \n\nFatigue Cost: " + physicalCost(50) + "");
 			addButton(1, "Tail wack", combat.OrcaWack).hint("Stun your opponent and smash it back into the air with your tail.\n\nFatigue Cost: " + physicalCost(20) + "");
@@ -380,26 +531,32 @@ public class CombatUI extends BaseCombatContent {
 			addButton(3, "Impale", combat.OrcaImpale).hint("End the game by viciously impaling your falling foe on your weapon. \n\nFatigue Cost: " + physicalCost(20) + "");
 			addButton(4, "Release", combat.OrcaLeggoMyEggo).hint("Stop playing early and let your prey fall to the ground.");
 		} else if (monster.hasStatusEffect(StatusEffects.Straddle)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Tease", combat.StraddleTease).hint("Use a powerful teasing attack");
 			vampireBiteDuringGrappleBreakHypnosis(3);
 			addButton(4, "Release", combat.straddleLeggoMyEggo).hint("Release your opponent.");
 		} else if (monster.hasStatusEffect(StatusEffects.ManticorePlug)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Feed", combat.ManticoreFeed).hint("Milk your victim's cock with your powerful tail!");
 		} else if (monster.hasStatusEffect(StatusEffects.DisplacerPlug)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Feed", combat.displacerFeedContinue).hint("Milk your victim's breast with your tentacles!");
 		} else if (monster.hasStatusEffect(StatusEffects.SlimeInsert)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Rape", combat.SlimeRapeFeed).hint("Violate your opponent from the inside!");
 			addButton(4, "Release", combat.SlimeRapeStop).hint("Release your opponent.");
 		} else if (monster.hasStatusEffect(StatusEffects.Swallowed)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Tease", combat.SwallowTease).hint("Use a powerful teasing attack").icon("A_Tease");
 			if (monster.lustVuln != 0 && player.hasPerk(PerkLib.Straddle) && monster.hasStatusEffect(StatusEffects.Stunned)) addButton(1, "Straddle", combat.Straddle).hint("Change position and initiate a straddling stance").icon("A_Tease");
 			addButton(4, "Release", combat.SwallowLeggoMyEggo).hint("Release your opponent.");
 		} else if (monster.hasStatusEffect(StatusEffects.Dig)) {
+			customMenu = true;
 			menu();
 			if (monster.statusEffectv1(StatusEffects.Dig) > 0){
 				if (player.lowerBody == LowerBody.CANCER) addButton(0, "Grab", combat.CancerGrab).hint("Dig underneath your opponent and attempt to grab it in your pincers");
@@ -423,6 +580,7 @@ public class CombatUI extends BaseCombatContent {
 			addButton(14, "Escape", combat.runAway).hint("Escape away from the battle through underground tunneling.");
 		//Singing
 		} else if (player.hasStatusEffect(StatusEffects.Sing)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Arouse", combat.SingArouse).hint("Arouse your opponent with lustful music.");
 			addButton(1, "Aria", combat.SingDevastatingAria).hint("Unleash a devastating wave of sound to deal magic damage.");
@@ -441,14 +599,17 @@ public class CombatUI extends BaseCombatContent {
 			if (!recalling) addButton(14, "Run", combat.runAway).hint("Escape away from the battle.");
 		}
 		else if (monster.hasStatusEffect(StatusEffects.GooEngulf)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Tease", combat.GooTease).hint("Toy with your opponent");
 			addButton(4, "Release", combat.GooLeggoMyEggo).hint("Release your opponent.");
 		} else if (monster.hasStatusEffect(StatusEffects.EmbraceVampire)) {
+			customMenu = true;
 			menu();
 			vampireBiteDuringGrappleV(0);
 			addButton(4, "Release", combat.VampireLeggoMyEggo);
 		} else if (monster.hasStatusEffect(StatusEffects.TelekineticGrab)) {
+			customMenu = true;
 			menu();
 			vampireBiteDuringGrappleV(0);
 			CombatAbilities.Tease.createButton(monster).copyTo(btnTease);
@@ -466,6 +627,7 @@ public class CombatUI extends BaseCombatContent {
 				btnMagic.disable("You are too angry to think straight. Smash your puny opponents first and think later.\n\n").icon("A_Magic")
 			} else if (!combat.canUseMagic()) btnMagic.disable().icon("A_Magic")
 		} else if (monster.hasStatusEffect(StatusEffects.MysticWeb) || monster.hasStatusEffect(StatusEffects.BloodWeb)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Tease", combat.WebTease).hint("Toy with your opponent");
 			addButton(1, "Bite", combat.spiderBiteAttack).hint("Inject your venom.");
@@ -483,6 +645,7 @@ public class CombatUI extends BaseCombatContent {
 				btnMagic.disable("You are too angry to think straight. Smash your puny opponents first and think later.\n\n").icon("A_Magic")
 			} else if (!combat.canUseMagic()) btnMagic.disable().icon("A_Magic")
 		} else if (monster.hasStatusEffect(StatusEffects.Pounce)) {
+			customMenu = true;
 			menu();
 			if (player.arms.type == Arms.DISPLACER) addButton(0, "Ravage", combat.clawsRend).hint("Rend your enemy using your four sets of claws. \n\nFatigue Cost: " + physicalCost(20) + "");
 			else addButton(0, "Claws", combat.clawsRend).hint("Rend your enemy using your claws. \n\nFatigue Cost: " + physicalCost(20) + "");
@@ -497,11 +660,13 @@ public class CombatUI extends BaseCombatContent {
 			vampireBiteDuringGrapple(3);
 			addButton(4, "Release", combat.PussyLeggoMyEggo);
 		} else if (monster.hasStatusEffect(StatusEffects.GrabBear)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Hug", combat.bearHug).hint("Crush your opponent with a bear hug. \n\nFatigue Cost: " + physicalCost(30) + "");
 			vampireBiteDuringGrapple(3);
 			addButton(4, "Release", combat.BearLeggoMyEggo);
 		} else if (monster.hasStatusEffect(StatusEffects.MummyBandage)) {
+			customMenu = true;
 			menu();
 			addButton(0, "Constrict", combat.mummyConstrict).hint("Constrict your opponent with your wrapping. \n\nFatigue Cost: " + physicalCost(30) + "");
 			if (monster.lustVuln != 0 && !monster.plural && player.hasPerk(PerkLib.Straddle)) addButton(1, "Straddle", combat.Straddle).hint("Change position and initiate a straddling stance");
@@ -568,27 +733,33 @@ public class CombatUI extends BaseCombatContent {
 			flushOutputTextToGUI();
 		}
 
+		if (customMenu) {
+			// Do not create default menu if it was overwritten
+			return;
+		}
 		/* OLD MENU
 		 0 [ Melee ] [ Range ] [ Tease ] [  Wait   ] [ Items ]
 		 5 ability groups
 		10 [   ?   ] [   ?   ] [   ?   ] [Fantasize] [  Run  ]
-		/**/
-		btnMelee.applyTo(button(0));
-		btnRanged.applyTo(button(1));
-		btnTease.applyTo(button(2));
-		btnWait.applyTo(button(3));
-		btnItems.applyTo(button(4));
-		btnPSpecials.applyTo(button(5));
-		btnMSpecials.applyTo(button(6));
-		btnMagic.applyTo(button(7));
-		btnSoulskills.applyTo(button(8));
-		btnOther.applyTo(button(9));
-		btnSpecial1.applyTo(button(10));
-		btnSpecial2.applyTo(button(11));
-		btnSpecial3.applyTo(button(12));
-		btnFantasize.applyTo(button(13));
-		btnRun.applyTo(button(14));
-		/**/
+		 */
+		if (!useNewMenu) {
+			btnMelee.applyToSlot(0);
+			btnRanged.applyToSlot(1);
+			btnTease.applyToSlot(2);
+			btnWait.applyToSlot(3);
+			btnItems.applyToSlot(4);
+			btnPSpecials.applyToSlot(5);
+			btnMSpecials.applyToSlot(6);
+			btnMagic.applyToSlot(7);
+			btnSoulskills.applyToSlot(8);
+			btnOther.applyToSlot(9);
+			btnSpecial1.applyToSlot(10);
+			btnSpecial2.applyToSlot(11);
+			btnSpecial3.applyToSlot(12);
+			btnFantasize.applyToSlot(13);
+			btnRun.applyToSlot(14);
+			return;
+		}
 
 		/* NEW MENU
 		 0 [ Fav. 1 ] [ Fav. 2 ] [ Fav. 3 ] [ Fav. 4 ] [ Fav. 5 ]
@@ -597,15 +768,91 @@ public class CombatUI extends BaseCombatContent {
 
 		Skills:
 		 0 [ Melee  ] [ Ranged ] [ Tease  ] [        ] [        ]
-		 5 [ PhySpc ] [ MagSpc ] [Soulskil] [        ] [        ]
+		 5 [ PhySpc ] [ MagSpc ] [Soulskil] [ Magic  ] [        ]
 		10 [        ] [        ] [        ] [        ] [        ]
 
 		Other:
-		 0 [ Items  ] [  Wait  ] [Fantasiz] [        ] [  Run   ]
-		 5 [        ] [        ] [        ] [        ] [        ]
+		 0 [ Items  ] [  Wait  ] [Fantasiz] [  Run   ] ...old "Other"
+		 */
+		favbd(btnMelee, "Melee Attack");
+		favbd(btnRanged, "Ranged Attack");
+		favbd(btnTease, "Tease");
+		favbd(btnItems, "Items");
+		favbd(btnFantasize, "Fantasize");
+		favbd(btnWait, "Wait");
+		var btnSkillsNew:ButtonData = new ButtonData();
+		btnSkillsNew.show("Skills",curry(skillsSubmenuNew, btnMelee, btnRanged, btnTease, btnPSpecials, btnMSpecials, btnSoulskills, btnMagic));
+		var btnOtherNew:ButtonData = new ButtonData();
+		otherButtons.prepend(btnRun);
+		otherButtons.prepend(btnFantasize);
+		otherButtons.prepend(btnWait);
+		otherButtons.prepend(btnItems);
+		bd = new ButtonData("Btn Config", curry(modFavCountMenu, mainMenu), "Configure number of favourite skills");
+		otherButtons.prepend(bd);
+		btnOtherNew.show("Other", submenuOther, "Combat options and uncategorized actions");
+		/**/
+		var i:int;
+		var bd:ButtonData;
+		for (i = 0; i < favCount; i++) {
+			if (favSkills[i] != null) {
+				bd = favMap[favSkills[i]] as ButtonData;
+				if (bd) {
+					bd.applyTo(button(i));
+				} else {
+					button(i).show("-", curry(unfavSlot, i), "The favourited ability '"+favSkills[i]+"' is not available. Shift-click to unfavourite it.").disable();
+				}
+			} else {
+				button(i).showDisabled("", "Shift+click an ability to favourite it", "Favourite slot "+(i+1))
+			}
+		}
+		for (i = favCount; i < 10; i++) {
+			if (favLastSkills[i-favCount] != null) {
+				bd = favMap[favLastSkills[i-favCount]] as ButtonData;
+				if (bd) {
+					bd.applyTo(button(i));
+				} else {
+					button (i).hide();
+				}
+			} else {
+				button(i).hide();
+			}
+		}
+		btnSpecial1.applyToSlot(10);
+		btnSpecial2.applyToSlot(11);
+		btnSpecial3.applyToSlot(12);
+		btnSkillsNew.applyToSlot(13);
+		btnOtherNew.applyToSlot(14);
+	}
+	private function unfavSlot(favSlot:int):void {
+		if (shiftKeyDown) {
+			favSkills[favSlot] = null;
+			mainMenu();
+		}
+	}
+	public function skillsSubmenuNew(
+			btnMelee:ButtonData,
+			btnRanged:ButtonData,
+			btnTease:ButtonData,
+			btnPSpecials:ButtonData,
+			btnMSpecials:ButtonData,
+			btnSoulskills:ButtonData,
+			btnMagic:ButtonData
+	): void {
+		/*
+		Skills:
+		 0 [ Melee  ] [ Ranged ] [ Tease  ] [        ] [        ]
+		 5 [ PhySpc ] [ MagSpc ] [Soulskil] [ Magic  ] [        ]
 		10 [        ] [        ] [        ] [        ] [        ]
 		 */
-		/**/
+		menu();
+		btnMelee.applyToSlot(0);
+		btnRanged.applyToSlot(1);
+		btnTease.applyToSlot(2);
+		btnPSpecials.applyToSlot(5);
+		btnMSpecials.applyToSlot(6);
+		btnSoulskills.applyToSlot(7);
+		btnMagic.applyToSlot(8);
+		button(14).show("Back", mainMenu);
 	}
 
 	public function isWispTurn():Boolean {
@@ -1092,8 +1339,8 @@ public class CombatUI extends BaseCombatContent {
 				addButton(2, "Dispell", (monster as Lethice).dispellRapetacles);
 			}
 		}
-		btnStruggle.applyTo(button(0));
-		btnStruggle.applyTo(button(1));
+		btnStruggle.applyToSlot(0);
+		btnStruggle.applyToSlot(1);
 	}
 
 	internal function mainMenuWhenChanneling():void {

--- a/classes/classes/Scenes/Combat/CombatUI.as
+++ b/classes/classes/Scenes/Combat/CombatUI.as
@@ -61,26 +61,21 @@ public class CombatUI extends BaseCombatContent {
 		eAspectButtons.clear();
 		otherButtons.clear();
 
-		var btnMelee:CoCButton      = button(0).icon("A_Melee");
-		var btnRanged:CoCButton     = button(1).icon("A_Ranged");
-		var btnTease:CoCButton      = button(2).icon("A_Tease");
-		var btnWait:CoCButton       = button(3);
-		var btnItems:CoCButton      = button(4).icon("A_Items")
-		var btnPSpecials:CoCButton  = button(5);
-		var btnMSpecials:CoCButton  = button(6);
-		var btnMagic:CoCButton      = button(7).icon("A_Magic")
-		var btnSoulskills:CoCButton = button(8);
-		var btnOther:CoCButton      = button(9);
-		var btnSpecial1:CoCButton   = button(10);
-		var btnSpecial2:CoCButton   = button(11);
-		var btnSpecial3:CoCButton   = button(12);
-		var btnFantasize:CoCButton  = button(13);
-		var btnRun:CoCButton        = button(14);
-		/*
-		 0 [ Melee ] [ Range ] [ Tease ] [  Wait   ] [ Items ]
-		 5 ability groups
-		10 [   ?   ] [   ?   ] [   ?   ] [Fantasize] [  Run  ]
-		 */
+		var btnMelee:ButtonData      = new ButtonData().icon("A_Melee");
+		var btnRanged:ButtonData     = new ButtonData().icon("A_Ranged");
+		var btnTease:ButtonData      = new ButtonData().icon("A_Tease");
+		var btnWait:ButtonData       = new ButtonData();
+		var btnItems:ButtonData      = new ButtonData().icon("A_Items")
+		var btnPSpecials:ButtonData  = new ButtonData();
+		var btnMSpecials:ButtonData  = new ButtonData();
+		var btnMagic:ButtonData      = new ButtonData().icon("A_Magic")
+		var btnSoulskills:ButtonData = new ButtonData();
+		var btnOther:ButtonData      = new ButtonData();
+		var btnSpecial1:ButtonData   = new ButtonData();
+		var btnSpecial2:ButtonData   = new ButtonData();
+		var btnSpecial3:ButtonData   = new ButtonData();
+		var btnFantasize:ButtonData  = new ButtonData();
+		var btnRun:ButtonData        = new ButtonData();
 
 		//Standard menu before modifications.
 		if (flags[kFLAGS.ELEMENTAL_CONJUER_SUMMONS] == 2 || flags[kFLAGS.ELEMENTAL_CONJUER_SUMMONS] == 4) {
@@ -261,11 +256,11 @@ public class CombatUI extends BaseCombatContent {
 
 		btnFantasize.show("Fantasize", combat.fantasize, "Fantasize about your opponent in a sexual way.  Its probably a pretty bad idea to do this unless you want to end up getting raped.");
 		if (CombatAbilities.GoblinLustBomb.isKnown) {
-			CombatAbilities.GoblinLustBomb.createButton(monster).applyTo(btnTease);
+			CombatAbilities.GoblinLustBomb.createButton(monster).copyTo(btnTease);
 		}
 		else if (player.vehicles == vehicles.HB_MECH) btnTease.disable("No way you could make an enemy more aroused by striking a seductive pose and exposing parts of your body while piloting elf mech.");
 		else if (monster.lustVuln != 0 && monster.hasStatusEffect(StatusEffects.Stunned) && player.hasPerk(PerkLib.Straddle) && !combat.isEnemyInvisible) btnTease.show("Straddle", combat.Straddle, "Go to town on your opponent with devastating teases.").icon("A_Tease");
-		else CombatAbilities.Tease.createButton(monster).applyTo(btnTease);
+		else CombatAbilities.Tease.createButton(monster).copyTo(btnTease);
 		btnWait.show("Wait", combat.wait, "Take no action for this round.  Why would you do this?  This is a terrible idea.");
 		if (monster.hasStatusEffect(StatusEffects.CreepingDoom)) btnRun.show("Struggle", combat.struggleCreepingDoom, "Shake away the pests.");
 		else btnRun.show("Run", combat.runAway, "Choosing to run will let you try to escape from your enemy. However, it will be hard to escape enemies that are faster than you and if you fail, your enemy will get a free attack.");
@@ -456,7 +451,7 @@ public class CombatUI extends BaseCombatContent {
 		} else if (monster.hasStatusEffect(StatusEffects.TelekineticGrab)) {
 			menu();
 			vampireBiteDuringGrappleV(0);
-			CombatAbilities.Tease.createButton(monster).applyTo(btnTease);
+			CombatAbilities.Tease.createButton(monster).copyTo(btnTease);
 			btnTease.hint("Attempt to make an enemy more aroused by striking a seductive pose and exposing parts of your body.");
 			//addButton(4, "Release", combat.VampireLeggoMyEggo);
 			//combat.mspecials.buildMenu(magspButtons);
@@ -572,6 +567,45 @@ public class CombatUI extends BaseCombatContent {
 			}
 			flushOutputTextToGUI();
 		}
+
+		/* OLD MENU
+		 0 [ Melee ] [ Range ] [ Tease ] [  Wait   ] [ Items ]
+		 5 ability groups
+		10 [   ?   ] [   ?   ] [   ?   ] [Fantasize] [  Run  ]
+		/**/
+		btnMelee.applyTo(button(0));
+		btnRanged.applyTo(button(1));
+		btnTease.applyTo(button(2));
+		btnWait.applyTo(button(3));
+		btnItems.applyTo(button(4));
+		btnPSpecials.applyTo(button(5));
+		btnMSpecials.applyTo(button(6));
+		btnMagic.applyTo(button(7));
+		btnSoulskills.applyTo(button(8));
+		btnOther.applyTo(button(9));
+		btnSpecial1.applyTo(button(10));
+		btnSpecial2.applyTo(button(11));
+		btnSpecial3.applyTo(button(12));
+		btnFantasize.applyTo(button(13));
+		btnRun.applyTo(button(14));
+		/**/
+
+		/* NEW MENU
+		 0 [ Fav. 1 ] [ Fav. 2 ] [ Fav. 3 ] [ Fav. 4 ] [ Fav. 5 ]
+		 5 [ Last 1 ] [ Last 2 ] [ Last 3 ] [ Last 4 ] [ Last 5 ]
+		10 [   ??   ] [   ??   ] [   ??   ] [ Skills ] [ Other  ]
+
+		Skills:
+		 0 [ Melee  ] [ Ranged ] [ Tease  ] [        ] [        ]
+		 5 [ PhySpc ] [ MagSpc ] [Soulskil] [        ] [        ]
+		10 [        ] [        ] [        ] [        ] [        ]
+
+		Other:
+		 0 [ Items  ] [  Wait  ] [Fantasiz] [        ] [  Run   ]
+		 5 [        ] [        ] [        ] [        ] [        ]
+		10 [        ] [        ] [        ] [        ] [        ]
+		 */
+		/**/
 	}
 
 	public function isWispTurn():Boolean {
@@ -1020,8 +1054,8 @@ public class CombatUI extends BaseCombatContent {
 
 	internal function mainMenuWhenBound():void {
 		menu();
-		var btnStruggle:CoCButton  = addButton(0, "Struggle", combat.struggle);
-		var btnBoundWait:CoCButton = addButton(1, "Wait", combat.wait);
+		var btnStruggle:ButtonData  = new ButtonData("Struggle", combat.struggle);
+		var btnBoundWait:ButtonData = new ButtonData("Wait", combat.wait);
 		if (player.hasPerk(PerkLib.Spectre) && player.hasPerk(PerkLib.Incorporeality)) {
 			if (player.hasStatusEffect(StatusEffects.CooldownPossess)) addButtonDisabled(3, "Possess", "<b>You need more time before you can use Possess again.</b>");
 			else addButton(3, "Possess", combat.mspecials.possess2);
@@ -1058,6 +1092,8 @@ public class CombatUI extends BaseCombatContent {
 				addButton(2, "Dispell", (monster as Lethice).dispellRapetacles);
 			}
 		}
+		btnStruggle.applyTo(button(0));
+		btnStruggle.applyTo(button(1));
 	}
 
 	internal function mainMenuWhenChanneling():void {

--- a/classes/classes/Scenes/Combat/MagicSpecials.as
+++ b/classes/classes/Scenes/Combat/MagicSpecials.as
@@ -115,46 +115,55 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownCursedRiddle)) {
 				bd.disable("<b>You need some time to think of a new riddle.</b>\n\n");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Cursed Riddle");
 		}
 		if (player.isRaceCached(Races.WENDIGO)) {
 			bd = buttons.add("Spectral scream", SpectralScream, "Let out a soul-chilling scream to stun your opponent and damage their sanity and soul. \n");
 			if (player.hasStatusEffect(StatusEffects.CooldownSpectralScream)) {
 				bd.disable("<b>You need more time before you can use Spectral scream again.</b>\n\n");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Spectral Scream");
 		}
 		if (player.hasPerk(PerkLib.ExanimationI)) {
 			bd = buttons.add("Sagitta", Sagitta, "Fire a volley of concussive soulforce bullets. \nWould go into cooldown after use for: 5 rounds\n");
 			if (player.hasStatusEffect(StatusEffects.CooldownSagitta)) {
 				bd.disable("<b>You need more time before you can use Sagitta again.</b>\n\n");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Sagitta");
 		}
 		if (player.hasPerk(PerkLib.ExanimationII)) {
 			bd = buttons.add("Acid Spit", AcidSpitHollow, "Spit acid at your opponent corroding his defence and dealing progressive damage. \nWould go into cooldown after use for: 2 rounds\n");
 			if (player.hasStatusEffect(StatusEffects.CooldownAcidSpit)) {
 				bd.disable("<b>You need more time before you can use Acid Spit again.</b>\n\n");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Acid Spit");
 		}
 		if (player.hasPerk(PerkLib.ExanimationIII)) {
 			bd = buttons.add("Cero", CeroHollow, "Fire a powerful blast of concentrated spiritual energy at the target. \nWould go into cooldown after use for: 3 rounds\n");
 			if (player.hasStatusEffect(StatusEffects.CooldownCero)) {
 				bd.disable("<b>You need more time before you can use Cero again.</b>\n\n");
 			}
+			favbd(bd, "Cero");
 			bd = buttons.add("Pacisci", PacisciHollow, "Creates a barrier that lasts 4 turns that repels all Magical and Soulforce attacks. \nWould go into cooldown after use for: 5 rounds\n");
 			if (player.hasStatusEffect(StatusEffects.CooldownPacisci)) {
 				bd.disable("<b>You need more time before you can use Pacisci again.</b>\n\n");
 			} else if (player.hasStatusEffect(StatusEffects.Pacisci)) bd.disable("<b>You already created barrier.</b>\n\n");
+			favbd(bd, "Pacisci");
 		}
 		if (player.hasPerk(PerkLib.ExanimationIV)) {
 			bd = buttons.add("Ferro Pellis", FerroPellisHollow, "Envelop yourself in a spiritual aura that makes your skin as hard as steel. \nWould go into cooldown after use for: 5 rounds\n");
 			if (player.hasStatusEffect(StatusEffects.CooldownFerroPellis)) {
 				bd.disable("<b>You need more time before you can use Ferro Pellis again.</b>\n\n");
 			} else if (player.hasStatusEffect(StatusEffects.FerroPellis)) bd.disable("<b>You already enveloped yourself in a spiritual aura.</b>\n\n");
+			favbd(bd, "Ferro Pellis");
 		}
 		if ((player.isRaceCached(Races.RAIJU) || (player.isRaceCached(Races.THUNDERBIRD) && player.tailType == Tail.THUNDERBIRD) || player.isRaceCached(Races.KIRIN)) && player.hasPerk(PerkLib.ElectrifiedDesire) >= 0) {
 			bd = buttons.add("Orgasmic L.S.", OrgasmicLightningStrike, "Masturbate to unleash a massive discharge.", "Orgasmic Lightning Strike");
 			if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Orgasmic Lightning Strike");
 			bd = buttons.add("Pleasure bolt", PleasureBolt, "Release a discharge of your lust inducing electricity. It will rise your lust by 2% of max lust after each use.", "Pleasure bolt");
 			if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Pleasure Bolt");
 			if ((player.hasVagina() && (player.isRaceCached(Races.COW) || player.perkv1(IMutationsLib.LactaBovinaOvariesIM) >= 1 || (player.perkv1(IMutationsLib.HumanOvariesIM) >= 3 && player.racialScore(Races.HUMAN) > 17))) ||
 			(player.hasCock() && (player.isRaceCached(Races.MINOTAUR) || player.perkv1(IMutationsLib.MinotaurTesticlesIM) >= 1 || (player.perkv1(IMutationsLib.HumanTesticlesIM) >= 3 && player.racialScore(Races.HUMAN) > 17)))) {
 				bd = buttons.add("Plasma blast", PlasmaBlast, "Masturbate to unleash a massive discharge of milk/cum mixed with plasma.", "Plasma blast");
@@ -162,11 +171,13 @@ public class MagicSpecials extends BaseCombatContent {
 					if (player.perkv1(IMutationsLib.LactaBovinaOvariesIM) >= 3 || player.perkv1(IMutationsLib.MinotaurTesticlesIM) >= 3) bd.disable("\n<b>You need more time before you can do it again.</b>");
 					else bd.disable("You can't use it more than once during fight.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Plasma Blast");
 			}
 			if (player.isRaceCached(Races.THUNDERBIRD) && player.isFlying()) {
 				// Lust Storm
 				bd = buttons.add("Lust storm", Luststorm).hint("Supercharge the air with your lusty electricity to unleash a thunderstorm.");
 				if (player.hasStatusEffect(StatusEffects.lustStorm)) bd.disable("<b>You already unleashed a thunderstorm on the battlefield</b>\n\n");
+				favbd(bd, "Lust Storm");
 			}
 			if (player.isRaceCached(Races.KIRIN) && (player.weapon.isDuelingType() || player.weapon.isSwordType() || player.weapon.isSpearType() || player.weapon.isStaffType() ||
 				player.weaponOff.isDuelingType() || player.weaponOff.isSwordType() || player.weaponOff.isSpearType() || player.weaponOff.isStaffType())) {
@@ -175,20 +186,24 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.ElectrifyWeapon)) {
 					bd.disable("Your weapon is already imbued with lightning!");
 				}
+				favbd(bd, "Electrify Weapon");
 			}
 		}
 		//Esper cool beans (start)
 		if (player.hasPerk(PerkLib.PsychicBarrier)) {
 			if (player.statStore.hasBuff("PsychoBarrier")) {
-				buttons.add("Psycho-Barrier/Off", combat.deactivatePsychoBarrier).hint("Disperse Psycho-Barrier.");
+				bd = buttons.add("Psycho-Barrier/Off", combat.deactivatePsychoBarrier).hint("Disperse Psycho-Barrier.");
+				favbd(bd, "Psycho Barrier");
 			} else {
 				bd = buttons.add("Psycho-Barrier/On", combat.activatePsychoBarrier, "Cover yourself with Psycho-Barrier. (It would drain fatigue until dispersed)\n");
 				bd.requireFatigue(20);
+				favbd(bd, "Psycho Barrier");
 			}
 		}
 		if (player.hasPerk(PerkLib.PsychicBolt)) {
 			bd = buttons.add("Psychic Bolt", combat.castPsychicBolt, "Attempt to attack the enemy with psychic bolt.  Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(10);
+			favbd(bd, "Psychic Bolt");
 		}
 		if (player.hasPerk(PerkLib.TelekineticGrapple) && !monster.hasStatusEffect(StatusEffects.TelekineticGrab)) {
 			bd = buttons.add("Telekinetic Grab", TelekineticGrab, "Use telekinesis to hold your opponent. \n\nWould go into cooldown after use for: 8 rounds");
@@ -196,46 +211,57 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownTelekineticGrab)) {
 				bd.disable("You need more time before you can use Telekinetic Grab again.\n\n");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Telekinetic Grab");
 		}
 		if (player.hasPerk(PerkLib.Pyrokinesis)) {
 			bd = buttons.add("Pyrokinesis", combat.usePyrokinesis, "Attempt to attack the enemy with fire ball. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Pyrokinesis");
 		}
 		if (player.hasPerk(PerkLib.Hydrokinesis)) {
 			bd = buttons.add("Hydrokinesis", combat.useHydrokinesis, "Attempt to attack the enemy with water sphere. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Hydrokinesis");
 		}
 		if (player.hasPerk(PerkLib.Cryokinesis)) {
 			bd = buttons.add("Cryokinesis", combat.useCryokinesis, "Attempt to attack the enemy with icicle. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Cryokinesis");
 		}
 		if (player.hasPerk(PerkLib.Geokinesis)) {
 			bd = buttons.add("Geokinesis", combat.useGeokinesis, "Attempt to attack the enemy with rock. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Geokinesis");
 		}
 		if (player.hasPerk(PerkLib.Electrokinesis)) {
 			bd = buttons.add("Electrokinesis", combat.useElectrokinesis, "Attempt to attack the enemy with bolt of lightning. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Electrokinesis");
 		}
 		if (player.hasPerk(PerkLib.Aerokinesis)) {
 			bd = buttons.add("Aerokinesis", combat.useAerokinesis, "Attempt to attack the enemy with wind sphere. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Aerokinesis");
 		}
 		if (player.hasPerk(PerkLib.Umbrakinesis)) {
 			bd = buttons.add("Umbrakinesis", combat.useUmbrakinesis, "Attempt to attack the enemy with darkness sphere. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Umbrakinesis");
 		}
 		if (player.hasPerk(PerkLib.Acidokinesis)) {
 			bd = buttons.add("Acidokinesis", combat.useAcidokinesis, "Attempt to attack the enemy with acid ball. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Acidokinesis");
 		}
 		if (player.hasPerk(PerkLib.Ionikinesis)) {
 			bd = buttons.add("Ionikinesis", combat.useIonikinesis, "Attempt to attack the enemy with plasma ball. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Ionikinesis");
 		}
 		if (player.hasPerk(PerkLib.Cocytokinesis)) {
 			bd = buttons.add("Cocytokinesis", combat.useCocytokinesis, "Attempt to attack the enemy with black icicle. Damage done is determined by your sensitivity.\n");
 			bd.requireFatigue(20);
+			favbd(bd, "Cocytokinesis");
 		}
 		//Esper cool beans (end)
 		if (!player.hasPerk(PerkLib.ElementalBody)) {
@@ -244,10 +270,12 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.CooldownPossess)) {
 					bd.disable("<b>You need more time before you can use Possess again.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Possess");
 			}
 			if (player.wings.type == Wings.SEA_DRAGON && player.antennae.type == Antennae.SEA_DRAGON && player.skin.base.pattern == Skin.PATTERN_SEA_DRAGON_UNDERBODY) {
 				bd = buttons.add("Electric Discharge", ElectricDischarge, "Release a deadly discharge of electricity.", "Electric discharge");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Electric Discharge");
 			}
 			if (player.hasPerk(PerkLib.TransformationImmunity2) && player.lowerBody == LowerBody.ATLACH_NACHA && !monster.hasStatusEffect(StatusEffects.MysticWeb)) {
 				bd = buttons.add("Mystic Web", MysticWeb, "Spin a thread of animated web using your magic to tie up your victim in place. Also reduce opponent speed after each use. \n");
@@ -257,6 +285,7 @@ public class MagicSpecials extends BaseCombatContent {
 				} else if (player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 					bd.disable("You cannot focus to use this ability while you're having so much difficult breathing.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Mystic Web");
 			}
 			if ((player.tailType == Tail.FOX && player.tailCount >= 2 && player.tailCount < 7) || (player.tailType == Tail.KITSHOO && player.tailCount >= 2)) {
 				bd = buttons.add("Fox Fire", basicFoxFire, "Unleash fox flame at your opponent for high damage. \n");
@@ -267,6 +296,7 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 					bd.disable("You cannot focus to use this ability while you're having so much difficult breathing.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Fox Fire");
 			}
 			if (player.hasPerk(PerkLib.NinetailsKitsuneOfBalance) && player.tailType == Tail.FOX && player.tailCount >= 7) {
 				bd = buttons.add("F.FoxFire", fusedFoxFire, "Unleash fused ethereal blue and corrupted purple flame at your opponent for high damage. \n");
@@ -275,6 +305,7 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 					bd.disable("You cannot focus to use this ability while you're having so much difficult breathing.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Fused Fox Fire");
 			}
 			if (player.hasPerk(PerkLib.CorruptedKitsune) && player.tailType == Tail.FOX && player.tailCount >= 7) {
 				// Corrupt Fox Fire
@@ -284,6 +315,7 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 					bd.disable("You cannot focus to use this ability while you're having so much difficult breathing.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Corrupted Fox Fire");
 				// Terror
 				bd = buttons.add("Terror", kitsuneTerror, "Instill fear into your opponent with eldritch horrors. The more you cast this in a battle, the lesser effective it becomes.  ");
 				var terror:Number = 9;
@@ -307,6 +339,7 @@ public class MagicSpecials extends BaseCombatContent {
 				} else if (player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 					bd.disable("You cannot focus to reach the enemy's mind while you're having so much difficult breathing.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Terror");
 			}
 			if (player.hasPerk(PerkLib.EnlightenedKitsune) && player.tailType == Tail.FOX && player.tailCount >= 7) {
 				// Pure Fox Fire
@@ -316,6 +349,7 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 					bd.disable("You cannot focus to use this ability while you're having so much difficult breathing.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Pure Fox Fire");
 				// Illusion
 				bd = buttons.add("Illusion", kitsuneIllusion, "Warp the reality around your opponent to temporary boost your evasion for 3 rounds and arouse target slightly.");
 				var illusion:Number = 9;
@@ -339,10 +373,12 @@ public class MagicSpecials extends BaseCombatContent {
 				} else if (player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 					bd.disable("You cannot focus to use this ability while you're having so much difficulty breathing.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Illusion");
 			}
 			if (player.tailType == Tail.KITSHOO && player.tailCount >= 6) {
 				if (player.statStore.hasBuff("FoxflamePelt")) {
-					buttons.add("Return", extinguishFoxflamePelt).hint("Release foxflames.");
+					bd = buttons.add("Return", extinguishFoxflamePelt).hint("Release foxflames.");
+					favbd(bd, "Foxflame Pelt");
 				} else {
 					bd = buttons.add("Foxflame Pelt", lightupFoxflamePelt, "Coat yourself with foxflame pelt. (It would drain soulforce and mana until deactivated)\n");
 					if (player.tailCount >= 9) {
@@ -353,6 +389,7 @@ public class MagicSpecials extends BaseCombatContent {
 						bd.requireSoulforce(Math.round(50 * soulskillCost() * soulskillcostmulti()));
 						bd.requireMana(spellCost(100 * kitsuneskill2Cost()));
 					}
+					favbd(bd, "Foxflame Pelt");
 				}
 			}
 			if ((player.tailType == Tail.NEKOMATA_FORKED_1_3 || player.tailType == Tail.NEKOMATA_FORKED_2_3 || (player.tailType == Tail.CAT && player.tailCount == 2))) {//player.hasPerk(MutationsLib.NekomataThyroidGland) ||
@@ -371,6 +408,7 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 					bd.disable("You cannot focus to use this ability while you're having so much difficult breathing.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Ghost Fire");
 				//bd = buttons.add("Puppeteer", nekomataPuppeteer).hint(". \n");
 			}	//also combining fatigue and soulfroce
 			if (player.rearBody.type == RearBody.TENTACLE_EYESTALKS && player.statusEffectv1(StatusEffects.GazerEyeStalksPlayer) >= 2) {
@@ -380,6 +418,7 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.CooldownChaosBeams)) {
 					bd.disable("You need time to gather enough winds to unleash a Chaos beams again.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Chaos Beams");
 			}
 			if (player.eyes.type == Eyes.MONOEYE && !monster.plural) {
 				bd = buttons.add("Dominating Gaze", DominatingGaze).hint("Obliterate your foe sense of self with your powerful gaze. \n", "Dominating Gaze");
@@ -389,10 +428,12 @@ public class MagicSpecials extends BaseCombatContent {
                     bd.disable("You need time to gather enough winds to unleash a wind scythe again.");
                 } else */
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Dominating Gaze");
 			}
 			if ((player.hasPerk(PerkLib.JobBeastWarrior) || player.necklaceName == "Crinos Shape necklace")) {
 				if (player.statStore.hasBuff("CrinosShape")) {
-					buttons.add("Return", returnToNormalShape).hint("Return to normal from Crinos Shape.");
+					bd = buttons.add("Return", returnToNormalShape).hint("Return to normal from Crinos Shape.");
+					favbd(bd, "Crinos Shape");
 				} else {
 					bd = buttons.add("CrinosShape", assumeCrinosShape).hint("Let your wrath flow thou you, transforming you into more bestial shape!  Greatly increases your strength, speed and fortitude! \n\nWrath Cost: " + crinosshapeCost() + " per turn");
 					if (player.wrath < crinosshapeCost()) {
@@ -401,22 +442,27 @@ public class MagicSpecials extends BaseCombatContent {
 					if (player.statStore.hasBuff("AsuraForm")) {// && !player.hasPerk(PerkLib.HiddenJobAsura)
 						bd.disable("You are under transformantion effect incompatibile with Crinos Shape!");
 					}
+					favbd(bd, "Crinos Shape");
 				}
 			}
 			if (player.hasPerk(PerkLib.Atavism)) {
 			if (player.statStore.hasBuff("Atavism")) {
-					buttons.add("Return", returnToNormalStateA).hint("Return to normal from Atavism State.");
+					bd = buttons.add("Return", returnToNormalStateA).hint("Return to normal from Atavism State.");
+					favbd(bd, "Atavism");
 				} else {
 					bd = buttons.add("Atavism", assumeAtavismState).hint("Turn feral for a while, abandoning yourself to your animalistic instincts. Unlock the full potential in your body by boosting your physical might and sharpening your senses but silence your ability to process intelligent logical thoughts. \n");
 					if (player.hasStatusEffect(StatusEffects.CooldownAtavism)) {
 						bd.disable("You lack the focus to use this ability at the time.");
 					}
+					favbd(bd, "Atavism");
 				}
 			}
 			if (player.hasPerk(PerkLib.HiddenJobAsura)) {
 				if (player.statStore.hasBuff("AsuraForm")) {
 					bd = buttons.add("Return", combat.returnToNormalShape).hint("Return to normal from Asura form.");
+					favbd(bd, "Asura Form");
 					bd = buttons.add("Asura's Howl", combat.asurasHowl).hint("Unleash a howl before giving enemy good punching. \n\nWrath Cost: 50");
+					favbd(bd, "Asura's Howl");
 					if (player.wrath < 50) {
 						bd.disable("Your wrath is too low to unleash howl!");
 					}
@@ -428,6 +474,7 @@ public class MagicSpecials extends BaseCombatContent {
 						if (player.wrath < (player.maxWrath() * 0.5)) {
 							bd.disable("Your wrath is too low to poke your enemies Asura Style!");
 						}
+						favbd(bd, "Fingers of Destruction");
 					}
 					if (player.hasPerk(PerkLib.AsuraStrength)) {
 
@@ -446,6 +493,7 @@ public class MagicSpecials extends BaseCombatContent {
 					if (player.statStore.hasBuff("CrinosShape")) {// && !player.hasPerk(PerkLib.HiddenJobAsura)
 						bd.disable("You are under transformantion effect incompatibile with Asura Form!");
 					}
+					favbd(bd, "Asura Form");
 				}
 			}
 			if (player.racialScore(Races.ONI) >= minOniScoreReq()) {
@@ -454,6 +502,7 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.OniRampage)) {
 					bd.disable("You already rampaging!");
 				}
+				favbd(bd, "Oni Rampage");
 			}
 			if (((player.eyes.type == Eyes.GORGON && player.hairType == Hair.GORGON) || player.perkv1(IMutationsLib.GorgonEyesIM) >= 1)) {
 				bd = buttons.add("Petrify", curry(petrify, false)).hint("Use your gaze to temporally turn your enemy into a stone. \n");
@@ -465,12 +514,14 @@ public class MagicSpecials extends BaseCombatContent {
 				} else if (isEnemyInvisible && player.hasStatusEffect(StatusEffects.MonsterDig)) {
 					bd.disable("You cannot use a gaze attack against an opponent you cannot see or target.");
 				}
+				favbd(bd, "Petrify");
 				if (player.perkv1(IMutationsLib.GorgonEyesIM) >= 4) {
 					bd = buttons.add("E. Petrify", curry(petrify, true)).hint("Use your enhanced gaze to temporally turn your enemy into a stone and even halt its recovery temporarily. \n");
 					bd.requireFatigue(spellCost(1000), true);
 					if (isEnemyInvisible && player.hasStatusEffect(StatusEffects.MonsterDig)) {
 						bd.disable("You cannot use a gaze attack against an opponent you cannot see or target.");
 					}
+					favbd(bd, "Enhanced Petrify");
 				}
 			}
 			if (player.lowerBody == LowerBody.HYDRA) {
@@ -478,14 +529,17 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.CooldownHydraAcidBreath)) {
 					bd.disable("You need more time before you can use Hydra acid breath again.\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Hydra Acid Breath");
 			}
 			if (player.isNaga() && flags[kFLAGS.SAMIRAH_HYPNOSIS] == 6 && !monster.plural) {
 				bd = buttons.add("Tactical Distraction", TacticalDistraction).hint("Make the target lose its current turn forcing it to interrupt whatever it is doing. \n\nWould go into cooldown after use for: " + (player.hasPerk(PerkLib.NaturalInstincts) ? "4" : "5") + " rounds", "Tactical Distraction");
 				if (player.hasStatusEffect(StatusEffects.CooldownTDistraction)) {
 					bd.disable("You need more time before you can use Tactical Distraction again.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Tactical Distraction");
 				bd = buttons.add("Hypnosis", NagaHypnosis).hint("Lull your opponent into a trance but only allow a limited set of options.", "Hypnosis");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Hypnosis");
 			}
 			if (player.racialScore(Races.ARIGEAN) >= 16) {
 				bd = buttons.add("Mana Shot", manaShot).hint("Fire a single blast from "+(player.tailCount>1?"one of your extra maws":"your large extra mouth")+". \n");
@@ -493,11 +547,13 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.CooldownManaShot)) {
 					bd.disable("You need more time before you can use Mana Shot again.\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Mana Shot");
 				bd = buttons.add("Mana Barrage", manaBarrage).hint("Fire a barrage of blasts from your extra maw"+(player.tailCount>1?"s":"")+". \n");
 				bd.requireMana(spellCost(200*arigeanMagicSpecialsCost()), true);
 				if (player.hasStatusEffect(StatusEffects.CooldownManaBarrage)) {
 					bd.disable("You need more time before you can use Mana Barrage again.\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Mana Barrage");
 			}
 			//Charged Shot & Finality Barrage
 			if (player.tailType == Tail.ARIGEAN_PRINCESS) {
@@ -506,6 +562,7 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.CooldownChargedShot)) {
 					bd.disable("You need more time before you can use Charged Shot again.\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Arigean Charged Shot");
 				if (player.perkv1(IMutationsLib.ArigeanAssociationCortexIM) >= 4) {
 					var amount:Number = 0.6;
 					if (player.hasStatusEffect(StatusEffects.DarkRitual)) amount += 0.1;
@@ -515,6 +572,7 @@ public class MagicSpecials extends BaseCombatContent {
 					} else if (player.hasStatusEffect(StatusEffects.CooldownFinalityBarrage)) {
 						bd.disable("You need more time before you can use Finality Barrage again.\n\n");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Finality Barrage");
 				}
 			}
 			if (player.isRaceCached(Races.LICH)) {
@@ -524,11 +582,13 @@ public class MagicSpecials extends BaseCombatContent {
 				} /*else if (player.hasStatusEffect(StatusEffects.CooldownHydraAcidBreath)) {
 					bd.disable("You need more time before you can use Hydra acid breath again.\n\n");
 				} */else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Paralyzing Touch");
 			}// \n\nWould go into cooldown after use for: " + (player.hasPerk(PerkLib.NaturalInstincts) ? "7" : "8") + " rounds 
 			if (player.hasStatusEffect(StatusEffects.WinterFlash) && player.statusEffectv1(StatusEffects.WinterFlash) > 1) {
 				bd = buttons.add("Winter Flash", winterFlash).hint("Bring cheerful radiance to the world with your nose. Deals heavy damage to naughty opponents and stun them for 3 rounds. \n");
 				bd.requireFatigue(spellCost(200), true);
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Winter Flash");
 			}
 		}
 		if (player.hasPerk(PerkLib.DarkCharm)) {
@@ -540,6 +600,7 @@ public class MagicSpecials extends BaseCombatContent {
 			} else if(player.hasStatusEffect(StatusEffects.Stunned)) {
 				bd.disable("You cannot focus to reach the enemy's mind with your charming display while you can't even move.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Fascinate");
 			// Lust Strike
 			bd = buttons.add("Lust Strike", LustStrike);
 			var word1:String = player.perkv1(IMutationsLib.BlackHeartIM) >= 1? ", intelligence" : "";
@@ -550,6 +611,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 				bd.disable("You cannot focus on drawing symbols while you're having so much difficult breathing.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Lust Strike");
 		}
 		if (player.hasPerk(PerkLib.Transference)) {
 			bd = buttons.add("Transfer", lustTransfer).hint("Transfer some of your own arousal to your opponent. \n");
@@ -557,24 +619,28 @@ public class MagicSpecials extends BaseCombatContent {
 			else if (player.hasPerk(PerkLib.GiftOfLust)) bd.requireFatigue(spellCost(30),true);
 			else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 			else bd.requireFatigue(spellCost(40),true);
+			favbd(bd, "Transference");
 		}
 		if (player.isRaceCached(Races.AZAZEL) || player.perkv1(IMutationsLib.DiamondHeartIM) >= 1) {
 			bd = buttons.add("Exorcism",exorcism).disableIf(player.hasStatusEffect(StatusEffects.Exorcism), "Already used in this fight.").hint("Damage any creature above 25% corruption for 50% of its hit point total. Can be used only once per battle. \n");
 			if (player.perkv1(IMutationsLib.DiamondHeartIM) >= 3) bd.requireMana(spellCost(100),true);
 			else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 			else bd.requireMana(spellCost(80),true);
+			favbd(bd, "Exorcism");
 		}
 		if (player.isRaceCached(Races.DEVIL) || player.perkv1(IMutationsLib.ObsidianHeartIM) >= 1) {
 			bd = buttons.add("Infernal flare", infernalflare).hint("Use corrupted flames to burn your opponent. \n");
 			if (player.perkv1(IMutationsLib.ObsidianHeartIM) >= 3) bd.requireMana(spellCost(50),true);
 			else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 			else bd.requireMana(spellCost(40),true);
+			favbd(bd, "Infernal Flare");
 		}
 		if (player.isRaceCached(Races.AZAZEL) || player.perkv1(IMutationsLib.DiamondHeartIM) >= 1) {
 			bd = buttons.add("JudgementFlare",judgementflare).hint("Unleash a burst of holy fire. \n");
 			if (player.perkv1(IMutationsLib.DiamondHeartIM) >= 3) bd.requireMana(spellCost(50),true);
 			else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 			else bd.requireMana(spellCost(40),true);
+			favbd(bd, "Judgement Flare");
 		}
 		if (player.isRaceCached(Races.HELLCAT)) {
 			//Feline Curse
@@ -582,11 +648,13 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownFelineCurse)) {
 				bd.disable("<b>You need more time before you can use Feline curse again.</b>\n\n");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Feline Curse");
 			//Infernal Claw
 			bd = buttons.add("Infernal claw", InfernalClaw, "Enhance your attack with magic then wound an opponent with your claw to inflict damage and status. \n");
 			if (player.hasStatusEffect(StatusEffects.CooldownInfernalClaw)) {
 				bd.disable("<b>You need more time before you can use Infernal claw again.</b>\n\n");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Infernal Claw");
 		}
 		if (player.statusEffectv1(StatusEffects.VampireThirst) >= 1) {
 			if (player.hasPerk(PerkLib.Araneathropy)) {
@@ -596,6 +664,7 @@ public class MagicSpecials extends BaseCombatContent {
 					if (player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 						bd.disable("You cannot focus to use this ability while you're having so much difficult breathing.");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Blood Web");
 				}
 				if (player.statusEffectv1(StatusEffects.VampireThirst) >= 3) {
 					//Sanguine Strength
@@ -603,6 +672,7 @@ public class MagicSpecials extends BaseCombatContent {
 					if (player.hasStatusEffect(StatusEffects.SanguineStrength)) {
 						bd.disable("<b>You already under Sanguine Strength effect.</b>\n\n");
 					}
+					favbd(bd, "Sanguine Strength");
 				}
 			}
 			if (player.isRaceCached(Races.DRACULA) || player.isRaceCached(Races.VAMPIRE)) {
@@ -611,11 +681,13 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.CooldownEclipsingShadow)) {
 					bd.disable("<b>You need more time before you can use Eclipsing shadow again.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Eclipsing Shadow");
 				//Sonic scream
 				bd = buttons.add("Sonic scream", SonicScream, "Draw on your tainted blood power to unleash a powerful sonic shockwave. \n");
 				if (player.hasStatusEffect(StatusEffects.CooldownSonicScream)) {
 					bd.disable("<b>You need more time before you can use Sonic scream again.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Sonic Scream");
 			}
 			if (player.statusEffectv1(StatusEffects.VampireThirst) >= 3) {
 				//Sanguine Haste
@@ -623,31 +695,37 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.SanguineHaste)) {
 					bd.disable("<b>You already under Sanguine Haste effect.</b>\n\n");
 				}
+				favbd(bd, "Sanguine Haste");
 			}
 			//Vampire Thirst Stacks To Health/Mana
 			bd = buttons.add("Health Tap (1)", curry(VampireThirstStacksToHealth, 1), "Draw on your tainted blood power to heal yourself. \n");
 			if (player.hasStatusEffect(StatusEffects.VampThirstStacksHPMana) && player.statusEffectv1(StatusEffects.VampThirstStacksHPMana) > 0) {
 				bd.disable("<b>You can't use Health Tap more than once a turn.</b>\n\n");
 			}
+			favbd(bd, "Health Tap (1)");
 			bd = buttons.add("Mana Tap (1)", curry(VampireThirstStacksToMana, 1), "Draw on your tainted blood power to recover some of your magic energies. \n");
 			if (player.hasStatusEffect(StatusEffects.VampThirstStacksHPMana) && player.statusEffectv2(StatusEffects.VampThirstStacksHPMana) > 0) {
 				bd.disable("<b>You can't use Mana Tap more than once a turn.</b>\n\n");
 			}
+			favbd(bd, "Mana Tap (1)");
 			if (player.statusEffectv1(StatusEffects.VampireThirst) >= 5) {
 				bd = buttons.add("Health Tap (5)", curry(VampireThirstStacksToHealth, 5), "Draw on your tainted blood power to heal yourself. \n");
 				if (player.hasStatusEffect(StatusEffects.VampThirstStacksHPMana) && player.statusEffectv1(StatusEffects.VampThirstStacksHPMana) > 0) {
 					bd.disable("<b>You can't use Health Tap more than once a turn.</b>\n\n");
 				}
+				favbd(bd, "Health Tap (5)");
 				bd = buttons.add("Mana Tap (5)", curry(VampireThirstStacksToMana, 5), "Draw on your tainted blood power to recover some of your magic energies. \n");
 				if (player.hasStatusEffect(StatusEffects.VampThirstStacksHPMana) && player.statusEffectv2(StatusEffects.VampThirstStacksHPMana) > 0) {
 					bd.disable("<b>You can't use Mana Tap more than once a turn.</b>\n\n");
 				}
+				favbd(bd, "Mana Tap (5)");
 			}
 			if (player.hasPerk(PerkLib.Araneathropy) && player.statusEffectv1(StatusEffects.VampireThirst) >= 10) {
 				bd = buttons.add("Health Tap (10)", curry(VampireThirstStacksToHealth, 10), "Draw on your tainted blood power to heal yourself. \n");
 				if (player.hasStatusEffect(StatusEffects.VampThirstStacksHPMana) && player.statusEffectv1(StatusEffects.VampThirstStacksHPMana) > 0) {
 					bd.disable("<b>You can't use Health Tap more than once a turn.</b>\n\n");
 				}
+				favbd(bd, "Health Tap (10)");
 			}
 		}
 		if (player.isRaceCached(Races.COUATL) && player.isFlying()) {
@@ -657,6 +735,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.CooldownHurricane)) {
 				bd.disable("You need time to gather enough winds to empower your Hurricane again.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Hurricane");
 		}
 		if (player.isRaceCached(Races.KAMAITACHI) && player.arms.type == Arms.KAMAITACHI) {
 			bd = buttons.add("Wind scythe", WindScythe).hint("Create a sharp wave of wind, slashing everything in its path for heavy bleed damage. More powerful against groups. \n", "Wind Scythe");
@@ -665,6 +744,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.CooldownWindScythe)) {
 				bd.disable("You need time to gather enough winds to unleash a wind scythe again.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Wind Scythe");
 		}
 		if (player.hasPerk(PerkLib.DragonFireBreath)) {
 			bd = buttons.add("Dragon(Fire)", dragonfireBreath);
@@ -678,6 +758,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.DragonFireBreathCooldown)) {
 				bd.disable("You try to tap into the power within you, but your aching throat reminds you that you're not yet ready to unleash it again...");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Dragon Fire");
 		}
 		if (player.hasPerk(PerkLib.DragonIceBreath)) {
 			bd = buttons.add("Dragon(Ice)", dragoniceBreath);
@@ -691,6 +772,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.DragonIceBreathCooldown)) {
 				bd.disable("You try to tap into the power within you, but your aching throat reminds you that you're not yet ready to unleash it again...");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Dragon Ice");
 		}
 		if (player.hasPerk(PerkLib.DragonLightningBreath)) {
 			bd = buttons.add("Dragon(Light)", dragonlightningBreath);
@@ -704,6 +786,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.DragonLightningBreathCooldown)) {
 				bd.disable("You try to tap into the power within you, but your aching throat reminds you that you're not yet ready to unleash it again...");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Dragon Lightning");
 		}
 		if (player.hasPerk(PerkLib.DragonDarknessBreath)) {
 			bd = buttons.add("Dragon(Dark)", dragondarknessBreath);
@@ -717,6 +800,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.DragonDarknessBreathCooldown)) {
 				bd.disable("You try to tap into the power within you, but your aching throat reminds you that you're not yet ready to unleash it again...");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Dragon Darkness");
 		}
 		if (player.hasPerk(PerkLib.DragonPoisonBreath)) {
 			bd = buttons.add("Dragon(Poison)", dragonpoisonBreath);
@@ -730,6 +814,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.DragonPoisonBreathCooldown)) {
 				bd.disable("You try to tap into the power within you, but your aching throat reminds you that you're not yet ready to unleash it again...");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Dragon Poison");
 		}
 		if (player.hasPerk(PerkLib.DragonWaterBreath)) {
 			bd = buttons.add("Dragon(Water)", dragonWaterBreath);
@@ -743,6 +828,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.DragonWaterBreathCooldown)) {
 				bd.disable("You try to tap into the power within you, but your aching throat reminds you that you're not yet ready to unleash it again...");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Dragon Water");
 		}
 		if (player.hasPerk(PerkLib.DragonFaerieBreath)) {
 			bd = buttons.add("Dragon(Faerie)", dragonFaerieBreath);
@@ -756,6 +842,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.DragonFaerieBreathCooldown)) {
 				bd.disable("You try to tap into the power within you, but your aching throat reminds you that you're not yet ready to unleash it again...");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Dragon Faerie");
 		}
 		if (player.hasPerk(PerkLib.DragonPoisonousSapBreath)) {
 			bd = buttons.add("Dragon(P.Sap)", dragonPoisonousSapBreath);
@@ -769,6 +856,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.DragonFaerieBreathCooldown)) {
 				bd.disable("You try to tap into the power within you, but your aching throat reminds you that you're not yet ready to unleash it again...");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Dragon Poisonous Sap Breath");
 		}
 		if (player.hasPerk(PerkLib.DragonRegalBreath)) {
 			bd = buttons.add("Dragon(Royal)", dragonRoyalBreath);
@@ -782,6 +870,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.DragonRoyalBreathCooldown)) {
 				bd.disable("You try to tap into the power within you, but your aching throat reminds you that you're not yet ready to unleash it again...");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Dragon Royal Breath");
 		}
 		if (player.perkv1(IMutationsLib.DrakeLungsIM) >= 1) {
 			bd = buttons.add("TrueDragonBreath", trueDragonBreath);
@@ -796,12 +885,14 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.perkv1(IMutationsLib.DrakeLungsIM) >= 3) bd.disable("Your throat is incredibly sore and hoarse. You aren’t sure you can talk let alone try that attack for a while.");
 				else bd.disable("Your throat is incredibly sore and hoarse. You aren’t sure you can talk let alone try that attack for more than a day.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "True Dragon Breath");
 		}
 		if (player.hasPerk(PerkLib.DragonLustPoisonBreath)) {
 			bd = buttons.add("Poison Breath", DragonLustPoisonBreath).hint("Unleash a cloud of aphrodisiac poison. Particularly powerful against groups.  \n\nVenom: " + player.tailVenom + "/" + player.maxVenom());
 			if (player.tailVenom < player.VenomWebCost() * 5) {
 				bd.disable("You do not have enough poison in your glands to breath a cloud right now! (Req. "+player.VenomWebCost()*5+"+)");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Dragon Lust Poison Breath");
 		}
 		if (player.faceType == Face.WOLF && player.hasKeyItem("Gleipnir Collar") >= 0) {
 			bd = buttons.add("FreezingBreath", fenrirFreezingBreath,"Freeze your foe solid with a powerful breath attack. \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "9":"10")+" rounds  \n<b>AoE attack.</b>");
@@ -809,6 +900,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownFreezingBreath)) {
 				bd.disable("You need more time before you can use Freezing Breath again.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Fenrir Freezing Breath");
 		}
 		if (player.hasPerk(PerkLib.FreezingBreathYeti) || player.perkv1(IMutationsLib.FrozenHeartIM) >= 1) {
 			bd = buttons.add("FreezingBreath", yetiFreezingBreath, "Freeze your foe solid with a powerful breath attack. \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "9":"10")+" rounds");
@@ -816,6 +908,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownFreezingBreathYeti)) {
 				bd.disable("You need more time before you can use Freezing Breath again.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Yeti Freezing Breath");
 		}
 		if ((player.isRaceCached(Races.YUKIONNA) && player.hasPerk(PerkLib.ColdAffinity)) || player.perkv1(IMutationsLib.FrozenHeartIM) >= 1) {
 			bd = buttons.add("Ice Barrage", iceBarrage).hint("Call up a frigid storm to freeze and bombard your enemies.", "Ice Barrage");
@@ -823,11 +916,13 @@ public class MagicSpecials extends BaseCombatContent {
 			var HCCDv:Number = 10;
 			if (player.perkv1(IMutationsLib.FrozenHeartIM) >= 2) HCCDv -= (player.perkv1(IMutationsLib.FrozenHeartIM) - 1);
 			if (player.hasPerk(PerkLib.NaturalInstincts)) HCCDv -= 1;
+			favbd(bd, "Ice Barrage");
 			bd = buttons.add("HungeringCold", hungeringCold).hint("Freeze the air around your target, encasing it in ice and dealing hypothermia damage. Weakens opponents ice resistance to further attacks damage by 50% stacking up to 3 times. \n\nWould go into cooldown after use for: " + HCCDv + " rounds", "Hungering cold");
 			bd.requireFatigue(spellCost(40));
 			if (player.hasStatusEffect(StatusEffects.CooldownHungeringCold)) {
 				bd.disable("You need more time before you can use Hungering Cold again.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Hungering Cold");
 		}
 		if ((player.isRaceCached(Races.YUKIONNA) && player.hasPerk(PerkLib.ColdAffinity)) || player.perkv1(IMutationsLib.FrozenHeartIM) >= 1) {
 			bd = buttons.add("Frozen Kiss", frozenKiss).hint("Inflict damage, drain health, stun for 2 rounds and lust out the opponent. Usable only if the victim is humanoid and non giant.", "Frozen Kiss");
@@ -835,6 +930,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownFrozenKiss)) {
 				bd.disable("You need more time before you can use Frozen Kiss again.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Frozen Kiss");
 		}
 		if (player.isRaceCached(Races.USHIONNA)) {
 			bd = buttons.add("ToxicBreath", ushiOnnaToxicBreath, "Poison your foe with a powerful breath attack. \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "9":"10")+" rounds");
@@ -842,22 +938,26 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownToxicBreathUshiOnna)) {
 				bd.disable("You need more time before you can use Toxic Breath again.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Ushi Onna Toxic Breath");
 		}
 		if (player.hasPerk(PerkLib.FireLord)) {
 			bd = buttons.add("Fire Breath",fireballuuuuu).hint("Unleash fire from your mouth. \n", "Fire Breath");
 			bd.requireFatigue(20);
 			if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Fire Lord Breath");
 		}
 		if (player.hasPerk(PerkLib.Hellfire)) {
 			if (player.faceType == Face.CERBERUS) {
 				bd = buttons.add("Hellfire",hellFire).hint("Unleash fire from your mouths.\n");
 				bd.requireFatigue(spellCost(150));
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Hellfire");
 			}
 			else {
 				bd = buttons.add("Hellfire",hellFire).hint("Unleash fire from your mouth.\n");
 				bd.requireFatigue(spellCost(50));
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Hellfire");
 			}
 		}
 		if (player.hasPerk(PerkLib.PhoenixFireBreath)) {
@@ -866,16 +966,19 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownPhoenixFireBreath)) {
 				bd.disable("You need more time before you can use Phoenix Fire again.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Phoenix Fire Breath");
 		}
 		if (player.hasPerk(PerkLib.AcidSpit)) {
 			bd = buttons.add("Acid Spit", acidSpitCaveWyrm).hint("Spit acid at your opponent corroding his defence and dealing progressive damage.", "Acid Spit");
 			bd.requireFatigue(spellCost(40));
 			if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Cave Wyrm Acid Spit");
 		}
 		if (player.hasPerk(PerkLib.AzureflameBreath)) {
 			bd = buttons.add("Azureflame B.", azureflameBreath).hint("Inhale a cone of bluish flames at your opponent. Cause burn.", "Azureflame Breath");
 			bd.requireFatigue(spellCost(40));
 			if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Azureflame Breath");
 		}
 		if ((player.isRaceCached(Races.MOUSE, 2)) || player.countRings(jewelries.INMORNG)) {
 			bd = buttons.add("Blazing battle spirit", blazingBattleSpirit);
@@ -890,18 +993,21 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.UnderwaterCombatBoost)) {
 				bd.disable("You can't use this underwater!");
 			}
+			favbd(bd, "Blazing Battle Spirit");
 		}
 		if (player.hasPerk(PerkLib.FromTheFrozenWaste)){
 			bd = buttons.add("Winter Claws", WinterClaws).hint("Natural weapon damage is increased by 200% as cold damage but take very highly increased damage from fire attacks.");
 			if(player.hasStatusEffect(StatusEffects.WinterClaw)) {
 				bd.disable("Your natural weapons are already generating cold!");
 			}
+			favbd(bd, "Winter Claws");
 		}
 		if ((player.isRaceCached(Races.MOUSE, 2)) || player.perkv1(IMutationsLib.HinezumiBurningBloodIM) >= 3) {
 			bd = buttons.add("Cauterize", cauterize).hint("Flash burn your wounds to cause them to close. Take damage but recover over time. \n", "Cauterize");
 			if(player.hasStatusEffect(StatusEffects.Cauterize)) {
 				bd.disable("You already cauterizing your wounds!");
 			}
+			favbd(bd, "Cauterize");
 		}
 		if ((((player.racialScore(Races.SALAMANDER) >= 12 || player.racialScore(Races.PHOENIX) >= 15) && player.tail.type == Tail.SALAMANDER) || (player.racialScore(Races.KITSHOO) >= 12 && player.tail.type == Tail.KITSHOO)) &&
 			(player.weapon.isDuelingType() || player.weaponOff.isDuelingType() || player.weapon.isSwordType() || player.weaponOff.isSwordType() || player.weapon.isAxeType() || player.weaponOff.isAxeType() || player.weapon.isDaggerType() || player.weaponOff.isDaggerType() || player.weapon.isScytheType() || player.weaponOff.isScytheType())) {
@@ -909,12 +1015,14 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.FlameBlade)) {
 				bd.disable("Your weapon is already on fire!");
 			}
+			favbd(bd, "Flame Blade");
 		}
 		if (player.isRaceCached(Races.DEER, 2)) {
 			bd = buttons.add("Winter Rider", winterRider).hint("Condense and freeze humidity around your weapon to coat the edge in deadly ice adding cold damage to attacks. \n", "Winter Rider");
 			if (player.hasStatusEffect(StatusEffects.WinterRider)) {
 				bd.disable("Your weapon is already coated with ice!");
 			}
+			favbd(bd, "Winter Rider");
 		}
 		if (player.hasPerk(PerkLib.JobWarrior)) {
 			bd = buttons.add("WarriorRage", warriorsrage).hint("Throw yourself into a warrior's rage!  Greatly increases your strength, speed and fortitude! \n", "Warrior's Rage");
@@ -922,6 +1030,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.statStore.hasBuff("WarriorsRage")) {
 				bd.disable("You already raging!");
 			}
+			favbd(bd, "Warrior's Rage");
 		}
 		if (player.hasPerk(PerkLib.Berzerker)) {
 			bd = buttons.add("Berserk G1", berzerk);
@@ -936,12 +1045,14 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.Berzerking)) {
 				bd.disable("You're already pretty goddamn mad!");
 			}
+			favbd(bd, "Berserk G1");
 			if (player.hasPerk(PerkLib.SubzeroLustfulFury) && player.hasPerk(PerkLib.EndlessRage)) {
 				bd = buttons.add("Berserk G1+2", berzerkG1and2);
 				bd.requireWrath(50);
 				if (player.hasStatusEffect(StatusEffects.Berzerking) && player.statusEffectv2(StatusEffects.Berzerking) >= 1) {
 					bd.disable("You're already reached 2nd grade of Berserk!");
 				}
+				favbd(bd, "Berserk G1+2");
 			}
 		}
 		if (player.hasPerk(PerkLib.PrestigeJobBerserker) && player.hasStatusEffect(StatusEffects.Berzerking)) {
@@ -955,23 +1066,27 @@ public class MagicSpecials extends BaseCombatContent {
 					bd.disable("You're already reached 3rd grade of Berserk!");
 				}
 			}
+			favbd(bd, "Berserk G2");
 			if (player.statusEffectv2(StatusEffects.Berzerking) >= 1) {
 				bd = buttons.add("Berserk G3", berzerkG3);
 				if (player.statusEffectv2(StatusEffects.Berzerking) >= 2) {
 					bd.disable("You're already reached 3rd grade of Berserk!");
 				}
+				favbd(bd, "Berserk G3");
 			}
 			if (player.hasPerk(PerkLib.EndlessRage) && player.statusEffectv2(StatusEffects.Berzerking) >= 1 && player.hasPerk(PerkLib.SubzeroLustfulFury)) {
 				bd = buttons.add("Berserk G3+4", berzerkG3and4);
 				if (player.statusEffectv2(StatusEffects.Berzerking) >= 3) {
 					bd.disable("You're already reached 4th grade of Berserk!");
 				}
+				favbd(bd, "Berserk G3+4");
 			}
 			if (player.hasPerk(PerkLib.EndlessRage) && player.statusEffectv2(StatusEffects.Berzerking) >= 2) {
 				bd = buttons.add("Berserk G4", berzerkG4);
 				if (player.statusEffectv2(StatusEffects.Berzerking) >= 3) {
 					bd.disable("You're already reached 4th grade of Berserk!");
 				}
+				favbd(bd, "Berserk G4");
 			}
 		}
 		if (player.perkv1(IMutationsLib.SharkOlfactorySystemIM) >= 1 || player.isAnyRaceCached(Races.SHARK, Races.ABYSSAL_SHARK)) {
@@ -983,6 +1098,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.statStore.hasBuff("Blood Frenzy")) {
 				bd.disable("You're already frenzied!");
 			}
+			favbd(bd, "Blood Frenzy");
 		}
 		if (player.hasPerk(PerkLib.Lustzerker) || player.countRings(jewelries.FLLIRNG)) {
 			bd = buttons.add("Lustserk G1", lustzerk);
@@ -997,12 +1113,14 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.Lustzerking)) {
 				bd.disable("You're already pretty goddamn mad & lustfull!");
 			}
+			favbd(bd, "Lustserk G1");
 			if (player.hasPerk(PerkLib.SubzeroLustfulFury) && player.hasPerk(PerkLib.EndlessRage)) {
 				bd = buttons.add("Lustserk G1+2", lustzerkG1and2);
 				bd.requireWrath(50);
 				if (player.hasStatusEffect(StatusEffects.Lustzerking) && player.statusEffectv2(StatusEffects.Lustzerking) >= 1) {
 					bd.disable("You're already reached 2nd grade of Lustserk!");
 				}
+				favbd(bd, "Lustserk G1+2");
 			}
 		}
 		if (player.hasPerk(PerkLib.PrestigeJobBerserker) && player.hasStatusEffect(StatusEffects.Lustzerking)) {
@@ -1010,29 +1128,34 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.statusEffectv2(StatusEffects.Lustzerking) >= 1) {
 				bd.disable("You're already reached 2nd grade of Lustserk!");
 			}
+			favbd(bd, "Lustserk G2");
 			if (player.hasPerk(PerkLib.EndlessRage) && player.hasPerk(PerkLib.SubzeroLustfulFury)) {
 				bd = buttons.add("Lustserk G2+3", lustzerkG2and3);
 				if (player.statusEffectv2(StatusEffects.Lustzerking) >= 2) {
 					bd.disable("You're already reached 3rd grade of Lustserk!");
 				}
+				favbd(bd, "Lustserk G2+3");
 			}
 			if (player.statusEffectv2(StatusEffects.Lustzerking) >= 1) {
 				bd = buttons.add("Lustserk G3", lustzerkG3);
 				if (player.statusEffectv2(StatusEffects.Lustzerking) >= 2) {
 					bd.disable("You're already reached 3rd grade of Lustserk!");
 				}
+				favbd(bd, "Lustserk G3");
 			}
 			if (player.hasPerk(PerkLib.EndlessRage) && player.statusEffectv2(StatusEffects.Lustzerking) >= 1 && player.hasPerk(PerkLib.SubzeroLustfulFury)) {
 				bd = buttons.add("Lustserk G3+4", lustzerkG3and4);
 				if (player.statusEffectv2(StatusEffects.Lustzerking) >= 3) {
 					bd.disable("You're already reached 4th grade of Lustserk!");
 				}
+				favbd(bd, "Lustserk G3+4");
 			}
 			if (player.hasPerk(PerkLib.EndlessRage) && player.statusEffectv2(StatusEffects.Lustzerking) >= 2) {
 				bd = buttons.add("Lustserk G4", lustzerkG4);
 				if (player.statusEffectv2(StatusEffects.Lustzerking) >= 3) {
 					bd.disable("You're already reached 4th grade of Lustserk!");
 				}
+				favbd(bd, "Lustserk G4");
 			}
 		}
 		if (player.hasStatusEffect(StatusEffects.KnowsTyrantState)) {
@@ -1042,8 +1165,10 @@ public class MagicSpecials extends BaseCombatContent {
 			if (TyrantiaFollower.TyrantiaTrainingSessions >= 40) boost *= 2;
 			if (player.hasStatusEffect(StatusEffects.TyrantState)) {
 				bd = buttons.add("TyrantState(Off)", deactivateTyrantState).hint("Deactivate Tyrant State.");
+				favbd(bd, "Tyrant State");
 			} else {
 				bd = buttons.add("TyrantState(On)", activateTyrantState).hint("Strain your body to its limit to increase melee damage dealt by "+boost+"% at the cost of getting horny. This also decrease physical resistance."+(TyrantiaFollower.TyrantiaTrainingSessions >= 30 ? " Would delay lust defeat by two turns. (Timer reset each time lust drop below max overlust value)":"")+"");
+				favbd(bd, "Tyrant State");
 			}
 			if (TyrantiaFollower.TyrantiaTrainingSessions >= 15) {
 				bd = buttons.add("False Weapon", activaterFalseWeapon).hint("Create False weapon based on currently wielded melee weapon to attack each time you attack with it. Deals 20% dmg (Phalluspear False Weapon deals 100%).");
@@ -1051,6 +1176,7 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.lust < Math.round(player.maxLust() * 0.1)) {
 					bd.disable("Your lust is too low!");
 				}
+				favbd(bd, "False Weapon");
 			}
 		}
 		if (player.hasPerk(PerkLib.TechOverdrive)) {
@@ -1059,6 +1185,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.TechOverdrive)) {
 				bd.disable("You're already activated Tech Overdrive!");
 			}
+			favbd(bd, "Tech Overdrive");
 		}
 		if (player.isRaceCached(Races.AUTOMATA)) {
 			bd = buttons.add("Overdrive", automataOverdrive).hint("Increase your weakness to electricity (100%) and physical trauma (20%) but drastically raise your own damage (100%).");
@@ -1066,6 +1193,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.AutomataOverdrive)) {
 				bd.disable("You're already activated Overdrive!");
 			}
+			favbd(bd, "Overdrive");
 		}
 		if (player.racialScore(Races.GREMLIN) >= 15) {
 			bd = buttons.add("Malfunction", malfunction).hint("Overload a magitech or construction, causing damage and immobilizing it for a while. Does not work on living things or sentient constructs.");
@@ -1075,6 +1203,7 @@ public class MagicSpecials extends BaseCombatContent {
 			} else if (!monster.hasPerk(PerkLib.EnemyConstructType) && !monster.hasPerk(PerkLib.EnemyFleshConstructType) && !monster.hasPerk(PerkLib.Sentience)) {
 				bd.disable("Only work on nonsentient constructs and technology.");
 			}
+			favbd(bd, "Malfunction");
 		}
 		if (player.hasPerk(PerkLib.Whispered)) {
 			bd = buttons.add("Whisper", superWhisperAttack).hint("Whisper and induce fear in your opponent. \n");
@@ -1082,18 +1211,21 @@ public class MagicSpecials extends BaseCombatContent {
 			if(player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 				bd.disable("You cannot focus to reach the enemy's mind while you're having so much difficult breathing.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Whisper");
 		}
 		if (player.isRaceCached(Races.DEVIL) || player.perkv1(IMutationsLib.ObsidianHeartIM) >= 1) {
 			bd = buttons.add("Maleficium", maleficium).hint("Infuse yourself with corrupt power empowering your magic but reducing your resistance to carnal assault.");
 			if(player.hasStatusEffect(StatusEffects.Maleficium)) {
 				bd.disable("You already empowered with corrupt power!");
 			}
+			favbd(bd, "Maleficium");
 		}
 		if (player.isRaceCached(Races.AZAZEL) || player.perkv1(IMutationsLib.DiamondHeartIM) >= 1) {
 			bd = buttons.add("PerfectClarity", perfectclarity).hint("Infuse yourself with holy power empowering your magic but reducing your resistance to physical assault.");
 			if(player.hasStatusEffect(StatusEffects.PerfectClarity)) {
 				bd.disable("You already empowered with holy power!");
 			}
+			favbd(bd, "Perfect Clarity");
 		}
 		if ((player.isRaceCached(Races.PLANT) || player.isRaceCached(Races.YGGDRASIL) || player.isRaceCached(Races.ALRAUNE) || player.isRaceCached(Races.WOODELF)) && player.hasStatusEffect(StatusEffects.KnowsGreenCovenant)) {
 			bd = buttons.add("Green Covenant", greenCovenant).hint("Enforce the full might of your elven pact. Connect with nearby plants gaining high regeneration damage reduction, and empowering elven magic but taking periodic lust damage and reducing evade.");
@@ -1107,6 +1239,7 @@ public class MagicSpecials extends BaseCombatContent {
 			else if(player.hasStatusEffect(StatusEffects.CooldownGreenCovenant)) {
 				bd.disable("You need more time before you can use Green Covenant again.");
 			}
+			favbd(bd, "Green Covenant");
 		}
 		if (player.isRaceCached(Races.CHESHIRE)) {
 			bd = buttons.add("Ever&Nowhere", EverywhereAndNowhere).hint("Periodically phase out of reality increasing your invasion as well as granting you the ability to surprise your opponent denying their defences.  \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "9":"10")+" rounds");
@@ -1114,6 +1247,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownEveryAndNowhere)) {
 				bd.disable("You need more time before you can use Everywhere and nowhere again.\n\n");
 			}
+			favbd(bd, "Evrywhere And Nowhere");
 		}
 		if (player.isRaceCached(Races.DRACULA)) {
 			bd = buttons.add("ShadowTeleport", ShadowTeleport).hint("Periodically phase out of reality increasing your invasion as well as granting you the ability to surprise your opponent denying their defences.  \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "9":"10")+" rounds");
@@ -1121,15 +1255,18 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownShadowTeleport)) {
 				bd.disable("You need more time before you can use Shadow Teleport again.\n\n");
 			}
+			favbd(bd, "Shadow Teleport");
 		}
 		if (player.isRaceCached(Races.FAIRY)) {
 			bd = buttons.add("Fae Storm", FaeStorm).hint("Use a beam of chaotic magic, damaging your foe and inflicting various status effects. Single target but very likely to cause a lot of effects.");
 			bd.requireMana(spellCost(80));
+			favbd(bd, "Fae Storm");
 			bd = buttons.add("Baleful Polymorph", BalefulPolymorph).hint("Turn an opponent into a cute harmless critter.");
 			bd.requireMana(spellCost(80));
 			if (player.hasStatusEffect(StatusEffects.CooldownBalefulPolymorph)) {
 				bd.disable("You need more time before you can use Baleful Polymorph again.\n\n");
 			}
+			favbd(bd, "Baleful Polymorph");
 		}
 		if (player.isRaceCached(Races.FAIRY) || player.isRaceCached(Races.FAERIEDRAGON)) {
 			bd = buttons.add("Flicker", Flicker).hint("Vanish out of sight for a short time. \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "3":"4")+" rounds");
@@ -1137,14 +1274,17 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownFlicker)) {
 				bd.disable("You need more time before you can use Flicker again.\n\n");
 			}
+			favbd(bd, "Flicker");
 		}
 		if (player.isRaceCached(Races.FAIRY) && !player.hasStatusEffect(StatusEffects.Minimise)) {
 			bd = buttons.add("Minimise", Minimise).hint("Shrink to the size of 5 inches, gaining highly increased evasion but reducing melee and ranged damage as well as physical strength.");
 			bd.requireMana(spellCost(50));
+			favbd(bd, "Minimise");
 		}
 		if (player.isRaceCached(Races.FAIRY) && player.hasStatusEffect(StatusEffects.Minimise)) {
 			bd = buttons.add("Enlarge", Enlarge).hint("Grow back to your normal size.");
 			bd.requireMana(spellCost(40));
+			favbd(bd, "Enlarge");
 		}
 		if (player.isRaceCached(Races.DISPLACERBEAST)) {
 			bd = buttons.add("Displacement", Displacement).hint("Teleport around to avoid your opponents attacks. \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "9":"10")+" rounds");
@@ -1152,6 +1292,7 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownDisplacement)) {
 				bd.disable("You need more time before you can use Displacement again.\n\n");
 			}
+			favbd(bd, "Displacement");
 		}
 		if (player.isRaceCached(Races.RACCOON, 2) || player.perkv1(IMutationsLib.NukiNutsIM) >= 1) {
 			if (!monster.plural) {
@@ -1159,11 +1300,13 @@ public class MagicSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.CooldownPrank)) {
 					bd.disable("You need more time before you can prank your opponent again.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Prank");
 			}
 			bd = buttons.add("Money Strike", MoneyStrike).hint("Attack your opponent using magically enhanced money. Damage is based on personal wealth. Cost some gems upon use.", "Money Strike");
 			bd.requireFatigue(spellCost(40),true);
 			if (player.gems < 100) bd.disable("You need more gems in order to use Money Strike.");
 			else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Money Strike");
 		}
 		if (player.isRaceCached(Races.RATATOSKR)) {
 			var cdko:Number = 12;
@@ -1178,11 +1321,13 @@ public class MagicSpecials extends BaseCombatContent {
 			var cdp:Number = 6;
 			if (player.perkv1(IMutationsLib.RatatoskrSmartsIM) >= 3) cdp -= 1;
 			if (player.hasPerk(PerkLib.NaturalInstincts)) cdp -= 1;
+			favbd(bd, "Knowledge Overload");
 			bd = buttons.add("Provoke", Provoke).hint("Insult your opponent and cause it to fly into a murderous rage increasing its damage but negating its defences and ability to do anything but attack blindly with physical strikes. \n\nWould go into cooldown after use for: "+cdp+" rounds", "Provoke");
 			bd.requireMana(spellCost(80));
 			if (player.hasStatusEffect(StatusEffects.CooldownProvoke)) {
 				bd.disable("You need more time before you can use Provoke again.\n\n");
 			}
+			favbd(bd, "Provoke");
 		}
 		if (player.isRaceCached(Races.RATATOSKR) || player.perkv1(IMutationsLib.RatatoskrSmartsIM) >= 1) {
 			var cdww:Number = 4;
@@ -1193,18 +1338,21 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownWeirdWords)) {
 				bd.disable("You need more time before you can use Weird words again.\n\n");
 			}
+			favbd(bd, "Weird Words");
 		}
 		if (player.isRaceCached(Races.SLIME) || player.isRaceCached(Races.MAGMASLIME) || player.isRaceCached(Races.DARKSLIME)) {
 			bd = buttons.add("Slime Bolt", SlimeBolt).hint("Summon a huge slimy projectile and toss it at your opponent causing serious lust and physical damage, reducing speed.\n\nMana Cost: " + spellCostWhite(50) + "");
 			if (player.mana < spellCost(50)) {
 				bd.disable("Your mana is too low to toss slime bolt.");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Slime Bolt");
 		}
 		if (Mindbreaker.MindBreakerQuest == Mindbreaker.QUEST_STAGE_ISMB){
 			bd = buttons.add("Mind Thrust", mindThrust).hint("Use your psychic powers to strike at the opponent’s mind dealing severe physical damage.\n\nMana Cost: " + spellCostWhite(100) + "");
 			if (player.mana < spellCost(100)) {
 				bd.disable("Your mana is too low to use mind thrust.");
 			}
+			favbd(bd, "Mind Thrust");
 			bd = buttons.add("Mind Blast", mindBlast).hint("Overload an opponent’s mind with lewd information, stunning it.\n\nMana Cost: " + spellCostWhite(100) + "");
 			if (player.mana < spellCost(50)) {
 				bd.disable("Your mana is too low to use mind blast.");
@@ -1212,15 +1360,18 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownSpellMindBlast)) {
 				bd.disable("You need more time before you can use mind blast again.\n\n");
 			}
+			favbd(bd, "Mind Blast");
 			bd = buttons.add("Mirror Image", mirrorImage).hint("Create multiple clone of yourself to distract your opponent.\n\nMana Cost: " + spellCostWhite(100) + "");
 			if (player.mana < spellCost(100)) {
 				bd.disable("Your mana is too low to use mirror image.");
 			}
+			favbd(bd, "Mirror Image");
 		}
 		//Sing
 		if (player.hasPerk(PerkLib.MelkieSong) || player.hasPerk(PerkLib.HarpySong) || player.hasPerk(PerkLib.PanLabyrinth) || player.hasPerk(PerkLib.PrestigeJobBard)) {
 			if (player.weapon.isMusicInstrument()) bd = buttons.add("Perform", SingInitiate).hint("Players begin a musical performance. While performing, players may add various mystical effects to the tune.\n.");
 			else bd = buttons.add("Sing", SingInitiate).hint("Begin singing. While singing, you may add various powerful effects to your tune.\n.");
+			favbd(bd, "Perform/Sing");
 		}
 		//Telekinetic Grab
 		if ((player.racialScore(Races.VAMPIRE) >= 20 || player.racialScore(Races.DRACULA) >= 22) && !player.hasPerk(PerkLib.TelekineticGrapple) && !monster.hasStatusEffect(StatusEffects.TelekineticGrab)) {
@@ -1229,23 +1380,36 @@ public class MagicSpecials extends BaseCombatContent {
 			if (player.hasStatusEffect(StatusEffects.CooldownTelekineticGrab)) {
 				bd.disable("You need more time before you can use Telekinetic Grab again.\n\n");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "Telekinetic Grab");
 		}
 		if (player.hasPerk(PerkLib.LookADistraction)) {
 			bd = buttons.add("LOOKOUT!", LookADistraction).hint("Mental special attack. Base 25% success rate, +0.5% for every point of WIS you have over your enemy’s WIS. Stuns and Doubles next melee hit if done next round, only works once per combat.");
 			if (player.hasStatusEffect(StatusEffects.LookoutUsed)) {
 				bd.disable("You already used this special in this fight.\n\n");
 			} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+			favbd(bd, "LOOKOUT!");
 		}
 		if (player.hasPerk(PerkLib.ElementalBody)) {
 			for each (var fusionAbility:CombatAbility in CombatAbilities.ALL_ELEMENTAL_FUSION_ATTACKS) {
                 if (fusionAbility.isKnown) {
-                    buttons.append(fusionAbility.createButton(monster));
+	                bd = fusionAbility.createButton(monster);
+	                buttons.append(bd);
+	                favbd(bd, fusionAbility.name);
                 }
             }
 		}
-		if (player.hasStatusEffect(StatusEffects.ShieldingSpell)) buttons.add("Shielding", shieldingSpell);
-		if (player.hasStatusEffect(StatusEffects.ImmolationSpell)) buttons.add("Immolation", immolationSpell);
-		if (player.hasStatusEffect(StatusEffects.IcePrisonSpell)) buttons.add("Ice Prison", iceprisonSpell);
+		if (player.hasStatusEffect(StatusEffects.ShieldingSpell)) {
+			bd = buttons.add("Shielding", shieldingSpell);
+			favbd(bd, "Shielding");
+		}
+		if (player.hasStatusEffect(StatusEffects.ImmolationSpell)) {
+			bd = buttons.add("Immolation", immolationSpell);
+			favbd(bd, "Immolation");
+		}
+		if (player.hasStatusEffect(StatusEffects.IcePrisonSpell)) {
+			bd = buttons.add("Ice Prison", iceprisonSpell);
+			favbd(bd, "Ice Prison");
+		}
 	}
 	
 	public function magicAbilitiesGoBrrr():Number {

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -572,8 +572,8 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (player.hasStatusEffect(StatusEffects.UnderwaterCombatBoost)) {
 						bd.disable("<b>You can't dig in open water!</b>\n\n");
 					}
+					favbd(bd, "Dig");
 				}
-				favbd(bd, "Dig");
 			}
 			//Drink
 			if (player.countMiscJewelry(miscjewelries.ONI_GOURD) > 0) {

--- a/classes/classes/Scenes/Combat/PhysicalSpecials.as
+++ b/classes/classes/Scenes/Combat/PhysicalSpecials.as
@@ -49,12 +49,14 @@ public class PhysicalSpecials extends BaseCombatContent {
 					bd = buttons.add("PowerAttack", powerAttack).hint("Do a single way more powerful wrath-enhanced melee strike.");
 					if (player.wrath100 < 1) bd.disable("You're too low on wrath to use Power Attack (below 1%)");
 					else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Power Attack");
 				}
 				if (player.statStore.hasBuff("AsuraForm")) {
 					bd = buttons.add("Asura's Howl", combat.asurasHowl).hint("Unleash a howl before giving enemy good punching. \n\nWrath Cost: 50");
 					if (player.wrath < 50) {
 						bd.disable("Your wrath is too low to unleash howl!");
 					}
+					favbd(bd, "Asura's Howl");
 					if (player.hasPerk(PerkLib.AbsoluteStrength)) {
 						if (player.hasPerk(PerkLib.ItsZerkingTime)) bd = buttons.add("TwFoD", combat.asuras12FingersOfDestruction).hint("Twelve Fingers of Destruction - Poke your enemies Asura Style. \n\nWrath Cost: 50% of max Wrath");
 						else if (player.hasPerk(PerkLib.LikeAnAsuraBoss)) bd = buttons.add("TFoD", combat.asuras10FingersOfDestruction).hint("Ten Fingers of Destruction - Poke your enemies Asura Style. \n\nWrath Cost: 50% of max Wrath");
@@ -63,6 +65,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 						if (player.wrath < (player.maxWrath() * 0.5)) {
 							bd.disable("Your wrath is too low to poke your enemies Asura Style!");
 						}
+						favbd(bd, "Fingers of Destruction");
 					}
 					if (player.hasPerk(PerkLib.LikeAnAsuraBoss)) {
 
@@ -71,12 +74,14 @@ public class PhysicalSpecials extends BaseCombatContent {
 				if (player.haveWeaponForCleave() && player.hasStatusEffect(StatusEffects.KnowsCleave)) {
 					bd = buttons.add("Cleave", pcCleave).hint("Deal extra damage to multiple foes. Cause area effect bleed damage.");
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Cleave");
 				}
 				if ((player.hasPerk(PerkLib.SneakyAttack) && player.haveWeaponForSneakAttack() && (monster.monsterIsStunned()
 					|| monster.hasStatusEffect(StatusEffects.Blind) || monster.hasStatusEffect(StatusEffects.InkBlind) || monster.hasStatusEffect(StatusEffects.Distracted)))||
 						((player.hasStatusEffect(StatusEffects.EverywhereAndNowhere) || player.hasStatusEffect(StatusEffects.ShadowTeleport)) && player.haveWeaponForSneakAttack())) {
 					bd = buttons.add("SneakAttack (M)", sneakAttack).hint("Strike the vitals of a stunned, blinded or distracted opponent for heavy damage. (Melee variant)");
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Sneak Attack");
 				}
 				if (!(player.weapon.isStaffType() && !player.hasPerk(PerkLib.Shillelagh)) && !(player.weaponOff.isStaffType() && !player.hasPerk(PerkLib.Shillelagh))) {
 					bd = buttons.add("Charge", charging).hint("Charge at your opponent for massive damage. Deals more damage if using a spear or lance. Gains extra damage from the usage of a horn or a pair of horns.");
@@ -90,6 +95,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 						}
 					}
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Charge");
 				}
 				if (!player.hasPerk(PerkLib.ElementalBody)) {
 					if (player.lowerBody == LowerBody.HOOFED || player.lowerBody == LowerBody.KIRIN || player.lowerBody == LowerBody.BAROMETZ) {
@@ -98,32 +104,39 @@ public class PhysicalSpecials extends BaseCombatContent {
 							bd = buttons.add("Gallop", gallopingStart).hint("Start galloping. Deals 50% more damage with physical specials but disable melee and range base attacks.");
 							bd.requireFatigue(combat.gallopingcoooooost());
 						}
+						favbd(bd, "Gallop");
 					}
 					if (player.hairType == 4) {
 						bd = buttons.add("AnemoneSting", anemoneSting).hint("Attempt to strike an opponent with the stinging tentacles growing from your scalp.  Reduces enemy speed and increases enemy lust.", "Anemone Sting");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Anemone Sting");
 					}
 					//Bitez
 					if (player.faceType == Face.SHARK_TEETH) {
 						bd = buttons.add("SharkBite", bite).hint("Attempt to bite your opponent with your shark-teeth causing bleed.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Shark Bite");
 					}
 					if (player.faceType == Face.ORCA) {
 						bd = buttons.add("OrcaBite", bite).hint("Bite your opponent with your sharp teeths causing bleed.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Orca Bite");
 					}
 					if (player.faceType == Face.WOLF) {
 						bd = buttons.add("ViciousBite", bite).hint("Viciously bite your opponent with your sharp teeths causing bleed.");
 						if (player.hasPerk(PerkLib.FreezingBreath)) buttons.add("Frostbite", fenrirFrostbite).hint("You bite in your foe slowly infecting it with cold chill weakening its strength and resolve.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Vicious Bite");
 					}
 					if (player.faceType == Face.CERBERUS) {
 						bd = buttons.add("TripleBite", bite).hint("Viciously bite your opponent with your sharp teeths causing bleed.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Triple Bite");
 					}
 					if (player.faceType == Face.ABYSSAL_SHARK) {
 						bd = buttons.add("ASharkBite", abyssalSharkbite).hint("Attempt to bite your opponent with your large shark-teeth ripping off piece of enemy body and causing bleed.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Abyssal Shark Bite");
 					}
 					//hydra bite - variant of snake bite
 					if ((player.faceType == Face.SNAKE_FANGS || player.perkv1(IMutationsLib.VenomGlandsIM) >= 1)) {
@@ -133,11 +146,13 @@ public class PhysicalSpecials extends BaseCombatContent {
 								bd.disable("You do not have enough venom to use hydra bite right now! (Req. " + player.VenomWebCost() * 5 + "+)");
 							} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 							bd.requireFatigue(physicalSpecialsCost(10 * player.statusEffectv1(StatusEffects.HydraTailsPlayer)));
+							favbd(bd, "Hydra Bite");
 						} else {
 							bd = buttons.add("SnakeBite", nagaBiteAttack).hint("Attempt to bite your opponent and inject venom. (lower enemy str and spe)  \n\nVenom: " + player.tailVenom + "/" + player.maxVenom());
 							if (player.tailVenom < player.VenomWebCost() * 5) {
 								bd.disable("You do not have enough venom to use snake bite right now! (Req. " + player.VenomWebCost() * 5 + "+)");
 							} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+							favbd(bd, "Snake Bite");
 						}
 					}
 					if ((player.faceType == Face.SPIDER_FANGS || player.faceType == Face.WERESPIDER_FANGS || player.faceType == Face.USHI_ONI || player.perkv1(IMutationsLib.VenomGlandsIM) >= 1)) {
@@ -145,6 +160,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 						if (player.tailVenom < player.VenomWebCost() * 5) {
 							bd.disable("You do not have enough venom to use spider bite right now!");
 						} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Spider Bite");
 					}
 					//Ant Bite
 					if ((player.faceType == Face.ANT || player.perkv1(IMutationsLib.VenomGlandsIM) >= 1)) {
@@ -152,10 +168,12 @@ public class PhysicalSpecials extends BaseCombatContent {
 						if (player.tailVenom < player.VenomWebCost() * 5) {
 							bd.disable("You do not have enough venom to use ant bite right now!");
 						} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Ant Bite");
 					}
 					if (player.isSandWorm()) {
 						bd = buttons.add("Devastating Bite", devastatingBiteAttack).hint("Attempt to bite your opponent with your giant sandworm maw. (deal acid dmg)");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Devastating Bite");
 					}
 					//Troll specials
 					if ((player.faceType == Face.TROLL || player.faceType == Face.GLACIAL_TROLL) && player.isAnyRaceCached([Races.TROLL, Races.GLACIAL_TROLL])) {
@@ -166,54 +184,65 @@ public class PhysicalSpecials extends BaseCombatContent {
 							bd.disable("<b>You need more time before you can perform Thunder Gore again.</b>\n\n");
 							if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 						}
+						favbd(bd, "Feint Bash");
 					}
 					if (player.arms.type == Arms.GLACIAL_TROLL && player.isRaceCached(Races.GLACIAL_TROLL)) {
 						bd = buttons.add("Savage Claws", savageClaws).hint("Your claws are sharp like other glacial trolls, they can easily rip and grip into things as well as tear through objects.");
 						if (player.hasPerk(PerkLib.PhantomStrike)) bd.requireFatigue(physicalSpecialsCost(200));
 						else bd.requireFatigue(physicalSpecialsCost(100));
+						favbd(bd, "Savage Claws");
 					}
 					//Constrict
 					if (player.isNaga()) {
 						bd = buttons.add("Constrict", SceneLib.desert.nagaScene.nagaPlayerConstrict).hint("Attempt to bind an enemy in your long snake-tail.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Constrict");
 					}
 					//Cancer Grab
 					if (player.lowerBody == LowerBody.CANCER || player.rearBody.type == RearBody.ARIGEAN_PINCER_LIMBS) {
 						bd = buttons.add("Grab", combat.CancerGrab).hint("Grab your opponents with your pincers, then proceed to crush them.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Grab");
 					}
 					//Engulf
 					if (player.lowerBody == LowerBody.GOO) {
 						bd = buttons.add("Engulf", gooEngulf).hint("Attempt to engulf a foe with your body.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Engulf");
 					}
 					//Slime-Based Skills
 					if (player.lowerBody == LowerBody.GOO && (player.isSlime() || player.hasPerk(PerkLib.DarkSlimeEmpressCore))) {
 						bd = buttons.add("Spread", spreadSlime).hint("Spread some of your slime around, covering some of the ground.\n HP cost: "+10+"% ("+Math.round(player.maxHP()/10)+")\n\nFree action");
 						if (player.isFlying()) bd.disable("You cannot spread slime while flying.");
+						favbd(bd, "Spread Slime");
 					}
 					//DarkSlime Skills
 					if (player.lowerBody == LowerBody.GOO && player.isRaceCached(Races.DARKSLIME) && (player.hasPerk(PerkLib.RoyalSlimeJelly) || player.hasPerk(PerkLib.DarkSlimeEmpressCore)) ) {
 						bd = buttons.add("Form Slimes", formSlimeArmy).hint("Create <b>"+monster.getStatusValue(StatusEffects.SlimeSurround,1)*(player.hasPerk(PerkLib.DarkSlimeEmpressCore) ? 4:2)+"</b> Slimes from slime you've spread on the ground");
 						if (!monster.hasStatusEffect(StatusEffects.SlimeSurround) || monster.getStatusValue(StatusEffects.SlimeSurround,1)<1) bd.disable("You cannot create Slimes without slime on the ground.");
+						favbd(bd, "Form Slimes");
 					}
 					if (player.lowerBody == LowerBody.GOO && player.isRaceCached(Races.DARKSLIME) && (player.hasPerk(PerkLib.RoyalSlimeJelly) || player.hasPerk(PerkLib.DarkSlimeEmpressCore))) {
 						bd = buttons.add("Slimes Attack", slimeArmyAttack).hint("Command your <b>"+monster.getStatusValue(StatusEffects.SlimeSurround,2)+"</b> slimes to attack with their various weapons");
 						if (!monster.hasStatusEffect(StatusEffects.SlimeSurround) || monster.getStatusValue(StatusEffects.SlimeSurround,2)<1) bd.disable("You have not formed any slimes.");
+						favbd(bd, "Slimes Attack");
 					}
 					//Embrace
 					if ((player.arms.type == Arms.BAT || player.wings.type == Wings.VAMPIRE) && !monster.hasPerk(PerkLib.EnemyGroupType) && !monster.hasPerk(PerkLib.EnemyLargeGroupType)) {
 						bd = buttons.add("Embrace", vampireEmbrace).hint("Embrace an opponent in your wings.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Vampire Embrace");
 					}
 					//Gore if mino horns or unicorn/alicorn/bicorn/nightmare horns
 					if ((player.horns.type == Horns.COW_MINOTAUR || player.horns.type == Horns.FROSTWYRM) && player.horns.count >= 6) {
 						bd = buttons.add("Gore", goreAttack).hint("Lower your head and charge your opponent, attempting to gore them on your horns. This attack is stronger and easier to land with large horns.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Gore");
 					}
 					if ((player.horns.type == Horns.UNICORN || player.horns.type == Horns.BICORN || player.horns.type == Horns.GOAT || player.horns.type == Horns.GOATQUAD) && player.horns.count >= 6) {
 						bd = buttons.add("Gore", goreAttack).hint("Lower your head and charge your opponent, attempting to gore them on your horn" + (player.horns.type == Horns.BICORN ? "s" : "") + ".  This attack is stronger and easier to land with large horn" + (player.horns.type == Horns.BICORN ? "s" : "") + ".");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Gore");
 					}
 					if ((player.horns.type == Horns.KIRIN) && player.horns.count >= 6) {
 						bd = buttons.add("Thunder Gore", thunderGoreAttack).hint("Lower your head and charge your opponent, attempting to gore them on your horn.  This attack is stronger and easier to land with large horn. Scales with electricity damage and stun but has a long cooldown.");
@@ -221,6 +250,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 							bd.disable("<b>You need more time before you can perform Thunder Gore again.</b>\n\n");
 							if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 						}
+						favbd(bd, "Thunder Gore");
 					}
 					//Upheaval - requires rhino horns
 					if (player.horns.type == Horns.RHINO && player.horns.count >= 2 && player.faceType == Face.RHINO) {
@@ -228,11 +258,13 @@ public class PhysicalSpecials extends BaseCombatContent {
 						if (player.hasPerk(PerkLib.PhantomStrike)) bd.requireFatigue(physicalSpecialsCost(30));
 						else bd.requireFatigue(physicalSpecialsCost(15));
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Upheaval");
 					}
 					//Grapple
 					if ((player.lowerBody == LowerBody.SCYLLA || player.lowerBody == LowerBody.KRAKEN || player.isRaceCached(Races.MMINDBREAKER) || player.isRaceCached(Races.FMINDBREAKER))) {
 						bd = buttons.add("Grapple", scyllaGrapple).hint("Attempt to grapple a foe with your tentacles.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Tentacle Grapple");
 					}
 					//Kick
 					if (player.isTaur() || player.lowerBody == LowerBody.HOOFED || player.lowerBody == LowerBody.KIRIN || player.lowerBody == LowerBody.BAROMETZ || player.lowerBody == LowerBody.BUNNY || player.lowerBody == LowerBody.KANGAROO || player.perkv1(IMutationsLib.MightyLegsIM) >= 1) {
@@ -240,38 +272,45 @@ public class PhysicalSpecials extends BaseCombatContent {
 						if (player.hasStatusEffect(StatusEffects.CooldownKick)) {
 							bd.disable("<b>You need more time before you can perform Kick again.</b>\n\n");
 						} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Kick");
 					}
 					//Pounce
 					if (player.canPounce() && !monster.hasPerk(PerkLib.EnemyGroupType) && !monster.hasPerk(PerkLib.EnemyLargeGroupType)) {
 						bd = buttons.add("Pounce", catPounce).hint("Pounce and rend your enemy using your claws, this initiate a grapple combo.");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Pounce");
 					}
 					//Crunch
 					if (player.racialScore(Races.ARIGEAN) >= 16) {
 						bd = buttons.add("Crunch", arigeanCrunch).hint("Deals Physical Damage based on Strength, also lowers opponent's physical defense by 30% for 3 turns.");
 						bd.requireFatigue(physicalSpecialsCost(100));
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Arigean Crunch");
 					}
 					//Ram
 					if (player.tailType == Tail.ARIGEAN_PRINCESS) {
 						bd = buttons.add("Ram", arigeanRam).hint("A physical attack that scales off of speed, does recoil damage to the user (10% of max HP).");
 						bd.requireFatigue(physicalCost(100));
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Arigean Ram");
 					}
 				}
 				//Grab & Slam
 				if ((player.isRaceCached(Races.BEARANDPANDA) || player.isRaceCached(Races.REDPANDA)) && !monster.hasPerk(PerkLib.EnemyGroupType) && !monster.hasPerk(PerkLib.EnemyLargeGroupType)) {
 					bd = buttons.add("Grab", bearGrab).hint("Attempt to grab the opponent in your powerful paws. Does not work on opponent taller than you.");
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Bear Grab");
 					bd = buttons.add("Slam", bearSlam).hint("Furiously slam your target with your powerful paw, staggering and stunning it.");
 					if (player.hasStatusEffect(StatusEffects.CooldownSlamBear)) {
 						bd.disable("<b>You need more time before you can perform Slam again.</b>\n\n");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Bear Slam");
 				}
 				//Mummy bandage
 				if (player.isRaceCached(Races.MUMMY) && !monster.hasPerk(PerkLib.EnemyGroupType) && !monster.hasPerk(PerkLib.EnemyLargeGroupType)) {
 					bd = buttons.add("Mummy bandage", mummyBandage).hint("You can initiate a grapple using your bandages.");
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Mummy Bandage");
 				}
 				//Kiss supercedes bite.
 				if (player.hasStatusEffect(StatusEffects.LustStickApplied)) {
@@ -279,6 +318,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if(player.playerIsBlinded()) {
 						bd.disable("There's no way you'd be able to find their lips while you're blind!");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Luststick Kiss");
 				}
 				if (player.arms.type == Arms.MANTIS && player.weapon.isNothing && !player.hasPerk(PerkLib.ElementalBody)) {
 					bd = buttons.add("Multi Slash", mantisMultiSlash);
@@ -305,6 +345,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 						}
 					}
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Multi Slash");
 				}
 				if ((player.tail.isAny(Tail.BEE_ABDOMEN, Tail.SCORPION) || player.isSandWorm()) && !player.hasPerk(PerkLib.ElementalBody)) {
 					bd = buttons.add("Sting", playerStinger);
@@ -323,10 +364,13 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (player.tailVenom < player.VenomWebCost() * 5) {
 						bd.disable("You do not have enough venom to sting right now! (Req. "+player.VenomWebCost()*5+"+)");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Sting");
 				}
 				if (player.tail.isAny(Tail.SHARK, Tail.LIZARD, Tail.KANGAROO, Tail.DRACONIC, Tail.RACCOON, Tail.RED_PANDA) && !player.hasPerk(PerkLib.ElementalBody)) {
 					bd = buttons.add("Tail Whip", tailWhipAttack).hint("Whip your foe with your tail to enrage them and lower their defense!");
-				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Tail Whip");
+				}
 				if ((player.tailType == Tail.SALAMANDER || player.tailType == Tail.KITSHOO) && !player.hasPerk(PerkLib.ElementalBody)) {
 					var kitshoo1:String = "";
 					var kitshoo2:String = "it";
@@ -338,6 +382,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (player.hasPerk(PerkLib.PhantomStrike)) bd.requireFatigue(physicalSpecialsCost(80));
 					else bd.requireFatigue(physicalSpecialsCost(40));
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Salamander Tail Slap");
 				}
 				if (player.tailType == Tail.ORCA && !player.hasPerk(PerkLib.ElementalBody)) {
 					bd = buttons.add("Tail Smack", tailSmackAttack).hint("Smack your powerful tail at your opponent face.");
@@ -345,55 +390,65 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (player.hasStatusEffect(StatusEffects.CooldownTailSmack)) {
 						bd.disable("<b>You need more time before you can perform Tail Smack again.</b>\n\n");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Orca Tail Slap");
 				}
 				if (player.tailType == Tail.HOLLOW && !player.hasPerk(PerkLib.ElementalBody)) {
 					bd = buttons.add("Tail Slash", tailSlashAttack).hint("Slashes with a sharp end of tail. High critical-hit ratio.");
 					if (player.hasPerk(PerkLib.PhantomStrike)) bd.requireFatigue(physicalSpecialsCost(80));
 					else bd.requireFatigue(physicalSpecialsCost(40));
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Hollow Tail Slash");
 				}
 				if ((player.isRaceCached(Races.PIG) || player.perkv1(IMutationsLib.PigBoarFatIM) >= 3 || player.isRaceCached(Races.REDPANDA)) && player.thickness >= minThicknessReq()) {
 					bd = buttons.add("Body Slam", bodySlam).hint("Body slam your opponent (small chance to stun). Damage scale with toughness and thickness.");
 					bd.requireFatigue(physicalSpecialsCost(50));
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Body Slam");
 				}
 				if (player.isShieldsForShieldBash()) {
 					bd = buttons.add("Shield Bash", shieldBash).hint("Bash your opponent with a shield. Has a chance to stun. Bypasses stun immunity. \n\nThe more you stun your opponent, the harder it is to stun them again.");
 					bd.requireWrath(shieldbashcostly());
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Shield Bash");
 				}
 				//ELF ARCHERY
 				if (player.weaponRangePerk == "Bow" && WoodElves.WoodElfBowTraining >= 1) {
 					bd = buttons.add("Pin Down", ELFarcheryPinDown).hint("Shoot for your opponent legs dealing damage and incapacitating them. (cooldown of 5 rounds before it can be used again)");
 					if (player.hasStatusEffect(StatusEffects.CooldownPinDown)) bd.disable("<b>You need more time before you can do it again.</b>\n\n");
 					else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Pin Down");
 				}
 				if (player.weaponRangePerk == "Bow" && WoodElves.WoodElfBowTraining >= 2) {
 					bd = buttons.add("Elven Eye", ELFarcheryElvenEye).hint("Elven ability, focus your aim to increase critical chances and greatly raise archery critical damage with bows for 8 rounds.");
 					if (player.hasStatusEffect(StatusEffects.ElvenEye)) bd.disable("<b>You are already focusing your aim.</b>\n\n");
 					else if (player.eyes.type != Eyes.ELF) bd.disable("<b>You would need an elf vision in order to use this ability.</b>\n\n");
+					favbd(bd, "Elven Eye");
 				}
 				//KINDRA ARCHERY
 				if (player.weaponRangePerk == "Bow" && player.hasStatusEffect(StatusEffects.KnowsSidewinder)) {
 					bd = buttons.add("Sidewinder", archerSidewinder).hint("The pinacle art of the hunter. Once per day draw on your fatigue to shoot a single heavily infused arrow at a beast or animal morph. This attack never miss.");
 					if (player.hasStatusEffect(StatusEffects.CooldownSideWinder)) bd.disable("<b>You've already used Sidewinder today.</b>\n\n");
 					else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Sidewinder");
 				}
 				if (monster.plural) {
 					// Whipping
 					if (player.isWeaponsForWhipping()) {
 						bd = buttons.add("Whipping", whipping).hint("Attack multiple opponent with your held weapon.  \n\n<b>AoE attack.</b>");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Whipping");
 					}
 					// Whirlwind
 					if ((player.isWeaponForWhirlwind() && !player.hasPerk(PerkLib.PowerSweep)) || ((player.isWeaponForWhirlwind() || player.isOneHandedWeapons()) && player.hasPerk(PerkLib.PowerSweep))) {
 						bd = buttons.add("Whirlwind", whirlwind).hint("Spin your weapon around to attack multiple enemies at once.  \n\n<b>AoE attack.</b>");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Whirlwind");
 					}
 					// Whirlwind (Beast Warrior)
 					if (player.hasPerk(PerkLib.JobBeastWarrior) && ((player.weaponName == "fists" && player.haveNaturalClaws()) || player.haveNaturalClawsTypeWeapon())) {
 						bd = buttons.add("F. Whirlwind", whirlwindClaws).hint("Spin yourself around to slash multiple enemies with your claws at once.  \n\n<b>AoE attack.</b>");
 						if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+						favbd(bd, "Feral Whirlwind");
 					}
 				}
 				if (player.isAlraune() && !player.hasPerk(PerkLib.ElementalBody)) {
@@ -401,12 +456,14 @@ public class PhysicalSpecials extends BaseCombatContent {
 					bd = buttons.add("Entangle", AlrauneEntangle).hint("Use your vines to hinder your opponent.");
 					if (player.hasStatusEffect(StatusEffects.AlrauneEntangle)) bd.disable("<b>You already entangle your opponent.</b>\n\n");
 					else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Alraune Entangle");
 				}
 				if (player.hasStatusEffect(StatusEffects.AlrauneEntangle) && !player.hasPerk(PerkLib.ElementalBody)) {
 					bd = buttons.add("Strangulate", AlrauneStrangulate).hint("Strangle your opponent with your vines.");
 					bd.requireFatigue(physicalSpecialsCost(60));
 					if (monster.tallness > 120 || monster.hasPerk(PerkLib.EnemyHugeType)) bd.disable("<b>Your opponent is too tall for Strangulate to have any effect on it.</b>\n\n");
 					else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Alraune Strangulate");
 				}
 				if (player.arms.type == Arms.GARGOYLE && !player.hasPerk(PerkLib.ElementalBody)) {
 					bd = buttons.add("Stone Claw", StoneClawAttack).hint("Rend your foe using your sharp stone claws.  \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "2":"3")+" rounds");
@@ -415,6 +472,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (player.hasStatusEffect(StatusEffects.CooldownStoneClaw)) {
 						bd.disable("<b>You need more time before you can perform Stone Claw again.</b>\n\n");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Stone Claw");
 				}
 				if (player.arms.type == Arms.GARGOYLE_2 && !player.hasPerk(PerkLib.ElementalBody)) {
 					bd = buttons.add("Stone Fist", StoneFistAttack).hint("Slam your two fist at your foe and attempt to stun them.  \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "2":"3")+" rounds");
@@ -423,6 +481,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (player.hasStatusEffect(StatusEffects.CooldownStoneFist)) {
 						bd.disable("<b>You need more time before you can perform Stone Fist again.</b>\n\n");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Stone Fist");
 				}
 				if (player.tailType == Tail.GARGOYLE && !player.hasPerk(PerkLib.ElementalBody)) {
 					bd = buttons.add("Tail Slam", TailSlamAttack).hint("Slam your mace-like tail on your foe's head, dealing severe damage, crushing its defences, and stunning it.  \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "4":"5")+" rounds");
@@ -431,6 +490,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (player.hasStatusEffect(StatusEffects.CooldownTailSlam)) {
 						bd.disable("<b>You need more time before you can perform Tail Slam again.</b>\n\n");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Tail Slam");
 				}
 				if (player.tailType == Tail.GARGOYLE_2 && !player.hasPerk(PerkLib.ElementalBody)) {
 					bd = buttons.add("Tail Cleave", TailCleaveAttack).hint("Swipe your axe-bladed tail, cleaving through multiple opponents and dealing severe bleeding damage.  \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "4":"5")+" rounds");
@@ -439,6 +499,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (player.hasStatusEffect(StatusEffects.CooldownTailCleave)) {
 						bd.disable("<b>You need more time before you can perform Tail Cleave again.</b>\n\n");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Tail Cleave");
 				}
 				if (player.wings.type == Wings.GARGOYLE_LIKE_LARGE && !player.hasPerk(PerkLib.ElementalBody)) {
 					bd = buttons.add("Wing Buffet", WingBuffetAttack).hint("Buffet your foe using your two massive wings, staggering them.  \n\nWould go into cooldown after use for: "+(player.hasPerk(PerkLib.NaturalInstincts) ? "5":"6")+" rounds");
@@ -447,6 +508,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (player.hasStatusEffect(StatusEffects.CooldownWingBuffet)) {
 						bd.disable("<b>You need more time before you can perform Wing Buffet again.</b>\n\n");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Wing Buffet");
 				}
 				if ((player.isRaceCached(Races.ORCA) || player.isRaceCached(Races.SEA_DRAGON)) && player.faceType == Face.ORCA) {
 					bd = buttons.add("Play", orcaPlay).hint("Begin toying with your prey by tossing it in the air, initiating a juggling combo.");
@@ -455,10 +517,12 @@ public class PhysicalSpecials extends BaseCombatContent {
 					else if (player.tallness < monster.tallness) bd.disable("<b>You need the ennemy to be smaller then you in order to use this ability.</b>\n\n");
 					else if (player.hasStatusEffect(StatusEffects.CooldownPlay)) bd.disable("<b>You need more time before you can use Play again.</b>\n\n");
 					else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Orca Play");
 				}
 				if (player.tail.type == Tail.AUTOMATA_TAIL_CABLE) {
 					bd = buttons.add("Tazer", automataTazer).hint("Deliver a paralyzing jolt with a melee attack.");
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Tazer");
 				}
 			}
 			if (player.hasPerk(PerkLib.PowerShot)) {
@@ -467,16 +531,19 @@ public class PhysicalSpecials extends BaseCombatContent {
 				else if (player.weaponRangePerk != "Bow" && player.weaponRangePerk != "Crossbow" && player.weaponRangePerk != "Throwing") {
 					bd.disable("<b>You need to use bow, crossbow or throwing weapon before you can use Power Shoot.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Power Shoot");
 			}
 			if ((player.hasPerk(PerkLib.MarkedForDeath) && player.haveWeaponForSneakAttackRange() && (monster.monsterIsStunned()
 				|| monster.hasStatusEffect(StatusEffects.Blind) || monster.hasStatusEffect(StatusEffects.InkBlind) || monster.hasStatusEffect(StatusEffects.Distracted)))||
 					((player.hasStatusEffect(StatusEffects.EverywhereAndNowhere) || player.hasStatusEffect(StatusEffects.ShadowTeleport)) && player.haveWeaponForSneakAttackRange())) {
 				bd = buttons.add("SneakAttack (R)", sneakAttackRange).hint("Strike the vitals of a stunned, blinded or distracted opponent for heavy damage. (Range variant)");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Sneak Attack Ranged");
 			}
 			if (player.hasPerk(PerkLib.Feint)) {
 				bd = buttons.add("Feint", feint).hint("Attempt to feint an opponent into dropping its guard.");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Feint");
 			}
 			if (player.hasPerk(PerkLib.ChallengingShout) || player.hasPerk(PerkLib.ChallengingShoutMastered)) {
 				var challengingShout:String = "20% of max/overmax wrath on use as a free action.\nWould go into cooldown after use for: 10 rounds";
@@ -496,6 +563,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.CooldownWarriorShout) && !player.hasPerk(PerkLib.ChallengingShoutSu) && !player.hasPerk(PerkLib.ChallengingShoutMastered)) {
 					bd.disable("<b>You need more time before you can perform Warrior Shout again.</b>\n\n");
 				}
+				favbd(bd, "Warrior Shout");
 			}
 			if (!player.hasPerk(PerkLib.ElementalBody)) {
 				//Dig
@@ -505,32 +573,38 @@ public class PhysicalSpecials extends BaseCombatContent {
 						bd.disable("<b>You can't dig in open water!</b>\n\n");
 					}
 				}
+				favbd(bd, "Dig");
 			}
 			//Drink
 			if (player.countMiscJewelry(miscjewelries.ONI_GOURD) > 0) {
 				bd = buttons.add("Drink", Drink).hint("Drink down some sake from your drinking jug. \n\nSpecial: May have additional effects on an oni.");
+				favbd(bd, "Oni Gourd Drink");
 			}
 			//Whip Grapple
 			if (player.hasPerk(PerkLib.PrestigeJobBindmaster) && (player.isWeaponsForWhipping() || player.weapon == weapons.D_FLAIL)) {
 				bd = buttons.add("Grapple(W)", whipGrapple).hint("Attempt to grapple a foe with your "+(player.weapon == weapons.D_FLAIL?"flail":"whip")+".");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 				else if (monster.plural) bd.disable("You cannot grapple more than one foe at once.");
+				favbd(bd, "Whip Grapple");
 			}
 			//Infest if infested
 			if (player.hasStatusEffect(StatusEffects.Infested) && player.statusEffectv1(StatusEffects.Infested) == 5 && player.hasCock()) {
 				bd = buttons.add("Infest", SceneLib.mountain.wormsScene.playerInfest).hint("The infest attack allows you to cum at will, launching a stream of semen and worms at your opponent in order to infest them.  Unless your foe is very aroused they are likely to simply avoid it.  Only works on males or herms. \n\nAlso great for reducing your lust.");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Worm Infest");
 			}
 			if (player.tailType == Tail.MANTICORE_PUSSYTAIL && !player.hasPerk(PerkLib.ElementalBody)) {
 				bd = buttons.add("Tail Spike", playerTailSpike).hint("Shoot an envenomed spike at your opponent dealing minor physical damage, slowing its movement speed and inflicting serious lust damage.  \n\nVenom: " + player.tailVenom + "/" + player.maxVenom());
 				if (player.tailVenom < player.VenomWebCost() * 5) {
 					bd.disable("You do not have enough venom to shoot a spike right now! (Req. "+player.VenomWebCost()*5+"+)");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Tail Spike");
 				if (player.perkv1(IMutationsLib.ManticoreMetabolismIM) >= 1) {
 					bd = buttons.add("Omni Tail Spike", playerOmniTailSpike).hint("Shoot a volley of envenomed spikes at your opponent dealing minor physical damage, slowing its movement speed and inflicting serious lust damage.  \n\nVenom: " + player.tailVenom + "/" + player.maxVenom());
 					if (player.tailVenom < player.VenomWebCost() * 10 && player.perkv1(IMutationsLib.ManticoreMetabolismIM) >= 1) {
 						bd.disable("You do not have enough venom to shoot multiple spikes right now! (Req. "+player.VenomWebCost()*10+"+)");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Omni Tail Spike");
 				}
 			}
 			if (player.tailType == Tail.SPIDER_ADBOMEN && !player.hasPerk(PerkLib.ElementalBody)) {
@@ -538,6 +612,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 				if (player.tailVenom < player.VenomWebCost() * 5) {
 					bd.disable("You do not have enough webbing to shoot right now! (Req. "+player.VenomWebCost()*5+"+)");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Web");
 			}
 			if (player.hasPerk(PerkLib.InkSpray) && player.gender > 0 && !player.hasPerk(PerkLib.ElementalBody)) {
 				var liftWhat:String = player.gender == 1 ? "your cock" : "your front tentacle";
@@ -554,6 +629,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 				} else if (player.hasStatusEffect(StatusEffects.CooldownInkSpray)) {
 					bd.disable("<b>You need more time before you can shoot ink again.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Ink Spray");
 			}
 			if (player.hasVagina() && (player.isRaceCached(Races.COW) || player.perkv1(IMutationsLib.LactaBovinaOvariesIM) >= 1 || (player.perkv1(IMutationsLib.HumanOvariesIM) >= 3 && player.racialScore(Races.HUMAN) > 17)) && !player.hasPerk(PerkLib.ElementalBody)) {
 				var blaaaast2:String = player.perkv1(IMutationsLib.LactaBovinaOvariesIM) >= 3 ? " (cooldown of "+(player.hasPerk(PerkLib.NaturalInstincts) ? "3":"4")+" rounds before it can be used again)" : "";
@@ -564,6 +640,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (player.perkv1(IMutationsLib.LactaBovinaOvariesIM) >= 3) bd.disable("\n<b>You need more time before you can do it again.</b>");
 					else bd.disable("You can't use it more than once during fight.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Milk Blast");
 			}
 			if (player.hasCock() && (player.isRaceCached(Races.MINOTAUR) || player.perkv1(IMutationsLib.MinotaurTesticlesIM) >= 1 || (player.perkv1(IMutationsLib.HumanTesticlesIM) >= 3 && player.racialScore(Races.HUMAN) > 17)) && !player.hasPerk(PerkLib.ElementalBody)) {
 				var blaaaast1:String = player.perkv1(IMutationsLib.MinotaurTesticlesIM) >= 3 ? " (cooldown of "+(player.hasPerk(PerkLib.NaturalInstincts) ? "3":"4")+" rounds before it can be used again)" : "";
@@ -574,10 +651,12 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (player.perkv1(IMutationsLib.MinotaurTesticlesIM) >= 3) bd.disable("\n<b>You need more time before you can do it again.</b>");
 					else bd.disable("You can't use it more than once during fight.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Cum Cannon");
 			}
 			if (player.isRaceCached(Races.SLIME) || player.isRaceCached(Races.MAGMASLIME) || player.isRaceCached(Races.DARKSLIME)) {
 				bd = buttons.add("Sling Goo", slinggoo).hint("Throw slime at your opponent, lacing it with your aphrodisiac compound and reduce their speed.");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Sling Goo");
 			}
 			if (player.isAnyRaceCached([Races.DOG, Races.CERBERUS])) {
 				bd = buttons.add("Terr. Howl", terrifyingHowl).hint("Release a powerful howl, dazing your opponent for 1 round.\n4 round cooldown.", "Terrifying Howl");
@@ -585,34 +664,40 @@ public class PhysicalSpecials extends BaseCombatContent {
 				if(player.hasStatusEffect(StatusEffects.ThroatPunch) || player.hasStatusEffect(StatusEffects.WebSilence)) {
 					bd.disable("You cannot howl while you're having so much difficult breathing.");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Terrifying Howl");
 			}
 			if (player.canFly() && !player.hasPerk(PerkLib.ElementalBody)) {
 				bd = buttons.add("Take Flight", takeFlight).hint("Make use of your wings to take flight into the air for up to " + combat.flightDurationNatural() + " turns. \n\nGives bonus to evasion, speed but also giving penalties to accuracy of range attacks or spells. Not to mention for non-spear users to attack in melee range.");
 				if (player.hasStatusEffect(StatusEffects.Tentagrappled) && monster is Barometz) {
 					bd.disable("ou are currently entangled in vines and can't fly!");
 				}
+				favbd(bd, "Take Flight");
 			}
 			if (player.shieldName == "Battle Net") {
 				bd = buttons.add("Entangle", netEntangle).hint("Toss your net at the enemy to entangle it. (cooldown of 5 rounds before it can be used again)");
 				if (player.hasStatusEffect(StatusEffects.CooldownNet)) bd.disable("<b>You need more time before you can do it again.</b>\n\n");
 				else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Battle Net Entangle");
 			}
 			// Barrage
 			if (player.weaponRangePerk == "Bow" && player.hasStatusEffect(StatusEffects.KnowsBarrage) && monster.plural) {
 				bd = buttons.add("Barrage", archerBarrage).hint("Draw multiple arrow and shoot them all at the same time to hit several target.  \n\n<b>AoE attack.</b>");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Barrage");
 			}
 			if ((player.isAlraune() || player.perkv1(IMutationsLib.FloralOvariesIM) >= 1) && !player.hasPerk(PerkLib.ElementalBody)) {
 				// Pollen
 				bd = buttons.add("AlraunePollen", AlraunePollen).hint("Release a cloud of your pollen in the air to arouse your foe.");
 				if (player.hasStatusEffect(StatusEffects.AlraunePollen)) bd.disable("<b>You already spread your pollen over battlefield.</b>\n\n");
 				else if (player.hasStatusEffect(StatusEffects.SporeCloud)) bd.disable("<b>There is no point to activate this ability as your current cloud causes a similar effect.</b>\n\n");
+				favbd(bd, "Alraune Pollen");
 			}
 			if ((player.isRaceCached(Races.MYCONID) || player.perkv1(IMutationsLib.MyconidSporeIM) >= 1) && !player.hasPerk(PerkLib.ElementalBody)) {
 				// Spore Cloud
 				bd = buttons.add("Spore Cloud", SporeCloud).hint("Release a cloud of your spore into the air to arouse your foe.");
 				if (player.hasStatusEffect(StatusEffects.SporeCloud)) bd.disable("<b>You already spread your spores over battlefield.</b>\n\n");
 				else if (player.hasStatusEffect(StatusEffects.AlraunePollen)) bd.disable("<b>There is no point to activate this ability as your current cloud causes a similar effect.</b>\n\n");
+				favbd(bd, "Spore Cloud");
 			}
 			if (player.hasKeyItem("Rocket Boots") >= 0 || player.hasKeyItem("Nitro Boots") >= 0) {
 				if (player.hasKeyItem("Nitro Boots") >= 0) bd = buttons.add("Blazing rocket kick", blazingRocketKick).hint("Deal fire damage using your boots. Also burns.");
@@ -620,10 +705,12 @@ public class PhysicalSpecials extends BaseCombatContent {
 					bd = buttons.add("Rocket kick", blazingRocketKick).hint("Deal fire damage using your boots.");
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 				}
+				favbd(bd, "Rocket Kick");
 			}
 			if (player.hasKeyItem("Flasherbang") >= 0 || player.hasKeyItem("Flasherbang II") >= 0) {
 				bd = buttons.add("Flasherbang", gadgetFlasherbang).hint("Throw a flasherbang to blind and arouse your opponents.");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Flasherbang");
 			}
 			if (player.hasKeyItem("Goonade") >= 0 || player.hasKeyItem("Caustic Goonade") >= 0) {
 				var goonade1:String = player.hasKeyItem("Caustic Goonade") >= 0 ? "corrosive " : "";
@@ -632,22 +719,26 @@ public class PhysicalSpecials extends BaseCombatContent {
 				bd = buttons.add(""+goonade3+"", gadgetGoonade).hint("Throw a grenade that splatter "+goonade1+"sticky goo everywhere hindering movement and flight."+goonade2+"");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 				else if (player.hasStatusEffect(StatusEffects.Grounded)) bd.disable("<b>You need wait until previous used Goonade effect wear off.</b>\n\n");
+				favbd(bd, "Goonade");
 			}
 			if (player.hasKeyItem("Fire Grenade") >= 0 || player.hasKeyItem("Fire Grenade II") >= 0) {
 				var fireGrenade:String = player.hasKeyItem("Fire Grenade II") >= 0 ? " Upgrade the fire grenade explosion to also deal fire damage." : "";
 				bd = buttons.add("Fire Grenade", gadgetFireGrenade).hint("Toss a grenade that sets foes on fire inflicting the burn status effect."+fireGrenade+"");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Fire Grenade");
 			}
 			if (player.hasKeyItem("Stun Grenade") >= 0 || player.hasKeyItem("Stun Grenade II") >= 0) {
 				var stunGrenade:String = player.hasKeyItem("Stun Grenade II") >= 0 ? " Upgrade the stun grenade explosion to also deal lightning damage." : "";
 				bd = buttons.add("Stun Grenade", gadgetStunGrenade).hint("Toss a grenade that sets stun foe for 1 round."+stunGrenade+" (4 round cd)");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 				else if (player.hasStatusEffect(StatusEffects.CooldownStunGrenade)) bd.disable("<b>You need wait more before you can use Stun Grenade again.</b>\n\n");
+				favbd(bd, "Stun Grenade");
 			}
 			if (player.hasKeyItem("Goblin Bomber") >= 0) {
 				bd = buttons.add("Goblin Bomber", optionGoblinBomber).hint("Call for an airstrike.");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 				else if (player.hasStatusEffect(StatusEffects.GoblinBomber)) bd.disable("<b>You need wait one hour before you can use Goblin Bomber again.</b>\n\n");
+				favbd(bd, "Goblin Bomber");
 			}
 			if (player.hasPerk(PerkLib.EasterBunnyBalls) && !player.hasPerk(PerkLib.ElementalBody)) {
 				if (!player.perkv1(IMutationsLib.EasterBunnyEggBagIM) >= 1 || (player.perkv1(IMutationsLib.EasterBunnyEggBagIM) >= 1 && flags[kFLAGS.EASTER_BUNNY_EGGS_STORED] == 1)) {
@@ -656,20 +747,25 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (flags[kFLAGS.EASTER_BUNNY_EGGS_STORED] == 0) {
 						bd.disable("<b>You need eggs to use this ability.</b>\n\n");
 					} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Egg Throw");
 				}
 				if (player.perkv1(IMutationsLib.EasterBunnyEggBagIM) >= 1 && flags[kFLAGS.EASTER_BUNNY_EGGS_STORED] > 1) {
 					bd = buttons.add("Omni Egg throw", OmniEggthrowAttack).hint("Throw one or more of your many stashed bunny eggs blinding and arousing the opponent. These attacks benefit from skills that improve thrown weapons. \n\n"+flags[kFLAGS.EASTER_BUNNY_EGGS_STORED]+" egg remaining.");
 					bd.requireFatigue(physicalSpecialsCost(30));
-				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Omni Egg Throw");
+				}
 			}
 			if (player.hasPerk(PerkLib.TransformationImmunityBeeHandmaiden)) {
 				bd = buttons.add("Buzzing tune", buzzingTone).hint("Sing a buzzing hypnotic tune in battle, causing the opponent to be stunned for 6 rounds with massive lust damage. This move takes 2 rounds of preparation during which pc must do nothing but sing.");
 				bd.requireFatigue(spellCost(50));
+				favbd(bd, "Buzzing Tune");
 			}
 			if (player.hasStatusEffect(StatusEffects.FieryBand)) {
 				bd = buttons.add("Call Kiha", callKiha).hint("Call out to Kiha using the Starfire band.");
 				bd.requireFatigue(physicalSpecialsCost(30));
 				if (monster is Kiha) bd.disable("You cannot call Kiha to fight... herself.");
+				favbd(bd, "Fiery Band");
 			}
 		}
 		if (player.isInGoblinMech() || player.hasPerk(PerkLib.SelfImprovement)) {
@@ -685,38 +781,45 @@ public class PhysicalSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.CooldownTazer)) {
 					bd.disable("<b>You need more time before you can use Tazer again.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Tazer");
 			}
 			if (player.hasKeyItem("Missile launcher") >= 0) {
 				bd = buttons.add("Missile launcher", mechOmniMissile).hint("Fire missile that will cover a wide area of effect.");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Missile Launcher");
 			}
 			if (player.hasKeyItem("Omni Missile") >= 0) {
 				bd = buttons.add("Omni Missile", mechOmniMissile).hint("Fire omni missiles that will cover a wide area of effect.");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Omni Missile");
 			}
 			if (player.hasKeyItem("Whitefire Beam Cannon") >= 0) {
 				bd = buttons.add("Whitefire B.C.", mechWhitefireBeamCannon).hint("Shoot with the whitefire beam cannon at enemy burning him. \n\nWould go into cooldown after use for: 8 rounds");
 				if (player.hasStatusEffect(StatusEffects.CooldownWhitefireBeamCannon)) {
 					bd.disable("<b>You need more time before you can use Whitefire Beam Cannon again.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Whitefire Beam Cannon");
 			}
 			if (player.hasKeyItem("Snowball Generator") >= 0) {
 				bd = buttons.add("Snowball G.", mechSnowballGenerator).hint("Activate the snowball generator taking aim and launching a volley of snowballs at the enemy. \n\nWould go into cooldown after use for: 8 rounds");
 				if (player.hasStatusEffect(StatusEffects.CooldownSnowballGenerator)) {
 					bd.disable("<b>You need more time before you can use Snowball Generator again.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Snowball Generator");
 			}
 			if (player.hasKeyItem("Raijin blaster") >= 0) {
 				bd = buttons.add("Raijin Blaster", mechRaijinBlaster).hint("Activate the raijin blaster taking aim and zapping enemy. \n\nWould go into cooldown after use for: 8 rounds");
 				if (player.hasStatusEffect(StatusEffects.CooldownRaijinBlaster)) {
 					bd.disable("<b>You need more time before you can use Raijin Blaster again.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Raijin Blaster");
 			}
 			if (player.hasKeyItem("Gravity shots") >= 0) {
 				bd = buttons.add("Gravity Shots", mechGravityShots).hint("Activate the gravity shots unleashing the gravity sphere at the enemy. \n\nWould go into cooldown after use for: 8 rounds");
 				if (player.hasStatusEffect(StatusEffects.CooldownGravityShots)) {
 					bd.disable("<b>You need more time before you can use Gravity Shots again.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Gravity Shots");
 			}
 			if (player.hasKeyItem("Stimpack Dispenser 1.0") >= 0 || player.hasKeyItem("Medical Dispenser 2.0") >= 0) {
 				if (player.hasKeyItem("Medical Dispenser 2.0") >= 0) bd = buttons.add("Medical Dispenser 2.0", mechStimpackMedicalDispenser).hint("Activate to gain swift improved medical treatment. Be wary of secondary effects. \n\nWould go into cooldown after use for: 15 rounds");
@@ -724,23 +827,27 @@ public class PhysicalSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.CooldownStimpackDispenser)) {
 					bd.disable("<b>You need more time before you can use "+(player.hasKeyItem("Medical Dispenser 2.0") >= 0 ? "Medical Dispenser":"Stimpack Dispenser")+" again.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Medical Dispenser");
 			}
 			if (player.jetpackChecks() && !player.hasPerk(PerkLib.SelfImprovement)) {
 				bd = buttons.add("Jetpack", takeFlightGoblinMechJetpack).hint("Make use of your mech jetpack to take flight into the air for up to 5 turns. \n\nWould go into cooldown after use for: 3 rounds");
 				if (player.hasStatusEffect(StatusEffects.CooldownJetpack)) {
 					bd.disable("<b>You need more time before you can use jetpack again.</b>\n\n");
 				} else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Jetpack");
 			}
 			if (player.hasKeyItem("Goblin Bomber") >= 0) {
 				bd = buttons.add("Goblin Bomber", optionGoblinBomber).hint("Call for an airstrike.");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 				else if (player.hasStatusEffect(StatusEffects.GoblinBomber)) bd.disable("<b>You need wait one hour before you can use Goblin Bomber again.</b>\n\n");
+				favbd(bd, "Goblin Bomber");
 			}
 			if (player.hasKeyItem("Grenade Launcher") >= 0) {
 				//tinkerer gadgets
 				if (player.hasKeyItem("Flasherbang") >= 0 || player.hasKeyItem("Flasherbang II") >= 0) {
 					bd = buttons.add("Flasherbang", gadgetFlasherbang).hint("Throw a flasherbang to blind and arouse your opponents.");
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Gadget Flasherbang");
 				}
 				if (player.hasKeyItem("Goonade") >= 0 || player.hasKeyItem("Caustic Goonade") >= 0) {
 					var goonade4:String = player.hasKeyItem("Caustic Goonade") >= 0 ? "corrosive " : "";
@@ -749,17 +856,20 @@ public class PhysicalSpecials extends BaseCombatContent {
 					bd = buttons.add(""+goonade6+"", gadgetGoonade).hint("Throw a grenade that splatter "+goonade4+"sticky goo everywhere hindering movement and flight."+goonade5+"");
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 					else if (player.hasStatusEffect(StatusEffects.Grounded)) bd.disable("<b>You need wait until previous used Goonade effect wear off.</b>\n\n");
+					favbd(bd, "Gadget Goonade");
 				}
 				if (player.hasKeyItem("Fire Grenade") >= 0 || player.hasKeyItem("Fire Grenade II") >= 0) {
 					var fireGrenade1:String = player.hasKeyItem("Fire Grenade II") >= 0 ? " Upgrade the fire grenade explosion to also deal fire damage." : "";
 					bd = buttons.add("Fire Grenade", gadgetFireGrenade).hint("Toss a grenade that sets foes on fire inflicting the burn status effect."+fireGrenade1+"");
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+					favbd(bd, "Gadget Fire Grenade");
 				}
 				if (player.hasKeyItem("Stun Grenade") >= 0 || player.hasKeyItem("Stun Grenade II") >= 0) {
 					var stunGrenade1:String = player.hasKeyItem("Stun Grenade II") >= 0 ? " Upgrade the stun grenade explosion to also deal lightning damage." : "";
 					bd = buttons.add("Stun Grenade", gadgetStunGrenade).hint("Toss a grenade that sets stun foe for 1 round."+stunGrenade1+" (4 round cd)");
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 					else if (player.hasStatusEffect(StatusEffects.CooldownStunGrenade)) bd.disable("<b>You need wait more before you can use Stun Grenade again.</b>\n\n");
+					favbd(bd, "Gadget Stun Grenade");
 				}
 			}
 		}
@@ -768,11 +878,13 @@ public class PhysicalSpecials extends BaseCombatContent {
 				if (player.keyItemvX("HB Stealth System", 1) >= 1) bd = buttons.add("Invisibility", StealthModeActivate).hint("Turn your mech invisible. \n\nWould drain "+combat.StealthModeMechCost()+" SF from mech reserves or your own SF pool per turn.");// Will not use combat action.
 				else bd = buttons.add("Camouflage", StealthModeActivate).hint("Turn your mech invisible for 1 turn. \n\nWould drain "+combat.StealthModeMechCost()+" SF from mech reserves or your own SF pool.");
 				if (flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] < combat.StealthModeMechCost() && player.soulforce < combat.StealthModeMechCost()) bd.disable("<b>You are too low on SF reserves to use this option.</b>\n\n");
+				favbd(bd, "Mech Invisibility");
 				if (monster.hasStatusEffect(StatusEffects.InvisibleOrStealth) || monster.monsterIsStunned()
 					|| monster.hasStatusEffect(StatusEffects.Blind) || monster.hasStatusEffect(StatusEffects.InkBlind) || monster.hasStatusEffect(StatusEffects.Distracted)) {
 					bd = buttons.add("SneakAttack (M)", sneakAttackMech).hint("Strike the vitals of a stunned, blinded or distracted opponent for heavy damage. (Melee variant)");
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 					else if (flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] < 100 && player.soulforce < 100) bd.disable("<b>You are too low on SF reserves to use this option.</b>");
+					favbd(bd, "Sneak Attack Mech");
 				}
 				if (monster.hasStatusEffect(StatusEffects.InvisibleOrStealth) || monster.monsterIsStunned()
 					|| monster.hasStatusEffect(StatusEffects.Blind) || monster.hasStatusEffect(StatusEffects.InkBlind) || monster.hasStatusEffect(StatusEffects.Distracted)) {
@@ -780,8 +892,12 @@ public class PhysicalSpecials extends BaseCombatContent {
 					if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 					else if (!player.isUsingHowlingBansheeMechFriendlyRangeWeapons()) bd.disable("Your range weapon is not compatibile to be used in this special attack.");
 					else if (flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] < 100 && player.soulforce < 100) bd.disable("<b>You are too low on SF reserves to use this option.</b>");
+					favbd(bd, "Sneak Attack Mech Ranged");
 				}
-				if (player.keyItemvX("HB Stealth System", 1) >= 1 && monster.hasStatusEffect(StatusEffects.InvisibleOrStealth)) bd = buttons.add("Visibility", StealthModeDeactivate).hint("Turn your mech visible.");// Will not use combat action.
+				if (player.keyItemvX("HB Stealth System", 1) >= 1 && monster.hasStatusEffect(StatusEffects.InvisibleOrStealth)) {
+					bd = buttons.add("Visibility", StealthModeDeactivate).hint("Turn your mech visible.");// Will not use combat action.
+					favbd(bd, "Mech Visibility");
+				}
 			}
 			if (player.hasKeyItem("HB Dragon's Breath Flamer") >= 0) {
 				var HBDBFC:Number = 100;
@@ -789,6 +905,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 				bd = buttons.add("DB Flamer", mechWhitefireBeamCannon).hint("Shoot with Dragon's Breath Flamer at enemy burning him. \n\nWould drain "+HBDBFC+" SF from mech reserves or your own SF pool.");
 				if (flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] < HBDBFC && player.soulforce < HBDBFC) bd.disable("<b>You are too low on SF reserves to use this option.</b>\n\n");
 				else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Dragon's Breath Flamer");
 			}
 			if (player.hasKeyItem("HB Scatter Laser") >= 0) {
 				var LazorC:Number = 100;
@@ -805,11 +922,13 @@ public class PhysicalSpecials extends BaseCombatContent {
 				bd = buttons.add("Scatter Laser", mechScatterLaser).hint("Shoot with Scatter Laser"+((player.keyItemvX("HB Scatter Laser", 1) > 1)?"s":"")+" at enemy. \n\nWould drain "+LazorC+" SF from mech reserves or your own SF pool.");
 				if (flags[kFLAGS.SOULFORCE_STORED_IN_AYO_ARMOR] < LazorC && player.soulforce < LazorC) bd.disable("<b>You are too low on SF reserves to use this option.</b>\n\n");
 				else if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Scatter Laser");
 			}
 			if (player.hasKeyItem("Goblin Bomber") >= 0) {
 				bd = buttons.add("Goblin Bomber", optionGoblinBomber).hint("Call for an airstrike.");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
 				else if (player.hasStatusEffect(StatusEffects.GoblinBomber)) bd.disable("<b>You need wait one hour before you can use Goblin Bomber again.</b>\n\n");
+				favbd(bd, "Goblin Bomber");
 			}
 		}
 	}
@@ -824,6 +943,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 			if ((player.arms.type == Arms.BAT || player.wings.type == Wings.VAMPIRE) && !monster.hasPerk(PerkLib.EnemyGroupType) && !monster.hasPerk(PerkLib.EnemyLargeGroupType)) {
 				bd = buttons.add("Embrace", vampireEmbrace).hint("Embrace an opponent in your wings.");
 				if (isEnemyInvisible) bd.disable("You cannot use offensive skills against an opponent you cannot see or target.");
+				favbd(bd, "Vampire Embrace");
 			}
 			//Sky Pounce
 			if (player.canPounce() && !monster.hasPerk(PerkLib.EnemyGroupType) && !monster.hasPerk(PerkLib.EnemyLargeGroupType)) {
@@ -876,6 +996,7 @@ public class PhysicalSpecials extends BaseCombatContent {
 				if (player.hasStatusEffect(StatusEffects.CooldownWarriorShout) && !player.hasPerk(PerkLib.ChallengingShoutSu) && !player.hasPerk(PerkLib.ChallengingShoutMastered)) {
 					bd.disable("<b>You need more time before you can perform Warrior Shout again.</b>\n\n");
 				}
+				favbd(bd, "Warrior Shout");
 			}
 			if (player.hasVagina() && (player.isRaceCached(Races.COW) || player.perkv1(IMutationsLib.LactaBovinaOvariesIM) >= 1 || (player.perkv1(IMutationsLib.HumanOvariesIM) >= 3 && player.racialScore(Races.HUMAN) > 17)) && !player.hasPerk(PerkLib.ElementalBody)) {
 				var blaaaast2:String = player.perkv1(IMutationsLib.LactaBovinaOvariesIM) >= 3 ? " (cooldown of "+(player.hasPerk(PerkLib.NaturalInstincts) ? "3":"4")+" rounds before it can be used again)" : "";

--- a/classes/classes/Scenes/Dungeons/D3/DriderIncubus.as
+++ b/classes/classes/Scenes/Dungeons/D3/DriderIncubus.as
@@ -10,7 +10,7 @@ import classes.Stats.Buff;
 import classes.StatusEffects;
 import classes.internals.WeightedDrop;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class DriderIncubus extends AbstractSpiderMorph
 	{
@@ -119,7 +119,7 @@ if (this.lust < .65 * this.maxLust() && this.HP < .33 * this.maxHP()) {
 			
 		}
 
-		override public function postPlayerBusyBtnSpecial(btnSpecial1:CoCButton, btnSpecial2:CoCButton):void{
+		override public function postPlayerBusyBtnSpecial(btnSpecial1:ButtonData, btnSpecial2:ButtonData):void{
 			if (!goblinFree) btnSpecial1.show("Free Goblin", freeGoblin);
 		}
 

--- a/classes/classes/Scenes/Dungeons/D3/Lethice.as
+++ b/classes/classes/Scenes/Dungeons/D3/Lethice.as
@@ -14,7 +14,7 @@ import classes.StatusEffectType;
 import classes.StatusEffects;
 import classes.internals.WeightedDrop;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class Lethice extends Monster
 	{
@@ -481,7 +481,7 @@ public class Lethice extends Monster
 			companionCheck = false;
 		}
 
-		override public function postPlayerBusyBtnSpecial(btnSpecial1:CoCButton, btnSpecial2:CoCButton):void{
+		override public function postPlayerBusyBtnSpecial(btnSpecial1:ButtonData, btnSpecial2:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.LethicesRapeTentacles)) {
 				if (player.lust < SceneLib.combat.magic.getWhiteMagicLustCap() && player.hasStatusEffect(StatusEffects.KnowsWhitefire)
 						&& ((!player.hasPerk(PerkLib.BloodMage) && player.mana >= 30) || (player.hasStatusEffect(StatusEffects.BloodMage) && ((player.HP + 30) > (player.minHP() + 30))))) {

--- a/classes/classes/Scenes/Dungeons/D3/MinotaurKing.as
+++ b/classes/classes/Scenes/Dungeons/D3/MinotaurKing.as
@@ -9,9 +9,8 @@ import classes.PerkLib;
 import classes.Scenes.SceneLib;
 import classes.StatusEffects;
 import classes.internals.WeightedDrop;
-import classes.EngineCore;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class MinotaurKing extends Monster
 	{
@@ -296,7 +295,7 @@ public class MinotaurKing extends Monster
 			}
 		}
 
-		override public function postPlayerBusyBtnSpecial(btnSpecial1:CoCButton, btnSpecial2:CoCButton):void{
+		override public function postPlayerBusyBtnSpecial(btnSpecial1:ButtonData, btnSpecial2:ButtonData):void{
 			if (!player.hasStatusEffect(StatusEffects.MinoKing) && player.companionsInPCParty()) btnSpecial1.show("Dish Helper", SceneLib.hexindao.dishHelper);
 			else btnSpecial1.showDisabled("Dish Helper", "You don't have anyone to take care of "+(player.hasStatusEffect(StatusEffects.SoulArena)?"cow maid":"Excellia")+"!");
 		}

--- a/classes/classes/Scenes/Dungeons/D3/SuccubusGardener.as
+++ b/classes/classes/Scenes/Dungeons/D3/SuccubusGardener.as
@@ -12,7 +12,7 @@ import classes.StatusEffects;
 import classes.StatusEffects.Combat.GardenerSapSpeedDebuff;
 import classes.internals.WeightedDrop;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 /**
 	 * ...
@@ -83,7 +83,7 @@ import coc.view.CoCButton;
 			else SceneLib.d3.succubusGardener.surrenderToTheGardener(hpVictory);
 		}
 
-		override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+		override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.Tentagrappled)) {
 				btnStruggle.call(grappleStruggle);
 				btnBoundWait.call(grappleWait);

--- a/classes/classes/Scenes/Dungeons/DemonLab/Incels.as
+++ b/classes/classes/Scenes/Dungeons/DemonLab/Incels.as
@@ -13,7 +13,7 @@ import classes.Scenes.SceneLib;
 import classes.StatusEffects;
 import classes.internals.WeightedDrop;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class Incels extends Monster {
 
@@ -69,7 +69,7 @@ public class Incels extends Monster {
         damageMult = damageMultBase + (Math.round(lust/1000) * 0.01);
     }
 
-    override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+    override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
         if (player.hasStatusEffect(StatusEffects.Pounced)) {
             outputText("You are buried under the incels’ writhing mass, and they’re still trying to tear you apart!");
             btnStruggle.call(RipStruggle);

--- a/classes/classes/Scenes/Dungeons/DemonLab/ProjectTyrant.as
+++ b/classes/classes/Scenes/Dungeons/DemonLab/ProjectTyrant.as
@@ -9,7 +9,7 @@ import classes.BodyParts.Horns;
 import classes.Scenes.SceneLib;
 import classes.internals.WeightedDrop;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class ProjectTyrant extends Monster {
 
@@ -138,7 +138,7 @@ public class ProjectTyrant extends Monster {
         }
     }
 
-    override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+    override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
         if (player.hasStatusEffect(StatusEffects.Pounced)) {
             outputText("You are pinned underneath the Drider-beast’s weight, and it begins to crush you!");
             btnStruggle.call(TackleGrappleStruggle);

--- a/classes/classes/Scenes/Dungeons/EbonLabyrinth/Draculina.as
+++ b/classes/classes/Scenes/Dungeons/EbonLabyrinth/Draculina.as
@@ -10,10 +10,8 @@ import classes.BodyParts.Hips;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
-import classes.Scenes.Combat.CombatAbility;
-import classes.Scenes.Combat.SpellsWhite.BlindSpell;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 use namespace CoC;
 
@@ -42,7 +40,7 @@ use namespace CoC;
 			return nagaBindWait();
 		}
 
-		override public function postPlayerBusyBtnSpecial(btnSpecial1:CoCButton, btnSpecial2:CoCButton):void{
+		override public function postPlayerBusyBtnSpecial(btnSpecial1:ButtonData, btnSpecial2:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.MonsterInvisible)) {
 				if (player.hasStatusEffect(StatusEffects.KnowsBlind) && ((!player.hasPerk(PerkLib.BloodMage) && player.mana >= 30) || (player.hasStatusEffect(StatusEffects.BloodMage) && ((player.HP + 30) > (player.minHP() + 30))))) {
 					btnSpecial1.show("Blind", dispellDarkness1);

--- a/classes/classes/Scenes/Dungeons/RiverDungeon/TwinBosses.as
+++ b/classes/classes/Scenes/Dungeons/RiverDungeon/TwinBosses.as
@@ -14,7 +14,7 @@ import classes.BodyParts.Tail;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 use namespace CoC;
 
@@ -171,7 +171,7 @@ use namespace CoC;
 			}
 		}
 
-		override public function postPlayerBusyBtnSpecial(btnSpecial1:CoCButton, btnSpecial2:CoCButton):void{
+		override public function postPlayerBusyBtnSpecial(btnSpecial1:ButtonData, btnSpecial2:ButtonData):void{
 			if (!player.hasStatusEffect(StatusEffects.MinoKing) && player.companionsInPCParty()) btnSpecial1.show("Dish Helper", SceneLib.dungeons.riverdungeon.dishHelperTB);
 			else btnSpecial1.showDisabled("Dish Helper", "You don't have anyone to take care of other twin!");
 		}

--- a/classes/classes/Scenes/Exploration.as
+++ b/classes/classes/Scenes/Exploration.as
@@ -523,18 +523,18 @@ public class Exploration extends BaseContent implements SaveableState
 			if (canMeetXuviel()) SceneLib.demonicLair.questProgressScenes();
 			else {
 				addButton(0, "Explore", tryDiscover).hint("Explore to find new regions or visit any discovered regions.");
-				btnExploreForestOutskirts().applyTo(button(1));
-				btnExploreLake().applyTo(button(2));
-				btnExploreDesertOuter().applyTo(button(3));
+				btnExploreForestOutskirts().applyToSlot(1);
+				btnExploreLake().applyToSlot(2);
+				btnExploreDesertOuter().applyToSlot(3);
 				
-				btnExploreBattlefieldBoundary().applyTo(button(5));
-				btnExploreHills().applyTo(button(6));
-				btnExplorePlains().applyTo(button(7));
-				btnExploreSwamp().applyTo(button(8));
+				btnExploreBattlefieldBoundary().applyToSlot(5);
+				btnExploreHills().applyToSlot(6);
+				btnExplorePlains().applyToSlot(7);
+				btnExploreSwamp().applyToSlot(8);
 				
-				btnExploreBlightRidge().applyTo(button(10));
-				btnExploreBeach().applyTo(button(11));
-				btnExploreCaves().applyTo(button(12));
+				btnExploreBlightRidge().applyToSlot(10);
+				btnExploreBeach().applyToSlot(11);
+				btnExploreCaves().applyToSlot(12);
 				
 				addButton(4, "Next", explorePageII);
 				addButton(9, "Menu Style", toggleMenuStyle).hint("Switch to the new menu style");
@@ -549,20 +549,20 @@ public class Exploration extends BaseContent implements SaveableState
 			hideMenus();
 			menu();
 			
-			btnExploreBattlefieldOuter().applyTo(button(0));
-			btnExploreForestInner().applyTo(button(1));
-			btnExploreLakeBoat().applyTo(button(2));
-			btnExploreDesertInner().applyTo(button(3));
+			btnExploreBattlefieldOuter().applyToSlot(0);
+			btnExploreForestInner().applyToSlot(1);
+			btnExploreLakeBoat().applyToSlot(2);
+			btnExploreDesertInner().applyToSlot(3);
 			
-			btnExploreDefiledRavine().applyTo(button(5));
-			btnExploreMountainsLow().applyTo(button(6));
+			btnExploreDefiledRavine().applyToSlot(5);
+			btnExploreMountainsLow().applyToSlot(6);
 			// 7 - plains inner part
-			btnExploreBog().applyTo(button(8));
+			btnExploreBog().applyToSlot(8);
 			
-			btnExploreTundra().applyTo(button(10));
-			btnExploreAshlands().applyTo(button(11));
-			btnExploreLightlessReach().applyTo(button(12));
-			btnExploreCliffs().applyTo(button(13));
+			btnExploreTundra().applyToSlot(10);
+			btnExploreAshlands().applyToSlot(11);
+			btnExploreLightlessReach().applyToSlot(12);
+			btnExploreCliffs().applyToSlot(13);
 			
 			addButton(4, "Next", explorePageIII);
 			addButton(9, "Previous", goBackToPageI);
@@ -574,19 +574,19 @@ public class Exploration extends BaseContent implements SaveableState
 			hideMenus();
 			menu();
 			// 0 - battlefield inner part
-			btnExploreDeepwoods().applyTo(button(1));
+			btnExploreDeepwoods().applyToSlot(1);
 			//addButtonDisabled(2, "Shore", "TBA");//Discovered when exploring using Lake Boat.
 			
 			//if (flags[kFLAGS.DISCOVERED_] > 0) addButton(5, "",	//Wuxia related area - ?latająca wyspa?
 			//if (flags[kFLAGS.DISCOVERED_] > 0) addButton(9, "",	//Wuxia related area - ?latająca wyspa?
 			//if (flags[kFLAGS.DISCOVERED_PIT] > 0) addButton(5, "Pit", CoC.instance.abyss.explorePit).hint("Visit the pit. " + (debug ? "\n\nTimes explored: " + flags[kFLAGS.DISCOVERED_PIT] : ""));
 			//if (flags[kFLAGS.DISCOVERED_ABYSS] > 0) addButton(5, "Abyss", CoC.instance.abyss.exploreAbyss).hint("Visit the abyss. " + (debug ? "\n\nTimes explored: " + flags[kFLAGS.DISCOVERED_ABYSS] : ""));
-			btnExploreMountainsMid().applyTo(button(6));
-			btnExploreOcean().applyTo(button(7));
-			btnExploreTunnels().applyTo(button(8));
+			btnExploreMountainsMid().applyToSlot(6);
+			btnExploreOcean().applyToSlot(7);
+			btnExploreTunnels().applyToSlot(8);
 			
-			btnExploreGlacialRiftOuter().applyTo(button(10));
-			btnExploreVolcanicCragOuter().applyTo(button(11));
+			btnExploreGlacialRiftOuter().applyToSlot(10);
+			btnExploreVolcanicCragOuter().applyToSlot(11);
 			
 			addButton(4, "Next", goBackToPageIV);
 			addButton(9, "Previous", goBackToPageII);
@@ -598,8 +598,8 @@ public class Exploration extends BaseContent implements SaveableState
 			hideMenus();
 			menu();
 			
-			btnExploreMountainsHigh().applyTo(button(6));
-			btnExploreInnerOcean().applyTo(button(8));
+			btnExploreMountainsHigh().applyToSlot(6);
+			btnExploreInnerOcean().applyToSlot(8);
 			//if (flags[kFLAGS.DISCOVERED_DEEP_SEA] > 0 && player.canSwimUnderwater()) addButton(8, "Deep Sea", SceneLib.deepsea.exploreDeepSea).hint("Visit the 'almost virgin' deep sea. But beware of... krakens. " + (debug ? "\n\nTimes explored: " + flags[kFLAGS.DISCOVERED_DEEP_SEA] : ""));
 			
 			addButton(4, "Next", goBackToPageV);

--- a/classes/classes/Scenes/Monsters/AngelLR.as
+++ b/classes/classes/Scenes/Monsters/AngelLR.as
@@ -5,14 +5,14 @@
 package classes.Scenes.Monsters 
 {
 
-	import classes.*;
-	import classes.BodyParts.Wings;
-	import classes.Items.DynamicItems;
-	import classes.Scenes.Dungeons.RiverDungeon;
-	import classes.Scenes.SceneLib;
-	import classes.internals.ChainedDrop;
+import classes.*;
+import classes.BodyParts.Wings;
+import classes.Items.DynamicItems;
+import classes.Scenes.Dungeons.RiverDungeon;
+import classes.Scenes.SceneLib;
+import classes.internals.ChainedDrop;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class AngelLR extends AbstractAngel
 	{
@@ -102,7 +102,7 @@ public class AngelLR extends AbstractAngel
 			if (choice == 0) AngelEnergyRays();
 			if (choice > 0) AngelBaseAttack();
 		}
-		override public function postPlayerBusyBtnSpecial(btnSpecial1:CoCButton, btnSpecial2:CoCButton):void{
+		override public function postPlayerBusyBtnSpecial(btnSpecial1:ButtonData, btnSpecial2:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.SoulArena)) {
 				if (!player.hasStatusEffect(StatusEffects.MinoKing) && player.companionsInPCParty()) btnSpecial1.show("Dish Helper", SceneLib.hexindao.dishHelperIL);
 				else btnSpecial1.showDisabled("Dish Helper", "You don't have anyone to take care of second angel!");

--- a/classes/classes/Scenes/Monsters/Hollow.as
+++ b/classes/classes/Scenes/Monsters/Hollow.as
@@ -9,9 +9,10 @@ import classes.BodyParts.*;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
-//import classes.Scenes.Combat.CombatAbilities;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
+
+//import classes.Scenes.Combat.CombatAbilities;
 
 use namespace CoC;
 
@@ -133,7 +134,7 @@ use namespace CoC;
 			}
 		}
 		
-		override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+		override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.Pounced)) {
 				btnStruggle.call(hollowPouncedStruggle);
 				btnBoundWait.call(hollowPouncedWait);

--- a/classes/classes/Scenes/NPCs/Ceraph.as
+++ b/classes/classes/Scenes/NPCs/Ceraph.as
@@ -9,7 +9,7 @@ import classes.Scenes.Combat.Combat;
 import classes.Scenes.SceneLib;
 import classes.display.SpriteDb;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class Ceraph extends Monster
 	{
@@ -221,7 +221,7 @@ public class Ceraph extends Monster
 			outputText("\n");
 		}
 
-		override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+		override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.Bound)) {
 				btnStruggle.call(ceraphBindingStruggle);
 				btnBoundWait.call(ceraphBoundWait);

--- a/classes/classes/Scenes/NPCs/Grayda.as
+++ b/classes/classes/Scenes/NPCs/Grayda.as
@@ -3,11 +3,11 @@ package classes.Scenes.NPCs
 import classes.*;
 import classes.BodyParts.Butt;
 import classes.BodyParts.Hips;
-import classes.Scenes.SceneLib;
 import classes.GlobalFlags.kFLAGS;
+import classes.Scenes.SceneLib;
 import classes.internals.*;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class Grayda extends Monster
 	{
@@ -89,7 +89,7 @@ public class Grayda extends Monster
 			player.removeStatusEffect(StatusEffects.Terrorize);
 			SceneLib.combat.enemyAIImpl();
 		}
-		override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+		override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.Terrorize)) {
 				btnStruggle.call(graydaTerrorizeStruggle);
 				btnBoundWait.call(graydaTerrorizeWait);

--- a/classes/classes/Scenes/NPCs/Tyrantia.as
+++ b/classes/classes/Scenes/NPCs/Tyrantia.as
@@ -13,9 +13,8 @@ import classes.BodyParts.LowerBody;
 import classes.GlobalFlags.kFLAGS;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
-import classes.Monster;
 
-import coc.view.CoCButton;
+import coc.view.ButtonData;
 
 public class Tyrantia extends Monster
 	{
@@ -150,7 +149,7 @@ public class Tyrantia extends Monster
 			player.takeLustDamage((lustFromHits() * 4), true);
 			player.buff("Goop Web").addStats( {"spe":-30} ).withText("Goop Web").combatPermanent();
 		}
-		override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+		override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.Pounced)) {
 				outputText("\n<b>You’re trapped underneath the giant Drider, and all you can see is her armored undercarriage. Eight legs jab down at you, steel glinting dangerously. You need to get out of here, or you’ll end up crushed!</b>");
 				btnStruggle.call(tyrantiaPouncedStruggle);

--- a/classes/classes/Scenes/NPCs/Yamata.as
+++ b/classes/classes/Scenes/NPCs/Yamata.as
@@ -13,6 +13,8 @@ import classes.Scenes.Combat.Combat;
 import classes.Scenes.SceneLib;
 import classes.internals.*;
 
+import coc.view.ButtonData;
+
 import coc.view.CoCButton;
 
 public class Yamata extends Monster
@@ -332,7 +334,7 @@ public class Yamata extends Monster
 			else return true;
 		}
 
-		override public function changeBtnWhenBound(btnStruggle:CoCButton, btnBoundWait:CoCButton):void{
+		override public function changeBtnWhenBound(btnStruggle:ButtonData, btnBoundWait:ButtonData):void{
 			if (player.hasStatusEffect(StatusEffects.YamataEntwine)) {
 				btnStruggle.call(entwineStruggle);
 				btnBoundWait.call(entwineWait);

--- a/classes/coc/view/ButtonData.as
+++ b/classes/coc/view/ButtonData.as
@@ -26,6 +26,7 @@ public class ButtonData {
 	public var iconId:String = null;
 	public var iconQty:String = "";
 	public var cornerLabelText:String = "";
+	public var clickOnDisabled:Boolean = false;
 	public function ButtonData(text:String="", callback:Function =null, toolTipText:String ="", toolTipHeader:String ="") {
 		this.text = text;
 		this.callback = callback;
@@ -44,6 +45,7 @@ public class ButtonData {
 		iconId = "";
 		iconQty = "";
 		cornerLabelText = "";
+		clickOnDisabled = false;
 		return this;
 	}
 	public function show(text:String,callback:Function,toolTipText:String="",toolTipHeader:String=""): ButtonData {
@@ -54,6 +56,10 @@ public class ButtonData {
 		this.toolTipHeader = toolTipHeader;
 		this.visible = !!text;
 		this.enabled = this.callback != null;
+		return this;
+	}
+	public function hide():ButtonData {
+		visible = false;
 		return this;
 	}
 	public function showDisabled(text:String,toolTipText:String="",toolTipHeader:String=""):ButtonData {
@@ -146,6 +152,12 @@ public class ButtonData {
 					.disableIf(!enabled)
 					.icon(iconId, iconQty)
 					.cornerLabel(cornerLabelText);
+			btn.clickOnDisabled = clickOnDisabled;
+		}
+	}
+	public function applyToSlot(i:int):void {
+		if (i >= 0 && i <= 14) {
+			applyTo(CoC.instance.mainView.bottomButtons[i]);
 		}
 	}
 	public function copyTo(bd:ButtonData):void {
@@ -163,6 +175,7 @@ public class ButtonData {
 		bd.iconId = iconId;
 		bd.iconQty = iconQty;
 		bd.cornerLabelText = cornerLabelText;
+		bd.clickOnDisabled = clickOnDisabled;
 	}
 	/**
 	 * Adds a Soulforce requirement hint, and disables if player has not enough.
@@ -258,6 +271,7 @@ public class ButtonData {
 		this.toolTipText = btn.toolTipText;
 		this.labelColor = btn.labelColor;
 		this.iconId = btn.iconId;
+		this.clickOnDisabled = btn.clickOnDisabled;
 		// Still not enough to copy fields associated with items
 		return this;
 	}

--- a/classes/coc/view/ButtonData.as
+++ b/classes/coc/view/ButtonData.as
@@ -9,6 +9,8 @@ import classes.PerkLib;
 import classes.StatusEffects;
 import classes.internals.Utils;
 
+import mx.controls.Button;
+
 public class ButtonData {
 	public var text:String = "";
 	public var callback:Function = null;
@@ -24,12 +26,46 @@ public class ButtonData {
 	public var iconId:String = null;
 	public var iconQty:String = "";
 	public var cornerLabelText:String = "";
-	public function ButtonData(text:String, callback:Function =null, toolTipText:String ="", toolTipHeader:String ="") {
+	public function ButtonData(text:String="", callback:Function =null, toolTipText:String ="", toolTipHeader:String ="") {
 		this.text = text;
 		this.callback = callback;
 		this.enabled = callback != null;
 		this.toolTipText = toolTipText;
 		this.toolTipHeader = toolTipHeader;
+	}
+	public function reset():ButtonData {
+		this.color(CoCButton.DEFAULT_COLOR);
+		visible = false;
+		text = "";
+		toolTipHeader = "";
+		toolTipText = "";
+		enabled = false;
+		callback = null;
+		iconId = "";
+		iconQty = "";
+		cornerLabelText = "";
+		return this;
+	}
+	public function show(text:String,callback:Function,toolTipText:String="",toolTipHeader:String=""): ButtonData {
+		this.reset();
+		this.text = text;
+		this.callback = callback;
+		this.toolTipText = toolTipText;
+		this.toolTipHeader = toolTipHeader;
+		this.visible = !!text;
+		this.enabled = this.callback != null;
+		return this;
+	}
+	public function showDisabled(text:String,toolTipText:String="",toolTipHeader:String=""):ButtonData {
+		return show(text, null, toolTipText, toolTipHeader);
+	}
+	public function call(fn:Function, ...args:Array):ButtonData {
+		if (args.length > 0) {
+			this.callback = Utils.curry.apply(null, [fn].concat(args));
+		} else {
+			this.callback = fn;
+		}
+		return this;
 	}
 	public function hint(toolTipText:String,toolTipHeader:String=""):ButtonData {
 		this.toolTipText = toolTipText;
@@ -111,6 +147,22 @@ public class ButtonData {
 					.icon(iconId, iconQty)
 					.cornerLabel(cornerLabelText);
 		}
+	}
+	public function copyTo(bd:ButtonData):void {
+		bd.text = text;
+		bd.callback = callback;
+		bd.enabled = enabled;
+		bd.visible = visible;
+		bd.toolTipHeader = toolTipHeader;
+		bd.toolTipText = toolTipText;
+		bd.labelColor = labelColor;
+		bd.extraData = extraData;
+		bd.draggable = draggable;
+		bd.slot = slot;
+		bd.slotType = slotType;
+		bd.iconId = iconId;
+		bd.iconQty = iconQty;
+		bd.cornerLabelText = cornerLabelText;
 	}
 	/**
 	 * Adds a Soulforce requirement hint, and disables if player has not enough.

--- a/classes/coc/view/ButtonDataList.as
+++ b/classes/coc/view/ButtonDataList.as
@@ -9,6 +9,9 @@ public class ButtonDataList {
 	public function append(bd:ButtonData):void {
 		list.push(bd);
 	}
+	public function prepend(bd:ButtonData):void {
+		list.unshift(bd);
+	}
 	public function add(text:String, callback:Function =null, toolTipText:String ="", toolTipHeader:String =""):ButtonData {
 		var bd:ButtonData = new ButtonData(text,callback,toolTipText,toolTipHeader);
 		list.push(bd);

--- a/classes/coc/view/CoCButton.as
+++ b/classes/coc/view/CoCButton.as
@@ -90,6 +90,7 @@ public class CoCButton extends Block {
 
 	public var toolTipHeader:String,
 			   toolTipText:String;
+	public var clickOnDisabled:Boolean;
 
 		/**
 		 * @param options  enabled, labelText, bitmapClass, callback
@@ -244,8 +245,9 @@ public class CoCButton extends Block {
 	}
 
 	public function click(event:MouseEvent = null):void {
-		if (!this.enabled) return;
+		if (!this.enabled && !this.clickOnDisabled) return;
 		CoC.instance.mainView.toolTipView.hide();
+		lastClicked = this;
 		try {
 			if (this._preCallback != null)
 				this._preCallback(this);
@@ -260,7 +262,7 @@ public class CoCButton extends Block {
 		}
 	}
 
-
+	public static var lastClicked:CoCButton = null;
 
 		//////// Getters and Setters ////////
 
@@ -578,6 +580,7 @@ public class CoCButton extends Block {
 		iconId          = null;
 		iconQty         = "";
 		cornerLabelText = "";
+		clickOnDisabled = false;
 		return this;
 	}
 	/**


### PR DESCRIPTION
New Combat UI:
* First 10 buttons are favourite skills and last used skills. The split is 5/5 by default and configurable in Other > Btn Config
* Shift+click on ability with yellow '*' icon to add/remove it from favourites.
* Old menu is not available, but you can recreate it by adding skills and buttons to favourites
* For mobile users, go to Other > Btn Config > Manual Mode. You will be prompted to use an ability or fav/unfav it when clicked.