### PR TITLE
Some tweaks and fixes for terminal corruption

### DIFF
--- a/classes/classes/Items/Consumables/DemonizeMe.as
+++ b/classes/classes/Items/Consumables/DemonizeMe.as
@@ -80,8 +80,9 @@ public class DemonizeMe extends Consumable {
 
 		public function demonizePlayer():void {
 			CoC.instance.mutations.terminalCorruption2(player);
-			player.skin.setBaseOnly({type:Skin.PLAIN, color1:"blue", pattern: Skin.PATTERN_DEMONIC_PLEASURE_RUNE});
-			outputText("\n<b>Gained Perk: Soulless!</b> "+PerkLib.Soulless.desc());
+			player.skin.setBaseOnly({type:Skin.PLAIN, color1:"blue"});
+			CoC.instance.transformations.SkinPatternDemonicPleasureRune.applyEffect(false);
+			outputText("\n\n<b>Gained Perk: Soulless!</b> "+PerkLib.Soulless.desc());
 			player.updateRacialParagon(Races.DEMON);
 			player.npcsThatLeaveSoullessPC();
 		}

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -1228,7 +1228,7 @@ public final class Mutations extends MutationsHelper {
 			transformations.ArmsHuman.applyEffect(false);
 			transformations.ArmsDemon.applyEffect(false);
 		}
-		if (player.lowerBody != LowerBody.DEMONIC_CLAWS && player.lowerBody != LowerBody.DEMONIC_HIGH_HEELS && player.lowerBody != LowerBody.DEMONIC_GRACEFUL_FEET) {
+		if (!InCollection(player.lowerBody, LowerBody.DEMONIC_CLAWS, LowerBody.DEMONIC_HIGH_HEELS, LowerBody.DEMONIC_GRACEFUL_FEET, LowerBody.DEMONIC_HOOFS, LowerBody.DEMONIC_CLOVEN_HOOFS)) {
 			if (player.gender <= 1 || (player.gender == 3 && player.mf("m", "f") == "m")) {
 				switch (rand(2)) {
 					case 0: transformations.LowerBodyDemonClawedBipedal.applyEffect(false); break;

--- a/classes/classes/Items/Mutations.as
+++ b/classes/classes/Items/Mutations.as
@@ -1178,9 +1178,7 @@ public final class Mutations extends MutationsHelper {
 	public function terminalCorruption(player:Player):void {
 		var choice1:String = randomChoice(DemonRace.DemonSkinColors);
 		var choice2:String = randomChoice(DemonRace.DemonSkin2Colors);
-		player.skinColor1 = choice1;
-		player.skinColor2 = choice2;
-        terminalCorruption2(player);
+		player.skin.setBaseOnly({type:Skin.PLAIN, color1: choice1, color2: choice2});
 		player.demonicenergy += 50;
 		if (player.hasStatusEffect(StatusEffects.ArigeanInfected)) player.removeStatusEffect(StatusEffects.ArigeanInfected);
 		if (player.hasPerk(PerkLib.WendigoCurse)) player.removePerk(PerkLib.WendigoCurse);
@@ -1202,6 +1200,9 @@ public final class Mutations extends MutationsHelper {
 		outputText("You seem to have struck a bottleneck unable to achieve release as your pleasure keep reaching intolerable heights but finally the dam breaks allowing you to release everything out. When you come down from your orgasm you finally realize what just happened. You didn’t just came you came your soul out now your no defrent from the demons who fucked you into this state. ");
 		outputText("You quickly adapt to the change however and take what's left of your soul from the ground eating it right away. It seems you’ve become a demon, there's no going back to having a soul now but that doesn’t mean your quest has to end there far from it, you’re going to turn this shity land into your playground and get back at it for everything that's been done to you. ");
 		outputText("The champion you is no more but you’ve got plenty of grievances with the place to address still and you will only rest until it's all under your demonic foot.\n\n");
+		transformations.SkinPatternDemonicPleasureRune.applyEffect(false);
+		terminalCorruption2(player);
+		outputText("\n\n<b>Gained Perk: Soulless!</b> "+PerkLib.Soulless.desc());
 	}
 	public function terminalCorruption2(player:Player):void {
 		if (player.hairType != Hair.NORMAL) transformations.HairHuman.applyEffect(false);

--- a/classes/classes/Scenes/Places/DemonLair.as
+++ b/classes/classes/Scenes/Places/DemonLair.as
@@ -242,8 +242,8 @@ public class DemonLair extends BaseContent
 				var how:Number = 28 - player.biggestTitSize();
 				player.growTits(how, 1, false, 3);
 			}
-			player.skin.setBaseOnly({type:Skin.PLAIN, color1:"blue", pattern: Skin.PATTERN_DEMONIC_PLEASURE_RUNE});
-			transformations.SkinPatternDemonicPleasureRune.applyEffect(false); // for the genetic memory mainly
+			player.skin.setBaseOnly({type:Skin.PLAIN, color1:"blue"});
+			transformations.SkinPatternDemonicPleasureRune.applyEffect(false);
 			if (!InCollection(player.skinColor1, DemonRace.DemonSkinColors) && !InCollection(player.skinColor2, DemonRace.DemonSkin2Colors)) {
 				var choice1:String = randomChoice(DemonRace.DemonSkinColors);
                 var choice2:String = randomChoice(DemonRace.DemonSkin2Colors);

--- a/classes/classes/Scenes/Places/DemonLair.as
+++ b/classes/classes/Scenes/Places/DemonLair.as
@@ -229,12 +229,19 @@ public class DemonLair extends BaseContent
 			outputText("\"<i>So you finally understand, [name], you were never truly free from me, it’s the reverse: you desire my touch and even more than anything, my cum to the point that the necklace is no longer necessary to keep you pliant. Well, allow me to properly reward you for your blind devotion to your beloved master.</i>\"\n\n");
 			outputText("He's right… you definitely desire him, it just took your mind a long time to reach the conclusion your body had already accepted. There is a very thin barrier between love and hate. Normally people take it the other way around, but after a while you end up not only desiring the pleasure he gives you, but also his own! Each trust of his fat, awe inspiring member teaches your flesh just that. Xuviel laughs as his cock unloads a massive amount of corrupted cum right into your pussy, ");
 			outputText("sending you straight to your climax as your blasphemous cunt devours every drop of it, absorbing it into your being. You feel something drip between your legs as your mind goes blank. Something breaks within you as you feel your juice flow from the multiple consecutive orgasm Xuviel’s unholy sperm provides you, your entire body spasming like a sexual organ as corruption soaks your entire being. You don’t know how it happened but when you finally come to your senses you take notice of something on the perfectly polished ground.\n\n");
-			if (player.hasCock()) player.lowerBody = LowerBody.DEMONIC_CLAWS;
-			else {
-				if (rand(2) == 0) player.lowerBody = LowerBody.DEMONIC_CLAWS;
+			if (!InCollection(player.lowerBody, LowerBody.DEMONIC_CLAWS, LowerBody.DEMONIC_HIGH_HEELS, LowerBody.DEMONIC_GRACEFUL_FEET, LowerBody.DEMONIC_HOOFS, LowerBody.DEMONIC_CLOVEN_HOOFS)) {
+				if (player.gender <= 1 || (player.gender == 3 && player.mf("m", "f") == "m")) {
+					switch (rand(2)) {
+						case 0: transformations.LowerBodyDemonClawedBipedal.applyEffect(false); break;
+						case 1: transformations.LowerBodyDemonHoofedBipedal.applyEffect(false); break;
+					}
+				}
 				else {
-					if (rand(2) == 0) player.lowerBody = LowerBody.DEMONIC_HIGH_HEELS;
-					else player.lowerBody = LowerBody.DEMONIC_GRACEFUL_FEET;
+					switch (rand(3)) {
+						case 0: transformations.LowerBodyDemonHighHeels.applyEffect(false); break;
+						case 1: transformations.LowerBodyDemonGracefulFeet.applyEffect(false); break;
+						case 2: transformations.LowerBodyDemonClovenHoofedBipedal.applyEffect(false); break;
+					}
 				}
 			}
 			player.legCount = 2;
@@ -242,15 +249,13 @@ public class DemonLair extends BaseContent
 				var how:Number = 28 - player.biggestTitSize();
 				player.growTits(how, 1, false, 3);
 			}
-			player.skin.setBaseOnly({type:Skin.PLAIN, color1:"blue"});
-			transformations.SkinPatternDemonicPleasureRune.applyEffect(false);
 			if (!InCollection(player.skinColor1, DemonRace.DemonSkinColors) && !InCollection(player.skinColor2, DemonRace.DemonSkin2Colors)) {
 				var choice1:String = randomChoice(DemonRace.DemonSkinColors);
-                var choice2:String = randomChoice(DemonRace.DemonSkin2Colors);
-                player.skinColor1 = choice1;
-                player.skinColor2 = choice2;
+				var choice2:String = randomChoice(DemonRace.DemonSkin2Colors);
+				player.skin.setBaseOnly({type:Skin.PLAIN, color1: choice1, color2: choice2});
 			}
 			if (rand(2) == 0) player.skinColor1 = "pink";
+			transformations.SkinPatternDemonicPleasureRune.applyEffect(false);
 			transformations.TailDemonic.applyEffect(false);
 			transformations.HairHuman.applyEffect(false);
 			transformations.FaceDemon.applyEffect(false);

--- a/classes/classes/Scenes/Places/DemonLair.as
+++ b/classes/classes/Scenes/Places/DemonLair.as
@@ -243,6 +243,7 @@ public class DemonLair extends BaseContent
 				player.growTits(how, 1, false, 3);
 			}
 			player.skin.setBaseOnly({type:Skin.PLAIN, color1:"blue", pattern: Skin.PATTERN_DEMONIC_PLEASURE_RUNE});
+			transformations.SkinPatternDemonicPleasureRune.applyEffect(false); // for the genetic memory mainly
 			if (!InCollection(player.skinColor1, DemonRace.DemonSkinColors) && !InCollection(player.skinColor2, DemonRace.DemonSkin2Colors)) {
 				var choice1:String = randomChoice(DemonRace.DemonSkinColors);
                 var choice2:String = randomChoice(DemonRace.DemonSkin2Colors);


### PR DESCRIPTION
- Moved the call to `terminalCorruption2` to the end aka after the text output. Now the check for tail == NONE makes sense again.
- Now you'll get the `DEMONIC_PLEASURE_RUNE` skin pattern from terminal corruption.
- Terminal corruption now displays the 'Gained Perk: Soulless!' message.
- Fixed: Gaining the `DEMONIC_PLEASURE_RUNE` skin pattern didn't add the genetic memory.
- **Update:** Added demonic hoofs and demonic cloven hoofs to Xuviel TF-scene