### PR TITLE
The workaround for HairDye is not needed for demonic (cloven) hoofs

### DIFF
--- a/classes/classes/Items/Consumables/HairDye.as
+++ b/classes/classes/Items/Consumables/HairDye.as
@@ -64,10 +64,9 @@ public class HairDye extends Consumable
 					}
 					
 					var present:Boolean = player.hasBodyMaterial(type);
-					// Workaround for demonic taur lowerbodies using reptaur (scales) or centaur (fur) lower Body.
+					// Workaround for demonic taur lowerbodies using reptaur (scales) lower Body.
 					// Remove me, if we have separate sprites for demon taurs!
-					if (player.legCount == 4 && (type == BodyMaterial.SCALES && player.lowerBody == LowerBody.DEMONIC_CLAWS)
-					                         || (type == BodyMaterial.FUR && InCollection(player.lowerBody, LowerBody.DEMONIC_HOOFS, LowerBody.DEMONIC_CLOVEN_HOOFS)))
+					if (player.legCount == 4 && type == BodyMaterial.SCALES && player.lowerBody == LowerBody.DEMONIC_CLAWS)
 						present = true;
 					// /Workaround
 					if (present) {

--- a/classes/classes/Transformations/Transformations/LowerBodyTransformations.as
+++ b/classes/classes/Transformations/Transformations/LowerBodyTransformations.as
@@ -411,7 +411,7 @@ public class LowerBodyTransformations extends MutationsHelper {
 				if (doOutput) outputText(desc);
 				player.lowerBody = LowerBody.DEMONIC_CLAWS;
 				player.legCount = legCount;
-				Metamorph.unlockMetamorph(LowerBodyMem.getMemory(LowerBodyMem.DRAGON));
+				Metamorph.unlockMetamorph(LowerBodyMem.getMemory(LowerBodyMem.DEMONIC_CLAWS));
 			},
 			// is present
 			function (): Boolean {


### PR DESCRIPTION
Removed the workaround for applying hair dye to demonic (cloven) hoofs, as they have `bodyMaterial` fur set to true.

**Update:** Genetic Memory for the demonic clawed lower body should be the same and not draconic. Fix that small oversight.